### PR TITLE
[test] t01-vec-f ceedvectorrestorearrayread call fix

### DIFF
--- a/tests/t01-vec-f.f
+++ b/tests/t01-vec-f.f
@@ -32,7 +32,7 @@ c-----------------------------------------------------------------------
         endif
       enddo
 
-      call ceedvectorrestorearrayread(x,b)
+      call ceedvectorrestorearrayread(x,b,err)
       call ceedvectordestroy(x,err)
       call ceeddestroy(ceed,err)
 


### PR DESCRIPTION
In tests/t01-vec-f.f, API fix for the ceedvectorrestorearrayread call.
Found with NDEBUG set, which toggles the -O2 option.