### PR TITLE
Jed/reference counting

### DIFF
--- a/ceed-basis.c
+++ b/ceed-basis.c
@@ -55,6 +55,7 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt ncomp, CeedInt P1d,
   ierr = CeedCalloc(1,basis); CeedChk(ierr);
   (*basis)->ceed = ceed;
   ceed->refcount++;
+  (*basis)->refcount = 1;
   (*basis)->dim = dim;
   (*basis)->ndof = ncomp;
   (*basis)->P1d = P1d;
@@ -316,7 +317,7 @@ int CeedBasisGetNumQuadraturePoints(CeedBasis basis, CeedInt *Q) {
 int CeedBasisDestroy(CeedBasis *basis) {
   int ierr;
 
-  if (!*basis) return 0;
+  if (!*basis || --(*basis)->refcount > 0) return 0;
   if ((*basis)->Destroy) {
     ierr = (*basis)->Destroy(*basis); CeedChk(ierr);
   }

--- a/ceed-basis.c
+++ b/ceed-basis.c
@@ -54,6 +54,7 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt ncomp, CeedInt P1d,
     return CeedError(ceed, 1, "Backend does not support BasisCreateTensorH1");
   ierr = CeedCalloc(1,basis); CeedChk(ierr);
   (*basis)->ceed = ceed;
+  ceed->refcount++;
   (*basis)->dim = dim;
   (*basis)->ndof = ncomp;
   (*basis)->P1d = P1d;
@@ -323,6 +324,7 @@ int CeedBasisDestroy(CeedBasis *basis) {
   ierr = CeedFree(&(*basis)->grad1d); CeedChk(ierr);
   ierr = CeedFree(&(*basis)->qref1d); CeedChk(ierr);
   ierr = CeedFree(&(*basis)->qweight1d); CeedChk(ierr);
+  ierr = CeedDestroy(&(*basis)->ceed); CeedChk(ierr);
   ierr = CeedFree(basis); CeedChk(ierr);
   return 0;
 }

--- a/ceed-elemrestriction.c
+++ b/ceed-elemrestriction.c
@@ -53,6 +53,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
     return CeedError(ceed, 1, "Backend does not support ElemRestrictionCreate");
   ierr = CeedCalloc(1,r); CeedChk(ierr);
   (*r)->ceed = ceed;
+  ceed->refcount++;
   (*r)->nelem = nelem;
   (*r)->elemsize = elemsize;
   (*r)->ndof = ndof;
@@ -128,6 +129,7 @@ int CeedElemRestrictionDestroy(CeedElemRestriction *r) {
   if ((*r)->Destroy) {
     ierr = (*r)->Destroy(*r); CeedChk(ierr);
   }
+  ierr = CeedDestroy(&(*r)->ceed); CeedChk(ierr);
   ierr = CeedFree(r); CeedChk(ierr);
   return 0;
 }

--- a/ceed-elemrestriction.c
+++ b/ceed-elemrestriction.c
@@ -54,6 +54,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
   ierr = CeedCalloc(1,r); CeedChk(ierr);
   (*r)->ceed = ceed;
   ceed->refcount++;
+  (*r)->refcount = 1;
   (*r)->nelem = nelem;
   (*r)->elemsize = elemsize;
   (*r)->ndof = ndof;
@@ -125,7 +126,7 @@ int CeedElemRestrictionApply(CeedElemRestriction r, CeedTransposeMode tmode,
 int CeedElemRestrictionDestroy(CeedElemRestriction *r) {
   int ierr;
 
-  if (!*r) return 0;
+  if (!*r || --(*r)->refcount > 0) return 0;
   if ((*r)->Destroy) {
     ierr = (*r)->Destroy(*r); CeedChk(ierr);
   }

--- a/ceed-operator.c
+++ b/ceed-operator.c
@@ -47,6 +47,7 @@ int CeedOperatorCreate(Ceed ceed, CeedElemRestriction r, CeedBasis b,
   ierr = CeedCalloc(1,op); CeedChk(ierr);
   (*op)->ceed = ceed;
   ceed->refcount++;
+  (*op)->refcount = 1;
   (*op)->Erestrict = r;
   r->refcount++;
   (*op)->basis = b;
@@ -108,7 +109,7 @@ int CeedOperatorGetQData(CeedOperator op, CeedVector *qdata) {
 int CeedOperatorDestroy(CeedOperator *op) {
   int ierr;
 
-  if (!*op) return 0;
+  if (!*op || --(*op)->refcount > 0) return 0;
   if ((*op)->Destroy) {
     ierr = (*op)->Destroy(*op); CeedChk(ierr);
   }

--- a/ceed-operator.c
+++ b/ceed-operator.c
@@ -52,8 +52,11 @@ int CeedOperatorCreate(Ceed ceed, CeedElemRestriction r, CeedBasis b,
   (*op)->basis = b;
   b->refcount++;
   (*op)->qf = qf;
+  qf->refcount++;
   (*op)->dqf = dqf;
+  if (dqf) dqf->refcount++;
   (*op)->dqfT = dqfT;
+  if (dqfT) dqfT->refcount++;
   ierr = ceed->OperatorCreate(*op); CeedChk(ierr);
   return 0;
 }
@@ -111,6 +114,9 @@ int CeedOperatorDestroy(CeedOperator *op) {
   }
   ierr = CeedElemRestrictionDestroy(&(*op)->Erestrict); CeedChk(ierr);
   ierr = CeedBasisDestroy(&(*op)->basis); CeedChk(ierr);
+  ierr = CeedQFunctionDestroy(&(*op)->qf); CeedChk(ierr);
+  ierr = CeedQFunctionDestroy(&(*op)->dqf); CeedChk(ierr);
+  ierr = CeedQFunctionDestroy(&(*op)->dqfT); CeedChk(ierr);
   ierr = CeedDestroy(&(*op)->ceed); CeedChk(ierr);
   ierr = CeedFree(op); CeedChk(ierr);
   return 0;

--- a/ceed-operator.c
+++ b/ceed-operator.c
@@ -46,6 +46,7 @@ int CeedOperatorCreate(Ceed ceed, CeedElemRestriction r, CeedBasis b,
                                       "Backend does not support OperatorCreate");
   ierr = CeedCalloc(1,op); CeedChk(ierr);
   (*op)->ceed = ceed;
+  ceed->refcount++;
   (*op)->Erestrict = r;
   (*op)->basis = b;
   (*op)->qf = qf;
@@ -106,6 +107,7 @@ int CeedOperatorDestroy(CeedOperator *op) {
   if ((*op)->Destroy) {
     ierr = (*op)->Destroy(*op); CeedChk(ierr);
   }
+  ierr = CeedDestroy(&(*op)->ceed); CeedChk(ierr);
   ierr = CeedFree(op); CeedChk(ierr);
   return 0;
 }

--- a/ceed-operator.c
+++ b/ceed-operator.c
@@ -50,6 +50,7 @@ int CeedOperatorCreate(Ceed ceed, CeedElemRestriction r, CeedBasis b,
   (*op)->Erestrict = r;
   r->refcount++;
   (*op)->basis = b;
+  b->refcount++;
   (*op)->qf = qf;
   (*op)->dqf = dqf;
   (*op)->dqfT = dqfT;
@@ -109,6 +110,7 @@ int CeedOperatorDestroy(CeedOperator *op) {
     ierr = (*op)->Destroy(*op); CeedChk(ierr);
   }
   ierr = CeedElemRestrictionDestroy(&(*op)->Erestrict); CeedChk(ierr);
+  ierr = CeedBasisDestroy(&(*op)->basis); CeedChk(ierr);
   ierr = CeedDestroy(&(*op)->ceed); CeedChk(ierr);
   ierr = CeedFree(op); CeedChk(ierr);
   return 0;

--- a/ceed-operator.c
+++ b/ceed-operator.c
@@ -48,6 +48,7 @@ int CeedOperatorCreate(Ceed ceed, CeedElemRestriction r, CeedBasis b,
   (*op)->ceed = ceed;
   ceed->refcount++;
   (*op)->Erestrict = r;
+  r->refcount++;
   (*op)->basis = b;
   (*op)->qf = qf;
   (*op)->dqf = dqf;
@@ -107,6 +108,7 @@ int CeedOperatorDestroy(CeedOperator *op) {
   if ((*op)->Destroy) {
     ierr = (*op)->Destroy(*op); CeedChk(ierr);
   }
+  ierr = CeedElemRestrictionDestroy(&(*op)->Erestrict); CeedChk(ierr);
   ierr = CeedDestroy(&(*op)->ceed); CeedChk(ierr);
   ierr = CeedFree(op); CeedChk(ierr);
   return 0;

--- a/ceed-qfunction.c
+++ b/ceed-qfunction.c
@@ -87,6 +87,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength, CeedInt nfields,
     return CeedError(ceed, 1, "Backend does not support QFunctionCreate");
   ierr = CeedCalloc(1,qf); CeedChk(ierr);
   (*qf)->ceed = ceed;
+  ceed->refcount++;
   (*qf)->vlength = vlength;
   (*qf)->nfields = nfields;
   (*qf)->qdatasize = qdatasize;
@@ -132,6 +133,7 @@ int CeedQFunctionDestroy(CeedQFunction *qf) {
   if ((*qf)->Destroy) {
     ierr = (*qf)->Destroy(*qf); CeedChk(ierr);
   }
+  ierr = CeedDestroy(&(*qf)->ceed); CeedChk(ierr);
   ierr = CeedFree(qf); CeedChk(ierr);
   return 0;
 }

--- a/ceed-qfunction.c
+++ b/ceed-qfunction.c
@@ -88,6 +88,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength, CeedInt nfields,
   ierr = CeedCalloc(1,qf); CeedChk(ierr);
   (*qf)->ceed = ceed;
   ceed->refcount++;
+  (*qf)->refcount = 1;
   (*qf)->vlength = vlength;
   (*qf)->nfields = nfields;
   (*qf)->qdatasize = qdatasize;
@@ -129,7 +130,7 @@ int CeedQFunctionApply(CeedQFunction qf, void *qdata, CeedInt Q,
 int CeedQFunctionDestroy(CeedQFunction *qf) {
   int ierr;
 
-  if (!*qf) return 0;
+  if (!*qf || --(*qf)->refcount > 0) return 0;
   if ((*qf)->Destroy) {
     ierr = (*qf)->Destroy(*qf); CeedChk(ierr);
   }

--- a/ceed-vec.c
+++ b/ceed-vec.c
@@ -35,6 +35,7 @@ int CeedVectorCreate(Ceed ceed, CeedInt length, CeedVector *vec) {
   ierr = CeedCalloc(1,vec); CeedChk(ierr);
   (*vec)->ceed = ceed;
   ceed->refcount++;
+  (*vec)->refcount = 1;
   (*vec)->length = length;
   ierr = ceed->VecCreate(ceed, length, *vec); CeedChk(ierr);
   return 0;
@@ -136,7 +137,7 @@ int CeedVectorView(CeedVector vec, const char *fpfmt, FILE *stream) {
 int CeedVectorDestroy(CeedVector *x) {
   int ierr;
 
-  if (!*x) return 0;
+  if (!*x || --(*x)->refcount > 0) return 0;
   if ((*x)->Destroy) {
     ierr = (*x)->Destroy(*x); CeedChk(ierr);
   }

--- a/ceed-vec.c
+++ b/ceed-vec.c
@@ -34,6 +34,7 @@ int CeedVectorCreate(Ceed ceed, CeedInt length, CeedVector *vec) {
     return CeedError(ceed, 1, "Backend does not support VecCreate");
   ierr = CeedCalloc(1,vec); CeedChk(ierr);
   (*vec)->ceed = ceed;
+  ceed->refcount++;
   (*vec)->length = length;
   ierr = ceed->VecCreate(ceed, length, *vec); CeedChk(ierr);
   return 0;
@@ -139,6 +140,7 @@ int CeedVectorDestroy(CeedVector *x) {
   if ((*x)->Destroy) {
     ierr = (*x)->Destroy(*x); CeedChk(ierr);
   }
+  ierr = CeedDestroy(&(*x)->ceed); CeedChk(ierr);
   ierr = CeedFree(x); CeedChk(ierr);
   return 0;
 }

--- a/ceed.c
+++ b/ceed.c
@@ -249,6 +249,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
   if (!matchlen) return CeedError(NULL, 1, "No suitable backend");
   ierr = CeedCalloc(1,ceed); CeedChk(ierr);
   (*ceed)->Error = CeedErrorAbort;
+  (*ceed)->refcount = 1;
   (*ceed)->data = NULL;
   ierr = backends[matchidx].init(resource, *ceed); CeedChk(ierr);
   return 0;
@@ -263,7 +264,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
 int CeedDestroy(Ceed *ceed) {
   int ierr;
 
-  if (!*ceed) return 0;
+  if (!*ceed || --(*ceed)->refcount > 0) return 0;
   if ((*ceed)->Destroy) {
     ierr = (*ceed)->Destroy(*ceed); CeedChk(ierr);
   }

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -104,6 +104,7 @@ struct CeedQFunction_private {
   int (*Apply)(CeedQFunction, void *, CeedInt, const CeedScalar *const *,
                CeedScalar *const *);
   int (*Destroy)(CeedQFunction);
+  int refcount;
   CeedInt vlength;    // Number of quadrature points must be padded to a multiple of vlength
   CeedInt nfields;
   size_t qdatasize;   // Number of bytes of qdata per quadrature point

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -84,6 +84,7 @@ struct CeedBasis_private {
   int (*Apply)(CeedBasis, CeedTransposeMode, CeedEvalMode, const CeedScalar *,
                CeedScalar *);
   int (*Destroy)(CeedBasis);
+  int refcount;
   CeedInt dim;
   CeedInt ndof;
   CeedInt P1d;

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -61,6 +61,7 @@ struct CeedVector_private {
   int (*RestoreArray)(CeedVector, CeedScalar **);
   int (*RestoreArrayRead)(CeedVector, const CeedScalar **);
   int (*Destroy)(CeedVector);
+  int refcount;
   CeedInt length;
   void *data;
 };

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -71,6 +71,7 @@ struct CeedElemRestriction_private {
   int (*Apply)(CeedElemRestriction, CeedTransposeMode, CeedInt, CeedTransposeMode,
                CeedVector, CeedVector, CeedRequest *);
   int (*Destroy)(CeedElemRestriction);
+  int refcount;
   CeedInt nelem;    /* number of elements */
   CeedInt elemsize; /* number of dofs per element */
   CeedInt ndof;     /* size of the L-vector, can be used for checking for

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -34,6 +34,7 @@ struct Ceed_private {
                              const CeedScalar *, const CeedScalar *, const CeedScalar *, CeedBasis);
   int (*QFunctionCreate)(CeedQFunction);
   int (*OperatorCreate)(CeedOperator);
+  int refcount;
   void *data;
 };
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -119,6 +119,7 @@ struct CeedQFunction_private {
 
 struct CeedOperator_private {
   Ceed ceed;
+  int refcount;
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyJacobian)(CeedOperator, CeedVector, CeedVector, CeedVector,
                        CeedVector, CeedRequest *);


### PR DESCRIPTION
Reference counting for all Ceed objects. This relieves the need for users to be careful about order of destruction (cf. https://github.com/CEED/libCEED/pull/54#issuecomment-377364268). (This was planned long ago, but implementation was forgotten.)