### PR TITLE
[WIP] t17-f bug

### DIFF
--- a/tests/t17-basis-f.f
+++ b/tests/t17-basis-f.f
@@ -52,7 +52,7 @@ c-----------------------------------------------------------------------
       call getarg(1,arg)
       call ceedinit(trim(arg)//char(0),ceed,err)
 
-      do dimn=1,2
+      do dimn=3,3
         qdimn=q**dimn
         pdimn=p**dimn
         xdim=2**dimn
@@ -94,11 +94,15 @@ c-----------------------------------------------------------------------
         call ceedbasisapply(bug,ceed_transpose,ceed_eval_grad,
      $    ones,gtposeones,err)
 
+        write(*,*) 'Sum 1:'
         do i=1,pdimn
           sum1=sum1+gtposeones(i)*u(i)
+          write(*,*) sum1
         enddo
+        write(*,*) 'Sum 2:'
         do i=1,dimxqdimn
           sum2=sum2+uq(i)
+          write(*,*) sum2
         enddo
         if(dabs(sum1-sum2) > 1.0D-10) then
           write(*,'(A,I1,A,F12.6,A,F12.6)')'[',dimn,'] Error: ',sum1,

--- a/tests/t17-basis.c
+++ b/tests/t17-basis.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
   Ceed ceed;
 
   CeedInit(argv[1], &ceed);
-  for (CeedInt dim=1; dim<=3; dim++) {
+  for (CeedInt dim=3; dim<=3; dim++) {
     CeedBasis bxl, bug;
     CeedInt P = 8, Q = 10, Pdim = CeedPowInt(P, dim), Qdim = CeedPowInt(Q, dim),
             Xdim = CeedPowInt(2, dim);
@@ -42,11 +42,15 @@ int main(int argc, char **argv) {
     CeedBasisApply(bug, CEED_TRANSPOSE, CEED_EVAL_GRAD, ones, gtposeones);
 
     // Check if 1' * G * u = u' * (G' * 1)
+    printf("Sum 1:\n");fflush(stdout);
     for (CeedInt i=0; i<Pdim; i++) {
       sum1 += gtposeones[i]*u[i];
+      printf("%f\n", sum1);fflush(stdout);
     }
+    printf("Sum 2:\n");fflush(stdout);
     for (CeedInt i=0; i<dim*Qdim; i++) {
       sum2 += uq[i];
+      printf("%f\n", sum2);fflush(stdout);
     }
     if (fabs(sum1 - sum2) > 1e-10) {
       printf("[%d] %f != %f\n", dim, sum1, sum2);


### PR DESCRIPTION
@jedbrown here is the `t17-basis-f` bug that I was talking about. Part of the (lengthy) output from the two 3D cases is below. The problem only manifests in the 3D case and the C test works perfectly. Every entry in the application of the transpose in the Fortran code is off by 3-5ish and the error adds up to ~280.

```
[jeremy@pheonix libceed]$ ./build/t17-basis /cpu/self
Sum 1:
11.954906
26.959247
37.632024
46.738399
61.571262
...
1104.169648
1160.009795
1208.067615
1251.295207
1279.877736
Sum 2:
0.857980
1.676995
2.335189
2.597477
2.301182
.....
1278.385231
1278.758357
1279.131483
1279.504609
1279.877736
[jeremy@pheonix libceed]$ ./build/t17-basis-f /cpu/self
 Sum 1:
   8.4254765043861806     
   19.957397471457611     
   27.932510394161067     
   34.772322694048817     
   45.820260058194123    
.....   
   964.97821921494437     
   1003.5077873767808     
   1036.2806850204406     
   1067.6815700674724     
   1084.6436215904973     
 Sum 2:
  0.85798013729573031     
   1.6769953721706286     
   2.3351893919667335     
   2.5974770340153555     
   2.3011814331908287 
.....    
   1278.3852263192830     
   1278.7583523706048     
   1279.1314784219267     
   1279.5046044732485     
   1279.8777305245703     
[3] Error:  1084.643622 !=  1279.877731
```