### PR TITLE
occa: fix memory leaks

### DIFF
--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -293,6 +293,14 @@ static int CeedBasisDestroy_Occa(CeedBasis basis) {
   const Ceed ceed = basis->ceed;
   CeedBasis_Occa *data = basis->data;
   dbg("[CeedBasis][Destroy]");
+  occaFree(data->kZero);
+  occaFree(data->kInterp);
+  occaFree(data->kGrad);
+  occaFree(data->kWeight);
+  occaFree(data->qref1d);
+  occaFree(data->qweight1d);
+  occaFree(data->interp1d);
+  occaFree(data->grad1d);
   ierr = CeedFree(&data); CeedChk(ierr);
   return 0;
 }

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -24,6 +24,8 @@ static int CeedOperatorDestroy_Occa(CeedOperator op) {
   dbg("[CeedOperator][Destroy]");
   CeedOperator_Occa *data = op->data;
   int ierr = CeedVectorDestroy(&data->etmp); CeedChk(ierr);
+  ierr = CeedVectorDestroy(&data->BEu); CeedChk(ierr);
+  ierr = CeedVectorDestroy(&data->BEv); CeedChk(ierr);
   ierr = CeedVectorDestroy(&data->qdata); CeedChk(ierr);
   ierr = CeedFree(&op->data); CeedChk(ierr);
   return 0;

--- a/backends/occa/ceed-occa-qfunction.c
+++ b/backends/occa/ceed-occa-qfunction.c
@@ -154,6 +154,7 @@ static int CeedQFunctionDestroy_Occa(CeedQFunction qf) {
   CeedQFunction_Occa *data=qf->data;
   free(data->oklPath);
   dbg("[CeedQFunction][Destroy]");
+  occaFree(data->kQFunctionApply);
   if (data->ready) {
     if (!data->op) occaFree(data->d_q);
     occaFree(data->d_u);

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -95,6 +95,9 @@ static int CeedElemRestrictionDestroy_Occa(CeedElemRestriction r) {
   const Ceed ceed = r->ceed;
   CeedElemRestriction_Occa *data = r->data;
   dbg("[CeedElemRestriction][Destroy]");
+  for (int i=0; i<9; i++) {
+    occaFree(data->kRestrict[i]);
+  }
   ierr = CeedFree(&data); CeedChk(ierr);
   return 0;
 }

--- a/backends/occa/ceed-occa.c
+++ b/backends/occa/ceed-occa.c
@@ -47,6 +47,7 @@ static int CeedDestroy_Occa(Ceed ceed) {
   int ierr;
   Ceed_Occa *data=ceed->data;
   dbg("[CeedDestroy]");
+  ierr = CeedFree(&data->occa_cache_dir); CeedChk(ierr);
   occaFree(data->device);
   ierr = CeedFree(&data->libceed_dir);
   ierr = CeedFree(&data); CeedChk(ierr);


### PR DESCRIPTION
Valgrind still says there is memory lost under some of these (plus a lot
from Occa static constructors), but this at least makes an attempt to
free from our end.

@camierjs @v-dobrev Could I get your quick input on this. I think it's uncotroversial, but would like at least one other set of eyes.