### PR TITLE
Fix and use QFunctionGetNumArgs

### DIFF
--- a/backends/optimized/ceed-opt-operator.c
+++ b/backends/optimized/ceed-opt-operator.c
@@ -115,18 +115,19 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
   if (op->setupdone) return 0;
   CeedOperator_Opt *impl = op->data;
   CeedQFunction qf = op->qf;
-  CeedInt Q = op->numqpoints;
+  CeedInt Q = op->numqpoints, numinputfields, numoutputfields;
   int ierr;
 
   // Count infield and outfield array sizes and evectors
-  impl->numein = qf->numinputfields;
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields); CeedChk(ierr);
+  impl->numein = numinputfields;
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     impl->numqin += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD) +
                     !!(emode & CEED_EVAL_WEIGHT);
   }
-  impl->numeout = qf->numoutputfields;
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  impl->numeout = numoutputfields;
+  for (CeedInt i=0; i<numoutputfields; i++) {
     CeedEvalMode emode = qf->outputfields[i].emode;
     impl->numqout += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD);
   }
@@ -141,7 +142,7 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
 
   ierr = CeedCalloc(impl->numqin + impl->numqout, &impl->qdata_alloc);
   CeedChk(ierr);
-  ierr = CeedCalloc(qf->numinputfields + qf->numoutputfields, &impl->qdata);
+  ierr = CeedCalloc(numinputfields + numoutputfields, &impl->qdata);
   CeedChk(ierr);
 
   ierr = CeedCalloc(16, &impl->indata); CeedChk(ierr);
@@ -152,26 +153,26 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
                                      impl->blkrestr, impl->evecs,
                                      impl->qdata, impl->qdata_alloc,
                                      impl->indata, 0,
-                                     0, qf->numinputfields, Q);
+                                     0, numinputfields, Q);
   CeedChk(ierr);
   // Outfields
   ierr = CeedOperatorSetupFields_Opt(qf->outputfields, op->outputfields,
                                      impl->blkrestr, impl->evecs,
                                      impl->qdata, impl->qdata_alloc,
-                                     impl->indata, qf->numinputfields,
-                                     impl->numqin, qf->numoutputfields, Q);
+                                     impl->indata, numinputfields,
+                                     impl->numqin, numoutputfields, Q);
   CeedChk(ierr);
   // Input Qvecs
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     if ((emode != CEED_EVAL_NONE) && (emode != CEED_EVAL_WEIGHT))
       impl->indata[i] =  impl->qdata[i];
   }
   // Output Qvecs
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  for (CeedInt i=0; i<numoutputfields; i++) {
     CeedEvalMode emode = qf->outputfields[i].emode;
     if (emode != CEED_EVAL_NONE)
-      impl->outdata[i] =  impl->qdata[i + qf->numinputfields];
+      impl->outdata[i] =  impl->qdata[i + numinputfields];
   }
 
   op->setupdone = 1;
