### PR TITLE
[RFC] occa: do not occaFree kernels

### DIFF
--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -293,10 +293,6 @@ static int CeedBasisDestroy_Occa(CeedBasis basis) {
   const Ceed ceed = basis->ceed;
   CeedBasis_Occa *data = basis->data;
   dbg("[CeedBasis][Destroy]");
-  occaFree(data->kZero);
-  occaFree(data->kInterp);
-  occaFree(data->kGrad);
-  occaFree(data->kWeight);
   occaFree(data->qref1d);
   occaFree(data->qweight1d);
   occaFree(data->interp1d);

--- a/backends/occa/ceed-occa-qfunction.c
+++ b/backends/occa/ceed-occa-qfunction.c
@@ -154,7 +154,6 @@ static int CeedQFunctionDestroy_Occa(CeedQFunction qf) {
   CeedQFunction_Occa *data=qf->data;
   free(data->oklPath);
   dbg("[CeedQFunction][Destroy]");
-  occaFree(data->kQFunctionApply);
   if (data->ready) {
     if (!data->op) occaFree(data->d_q);
     occaFree(data->d_u);

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -95,9 +95,6 @@ static int CeedElemRestrictionDestroy_Occa(CeedElemRestriction r) {
   const Ceed ceed = r->ceed;
   CeedElemRestriction_Occa *data = r->data;
   dbg("[CeedElemRestriction][Destroy]");
-  for (int i=0; i<9; i++) {
-    occaFree(data->kRestrict[i]);
-  }
   ierr = CeedFree(&data); CeedChk(ierr);
   return 0;
 }


### PR DESCRIPTION
Repeated creation and freeing of kernels appears to expose a caching bug in OCCA, leading to SEGV.

This patch is used in spack for libceed@0.2 so that the nek5000 example works with `-ceed /cpu/occa`. Thread: https://github.com/spack/spack/pull/7423#issuecomment-377667200 Cc: @tzanio @v-dobrev 

If this can be fixed in the occa-1.0 release (@dmed256) then this PR should not be merged. If it will not be fixed (or is actually not an OCCA issue) then this should be merged and we will release v0.2.1.

From a performance and cleanliness standpoint, the nek5000 example should persist the CeedOperator between CG iterations. This would also hide the bug. @thilinarmtb 