### PR TITLE
Create RestrictionCreateIdentity

### DIFF
--- a/backends/magma/ceed-magma.c
+++ b/backends/magma/ceed-magma.c
@@ -351,7 +351,9 @@ static int CeedElemRestrictionApply_Magma(CeedElemRestriction r,
 
   if (tmode == CEED_NOTRANSPOSE) {
     // Perform: v = r * u
-    if (ncomp == 1) {
+    if (!impl->indices) {
+      for (CeedInt i=0; i<esize*ncomp; i++) vv[i] = uu[i];
+    } else if (ncomp == 1) {
 #ifdef USE_MAGMA_BATCH2
 magma_template<<i=0:esize>>
       (const CeedScalar *uu, CeedScalar *vv, CeedInt *dindices) {
@@ -394,7 +396,9 @@ magma_template<<e=0:nelem, d=0:ncomp, i=0:elemsize>>
     }
   } else {
     // Note: in transpose mode, we perform: v += r^t * u
-    if (ncomp == 1) {
+    if (!impl->indices) {
+      for (CeedInt i=0; i<esize; i++) vv[i] += uu[i];
+    } else if (ncomp == 1) {
       // fprintf(stderr,"3 ---------\n");
 #ifdef USE_MAGMA_BATCH2
 magma_template<<i=0:esize>>
@@ -717,7 +721,9 @@ static int CeedOperatorDestroy_Magma(CeedOperator op) {
   int ierr;
 
   for (CeedInt i=0; i<impl->numein+impl->numeout; i++) {
-    ierr = CeedVectorDestroy(&impl->evecs[i]); CeedChk(ierr);
+    if (&impl->evecs[i]) {
+      ierr = CeedVectorDestroy(&impl->evecs[i]); CeedChk(ierr);
+    }
   }
   ierr = CeedFree(&impl->evecs); CeedChk(ierr);
   ierr = CeedFree(&impl->edata); CeedChk(ierr);
@@ -743,18 +749,17 @@ static int CeedOperatorSetupFields_Magma(struct CeedQFunctionField qfields[16],
                                        struct CeedOperatorField ofields[16],
                                        CeedVector *evecs, CeedScalar **qdata,
                                        CeedScalar **qdata_alloc, CeedScalar **indata,
-                                       CeedInt starti, CeedInt starte,
-                                       CeedInt startq, CeedInt numfields, CeedInt Q) {
-  CeedInt dim, ierr, ie=starte, iq=startq, ncomp;
+                                       CeedInt starti, CeedInt startq,
+                                       CeedInt numfields, CeedInt Q) {
+  CeedInt dim, ierr, iq=startq, ncomp;
 
   // Loop over fields
   for (CeedInt i=0; i<numfields; i++) {
-    if (ofields[i].Erestrict != CEED_RESTRICTION_IDENTITY) {
-      ierr = CeedElemRestrictionCreateVector(ofields[i].Erestrict, NULL, &evecs[ie]);
-      CeedChk(ierr);
-      ie++;
-    }
     CeedEvalMode emode = qfields[i].emode;
+    if (emode != CEED_EVAL_WEIGHT) {
+      ierr = CeedElemRestrictionCreateVector(ofields[i].Erestrict, NULL, &evecs[i]);
+      CeedChk(ierr);
+    }
     switch(emode) {
     case CEED_EVAL_NONE:
       break; // No action
@@ -800,22 +805,21 @@ static int CeedOperatorSetup_Magma(CeedOperator op) {
   int ierr;
 
   // Count infield and outfield array sizes and evectors
+  opmagma->numein = qf->numinfutfields;
   for (CeedInt i=0; i<qf->numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     opmagma->numqin += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD) + !!
                      (emode & CEED_EVAL_WEIGHT);
-    opmagma->numein +=
-      (op->inputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY); // Need E-vector when non-identity restriction exists
   }
+  qpmagma->numeout = qf->numoutputfields;
   for (CeedInt i=0; i<qf->numoutputfields; i++) {
     CeedEvalMode emode = qf->outputfields[i].emode;
     opmagma->numqout += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD);
-    opmagma->numeout += (op->outputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY);
   }
 
   // Allocate
   ierr = CeedCalloc(opmagma->numein + opmagma->numeout, &opmagma->evecs); CeedChk(ierr);
-  ierr = CeedCalloc(qf->numinputfields + qf->numoutputfields, &opmagma->edata);
+  ierr = CeedCalloc(opmagma->numein + opmagma->numeout, &opmagma->edata);
   CeedChk(ierr);
 
   ierr = CeedCalloc(opmagma->numqin + opmagma->numqout, &opmagma->qdata_alloc);
@@ -830,13 +834,13 @@ static int CeedOperatorSetup_Magma(CeedOperator op) {
   // Infields
   ierr = CeedOperatorSetupFields_Magma(qf->inputfields, op->inputfields,
                                      opmagma->evecs, opmagma->qdata, opmagma->qdata_alloc,
-                                     opmagma->indata, 0, 0, 0,
+                                     opmagma->indata, 0, 0,
                                      qf->numinputfields, Q); CeedChk(ierr);
 
   // Outfields
   ierr = CeedOperatorSetupFields_Magma(qf->outputfields, op->outputfields,
                                      opmagma->evecs, opmagma->qdata, opmagma->qdata_alloc,
-                                     opmagma->indata, qf->numinputfields, opmagma->numein,
+                                     opmagma->indata, qf->numinputfields,
                                      opmagma->numqin, qf->numoutputfields, Q); CeedChk(ierr);
 
   // Output Qvecs
@@ -865,72 +869,43 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
   ierr = CeedOperatorSetup_Magma(op); CeedChk(ierr);
 
   // Input Evecs and Restriction
-  for (CeedInt i=0,iein=0; i<qf->numinputfields; i++) {
-    // No Restriction
-    if (op->inputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      CeedEvalMode emode = qf->inputfields[i].emode;
-      if (emode & CEED_EVAL_WEIGHT) {
-      } else {
-        // Active
-        if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
-          ierr = CeedVectorGetArrayRead(invec, CEED_MEM_HOST,
-                                        (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-          // Passive
-        } else {
-          ierr = CeedVectorGetArrayRead(op->inputfields[i].vec, CEED_MEM_HOST,
-                                        (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-        }
-      }
+  for (CeedInt i=0; i<qf->numinputfields; i++) {
+    CeedEvalMode emode = qf->inputfields[i].emode;
+    if (emode & CEED_EVAL_WEIGHT) { // Skip
     } else {
-      // Restriction
       // Zero evec
-      ierr = CeedVectorGetArray(opmagma->evecs[iein], CEED_MEM_HOST, &vec_temp);
+      ierr = CeedVectorGetArray(opmagma->evecs[i], CEED_MEM_HOST, &vec_temp);
       CeedChk(ierr);
-      for (CeedInt j=0; j<opmagma->evecs[iein]->length; j++)
+      for (CeedInt j=0; j<opmagma->evecs[i]->length; j++)
         vec_temp[j] = 0.;
-      ierr = CeedVectorRestoreArray(opmagma->evecs[iein], &vec_temp); CeedChk(ierr);
+      ierr = CeedVectorRestoreArray(opmagma->evecs[i], &vec_temp); CeedChk(ierr);
       // Active
       if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
         // Restrict
         ierr = CeedElemRestrictionApply(op->inputfields[i].Erestrict, CEED_NOTRANSPOSE,
-                                        lmode, invec, opmagma->evecs[iein],
+                                        lmode, invec, opmagma->evecs[ieiin],
                                         request); CeedChk(ierr);
         // Get evec
-        ierr = CeedVectorGetArrayRead(opmagma->evecs[iein], CEED_MEM_HOST,
+        ierr = CeedVectorGetArrayRead(opmagma->evecs[i], CEED_MEM_HOST,
                                       (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-        iein++;
       } else {
         // Passive
         // Restrict
         ierr = CeedElemRestrictionApply(op->inputfields[i].Erestrict, CEED_NOTRANSPOSE,
-                                        lmode, op->inputfields[i].vec, opmagma->evecs[iein],
+                                        lmode, op->inputfields[i].vec, opmagma->evecs[i],
                                         request); CeedChk(ierr);
         // Get evec
-        ierr = CeedVectorGetArrayRead(opmagma->evecs[iein], CEED_MEM_HOST,
+        ierr = CeedVectorGetArrayRead(opmagma->evecs[i], CEED_MEM_HOST,
                                       (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-        iein++;
       }
     }
   }
 
   // Output Evecs
-  for (CeedInt i=0,ieout=opmagma->numein; i<qf->numoutputfields; i++) {
-    // No Restriction
-    if (op->outputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      // Active
-      if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-        ierr = CeedVectorGetArray(outvec, CEED_MEM_HOST,
-                                  &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
-      } else {
-        // Passive
-        ierr = CeedVectorGetArray(op->outputfields[i].vec, CEED_MEM_HOST,
-                                  &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
-      }
-    } else {
-      // Restriction
-      ierr = CeedVectorGetArray(opmagma->evecs[ieout], CEED_MEM_HOST,
-                                &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
-      ieout++;
+  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    ierr = CeedVectorGetArray(opmagma->evecs[i+opmagma->numein], CEED_MEM_HOST,
+                              &opmagma->edata[i + qf->numinputfields]);
+    CeedChk(ierr);
     }
   }
 
@@ -938,13 +913,8 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
   for (CeedInt e=0; e<op->numelements; e++) {
     // Input basis apply if needed
     for (CeedInt i=0; i<qf->numinputfields; i++) {
-      // Get elemsize
-      if (op->inputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY) {
-        elemsize = op->inputfields[i].Erestrict->elemsize;
-      } else {
-        elemsize = Q;
-      }
-      // Get emode, ncomp
+      // Get elemsize, emode, ncomp
+      elemsize = op->inputfields[i].Erestrict->elemsize;
       CeedEvalMode emode = qf->inputfields[i].emode;
       CeedInt ncomp = qf->inputfields[i].ncomp;
       // Basis action
@@ -986,13 +956,8 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
 
     // Output basis apply if needed
     for (CeedInt i=0; i<qf->numoutputfields; i++) {
-      // Get elemsize
-      if (op->outputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY) {
-        elemsize = op->outputfields[i].Erestrict->elemsize;
-      } else {
-        elemsize = Q;
-      }
-      // Get emode, ncomp
+      // Get elemsize, emode, ncomp
+      elemsize = op->outputfields[i].Erestrict->elemsize;
       CeedInt ncomp = qf->outputfields[i].ncomp;
       CeedEvalMode emode = qf->outputfields[i].emode;
       // Basis action
@@ -1020,77 +985,46 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
   }
 
   // Output restriction
-  for (CeedInt i=0,ieout=opmagma->numein; i<qf->numoutputfields; i++) {
-    // No Restriction
-    if (op->outputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      // Active
-      if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-        ierr = CeedVectorRestoreArray(outvec, &opmagma->edata[i + qf->numinputfields]);
-        CeedChk(ierr);
-      } else {
-        // Passive
-        ierr = CeedVectorRestoreArray(op->outputfields[i].vec,
-                                      &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
-      }
+  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    // Active
+    if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
+      // Restore evec
+      ierr = CeedVectorRestoreArray(opmagma->evecs[i+opmagma->numein],
+                                    &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
+      // Zero lvec
+      ierr = CeedVectorGetArray(outvec, CEED_MEM_HOST, &vec_temp); CeedChk(ierr);
+      for (CeedInt j=0; j<outvec->length; j++)
+        vec_temp[j] = 0.;
+      ierr = CeedVectorRestoreArray(outvec, &vec_temp); CeedChk(ierr);
+      // Restrict
+      ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
+                                      lmode, opmagma->evecs[i+opmagma->numein], outvec, request); CeedChk(ierr);
     } else {
-      // Restriction
-      // Active
-      if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-        // Restore evec
-        ierr = CeedVectorRestoreArray(opmagma->evecs[ieout],
-                                      &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
-        // Zero lvec
-        ierr = CeedVectorGetArray(outvec, CEED_MEM_HOST, &vec_temp); CeedChk(ierr);
-        for (CeedInt j=0; j<outvec->length; j++)
-          vec_temp[j] = 0.;
-        ierr = CeedVectorRestoreArray(outvec, &vec_temp); CeedChk(ierr);
-        // Restrict
-        ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
-                                        lmode, opmagma->evecs[ieout], outvec, request); CeedChk(ierr);
-        ieout++;
-      } else {
-        // Passive
-        // Restore evec
-        ierr = CeedVectorRestoreArray(opmagma->evecs[ieout],
-                                      &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
-        // Zero lvec
-        ierr = CeedVectorGetArray(op->outputfields[i].vec, CEED_MEM_HOST, &vec_temp);
-        CeedChk(ierr);
-        for (CeedInt j=0; j<op->outputfields[i].vec->length; j++)
-          vec_temp[j] = 0.;
-        ierr = CeedVectorRestoreArray(op->outputfields[i].vec, &vec_temp);
-        CeedChk(ierr);
-        // Restrict
-        ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
-                                        lmode, opmagma->evecs[ieout], op->outputfields[i].vec,
-                                        request); CeedChk(ierr);
-        ieout++;
-      }
+      // Passive
+      // Restore evec
+      ierr = CeedVectorRestoreArray(opmagma->evecs[i+opmagma->numein],
+                                    &opmagma->edata[i + qf->numinputfields]); CeedChk(ierr);
+      // Zero lvec
+      ierr = CeedVectorGetArray(op->outputfields[i].vec, CEED_MEM_HOST, &vec_temp);
+      CeedChk(ierr);
+      for (CeedInt j=0; j<op->outputfields[i].vec->length; j++)
+        vec_temp[j] = 0.;
+      ierr = CeedVectorRestoreArray(op->outputfields[i].vec, &vec_temp);
+      CeedChk(ierr);
+      // Restrict
+      ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
+                                      lmode, opmagma->evecs[i+opmagma->numein], op->outputfields[i].vec,
+                                      request); CeedChk(ierr);
     }
   }
 
   // Restore input arrays
-  for (CeedInt i=0,iein=0; i<qf->numinputfields; i++) {
-    // No Restriction
-    if (op->inputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      CeedEvalMode emode = qf->inputfields[i].emode;
-      if (emode & CEED_EVAL_WEIGHT) {
-      } else {
-        // Active
-        if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
-          ierr = CeedVectorRestoreArrayRead(invec,
-                                            (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-          // Passive
-        } else {
-          ierr = CeedVectorRestoreArrayRead(op->inputfields[i].vec,
-                                            (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-        }
-      }
+  for (CeedInt i=0; i<qf->numinputfields; i++) {
+    CeedEvalMode emode = qf->inputfields[i].emode;
+    if (emode & CEED_EVAL_WEIGHT) {
     } else {
-      // Restriction
-      ierr = CeedVectorRestoreArrayRead(opmagma->evecs[iein],
+      ierr = CeedVectorRestoreArrayRead(opmagma->evecs[i],
                                         (const CeedScalar **) &opmagma->edata[i]); CeedChk(ierr);
-      iein++;
     }
   }
 

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -23,7 +23,9 @@ static int CeedOperatorDestroy_Ref(CeedOperator op) {
   int ierr;
 
   for (CeedInt i=0; i<impl->numein+impl->numeout; i++) {
-    ierr = CeedVectorDestroy(&impl->evecs[i]); CeedChk(ierr);
+    if (impl->evecs[i]) {
+      ierr = CeedVectorDestroy(&impl->evecs[i]); CeedChk(ierr);
+    }
   }
   ierr = CeedFree(&impl->evecs); CeedChk(ierr);
   ierr = CeedFree(&impl->edata); CeedChk(ierr);
@@ -48,18 +50,19 @@ static int CeedOperatorSetupFields_Ref(struct CeedQFunctionField qfields[16],
                                        struct CeedOperatorField ofields[16],
                                        CeedVector *evecs, CeedScalar **qdata,
                                        CeedScalar **qdata_alloc, CeedScalar **indata,
-                                       CeedInt starti, CeedInt starte,
-                                       CeedInt startq, CeedInt numfields, CeedInt Q) {
-  CeedInt dim, ierr, ie=starte, iq=startq, ncomp;
+                                       CeedInt starti, CeedInt startq,
+                                       CeedInt numfields, CeedInt Q) {
+  CeedInt dim, ierr, iq=startq, ncomp;
 
   // Loop over fields
   for (CeedInt i=0; i<numfields; i++) {
-    if (ofields[i].Erestrict != CEED_RESTRICTION_IDENTITY) {
-      ierr = CeedElemRestrictionCreateVector(ofields[i].Erestrict, NULL, &evecs[ie]);
-      CeedChk(ierr);
-      ie++;
-    }
     CeedEvalMode emode = qfields[i].emode;
+    
+    if (emode != CEED_EVAL_WEIGHT) {
+      ierr = CeedElemRestrictionCreateVector(ofields[i].Erestrict, NULL, &evecs[i+starti]);
+      CeedChk(ierr);
+    }
+
     switch(emode) {
     case CEED_EVAL_NONE:
       break; // No action
@@ -105,23 +108,21 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
   int ierr;
 
   // Count infield and outfield array sizes and evectors
+  opref->numein = qf->numinputfields;
   for (CeedInt i=0; i<qf->numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     opref->numqin += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD) + !!
                      (emode & CEED_EVAL_WEIGHT);
-    opref->numein +=
-      (op->inputfields[i].Erestrict !=
-       CEED_RESTRICTION_IDENTITY); // Need E-vector when non-identity restriction exists
   }
+  opref->numeout = qf->numoutputfields;
   for (CeedInt i=0; i<qf->numoutputfields; i++) {
     CeedEvalMode emode = qf->outputfields[i].emode;
     opref->numqout += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD);
-    opref->numeout += (op->outputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY);
   }
 
   // Allocate
   ierr = CeedCalloc(opref->numein + opref->numeout, &opref->evecs); CeedChk(ierr);
-  ierr = CeedCalloc(qf->numinputfields + qf->numoutputfields, &opref->edata);
+  ierr = CeedCalloc(opref->numein + opref->numeout, &opref->edata);
   CeedChk(ierr);
 
   ierr = CeedCalloc(opref->numqin + opref->numqout, &opref->qdata_alloc);
@@ -136,13 +137,13 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
   // Infields
   ierr = CeedOperatorSetupFields_Ref(qf->inputfields, op->inputfields,
                                      opref->evecs, opref->qdata, opref->qdata_alloc,
-                                     opref->indata, 0, 0, 0,
+                                     opref->indata, 0, 0,
                                      qf->numinputfields, Q); CeedChk(ierr);
 
   // Outfields
   ierr = CeedOperatorSetupFields_Ref(qf->outputfields, op->outputfields,
                                      opref->evecs, opref->qdata, opref->qdata_alloc,
-                                     opref->indata, qf->numinputfields, opref->numein,
+                                     opref->indata, qf->numinputfields,
                                      opref->numqin, qf->numoutputfields, Q); CeedChk(ierr);
 
   // Output Qvecs
@@ -171,86 +172,50 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   ierr = CeedOperatorSetup_Ref(op); CeedChk(ierr);
 
   // Input Evecs and Restriction
-  for (CeedInt i=0,iein=0; i<qf->numinputfields; i++) {
-    // No Restriction
-    if (op->inputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      CeedEvalMode emode = qf->inputfields[i].emode;
-      if (emode & CEED_EVAL_WEIGHT) {
-      } else {
-        // Active
-        if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
-          ierr = CeedVectorGetArrayRead(invec, CEED_MEM_HOST,
-                                        (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-          // Passive
-        } else {
-          ierr = CeedVectorGetArrayRead(op->inputfields[i].vec, CEED_MEM_HOST,
-                                        (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-        }
-      }
+  for (CeedInt i=0; i<qf->numinputfields; i++) {
+    CeedEvalMode emode = qf->inputfields[i].emode;
+    if (emode == CEED_EVAL_WEIGHT) { // Skip
     } else {
-      // Restriction
       // Zero evec
-      ierr = CeedVectorGetArray(opref->evecs[iein], CEED_MEM_HOST, &vec_temp);
+      ierr = CeedVectorGetArray(opref->evecs[i], CEED_MEM_HOST, &vec_temp);
       CeedChk(ierr);
-      for (CeedInt j=0; j<opref->evecs[iein]->length; j++)
+      for (CeedInt j=0; j<opref->evecs[i]->length; j++)
         vec_temp[j] = 0.;
-      ierr = CeedVectorRestoreArray(opref->evecs[iein], &vec_temp); CeedChk(ierr);
+      ierr = CeedVectorRestoreArray(opref->evecs[i], &vec_temp); CeedChk(ierr);
       // Active
       if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
         // Restrict
         ierr = CeedElemRestrictionApply(op->inputfields[i].Erestrict, CEED_NOTRANSPOSE,
-                                        lmode, invec, opref->evecs[iein],
+                                        lmode, invec, opref->evecs[i],
                                         request); CeedChk(ierr);
         // Get evec
-        ierr = CeedVectorGetArrayRead(opref->evecs[iein], CEED_MEM_HOST,
+        ierr = CeedVectorGetArrayRead(opref->evecs[i], CEED_MEM_HOST,
                                       (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-        iein++;
       } else {
         // Passive
         // Restrict
         ierr = CeedElemRestrictionApply(op->inputfields[i].Erestrict, CEED_NOTRANSPOSE,
-                                        lmode, op->inputfields[i].vec, opref->evecs[iein],
+                                        lmode, op->inputfields[i].vec, opref->evecs[i],
                                         request); CeedChk(ierr);
         // Get evec
-        ierr = CeedVectorGetArrayRead(opref->evecs[iein], CEED_MEM_HOST,
+        ierr = CeedVectorGetArrayRead(opref->evecs[i], CEED_MEM_HOST,
                                       (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-        iein++;
       }
     }
   }
 
   // Output Evecs
-  for (CeedInt i=0,ieout=opref->numein; i<qf->numoutputfields; i++) {
-    // No Restriction
-    if (op->outputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      // Active
-      if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-        ierr = CeedVectorGetArray(outvec, CEED_MEM_HOST,
-                                  &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
-      } else {
-        // Passive
-        ierr = CeedVectorGetArray(op->outputfields[i].vec, CEED_MEM_HOST,
-                                  &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
-      }
-    } else {
-      // Restriction
-      ierr = CeedVectorGetArray(opref->evecs[ieout], CEED_MEM_HOST,
-                                &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
-      ieout++;
-    }
+  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    ierr = CeedVectorGetArray(opref->evecs[i+opref->numein], CEED_MEM_HOST,
+                              &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
   }
 
   // Loop through elements
   for (CeedInt e=0; e<op->numelements; e++) {
     // Input basis apply if needed
     for (CeedInt i=0; i<qf->numinputfields; i++) {
-      // Get elemsize
-      if (op->inputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY) {
-        elemsize = op->inputfields[i].Erestrict->elemsize;
-      } else {
-        elemsize = Q;
-      }
-      // Get emode, ncomp
+      // Get elemsize, emode, ncomp
+      elemsize = op->inputfields[i].Erestrict->elemsize;
       CeedEvalMode emode = qf->inputfields[i].emode;
       CeedInt ncomp = qf->inputfields[i].ncomp;
       // Basis action
@@ -292,13 +257,8 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
 
     // Output basis apply if needed
     for (CeedInt i=0; i<qf->numoutputfields; i++) {
-      // Get elemsize
-      if (op->outputfields[i].Erestrict != CEED_RESTRICTION_IDENTITY) {
-        elemsize = op->outputfields[i].Erestrict->elemsize;
-      } else {
-        elemsize = Q;
-      }
-      // Get emode, ncomp
+      // Get elemsize, emode, ncomp
+      elemsize = op->outputfields[i].Erestrict->elemsize;
       CeedInt ncomp = qf->outputfields[i].ncomp;
       CeedEvalMode emode = qf->outputfields[i].emode;
       // Basis action
@@ -327,77 +287,46 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   }
 
   // Output restriction
-  for (CeedInt i=0,ieout=opref->numein; i<qf->numoutputfields; i++) {
-    // No Restriction
-    if (op->outputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      // Active
-      if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-        ierr = CeedVectorRestoreArray(outvec, &opref->edata[i + qf->numinputfields]);
-        CeedChk(ierr);
-      } else {
-        // Passive
-        ierr = CeedVectorRestoreArray(op->outputfields[i].vec,
-                                      &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
-      }
+  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    // Active
+    if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
+      // Restore evec
+      ierr = CeedVectorRestoreArray(opref->evecs[i+opref->numein],
+                                    &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
+      // Zero lvec
+      ierr = CeedVectorGetArray(outvec, CEED_MEM_HOST, &vec_temp); CeedChk(ierr);
+      for (CeedInt j=0; j<outvec->length; j++)
+        vec_temp[j] = 0.;
+      ierr = CeedVectorRestoreArray(outvec, &vec_temp); CeedChk(ierr);
+      // Restrict
+      ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
+                                      lmode, opref->evecs[i+opref->numein], outvec, request); CeedChk(ierr);
     } else {
-      // Restriction
-      // Active
-      if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-        // Restore evec
-        ierr = CeedVectorRestoreArray(opref->evecs[ieout],
-                                      &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
-        // Zero lvec
-        ierr = CeedVectorGetArray(outvec, CEED_MEM_HOST, &vec_temp); CeedChk(ierr);
-        for (CeedInt j=0; j<outvec->length; j++)
-          vec_temp[j] = 0.;
-        ierr = CeedVectorRestoreArray(outvec, &vec_temp); CeedChk(ierr);
-        // Restrict
-        ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
-                                        lmode, opref->evecs[ieout], outvec, request); CeedChk(ierr);
-        ieout++;
-      } else {
-        // Passive
-        // Restore evec
-        ierr = CeedVectorRestoreArray(opref->evecs[ieout],
-                                      &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
-        // Zero lvec
-        ierr = CeedVectorGetArray(op->outputfields[i].vec, CEED_MEM_HOST, &vec_temp);
-        CeedChk(ierr);
-        for (CeedInt j=0; j<op->outputfields[i].vec->length; j++)
-          vec_temp[j] = 0.;
-        ierr = CeedVectorRestoreArray(op->outputfields[i].vec, &vec_temp);
-        CeedChk(ierr);
-        // Restrict
-        ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
-                                        lmode, opref->evecs[ieout], op->outputfields[i].vec,
-                                        request); CeedChk(ierr);
-        ieout++;
-      }
+      // Passive
+      // Restore evec
+      ierr = CeedVectorRestoreArray(opref->evecs[i+opref->numein],
+                                    &opref->edata[i + qf->numinputfields]); CeedChk(ierr);
+      // Zero lvec
+      ierr = CeedVectorGetArray(op->outputfields[i].vec, CEED_MEM_HOST, &vec_temp);
+      CeedChk(ierr);
+      for (CeedInt j=0; j<op->outputfields[i].vec->length; j++)
+        vec_temp[j] = 0.;
+      ierr = CeedVectorRestoreArray(op->outputfields[i].vec, &vec_temp);
+      CeedChk(ierr);
+      // Restrict
+      ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
+                                      lmode, opref->evecs[i+opref->numein], op->outputfields[i].vec,
+                                      request); CeedChk(ierr);
     }
   }
 
   // Restore input arrays
-  for (CeedInt i=0,iein=0; i<qf->numinputfields; i++) {
-    // No Restriction
-    if (op->inputfields[i].Erestrict == CEED_RESTRICTION_IDENTITY) {
-      CeedEvalMode emode = qf->inputfields[i].emode;
-      if (emode & CEED_EVAL_WEIGHT) {
-      } else {
-        // Active
-        if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
-          ierr = CeedVectorRestoreArrayRead(invec,
-                                            (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-          // Passive
-        } else {
-          ierr = CeedVectorRestoreArrayRead(op->inputfields[i].vec,
-                                            (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-        }
-      }
+  for (CeedInt i=0; i<qf->numinputfields; i++) {
+    CeedEvalMode emode = qf->inputfields[i].emode;
+    if (emode == CEED_EVAL_WEIGHT) { // Skip
     } else {
-      // Restriction
-      ierr = CeedVectorRestoreArrayRead(opref->evecs[iein],
+      ierr = CeedVectorRestoreArrayRead(opref->evecs[i],
                                         (const CeedScalar **) &opref->edata[i]); CeedChk(ierr);
-      iein++;
     }
   }
 

--- a/ceed-operator.c
+++ b/ceed-operator.c
@@ -69,7 +69,7 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
 
   @param op the operator on which to provide the field
   @param fieldname name of the field (to be matched with the name used by CeedQFunction)
-  @param r element restriction or CEED_RESTRICTION_IDENTITY to use the identity
+  @param r element restriction
   @param b basis in which the field resides or CEED_BASIS_COLOCATED if collocated
            with quadrature points
   @param v vector to be used by CeedOperator, CEED_VECTOR_ACTIVE if field is
@@ -79,15 +79,14 @@ int CeedOperatorSetField(CeedOperator op, const char *fieldname,
                          CeedElemRestriction r, CeedBasis b,
                          CeedVector v) {
   int ierr;
-  if (r != CEED_RESTRICTION_IDENTITY) {
-    CeedInt numelements;
-    ierr = CeedElemRestrictionGetNumElements(r, &numelements); CeedChk(ierr);
-    if (op->numelements && op->numelements != numelements)
-      return CeedError(op->ceed, 1,
-                       "ElemRestriction with %d elements incompatible with prior %d elements",
-                       numelements, op->numelements);
-    op->numelements = numelements;
-  }
+  CeedInt numelements;
+  ierr = CeedElemRestrictionGetNumElements(r, &numelements); CeedChk(ierr);
+  if (op->numelements && op->numelements != numelements)
+    return CeedError(op->ceed, 1,
+                     "ElemRestriction with %d elements incompatible with prior %d elements",
+                     numelements, op->numelements);
+  op->numelements = numelements;
+
   if (b != CEED_BASIS_COLOCATED) {
     CeedInt numqpoints;
     ierr = CeedBasisGetNumQuadraturePoints(b, &numqpoints); CeedChk(ierr);
@@ -146,7 +145,7 @@ int CeedOperatorApply(CeedOperator op, CeedVector in,
   if (op->nfields < qf->numinputfields + qf->numoutputfields) return CeedError(
           ceed, 1, "Not all operator fields set");
   if (op->numelements == 0) return CeedError(ceed, 1,
-                                     "At least one non-identity restriction required");
+                                     "At least one restriction required");
   if (op->numqpoints == 0) return CeedError(ceed, 1,
                                     "At least one non-colocated basis required");
   ierr = op->Apply(op, in, out, request); CeedChk(ierr);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -144,10 +144,6 @@ CEED_EXTERN CeedRequest *const CEED_REQUEST_IMMEDIATE;
 CEED_EXTERN CeedRequest *const CEED_REQUEST_ORDERED;
 CEED_EXTERN int CeedRequestWait(CeedRequest *req);
 
-CEED_EXTERN CeedElemRestriction CEED_RESTRICTION_IDENTITY;
-/// Argument for CeedOperatorSetField to use no restriction
-/// @ingroup CeedElemRestriction
-/// @ingroup CeedOperator
 CEED_EXTERN CeedBasis CEED_BASIS_COLOCATED;
 /// Argument for CeedOperatorSetField that vector is colocated with
 /// quadrature points, used with qfunction eval mode CEED_EVAL_NONE
@@ -176,9 +172,11 @@ typedef enum {
 CEED_EXTERN int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem,
     CeedInt elemsize, CeedInt ndof, CeedInt ncomp, CeedMemType mtype, CeedCopyMode cmode,
     const CeedInt *indices, CeedElemRestriction *r);
+CEED_EXTERN int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
+    CeedInt elemsize, CeedInt ndof, CeedInt ncomp, CeedElemRestriction *r);
 CEED_EXTERN int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem,
-    CeedInt elemsize, CeedInt blksize, CeedInt ndof, CeedInt ncomp, CeedMemType mtype, CeedCopyMode cmode,
-    const CeedInt *indices, CeedElemRestriction *r);
+    CeedInt elemsize, CeedInt blksize, CeedInt ndof, CeedInt ncomp, CeedMemType mtype,
+    CeedCopyMode cmode, const CeedInt *indices, CeedElemRestriction *r);
 CEED_EXTERN int CeedElemRestrictionCreateVector(CeedElemRestriction r,
                                                 CeedVector *lvec,
                                                 CeedVector *evec);

--- a/include/ceedf.h
+++ b/include/ceedf.h
@@ -69,17 +69,10 @@ c
 
       integer ceed_gauss_lobatto
       parameter(ceed_gauss_lobatto = 1)
-c
-c CeedElemRestriction
-c
-      integer ceed_elemrestrict_identity
-      parameter(ceed_elemrestrict_identity = -1)
 
 c
 c OperatorFieldConstants
 c
-      integer ceed_restriction_identity
-      parameter(ceed_restriction_identity = -1)
 
       integer ceed_basis_colocated
       parameter(ceed_basis_colocated      = -1)

--- a/tests/t30-operator-f.f
+++ b/tests/t30-operator-f.f
@@ -36,7 +36,7 @@ c-----------------------------------------------------------------------
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer erestrictx,erestrictu
+      integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
       integer op_setup,op_mass
@@ -66,8 +66,10 @@ c-----------------------------------------------------------------------
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,
-     $  ceed_use_pointer,indx,erestrictx,err)
+      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,
+     $  ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,
+     $  erestrictxi,err)
 
       do i=0,nelem-1
         do j=0,p-1
@@ -75,8 +77,10 @@ c-----------------------------------------------------------------------
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,
-     $  ceed_use_pointer,indu,erestrictu,err)
+      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,
+     $  ceed_mem_host,ceed_use_pointer,indu,erestrictu,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,
+     $  erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,
      $  bx,err)
@@ -112,14 +116,14 @@ c     $  't30-operator-f.f:mass',qf_mass,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
       call ceedoperatorsetfield(op_setup,'_weight',
-     $  ceed_restriction_identity,bx,ceed_vector_none,err)
+     $  erestrictxi,bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,
      $  ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',
-     $  ceed_restriction_identity,ceed_basis_colocated,
+     $  erestrictui,ceed_basis_colocated,
      $  ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',
-     $  ceed_restriction_identity,ceed_basis_colocated,
+     $  erestrictui,ceed_basis_colocated,
      $  qdata,err)
       call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,
      $  ceed_vector_active,err)
@@ -144,6 +148,8 @@ c     $  't30-operator-f.f:mass',qf_mass,err)
       call ceedbasisdestroy(bx,err)
       call ceedelemrestrictiondestroy(erestrictu,err)
       call ceedelemrestrictiondestroy(erestrictx,err)
+      call ceedelemrestrictiondestroy(erestrictui,err)
+      call ceedelemrestrictiondestroy(erestrictxi,err)
       call ceeddestroy(ceed,err)
       end
 c-----------------------------------------------------------------------


### PR DESCRIPTION
This changes `CEED_RESTRICTION_IDENTITY` out for `CeedElemRestrictionCreateIdentity()`. This change simplifies `OperatorApply` code and enables future optimization. All backends and examples except MAGMA and Nek have been tested.

I would appreciate comments on the arguments for my new function. Technically `ndof` is superfluous, but I kept it for now to match the other two `RestrictionCreate` functions.