@@ -183,7 +184,7 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
                                  CeedVector outvec, CeedRequest *request) {
   CeedOperator_Opt *impl = op->data;
   const CeedInt blksize = 8;
-  CeedInt Q = op->numqpoints, elemsize,
+  CeedInt Q = op->numqpoints, elemsize, numinputfields, numoutputfields,
           nblks = (op->numelements/blksize) + !!(op->numelements%blksize);
   int ierr;
   CeedQFunction qf = op->qf;
@@ -191,9 +192,10 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
 
   // Setup
   ierr = CeedOperatorSetup_Opt(op); CeedChk(ierr);
+  ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields); CeedChk(ierr);
 
   // Input Evecs and Restriction
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     if (emode == CEED_EVAL_WEIGHT) { // Skip
     } else {
@@ -218,15 +220,15 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
   }
 
   // Output Evecs
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  for (CeedInt i=0; i<numoutputfields; i++) {
     ierr = CeedVectorGetArray(impl->evecs[i+impl->numein], CEED_MEM_HOST,
-                              &impl->edata[i + qf->numinputfields]); CeedChk(ierr);
+                              &impl->edata[i + numinputfields]); CeedChk(ierr);
   }
 
   // Loop through elements
   for (CeedInt e=0; e<nblks*blksize; e+=blksize) {
     // Input basis apply if needed
-    for (CeedInt i=0; i<qf->numinputfields; i++) {
+    for (CeedInt i=0; i<numinputfields; i++) {
       // Get elemsize, emode, ncomp
       elemsize = op->inputfields[i].Erestrict->elemsize;
       CeedEvalMode emode = qf->inputfields[i].emode;
@@ -256,11 +258,11 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
     }
 
     // Output pointers
-    for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    for (CeedInt i=0; i<numoutputfields; i++) {
       CeedEvalMode emode = qf->outputfields[i].emode;
       if (emode == CEED_EVAL_NONE) {
         CeedInt ncomp = qf->outputfields[i].ncomp;
-        impl->outdata[i] = &impl->edata[i + qf->numinputfields][e*Q*ncomp];
+        impl->outdata[i] = &impl->edata[i + numinputfields][e*Q*ncomp];
       }
     }
     // Q function
@@ -269,7 +271,7 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
                               impl->outdata); CeedChk(ierr);
 
     // Output basis apply if needed
-    for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    for (CeedInt i=0; i<numoutputfields; i++) {
       // Get elemsize, emode, ncomp
       elemsize = op->outputfields[i].Erestrict->elemsize;
       CeedInt ncomp = qf->outputfields[i].ncomp;
@@ -281,13 +283,13 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
       case CEED_EVAL_INTERP:
         ierr = CeedBasisApply(op->outputfields[i].basis, blksize, CEED_TRANSPOSE,
                               CEED_EVAL_INTERP, impl->outdata[i],
-                              &impl->edata[i + qf->numinputfields][e*elemsize*ncomp]);
+                              &impl->edata[i + numinputfields][e*elemsize*ncomp]);
         CeedChk(ierr);
         break;
       case CEED_EVAL_GRAD:
         ierr = CeedBasisApply(op->outputfields[i].basis, blksize, CEED_TRANSPOSE,
                               CEED_EVAL_GRAD,
-                              impl->outdata[i], &impl->edata[i + qf->numinputfields][e*elemsize*ncomp]);
+                              impl->outdata[i], &impl->edata[i + numinputfields][e*elemsize*ncomp]);
         CeedChk(ierr);
         break;
       case CEED_EVAL_WEIGHT:
@@ -303,10 +305,10 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
   }
 
   // Output restriction
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  for (CeedInt i=0; i<numoutputfields; i++) {
     // Restore evec
     ierr = CeedVectorRestoreArray(impl->evecs[i+impl->numein],
-                                  &impl->edata[i + qf->numinputfields]); CeedChk(ierr);
+                                  &impl->edata[i + numinputfields]); CeedChk(ierr);
     // Active
     if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
       // Zero lvec
@@ -326,7 +328,7 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
   }
 
   // Restore input arrays
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     if (emode == CEED_EVAL_WEIGHT) { // Skip
     } else {

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -103,18 +103,19 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
   if (op->setupdone) return 0;
   CeedOperator_Ref *impl = op->data;
   CeedQFunction qf = op->qf;
-  CeedInt Q = op->numqpoints;
+  CeedInt Q = op->numqpoints, numinputfields, numoutputfields;
   int ierr;
 
   // Count infield and outfield array sizes and evectors
-  impl->numein = qf->numinputfields;
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields); CeedChk(ierr);
+  impl->numein = numinputfields;
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     impl->numqin += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD) +
                     !!(emode & CEED_EVAL_WEIGHT);
   }
-  impl->numeout = qf->numoutputfields;
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  impl->numeout = numoutputfields;
+  for (CeedInt i=0; i<numoutputfields; i++) {
     CeedEvalMode emode = qf->outputfields[i].emode;
     impl->numqout += !!(emode & CEED_EVAL_INTERP) + !!(emode & CEED_EVAL_GRAD);
   }
