### PR TITLE
examples/nek5000/run-nek-example.sh: error if -b is not provided

### DIFF
--- a/examples/nek5000/run-nek-example.sh
+++ b/examples/nek5000/run-nek-example.sh
@@ -79,6 +79,12 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+if [[ -z "${nek_box}" ]]; then
+    echo "$0: You must specify option -b <number of boxes>."
+    echo "$NEK_HELP_MSG"
+    ${NEK_EXIT_CMD} 1
+fi
+
 if [[ ! -f ${nek_ex} ]]; then
   echo "Example ${nek_ex} does not exist. Build it with make-nek-examples.sh"
   ${NEK_EXIT_CMD} 1


### PR DESCRIPTION
I would prefer to just make a default like there is for all the other examples, but in lieu of that, here is a patch to error when the user invariably forgets.

It would be even better if we could have the makefile build an executable named something other than bp1, then make bp1 a symlink to the script that checks $0 to decide what to do. That way we'd be able to run `nek5000/bp1 -ceed /cpu/self` just like we can for all the other examples. But that's a more intrusive change.