### PR TITLE
Add CeedErrorExit to exit without signals, use in tests

### DIFF
--- a/include/ceed.h
+++ b/include/ceed.h
@@ -97,6 +97,8 @@ CEED_EXTERN int CeedErrorReturn(Ceed, const char *, int, const char *, int,
                                 const char *, va_list);
 CEED_EXTERN int CeedErrorAbort(Ceed, const char *, int, const char *, int,
                                const char *, va_list);
+CEED_EXTERN int CeedErrorExit(Ceed, const char *, int, const char *, int,
+                               const char *, va_list);
 CEED_EXTERN int CeedSetErrorHandler(Ceed ceed,
                                     int (eh)(Ceed, const char *, int, const char *,
                                         int, const char *, va_list));

--- a/tests/tap.sh
+++ b/tests/tap.sh
@@ -2,6 +2,9 @@
 
 ulimit -c 0 # Do not dump core
 
+# Make CeedError exit nonzero without using signals/abort()
+export CEED_ERROR_HANDLER=exit
+
 output=$(mktemp $1.XXXX)
 
 backends=(${BACKENDS:?Variable must be set, e.g., \"/cpu/self/ref /cpu/self/opt\"})


### PR DESCRIPTION
This allows gcov to finish writing outputs even if the test
crashes (especially in tests that confirm error handling).