### PR TITLE
Optimize the reference tensor contraction

### DIFF
--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -38,18 +38,14 @@ static int CeedTensorContract_Ref(Ceed ceed,
     }
   }
 
-  const CeedScalar *uP = u;
   for (CeedInt a=0; a<A; a++) {
     for (CeedInt b=0; b<B; b++) {
-      CeedScalar *vP = v + a * J * C;
       for (CeedInt j=0; j<J; j++) {
         CeedScalar tq = t[j*tstride0 + b*tstride1];
         for (CeedInt c=0; c<C; c++) {
-          *vP += tq * uP[c];
-          vP++;
+          v[(a*J+j)*C+c] += tq * u[(a*B+b)*C+c];
         }
       }
-      uP += C;
     }
   }
   return 0;

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -32,17 +32,24 @@ static int CeedTensorContract_Ref(Ceed ceed,
     tstride0 = 1; tstride1 = J;
   }
 
+  if (!Add) {
+    for (CeedInt q=0; q<A*J*C; q++) {
+      v[q] = (CeedScalar) 0.0;
+    }
+  }
+
+  const CeedScalar *uP = u;
   for (CeedInt a=0; a<A; a++) {
-    for (CeedInt j=0; j<J; j++) {
-      if (!Add) {
-        for (CeedInt c=0; c<C; c++)
-          v[(a*J+j)*C+c] = 0;
-      }
-      for (CeedInt b=0; b<B; b++) {
+    for (CeedInt b=0; b<B; b++) {
+      CeedScalar *vP = v + a * J * C;
+      for (CeedInt j=0; j<J; j++) {
+        CeedScalar tq = t[j*tstride0 + b*tstride1];
         for (CeedInt c=0; c<C; c++) {
-          v[(a*J+j)*C+c] += t[j*tstride0 + b*tstride1] * u[(a*B+b)*C+c];
+          *vP += tq * uP[c];
+          vP++;
         }
       }
+      uP += C;
     }
   }
   return 0;

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -24,9 +24,9 @@
 // If Add != 0, "=" is replaced by "+="
 static int CeedTensorContract_Ref(Ceed ceed,
                                   CeedInt A, CeedInt B, CeedInt C, CeedInt J,
-                                  const CeedScalar *t, CeedTransposeMode tmode,
+                                  const CeedScalar *restrict t, CeedTransposeMode tmode,
                                   const CeedInt Add,
-                                  const CeedScalar *u, CeedScalar *v) {
+                                  const CeedScalar *restrict u, CeedScalar *restrict v) {
   CeedInt tstride0 = B, tstride1 = 1;
   if (tmode == CEED_TRANSPOSE) {
     tstride0 = 1; tstride1 = J;


### PR DESCRIPTION
This new version of `CeedTensorContract_Ref` is about 50% faster.  Example 1 has about a 35-40% speedup.