### PR TITLE
Add OCCA to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ env:
 install:
   - git clone --depth 1 https://github.com/mfem/mfem.git
   - make -C mfem -j2 serial MFEM_CXXFLAGS=-O
-  - export MFEM_DIR=$PWD/mfem PETSC_INSTALL=$HOME/install/petsc-3.9.3
+  - git clone --depth 1 https://github.com/libocca/occa.git
+  - make -C occa -j2
+  - export OCCA_DIR=$PWD/occa MFEM_DIR=$PWD/mfem PETSC_INSTALL=$HOME/install/petsc-3.9.3
   - test -d $PETSC_INSTALL
     || ( curl -O http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.3.tar.gz
         && tar xf petsc-lite-3.9.3.tar.gz


### PR DESCRIPTION
This PR adds OCCA, specifically `/cpu/occa` and `/omp/occa` to Travis CI. This PR addresses Issue #94.