### PR TITLE
Fix typo in tmpl backend init

### DIFF
--- a/backends/template/ceed-tmpl.c
+++ b/backends/template/ceed-tmpl.c
@@ -37,7 +37,7 @@ static int CeedInit_Tmpl(const char *resource, Ceed ceed) {
   Ceed ceedref;
 
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
-  CeedInit("/cpu/self/", &ceedref);
+  CeedInit("/cpu/self/ref", &ceedref);
   ceed->data = impl;
   impl->ceedref = ceedref;
 


### PR DESCRIPTION
This PR fixes a typo in the tmpl backend that was preventing it from being used/tested.