### PR TITLE
Fix debug option in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,17 @@ ifneq ($(filter %xlf %xlf_r,$(FC)),)
   FFLAGS = -qpreprocess -qextname -qpic -MMD
 endif
 
-CFLAGS += $(if $(NDEBUG),-O2 -DNDEBUG=1,-g)
+ifeq ($(NDEBUG), 1)
+	CFLAGS += -O2 -DNDEBUG=1
+	FFLAGS += -O2 -DNDEBUG=1
+else
+	CFLAGS += -g
+	FFLAGS += -g
+endif
 
 ifeq ($(UNDERSCORE), 1)
   CFLAGS += -DUNDERSCORE
 endif
-
-FFLAGS += $(if $(NDEBUG),-O2 -DNDEBUG=1,-g)
 
 CFLAGS += $(if $(ASAN),$(AFLAGS))
 FFLAGS += $(if $(ASAN),$(AFLAGS))


### PR DESCRIPTION
It seems `NDEBUG` can never be set to false due to
https://github.com/CEED/libCEED/blob/a460c33b23cf49899be5782d753f25b389750a7f/Makefile#L27
This change fixes this issue and is consistent with the checking of the `UNDERSCORE` variable.