### PR TITLE
backends: add missing CeedVectorRestoreArray calls

### DIFF
--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -116,6 +116,7 @@ static int CeedOperatorApply_Occa(CeedOperator op, CeedVector qdata,
                                   data->BEv,data->etmp); CeedChk(ierr);
   // *************************************************************************
   ierr = CeedVectorRestoreArray(etmp, &Eu); CeedChk(ierr);
+  ierr = CeedVectorRestoreArray(qdata, (CeedScalar**)&qd); CeedChk(ierr);
   // ***************************************************************************
   if (residual) {
     dbg("[CeedOperator][Apply] residual");

--- a/backends/occa/ceed-occa-qfunction.c
+++ b/backends/occa/ceed-occa-qfunction.c
@@ -130,16 +130,16 @@ static int CeedQFunctionApply_Occa(CeedQFunction qf, void *qdata, CeedInt Q,
   else
     CeedQFunctionFillOp_Occa(d_u,u,inmode,Q,nc,dim,bytes);
   // ***************************************************************************
-  if (cbytes>0) occaCopyPtrToMem(data->d_c,qf->ctx,cbytes,0,NO_PROPS);
+  if (cbytes>0) occaCopyPtrToMem(d_c,qf->ctx,cbytes,0,NO_PROPS);
   // ***************************************************************************
   occaKernelRun(data->kQFunctionApply,
                 d_c, d_q, occaInt(e), occaInt(Q),
                 d_u, b_u,d_v, b_v);
   // ***************************************************************************
-  if (cbytes>0) occaCopyMemToPtr(qf->ctx,data->d_c,cbytes,0,NO_PROPS);
+  if (cbytes>0) occaCopyMemToPtr(qf->ctx,d_c,cbytes,0,NO_PROPS);
   // ***************************************************************************
-  if (outmode==CEED_EVAL_NONE && !data->op)
-    occaCopyMemToPtr(qdata,d_q,qbytes,NO_OFFSET,NO_PROPS);
+  if (outmode==CEED_EVAL_NONE)
+    occaCopyMemToPtr(qdata,d_q,qbytes,e*Q*bytes,NO_PROPS);
   if (outmode==CEED_EVAL_INTERP)
     occaCopyMemToPtr(*v,d_v,vbytes,NO_OFFSET,NO_PROPS);
   assert(outmode==CEED_EVAL_NONE || outmode==CEED_EVAL_INTERP);

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -428,14 +428,16 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector qdata,
     CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(etmp, &Eu); CeedChk(ierr);
+  ierr = CeedVectorRestoreArray(qdata, (CeedScalar**)&qd); CeedChk(ierr);
   if (residual) {
     CeedScalar *res;
-    CeedVectorGetArray(residual, CEED_MEM_HOST, &res);
+    ierr = CeedVectorGetArray(residual, CEED_MEM_HOST, &res); CeedChk(ierr);
     for (int i = 0; i < residual->length; i++)
       res[i] = (CeedScalar)0;
     ierr = CeedElemRestrictionApply(op->Erestrict, CEED_TRANSPOSE,
                                     nc, lmode, etmp, residual,
                                     CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
+    ierr = CeedVectorRestoreArray(residual, &res); CeedChk(ierr);
   }
   if (request != CEED_REQUEST_IMMEDIATE && request != CEED_REQUEST_ORDERED)
     *request = NULL;


### PR DESCRIPTION
@camierjs This oddly breaks ceed ex1 for me with `/cpu/occa`. Can you test it?