@@ -126,7 +127,7 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
 
   ierr = CeedCalloc(impl->numqin + impl->numqout, &impl->qdata_alloc);
   CeedChk(ierr);
-  ierr = CeedCalloc(qf->numinputfields + qf->numoutputfields, &impl->qdata);
+  ierr = CeedCalloc(numinputfields + numoutputfields, &impl->qdata);
   CeedChk(ierr);
 
   ierr = CeedCalloc(16, &impl->indata); CeedChk(ierr);
@@ -137,25 +138,25 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
   ierr = CeedOperatorSetupFields_Ref(qf->inputfields, op->inputfields,
                                      impl->evecs, impl->qdata, impl->qdata_alloc,
                                      impl->indata, 0, 0,
-                                     qf->numinputfields, Q); CeedChk(ierr);
+                                     numinputfields, Q); CeedChk(ierr);
 
   // Outfields
   ierr = CeedOperatorSetupFields_Ref(qf->outputfields, op->outputfields,
                                      impl->evecs, impl->qdata, impl->qdata_alloc,
-                                     impl->indata, qf->numinputfields,
-                                     impl->numqin, qf->numoutputfields, Q); CeedChk(ierr);
+                                     impl->indata, numinputfields,
+                                     impl->numqin, numoutputfields, Q); CeedChk(ierr);
 
   // Input Qvecs
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     if ((emode != CEED_EVAL_NONE) && (emode != CEED_EVAL_WEIGHT))
       impl->indata[i] =  impl->qdata[i];
   }
   // Output Qvecs
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  for (CeedInt i=0; i<numoutputfields; i++) {
     CeedEvalMode emode = qf->outputfields[i].emode;
     if (emode != CEED_EVAL_NONE)
-      impl->outdata[i] =  impl->qdata[i + qf->numinputfields];
+      impl->outdata[i] =  impl->qdata[i + numinputfields];
   }
 
   op->setupdone = 1;
@@ -166,16 +167,17 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
 static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
                                  CeedVector outvec, CeedRequest *request) {
   CeedOperator_Ref *impl = op->data;
-  CeedInt Q = op->numqpoints, elemsize;
+  CeedInt Q = op->numqpoints, elemsize, numinputfields, numoutputfields;
   int ierr;
   CeedQFunction qf = op->qf;
   CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   // Setup
   ierr = CeedOperatorSetup_Ref(op); CeedChk(ierr);
+  ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields); CeedChk(ierr);
 
   // Input Evecs and Restriction
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     if (emode == CEED_EVAL_WEIGHT) { // Skip
     } else {
@@ -202,15 +204,15 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   }
 
   // Output Evecs
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  for (CeedInt i=0; i<numoutputfields; i++) {
     ierr = CeedVectorGetArray(impl->evecs[i+impl->numein], CEED_MEM_HOST,
-                              &impl->edata[i + qf->numinputfields]); CeedChk(ierr);
+                              &impl->edata[i + numinputfields]); CeedChk(ierr);
   }
 
   // Loop through elements
   for (CeedInt e=0; e<op->numelements; e++) {
     // Input basis apply if needed
-    for (CeedInt i=0; i<qf->numinputfields; i++) {
+    for (CeedInt i=0; i<numinputfields; i++) {
       // Get elemsize, emode, ncomp
       elemsize = op->inputfields[i].Erestrict->elemsize;
       CeedEvalMode emode = qf->inputfields[i].emode;
@@ -239,11 +241,11 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
       }
     }
     // Output pointers
-    for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    for (CeedInt i=0; i<numoutputfields; i++) {
       CeedEvalMode emode = qf->outputfields[i].emode;
       if (emode == CEED_EVAL_NONE) {
         CeedInt ncomp = qf->outputfields[i].ncomp;
-        impl->outdata[i] = &impl->edata[i + qf->numinputfields][e*Q*ncomp];
+        impl->outdata[i] = &impl->edata[i + numinputfields][e*Q*ncomp];
       }
     }
     // Q function
@@ -251,7 +253,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
                               impl->outdata); CeedChk(ierr);
 
     // Output basis apply if needed
