### PR TITLE
CeedVectorSetValue: fix doc and test prior to setting the array

### DIFF
--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -76,7 +76,7 @@ int CeedVectorSetArray(CeedVector vec, CeedMemType mtype, CeedCopyMode cmode,
 }
 
 /**
-  @brief Set the array used by a CeedVector, allocating the array if applicable
+  @brief Set the CeedVector to a constant value
 
   @param vec        CeedVector
   @param[in] value  Value to be used


### PR DESCRIPTION
When backends provide a fast path, it would be easy to forget that it
is acceptable to set the value before setting or getting an array.