### PR TITLE
Only zero lvecs once

### DIFF
--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -493,6 +493,13 @@ static int CeedOperatorApply_Occa(CeedOperator op,
     }
   } // numelements
 
+  // Zero lvecs
+  ierr = CeedVectorSetValue(outvec, 0.0); CeedChk(ierr);
+  for (CeedInt i=0; i<qf->numoutputfields; i++)
+    if (op->outputfields[i].vec != CEED_VECTOR_ACTIVE) {
+      ierr = CeedVectorSetValue(op->outputfields[i].vec, 0.0); CeedChk(ierr);
+    }
+
   // Output restriction
   for (CeedInt i=0; i<qf->numoutputfields; i++) {
     // Restore evec
@@ -500,16 +507,12 @@ static int CeedOperatorApply_Occa(CeedOperator op,
                                     &data->Edata[i + qf->numinputfields]); CeedChk(ierr);
     // Active
     if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-      // Zero lvec
-      ierr = CeedVectorSetValue(outvec, 0.0); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
                                       lmode, data->Evecs[i+data->numein], outvec, request); CeedChk(ierr);
       ierr = SyncToHostPointer(outvec); CeedChk(ierr);
     } else {
       // Passive
-      // Zero lvec
-      ierr = CeedVectorSetValue(op->outputfields[i].vec, 0.0); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
                                       lmode, data->Evecs[i+data->numein], op->outputfields[i].vec, request); CeedChk(ierr);

--- a/backends/optimized/ceed-opt-operator.c
+++ b/backends/optimized/ceed-opt-operator.c
@@ -302,6 +302,13 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
     }
   }
 
+  // Zero lvecs
+  ierr = CeedVectorSetValue(outvec, 0.0); CeedChk(ierr);
+  for (CeedInt i=0; i<qf->numoutputfields; i++)
+    if (op->outputfields[i].vec != CEED_VECTOR_ACTIVE) {
+      ierr = CeedVectorSetValue(op->outputfields[i].vec, 0.0); CeedChk(ierr);
+    }
+
   // Output restriction
   for (CeedInt i=0; i<qf->numoutputfields; i++) {
     // Restore evec
@@ -309,15 +316,11 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
                                   &impl->edata[i + qf->numinputfields]); CeedChk(ierr);
     // Active
     if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-      // Zero lvec
-      ierr = CeedVectorSetValue(outvec, 0.0); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(impl->blkrestr[i+impl->numein], CEED_TRANSPOSE,
                                       lmode, impl->evecs[i+impl->numein], outvec, request); CeedChk(ierr);
     } else {
       // Passive
-      // Zero lvec
-      ierr = CeedVectorSetValue(op->outputfields[i].vec, 0.0); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(impl->blkrestr[i+impl->numein], CEED_TRANSPOSE,
                                       lmode, impl->evecs[i+impl->numein], op->outputfields[i].vec,

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -284,6 +284,13 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
     }
   }
 
+  // Zero lvecs
+  ierr = CeedVectorSetValue(outvec, 0.0); CeedChk(ierr);
+  for (CeedInt i=0; i<qf->numoutputfields; i++)
+    if (op->outputfields[i].vec != CEED_VECTOR_ACTIVE) {
+      ierr = CeedVectorSetValue(op->outputfields[i].vec, 0.0); CeedChk(ierr);
+    }
+
   // Output restriction
   for (CeedInt i=0; i<qf->numoutputfields; i++) {
     // Restore evec
@@ -291,15 +298,11 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
                                   &impl->edata[i + qf->numinputfields]); CeedChk(ierr);
     // Active
     if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
-      // Zero lvec
-      ierr = CeedVectorSetValue(outvec, 0.0); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
                                       lmode, impl->evecs[i+impl->numein], outvec, request); CeedChk(ierr);
     } else {
       // Passive
-      // Zero lvec
-      ierr = CeedVectorSetValue(op->outputfields[i].vec, 0.0); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
                                       lmode, impl->evecs[i+impl->numein], op->outputfields[i].vec,


### PR DESCRIPTION
This PR moves the 'zero lvec' phase out of the output restriction apply loop in OpApply for the ref, opt, and occa backends. This lets multiple outputs for an operator write to the same vector, making more flexible operators.

This feature will be separately added in the MAGMA PR #111. (?)