-    for (CeedInt i=0; i<qf->numoutputfields; i++) {
+    for (CeedInt i=0; i<numoutputfields; i++) {
       // Get elemsize, emode, ncomp
       elemsize = op->outputfields[i].Erestrict->elemsize;
       CeedInt ncomp = qf->outputfields[i].ncomp;
@@ -263,13 +265,13 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
       case CEED_EVAL_INTERP:
         ierr = CeedBasisApply(op->outputfields[i].basis, 1, CEED_TRANSPOSE,
                               CEED_EVAL_INTERP, impl->outdata[i],
-                              &impl->edata[i + qf->numinputfields][e*elemsize*ncomp]);
+                              &impl->edata[i + numinputfields][e*elemsize*ncomp]);
         CeedChk(ierr);
         break;
       case CEED_EVAL_GRAD:
         ierr = CeedBasisApply(op->outputfields[i].basis, 1, CEED_TRANSPOSE,
                               CEED_EVAL_GRAD,
-                              impl->outdata[i], &impl->edata[i + qf->numinputfields][e*elemsize*ncomp]);
+                              impl->outdata[i], &impl->edata[i + numinputfields][e*elemsize*ncomp]);
         CeedChk(ierr);
         break;
       case CEED_EVAL_WEIGHT:
@@ -285,10 +287,10 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   }
 
   // Output restriction
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
+  for (CeedInt i=0; i<numoutputfields; i++) {
     // Restore evec
     ierr = CeedVectorRestoreArray(impl->evecs[i+impl->numein],
-                                  &impl->edata[i + qf->numinputfields]); CeedChk(ierr);
+                                  &impl->edata[i + numinputfields]); CeedChk(ierr);
     // Active
     if (op->outputfields[i].vec == CEED_VECTOR_ACTIVE) {
       // Zero lvec
@@ -308,7 +310,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   }
 
   // Restore input arrays
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
+  for (CeedInt i=0; i<numinputfields; i++) {
     CeedEvalMode emode = qf->inputfields[i].emode;
     if (emode == CEED_EVAL_WEIGHT) { // Skip
     } else {

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -157,21 +157,8 @@ int CeedQFunctionAddOutput(CeedQFunction qf, const char *fieldname,
 
 int CeedQFunctionGetNumArgs(CeedQFunction qf, CeedInt *numinput,
                             CeedInt *numoutput) {
-  CeedInt nin = 0, nout = 0;
-  for (CeedInt i=0; i<qf->numinputfields; i++) {
-    CeedEvalMode emode = qf->inputfields[i].emode;
-    if (emode == CEED_EVAL_NONE) nin++;  // Colocated field is input directly
-    if (emode & CEED_EVAL_INTERP) nin++; // Interpolate to quadrature points
-    if (emode & CEED_EVAL_GRAD) nin++;   // Gradients at quadrature points
-  }
-  for (CeedInt i=0; i<qf->numoutputfields; i++) {
-    CeedEvalMode emode = qf->outputfields[i].emode;
-    if (emode == CEED_EVAL_NONE) nout++;
-    if (emode & CEED_EVAL_INTERP) nout++;
-    if (emode & CEED_EVAL_GRAD) nout++;
-  }
-  if (numinput) *numinput = nin;
-  if (numoutput) *numoutput = nout;
+  if (numinput) *numinput = qf->numinputfields;
+  if (numoutput) *numoutput = qf->numoutputfields;
   return 0;
 }
 


### PR DESCRIPTION
This PR fixes "QFunctionGetNumArgs" to reflect the fact that we only allow one emode per field now and uses it to clean up the backend code. Eventually it would be nice to have similar functions for all private data backends may want to use.

Again, will be added to PR #111 separately.

With this PR, it looks like only the error handling and request functionality in the interface won't be fully tested.