### PR TITLE
Occa backend, part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ prove : $(tests)
 examples : $(examples)
 
 .PHONY: clean print test examples astyle
-clean :
+cln clean :
 	$(RM) *.o $(OBJDIR)/*.o *.d $(OBJDIR)/*.d $(libceed) $(tests)
 	$(RM) -r *.dSYM $(OBJDIR)/backends
 	$(MAKE) -C examples/mfem clean

--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -32,7 +32,7 @@ static int CeedBasisApply_Occa(CeedBasis basis, CeedTransposeMode tmode,
       P = basis->Q1d; Q = basis->P1d;
     }
     CeedInt pre = ndof*CeedPowInt(P, dim-1), post = 1;
-    CeedScalar tmp[2][Q*CeedPowInt(P>Q?P:Q, dim-1)];
+    CeedScalar tmp[2][ndof*Q*CeedPowInt(P>Q?P:Q, dim-1)];
     for (CeedInt d=0; d<dim; d++) {
       ierr = CeedTensorContract_Occa(basis->ceed, pre, P, post, Q, basis->interp1d,
                                      tmode, d==0?u:tmp[d%2], d==dim-1?v:tmp[(d+1)%2]);
@@ -51,7 +51,7 @@ static int CeedBasisApply_Occa(CeedBasis basis, CeedTransposeMode tmode,
     if (tmode == CEED_NOTRANSPOSE) {
       // u is (P^dim x nc), column-major layout (nc = ndof)
       // v is (Q^dim x nc x dim), column-major layout (nc = ndof)
-      CeedScalar tmp[2][Q*CeedPowInt(P>Q?P:Q, dim-1)];
+      CeedScalar tmp[2][ndof*Q*CeedPowInt(P>Q?P:Q, dim-1)];
       for (CeedInt p = 0; p < dim; p++) {
         CeedInt pre = ndof*CeedPowInt(P, dim-1), post = 1;
         for (CeedInt d=0; d<dim; d++) {

--- a/backends/occa/ceed-occa-qfunction.c
+++ b/backends/occa/ceed-occa-qfunction.c
@@ -25,7 +25,6 @@ static int CeedQFunctionApply_Occa(CeedQFunction qf, void *qdata, CeedInt Q,
   int ierr;
   //CeedDebug("\033[36m[CeedQFunction][Apply]");
   ierr = qf->function(qf->ctx, qdata, Q, u, v); CeedChk(ierr);
-
   return 0;
 }
 

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -74,7 +74,7 @@ kernel void kRestrict5(const int ncomp,
                        const double* uu,
                        double* vv) {
   // vv is (ncomp x ndof), column-major
-  for (int e = 0; e < rnelem; e++){
+  for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
     if (e >= rnelem) return;
     for (int d = 0; d < ncomp; d++){
       for (int i=0; i<relemsize; i++) {

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -3,7 +3,7 @@ kernel void kRestrict0(const int *indices,
                        const double* uu,
                        double* vv) {
   for (int i=0; i<esize; i++; tile(TILE_SIZE)){
-    if (i >= esize) return;
+    if (i >= esize) continue;
     vv[i] = uu[indices[i]];
   }
 }
@@ -13,9 +13,8 @@ kernel void kRestrict1(const int ncomp,
                        const int *indices,
                        const double* uu,
                        double* vv) {
-  // u is (ndof x ncomp), column-major
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) return;
+    if (e >= rnelem) continue;
     for (int d = 0; d < ncomp; d++){
       for (int i=0; i<relemsize; i++) {
         vv[i+relemsize*(d+ncomp*e)] =
@@ -30,9 +29,8 @@ kernel void kRestrict2(const int ncomp,
                        const int *indices,
                        const double* uu,
                        double* vv) {
-  // u is (ncomp x ndof), column-major
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) return;
+    if (e >= rnelem) continue;
     for (int d = 0; d < ncomp; d++){
       for (int i=0; i<relemsize; i++) {
         vv[i+relemsize*(d+ncomp*e)] =
@@ -47,7 +45,7 @@ kernel void kRestrict3(const int *indices,
                        const double* uu,
                        double* vv) {
   for (int i=0; i<esize; i++; tile(TILE_SIZE)){
-    if (i >= esize) return;
+    if (i >= esize) continue;
     vv[indices[i]] += uu[i];
   }
 }
@@ -58,7 +56,7 @@ kernel void kRestrict4(const int ncomp,
                        const double* uu,
                        double* vv) {
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) return;
+    if (e >= rnelem) continue;
     for (int d = 0; d < ncomp; d++){
       for (int i=0; i<relemsize; i++) {
         vv[indices[i+relemsize*e]+rndof*d] +=
@@ -73,9 +71,8 @@ kernel void kRestrict5(const int ncomp,
                        const int *indices,
                        const double* uu,
                        double* vv) {
-  // vv is (ncomp x ndof), column-major
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) return;
+    if (e >= rnelem) continue;
     for (int d = 0; d < ncomp; d++){
       for (int i=0; i<relemsize; i++) {
         vv[d+ncomp*indices[i+relemsize*e]] +=

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -49,7 +49,7 @@ kernel void kRestrict3(const int *indices,
                        double* vv) {
   for (int i=0; i<esize; i++; tile(TILE_SIZE)){
     if (i < esize) {
-      vv[indices[i]] += uu[i];
+      atomicAdd(vv + indices[i], uu[i]);
     }
   }
 }
@@ -63,8 +63,7 @@ kernel void kRestrict4(const int ncomp,
     if (e < rnelem) {
       for (int d = 0; d < ncomp; d++){
         for (int i=0; i<relemsize; i++) {
-          vv[indices[i+relemsize*e]+rndof*d] +=
-            uu[i+relemsize*(d+e*ncomp)];
+          atomicAdd(vv + (i+relemsize*e+rndof*d), uu[i+relemsize*(d+e*ncomp)]);
         }
       }
     }
@@ -80,8 +79,7 @@ kernel void kRestrict5(const int ncomp,
     if (e < rnelem) {
       for (int d = 0; d < ncomp; d++){
         for (int i=0; i<relemsize; i++) {
-          vv[d+ncomp*indices[i+relemsize*e]] +=
-            uu[i+relemsize*(d+e*ncomp)];
+          atomicAdd(vv + (d+ncomp*indices[i+relemsize*e]), uu[i+relemsize*(d+e*ncomp)]);
         }
       }
     }

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -1,55 +1,85 @@
-kernel void kRestrict(const bool T_TRANSPOSE,
-                      const bool L_TRANSPOSE,
-                      const int ncomp,
-                      const int *indices,
-                      const double* uu,
-                      double* vv) {
+// *****************************************************************************
+kernel void kRestrict0(const int *indices,
+                       const double* uu,
+                       double* vv) {
   for (int i=0; i<esize; i++; tile(TILE_SIZE)){
     if (i >= esize) return;
-    
-    if (T_TRANSPOSE) {
-      // Perform: v = r * u
-      if (ncomp == 1) {
-        for (int i=0; i<esize; i++) vv[i] = uu[indices[i]];
-      } else {
-        // vv is (elemsize x ncomp x nelem), column-major
-        if (L_TRANSPOSE) { // u is (ndof x ncomp), column-major
-          for (int e = 0; e < rnelem; e++)
-            for (int d = 0; d < ncomp; d++)
-              for (int i=0; i<relemsize; i++) {
-                vv[i+relemsize*(d+ncomp*e)] =
-                  uu[indices[i+relemsize*e]+rndof*d];
-              }
-        } else { // u is (ncomp x ndof), column-major
-          for (int e = 0; e < rnelem; e++)
-            for (int d = 0; d < ncomp; d++)
-              for (int i=0; i<relemsize; i++) {
-                vv[i+relemsize*(d+ncomp*e)] =
-                  uu[d+ncomp*indices[i+relemsize*e]];
-              }
-        }
+    vv[i] = uu[indices[i]];
+  }
+}
+
+// *****************************************************************************
+kernel void kRestrict1(const int ncomp,
+                       const int *indices,
+                       const double* uu,
+                       double* vv) {
+  // u is (ndof x ncomp), column-major
+  for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
+    if (e >= rnelem) return;
+    for (int d = 0; d < ncomp; d++){
+      for (int i=0; i<relemsize; i++) {
+        vv[i+relemsize*(d+ncomp*e)] =
+          uu[indices[i+relemsize*e]+rndof*d];
       }
-    } else {
-      // Note: in transpose mode, we perform: v += r^t * u
-      if (ncomp == 1) {
-        for (int i=0; i<esize; i++) vv[indices[i]] += uu[i];
-      } else {
-        // u is (elemsize x ncomp x nelem)
-        if (L_TRANSPOSE) { // vv is (ndof x ncomp), column-major
-          for (int e = 0; e < rnelem; e++)
-            for (int d = 0; d < ncomp; d++)
-              for (int i=0; i<relemsize; i++) {
-                vv[indices[i+relemsize*e]+rndof*d] +=
-                  uu[i+relemsize*(d+e*ncomp)];
-              }
-        } else { // vv is (ncomp x ndof), column-major
-          for (int e = 0; e < rnelem; e++)
-            for (int d = 0; d < ncomp; d++)
-              for (int i=0; i<relemsize; i++) {
-                vv[d+ncomp*indices[i+relemsize*e]] +=
-                  uu[i+relemsize*(d+e*ncomp)];
-              }
-        }
+    }
+  }
+}
+
+// *****************************************************************************
+kernel void kRestrict2(const int ncomp,
+                       const int *indices,
+                       const double* uu,
+                       double* vv) {
+  // u is (ncomp x ndof), column-major
+  for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
+    if (e >= rnelem) return;
+    for (int d = 0; d < ncomp; d++){
+      for (int i=0; i<relemsize; i++) {
+        vv[i+relemsize*(d+ncomp*e)] =
+          uu[d+ncomp*indices[i+relemsize*e]];
+      }
+    }
+  }
+}
+
+// *****************************************************************************
+kernel void kRestrict3(const int *indices,
+                       const double* uu,
+                       double* vv) {
+  for (int i=0; i<esize; i++; tile(TILE_SIZE)){
+    if (i >= esize) return;
+    vv[indices[i]] += uu[i];
+  }
+}
+
+// *****************************************************************************
+kernel void kRestrict4(const int ncomp,
+                       const int *indices,
+                       const double* uu,
+                       double* vv) {
+  for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
+    if (e >= rnelem) return;
+    for (int d = 0; d < ncomp; d++){
+      for (int i=0; i<relemsize; i++) {
+        vv[indices[i+relemsize*e]+rndof*d] +=
+          uu[i+relemsize*(d+e*ncomp)];
+      }
+    }
+  }
+}
+
+// *****************************************************************************
+kernel void kRestrict5(const int ncomp,
+                       const int *indices,
+                       const double* uu,
+                       double* vv) {
+  // vv is (ncomp x ndof), column-major
+  for (int e = 0; e < rnelem; e++){
+    if (e >= rnelem) return;
+    for (int d = 0; d < ncomp; d++){
+      for (int i=0; i<relemsize; i++) {
+        vv[d+ncomp*indices[i+relemsize*e]] +=
+          uu[i+relemsize*(d+e*ncomp)];
       }
     }
   }

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -3,8 +3,9 @@ kernel void kRestrict0(const int *indices,
                        const double* uu,
                        double* vv) {
   for (int i=0; i<esize; i++; tile(TILE_SIZE)){
-    if (i >= esize) continue;
-    vv[i] = uu[indices[i]];
+    if (i < esize){
+      vv[i] = uu[indices[i]];
+    }
   }
 }
 
@@ -14,11 +15,12 @@ kernel void kRestrict1(const int ncomp,
                        const double* uu,
                        double* vv) {
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) continue;
-    for (int d = 0; d < ncomp; d++){
-      for (int i=0; i<relemsize; i++) {
-        vv[i+relemsize*(d+ncomp*e)] =
-          uu[indices[i+relemsize*e]+rndof*d];
+    if (e < rnelem) {
+      for (int d = 0; d < ncomp; d++){
+        for (int i=0; i<relemsize; i++) {
+          vv[i+relemsize*(d+ncomp*e)] =
+            uu[indices[i+relemsize*e]+rndof*d];
+        }
       }
     }
   }
@@ -30,11 +32,12 @@ kernel void kRestrict2(const int ncomp,
                        const double* uu,
                        double* vv) {
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) continue;
-    for (int d = 0; d < ncomp; d++){
-      for (int i=0; i<relemsize; i++) {
-        vv[i+relemsize*(d+ncomp*e)] =
-          uu[d+ncomp*indices[i+relemsize*e]];
+    if (e < rnelem) {
+      for (int d = 0; d < ncomp; d++){
+        for (int i=0; i<relemsize; i++) {
+          vv[i+relemsize*(d+ncomp*e)] =
+            uu[d+ncomp*indices[i+relemsize*e]];
+        }
       }
     }
   }
@@ -45,8 +48,9 @@ kernel void kRestrict3(const int *indices,
                        const double* uu,
                        double* vv) {
   for (int i=0; i<esize; i++; tile(TILE_SIZE)){
-    if (i >= esize) continue;
-    vv[indices[i]] += uu[i];
+    if (i < esize) {
+      vv[indices[i]] += uu[i];
+    }
   }
 }
 
@@ -56,11 +60,12 @@ kernel void kRestrict4(const int ncomp,
                        const double* uu,
                        double* vv) {
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) continue;
-    for (int d = 0; d < ncomp; d++){
-      for (int i=0; i<relemsize; i++) {
-        vv[indices[i+relemsize*e]+rndof*d] +=
-          uu[i+relemsize*(d+e*ncomp)];
+    if (e < rnelem) {
+      for (int d = 0; d < ncomp; d++){
+        for (int i=0; i<relemsize; i++) {
+          vv[indices[i+relemsize*e]+rndof*d] +=
+            uu[i+relemsize*(d+e*ncomp)];
+        }
       }
     }
   }
@@ -72,11 +77,12 @@ kernel void kRestrict5(const int ncomp,
                        const double* uu,
                        double* vv) {
   for (int e = 0; e < rnelem; e++; tile(TILE_SIZE)){
-    if (e >= rnelem) continue;
-    for (int d = 0; d < ncomp; d++){
-      for (int i=0; i<relemsize; i++) {
-        vv[d+ncomp*indices[i+relemsize*e]] +=
-          uu[i+relemsize*(d+e*ncomp)];
+    if (e < rnelem) {
+      for (int d = 0; d < ncomp; d++){
+        for (int i=0; i<relemsize; i++) {
+          vv[d+ncomp*indices[i+relemsize*e]] +=
+            uu[i+relemsize*(d+e*ncomp)];
+        }
       }
     }
   }

--- a/backends/occa/ceed-occa-vector.c
+++ b/backends/occa/ceed-occa-vector.c
@@ -39,13 +39,14 @@ static inline void occaSyncH2D(const CeedVector vec) {
   const CeedVector_Occa *impl = vec->data;
   assert(impl);
   assert(impl->device);
-  occaCopyPtrToMem(*impl->device, impl->host, bytes(vec), NO_OFFSET, NO_PROPS);
+  occaCopyPtrToMem(*impl->device, impl->array, bytes(vec), NO_OFFSET, NO_PROPS);
 }
 static inline void occaSyncD2H(const CeedVector vec) {
   const CeedVector_Occa *impl = vec->data;
   assert(impl);
-  assert(impl->host);
-  occaCopyMemToPtr(impl->host, *impl->device, bytes(vec), NO_OFFSET, NO_PROPS);
+  assert(impl->array);
+  assert(impl->device);
+  occaCopyMemToPtr(impl->array, *impl->device, bytes(vec), NO_OFFSET, NO_PROPS);
 }
 
 // *****************************************************************************
@@ -66,22 +67,6 @@ static inline void occaCopyH2D(const CeedVector vec, void *from) {
 //}
 
 // *****************************************************************************
-// * Destroy
-// *****************************************************************************
-static int CeedVectorDestroy_Occa(const CeedVector vec) {
-  CeedVector_Occa *impl = vec->data;
-
-  CeedDebug("\033[33m[CeedVector][Destroy]");
-  // free device memory
-  occaMemoryFree(*impl->device);
-  // free device object
-  CeedChk(CeedFree(&impl->device));
-  // free our CeedVector_Occa struct
-  CeedChk(CeedFree(&vec->data));
-  return 0;
-}
-
-// *****************************************************************************
 // * Set
 // *****************************************************************************
 static int CeedVectorSetArray_Occa(const CeedVector vec,
@@ -89,47 +74,30 @@ static int CeedVectorSetArray_Occa(const CeedVector vec,
                                    const CeedCopyMode cmode,
                                    CeedScalar *array) {
   CeedVector_Occa *impl = vec->data;
+  int ierr;
 
   CeedDebug("\033[33m[CeedVector][SetArray]");
   if (mtype != CEED_MEM_HOST)
     return CeedError(vec->ceed, 1, "Only MemType = HOST supported");
-  // ***************************************************************************
-  // free previous allocated array
-  //occaMemoryFree(*impl->device);
-  // free device object
-  //ierr = CeedFree(&impl->device); CeedChk(ierr);
-  // and rallocate everything
-  //CeedChk(CeedCalloc(1,&impl->device));
-  // Allocating memory on device
-  //*impl->device = occaDeviceMalloc(device, bytes(vec), NULL, occaDefault);
-  // ***************************************************************************
+  ierr = CeedFree(&impl->array_allocated); CeedChk(ierr);
   switch (cmode) {
   case CEED_COPY_VALUES:
     CeedDebug("\t\033[33m[CeedVector][SetArray] CEED_COPY_VALUES");
-    CeedChk(CeedCalloc(vec->length,&impl->host));
-    if (array) memcpy(impl->host, array, bytes(vec));
-    // now sync the host to the device
-    if (array) {
-      CeedDebug("\033[33m[CeedVector][SetArray] occaSyncH2D");
-      occaSyncH2D(vec);
-    }
+    ierr = CeedMalloc(vec->length, &impl->array_allocated); CeedChk(ierr);
+    if (array) memcpy(impl->array_allocated, array, bytes(vec));
+    impl->array = impl->array_allocated;
+    if (array) occaSyncH2D(vec);
     break;
   case CEED_OWN_POINTER:
     CeedDebug("\t\033[33m[CeedVector][SetArray] CEED_OWN_POINTER");
-    impl->host = array;
-    if (array){
-      CeedDebug("\033[33m[CeedVector][SetArray] occaSyncH2D");
-      occaCopyH2D(vec,array);
-    }
+    impl->array_allocated = array;
+    impl->array = array;
+    occaSyncH2D(vec);
     break;
   case CEED_USE_POINTER:
     CeedDebug("\t\033[33m[CeedVector][SetArray] CEED_USE_POINTER");
-    impl->host = array;
-    if (array) memcpy(impl->host, array, bytes(vec));
-    if (array){
-      CeedDebug("\033[33m[CeedVector][SetArray] occaSyncH2D");
-       occaCopyH2D(vec,array);
-    }
+    impl->array = array;
+    occaSyncH2D(vec);
     break;
   default: CeedError(vec->ceed,1," OCCA backend no default error");
   }
@@ -142,24 +110,17 @@ static int CeedVectorSetArray_Occa(const CeedVector vec,
 static int CeedVectorGetArray_Occa(const CeedVector vec,
                                    const CeedMemType mtype,
                                    CeedScalar **array) {
-  int ierr;
   CeedVector_Occa *impl = vec->data;
+  int ierr;
 
-  CeedDebug("\033[33m[CeedVector][GetArray]");
   if (mtype != CEED_MEM_HOST)
     return CeedError(vec->ceed, 1, "Can only provide to HOST memory");
-  assert(impl);
-  assert(array);
-  // Allocating space on host to allow the view
-  CeedDebug("\033[33m[CeedVector][GetArray] alloc");
-  ierr=CeedCalloc(vec->length,&impl->host);CeedChk(ierr);
-  assert(impl->host);
-  assert(impl->device);
-  // sync'ing back device to the host
-  CeedDebug("\033[33m[CeedVector][GetArray] occaSyncD2H");
-  occaSyncD2H(vec);
-  *array = impl->host;
-  CeedDebug("\033[33m[CeedVector][GetArray] done");
+  if (!impl->array) { // Allocate if array is not yet allocated
+    ierr = CeedVectorSetArray(vec, CEED_MEM_HOST, CEED_COPY_VALUES, NULL);
+    CeedChk(ierr);
+  }
+  occaSyncH2D(vec);
+  *array = impl->array;
   return 0;
 }
 
@@ -170,16 +131,17 @@ static int CeedVectorGetArrayRead_Occa(const CeedVector vec,
                                        const CeedMemType mtype,
                                        const CeedScalar **array) {
   CeedVector_Occa *impl = vec->data;
-
+  int ierr;
+  
   CeedDebug("\033[33m[CeedVector][GetArray][Const]");
   if (mtype != CEED_MEM_HOST)
     return CeedError(vec->ceed, 1, "Can only provide to HOST memory");
-  // Allocating space on host to allow the view
-  CeedChk(CeedCalloc(vec->length,&impl->host));
-  // sync'ing back device to the host
-  occaSyncD2H(vec);
-  // providing the view
-  *array = impl->host;
+  if (!impl->array) { // Allocate if array is not yet allocated
+    ierr = CeedVectorSetArray(vec, CEED_MEM_HOST, CEED_COPY_VALUES, NULL);
+    CeedChk(ierr);
+  }
+  occaSyncH2D(vec);
+  *array = impl->array;
   return 0;
 }
 
@@ -188,12 +150,13 @@ static int CeedVectorGetArrayRead_Occa(const CeedVector vec,
 // *****************************************************************************
 static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec,
                                            const CeedScalar **array) {
-  CeedVector_Occa *impl = vec->data;
+  //CeedVector_Occa *impl = vec->data;
 
   CeedDebug("\033[33m[CeedVector][RestoreArray][Const]");
   // free memory we used for the view
-  CeedChk(CeedFree(&impl->host));
+  //CeedChk(CeedFree(&impl->array));
   *array = NULL;
+  //occaSyncD2H(vec); // not good for t05
   return 0;
 }
 
@@ -202,11 +165,30 @@ static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec,
 // *****************************************************************************
 static int CeedVectorRestoreArray_Occa(const CeedVector vec,
                                        CeedScalar **array) {
-  CeedVector_Occa *impl = vec->data;
+  //CeedVector_Occa *impl = vec->data;
 
   CeedDebug("\033[33m[CeedVector][RestoreArray]");
-  impl->host = NULL;
+  //impl->array = NULL;
   *array = NULL;
+  //occaSyncD2H(vec); // not good for t05
+  return 0;
+}
+
+// *****************************************************************************
+// * Destroy
+// *****************************************************************************
+static int CeedVectorDestroy_Occa(const CeedVector vec) {
+  CeedVector_Occa *impl = vec->data;
+  int ierr;
+
+  CeedDebug("\033[33m[CeedVector][Destroy]");
+  ierr = CeedFree(&impl->array_allocated); CeedChk(ierr);
+  ierr = CeedFree(&vec->data); CeedChk(ierr);
+  // free device memory
+  //occaMemoryFree(*impl->device);
+  // free device object
+  //CeedChk(CeedFree(&impl->device));
+  // free our CeedVector_Occa struct
   return 0;
 }
 
@@ -216,6 +198,7 @@ static int CeedVectorRestoreArray_Occa(const CeedVector vec,
 int CeedVectorCreate_Occa(const Ceed ceed, const CeedInt n, CeedVector vec) {
   CeedVector_Occa *impl;
   Ceed_Occa *ceed_data=ceed->data;
+  int ierr;
 
   CeedDebug("\033[33m[CeedVector][Create] n=%d", n);
   // ***************************************************************************
@@ -226,10 +209,9 @@ int CeedVectorCreate_Occa(const Ceed ceed, const CeedInt n, CeedVector vec) {
   vec->RestoreArrayRead = CeedVectorRestoreArrayRead_Occa;
   vec->Destroy = CeedVectorDestroy_Occa;
   // Allocating impl, host & device
-  CeedChk(CeedCalloc(1,&impl));
-  CeedChk(CeedCalloc(1,&impl->device));
+  ierr = CeedCalloc(1,&impl); CeedChk(ierr);
+  ierr = CeedCalloc(1,&impl->device); CeedChk(ierr);
   *impl->device = occaDeviceMalloc(ceed_data->device, bytes(vec), NULL, NO_PROPS);
   vec->data = impl;
-  //CeedDebug("\033[33m[CeedVector][Create] done");
   return 0;
 }

--- a/backends/occa/ceed-occa.c
+++ b/backends/occa/ceed-occa.c
@@ -79,8 +79,8 @@ static int CeedInit_Occa(const char *resource, Ceed ceed) {
     (resource[1]=='g') ? occaGPU :
     (resource[1]=='o') ? occaOMP : occaCPU;
   impl->device = occaCreateDevice(occaString(mode));
-  if (resource[1] == 'g' && resource[1] == 'o' &&
-      !strcmp(occaDeviceMode(impl->device), "Serial"))
+  if ((resource[1] == 'g' || resource[1] == 'o')
+      && !strcmp(occaDeviceMode(impl->device), "Serial"))
     return CeedError(ceed, 1, "OCCA backend failed to use GPU resource");
   return 0;
 }

--- a/backends/occa/ceed-occa.h
+++ b/backends/occa/ceed-occa.h
@@ -41,7 +41,8 @@ typedef struct {
 // * CeedVector_Occa struct needed by some other functions below
 // *****************************************************************************
 typedef struct {
-  CeedScalar *host;
+  CeedScalar *array;
+  CeedScalar *array_allocated;
   occaMemory *device;
 } CeedVector_Occa;
 

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -262,7 +262,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedTransposeMode tmode,
       P = basis->Q1d; Q = basis->P1d;
     }
     CeedInt pre = ndof*CeedPowInt(P, dim-1), post = 1;
-    CeedScalar tmp[2][Q*CeedPowInt(P>Q?P:Q, dim-1)];
+    CeedScalar tmp[2][ndof*Q*CeedPowInt(P>Q?P:Q, dim-1)];
     for (CeedInt d=0; d<dim; d++) {
       ierr = CeedTensorContract_Ref(basis->ceed, pre, P, post, Q, basis->interp1d,
                                     tmode, d==0?u:tmp[d%2], d==dim-1?v:tmp[(d+1)%2]);
@@ -281,7 +281,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedTransposeMode tmode,
     if (tmode == CEED_NOTRANSPOSE) {
       // u is (P^dim x nc), column-major layout (nc = ndof)
       // v is (Q^dim x nc x dim), column-major layout (nc = ndof)
-      CeedScalar tmp[2][Q*CeedPowInt(P>Q?P:Q, dim-1)];
+      CeedScalar tmp[2][ndof*Q*CeedPowInt(P>Q?P:Q, dim-1)];
       for (CeedInt p = 0; p < dim; p++) {
         CeedInt pre = ndof*CeedPowInt(P, dim-1), post = 1;
         for (CeedInt d=0; d<dim; d++) {

--- a/examples/mfem/ex1.cpp
+++ b/examples/mfem/ex1.cpp
@@ -273,8 +273,8 @@ int main(int argc, char *argv[]) {
   //    largest number that gives a final mesh with no more than 50,000
   //    elements.
   {
-    int ref_levels = 2;
-    //(int)floor(log(50000./mesh->GetNE())/log(2.)/dim);
+    int ref_levels = 
+      (int)floor(log(50000./mesh->GetNE())/log(2.)/dim);
     for (int l = 0; l < ref_levels; l++) {
       mesh->UniformRefinement();
     }
@@ -312,7 +312,8 @@ int main(int argc, char *argv[]) {
   mfem::GridFunction sol(fespace);
   sol = 0.0;
   cg.Mult(b, sol);
-
+  //std::cout << "sol="<<sol<< std::endl;
+ 
   // 9. Compute and print the L2 projection error.
   std::cout << "L2 projection error: " << sol.ComputeL2Error(sol_coeff)
             << std::endl;

--- a/tests/tap.sh
+++ b/tests/tap.sh
@@ -1,34 +1,44 @@
 #!/bin/bash
 
+ulimit -c 0 # Do not dump core
+
 output=$(mktemp $1.XXXX)
 
-backends=(/cpu/self)
-
-if [ -z "$OCCA_DIR" ]
-then
-printf "1..3\n"
-else
-backends+=(/cpu/occa /gpu/occa)
-printf "1..9\n"
-fi
+backends=(/cpu/self /cpu/occa /gpu/occa)
+printf "1..$[3*${#backends[@]}]\n";
 
 for ((i=0;i<${#backends[@]}; ++i)); do
     i0=$((3*$i+1)) # return code
     i1=$(($i0+1))  # stdout
     i2=$(($i0+2))  # stderr
     backend=${backends[$i]}
-    
-    if build/$1 $backend > ${output}.out 2> ${output}.err ; then
+
+    # Run in subshell
+    (build/$1 $backend || false) > ${output}.out 2> ${output}.err
+    status=$?
+    if grep -F -q -e 'backend cannot use resource' \
+            -e 'backend failed to use GPU resource' ${output}.err; then
+        printf "ok $i0 # SKIP $1 $backend\n"
+        printf "ok $i1 # SKIP $1 $backend stdout\n"
+        printf "ok $i2 # SKIP $1 $backend stderr\n"
+        continue
+    fi
+
+    if [ $status -eq 0 ]; then
         printf "ok $i0 $1 $backend\n"
     else
         printf "not ok $i0 $1 $backend\n"
     fi
+
     # stdout
     if [ -f output/$1.out ]; then
-        if diff -u output/$1.out ${output}.out; then
+        if diff -u output/$1.out ${output}.out > ${output}.diff; then
             printf "ok $i1 $1 $backend stdout\n"
         else
-            printf "not ok $i1 $1 $backend stdout\n" 
+            printf "not ok $i1 $1 $backend stdout\n"
+            while read line; do
+                printf "# ${line}\n"
+            done < ${output}.diff
         fi
     elif [ -s ${output}.out ]; then
         printf "not ok $i1 $1 $backend stdout\n"
@@ -42,10 +52,10 @@ for ((i=0;i<${#backends[@]}; ++i)); do
     if [ -s ${output}.err ]; then
         printf "not ok $i2 $1 $backend stderr\n"
         while read line; do
-            printf "# + ${line}\n"
+            printf "# +${line}\n"
         done < ${output}.err
     else
         printf "ok $i2 $1 $backend stderr\n"
     fi
 done
-rm -f ${output} ${output}.out ${output}.err; 
+rm -f ${output} ${output}.out ${output}.diff ${output}.err


### PR DESCRIPTION
First version using the OCCA memory and kernels for the restriction operator.
- [x] Tests are passing 
- [x] Tests are proving
- [x] Makefile behavior from [50f0ebd](https://github.com/CEED/libCEED/commit/50f0ebda12417eb818eab1772e3f1726aed6077b)
- [x] Skip the test when the OCCA_DIR env variable is not set
- [x] Skip all the asserts in user code and just have CeedInit check for NULL itself
- [x] Underscored Ceed*_Occa, so that it's clearer
- [x] Added occaDevice to a data member of Ceed_private
- [x] Turned dbg to CeedDebug
- [x] Kernels for the ceed-restrict
- [x] MFEM example passes with /cpu/occa
- [x] MFEM example /gpu/occa: CG now converges
- [x] MFEM example /omp/occa: L2 projection now ok
