### PR TITLE
Occa Backend Fixes

### DIFF
--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -296,8 +296,8 @@ static int SyncToHostPointer(CeedVector vec) {
   // hold an output quantity.  This should at least be lazy instead of eager
   // and we should do better about avoiding copies.
   const CeedVector_Occa *outvdata = (CeedVector_Occa*)vec->data;
-  if (outvdata->used_pointer) {
-    occaCopyMemToPtr(outvdata->used_pointer, outvdata->d_array,
+  if (outvdata->h_array) {
+    occaCopyMemToPtr(outvdata->h_array, outvdata->d_array,
                      vec->length * sizeof(CeedScalar), NO_OFFSET, NO_PROPS);
   }
   return 0;

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -160,7 +160,8 @@ int CeedElemRestrictionCreate_Occa(const CeedElemRestriction r,
   data->d_tindices = occaDeviceMalloc(dev, bytes(r), NULL, NO_PROPS);
   // ***************************************************************************
   CeedInt toffsets[r->ndof+1];
-  CeedInt tindices[r->elemsize*r->nelem];
+  CeedInt *tindices;
+  CeedMalloc(r->elemsize*r->nelem, &tindices);
   CeedElemRestrictionOffset_Occa(r,indices,toffsets,tindices);
   occaCopyPtrToMem(data->d_toffsets,toffsets,
                    (1+r->ndof)*sizeof(CeedInt),NO_OFFSET,NO_PROPS);
@@ -196,6 +197,7 @@ int CeedElemRestrictionCreate_Occa(const CeedElemRestriction r,
   data->kRestrict[7] = occaDeviceBuildKernel(dev, oklPath, "kRestrict4b", pKR);
   // data->kRestrict[8] = occaDeviceBuildKernel(dev, oklPath, "kRestrict5b", pKR);
   // free local usage **********************************************************
+  CeedFree(&tindices);
   occaFree(pKR);
   ierr = CeedFree(&oklPath); CeedChk(ierr);
   dbg("[CeedElemRestriction][Create] done");

--- a/backends/occa/ceed-occa.c
+++ b/backends/occa/ceed-occa.c
@@ -17,7 +17,7 @@
 #include "ceed-occa.h"
 
 // *****************************************************************************
-// * OCCA modes, default deviceID is 0, but can be changed with /ocl/occa/1
+// * OCCA modes, default device_id is 0, but can be changed with /ocl/occa/1
 // *****************************************************************************
 static const char *occaCPU = "mode: 'Serial'";
 static const char *occaOMP = "mode: 'OpenMP'";

--- a/backends/occa/ceed-occa.h
+++ b/backends/occa/ceed-occa.h
@@ -42,7 +42,7 @@
 // *****************************************************************************
 typedef struct {
   CeedScalar *h_array;
-  CeedScalar *used_pointer;
+  CeedScalar *h_array_allocated;
   occaMemory d_array;
 } CeedVector_Occa;
 

--- a/tests/t02-vec-f.f
+++ b/tests/t02-vec-f.f
@@ -1,0 +1,38 @@
+c-----------------------------------------------------------------------
+      program test
+
+      include 'ceedf.h'
+
+      integer ceed,err
+      integer x,n
+      real*8 a(10)
+      real*8 b(10)
+      real*8 diff
+      character arg*32
+
+      call getarg(1,arg)
+
+      call ceedinit(trim(arg)//char(0),ceed,err)
+
+      n = 10
+
+      call ceedvectorcreate(ceed,n,x,err)
+
+      do i=1,10
+        a(i)=0
+      enddo
+
+      call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,err)
+      call ceedvectorgetarray(x,ceed_mem_host,b,err)
+      b(3) = -3.14
+      call ceedvectorrestorearray(x,b,err)
+      diff=a(3)+3.14
+      if (abs(diff)>1.0D-15) then
+        write(*,*) 'Error writing array a(3)=',a(3)
+      endif
+
+      call ceedvectordestroy(x,err)
+      call ceeddestroy(ceed,err)
+
+      end
+c-----------------------------------------------------------------------

--- a/tests/t02-vec.c
+++ b/tests/t02-vec.c
@@ -1,0 +1,24 @@
+#include <ceed.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector x;
+  const CeedInt n = 10;
+  CeedScalar a[n];
+  CeedScalar *b;
+
+  CeedInit(argv[1], &ceed);
+  CeedVectorCreate(ceed, n, &x);
+  for (CeedInt i=0; i<n; i++) a[i] = 0;
+  CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
+  CeedVectorGetArray(x, CEED_MEM_HOST, &b);
+  b[3] = -3.14;
+  CeedVectorRestoreArray(x, &b);
+  if (a[3] != -3.14)
+    return CeedError(ceed, 3, "Error writing array a[3] = %f", (double)b[3]);
+
+  CeedVectorDestroy(&x);
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
I noticed the memory management for occa vectors seemed a bit off.  When a user passes an array `a` to `CeedVectorSetArray` with `CEED_USE_POINTER` or `CEED_OWN_POINTER` mode then calls `CeedVectorGetArray` to make changes, those changes should be reflected in `a`.  This is the case for the cpu backends but not the occa one.  I added a new test for this, which fails for the current occa backend, but works for this new one.  I then realized that the fortran wrappers also break this "feature."  Perhaps this can be ignored.  Either way, this new implementation is a bit cleaner and more consistent with the ref vector.

Other changes:
- Added missing `occaFree` for vector
- Replaced potentially large array allocation on stack with malloc/free
- Renamed occa properties to support latest version (https://github.com/libocca/occa/commit/d1fd6e0f3b569ebf7614f09f02ab7394a3f2804e)

Some tests with Valgrind indicate there may be some more memory issues.