### PR TITLE
Rename /cpu/self/opt to /cpu/self/vec

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -800,7 +800,7 @@ INPUT                  = . \
                          examples/petsc \
                          backends/ref \
                          backends/occa \
-                         backends/optimized \
+                         backends/blocked \
                          backends/tmpl \
                          backends/magma \
                          tests \

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ SO_EXT := $(if $(DARWIN),dylib,so)
 ceed.pc := $(LIBDIR)/pkgconfig/ceed.pc
 libceed := $(LIBDIR)/libceed.$(SO_EXT)
 libceed.c := $(wildcard interface/ceed*.c)
-BACKENDS_BUILTIN := /cpu/self/ref /cpu/self/tmpl /cpu/self/opt
+BACKENDS_BUILTIN := /cpu/self/ref /cpu/self/tmpl /cpu/self/blocked
 BACKENDS := $(BACKENDS_BUILTIN)
 
 # Tests
@@ -118,10 +118,10 @@ mfemexamples  := $(mfemexamples.cpp:examples/mfem/%.cpp=$(OBJDIR)/mfem-%)
 petscexamples.c := $(sort $(wildcard examples/petsc/*.c))
 petscexamples  := $(petscexamples.c:examples/petsc/%.c=$(OBJDIR)/petsc-%)
 
-# backends/[ref, template, optimized, occa, magma]
+# backends/[ref, template, blocked, occa, magma]
 ref.c      := $(sort $(wildcard backends/ref/*.c))
 template.c := $(sort $(wildcard backends/template/*.c))
-optimized.c:= $(sort $(wildcard backends/optimized/*.c))
+blocked.c  := $(sort $(wildcard backends/blocked/*.c))
 occa.c     := $(sort $(wildcard backends/occa/*.c))
 magma_preprocessor := python backends/magma/gccm.py
 magma_pre_src  := $(filter-out %_tmp.c, $(wildcard backends/magma/ceed-*.c))
@@ -202,7 +202,7 @@ $(libceed) : LDFLAGS += $(if $(DARWIN), -install_name @rpath/$(notdir $(libceed)
 
 libceed.c += $(ref.c)
 libceed.c += $(template.c)
-libceed.c += $(optimized.c)
+libceed.c += $(blocked.c)
 
 ifneq ($(wildcard $(OCCA_DIR)/lib/libocca.*),)
   $(libceed) : LDFLAGS += -L$(OCCA_DIR)/lib -Wl,-rpath,$(abspath $(OCCA_DIR)/lib)

--- a/README.md
+++ b/README.md
@@ -110,16 +110,16 @@ The above code assumes a GPU-capable machine enabled in the OCCA
 backend. Depending on the available backends, other Ceed resource specifiers can
 be provided with the `-ceed` option, for example:
 
-|  CEED resource (`-ceed`) | Backend                                       |
-| :----------------------- | :-------------------------------------------- |
-| `/cpu/self/opt`          | Serial optimized implementation               |
-| `/cpu/self/ref`          | Serial reference implementation               |
-| `/cpu/self/tmpl`         | Backend template, dispatches to /cpu/self/opt |
-| `/cpu/occa`              | Serial OCCA kernels                           |
-| `/gpu/occa`              | CUDA OCCA kernels                             |
-| `/omp/occa`              | OpenMP OCCA kernels                           |
-| `/ocl/occa`              | OpenCL OCCA kernels                           |
-| `/gpu/magma`             | CUDA MAGMA kernels                            |
+|  CEED resource (`-ceed`) | Backend                                           |
+| :----------------------- | :------------------------------------------------ |
+| `/cpu/self/blocked`      | Serial blocked implementation                     |
+| `/cpu/self/ref`          | Serial reference implementation                   |
+| `/cpu/self/tmpl`         | Backend template, dispatches to /cpu/self/blocked |
+| `/cpu/occa`              | Serial OCCA kernels                               |
+| `/gpu/occa`              | CUDA OCCA kernels                                 |
+| `/omp/occa`              | OpenMP OCCA kernels                               |
+| `/ocl/occa`              | OpenCL OCCA kernels                               |
+| `/gpu/magma`             | CUDA MAGMA kernels                                |
 
 ## Install
 

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -16,11 +16,11 @@
 
 #include <ceed-impl.h>
 #include <string.h>
-#include "ceed-opt.h"
+#include "ceed-blocked.h"
 #include "../ref/ceed-ref.h"
 
-static int CeedOperatorDestroy_Opt(CeedOperator op) {
-  CeedOperator_Opt *impl = op->data;
+static int CeedOperatorDestroy_Blocked(CeedOperator op) {
+  CeedOperator_Blocked *impl = op->data;
   int ierr;
 
   for (CeedInt i=0; i<impl->numein+impl->numeout; i++) {
@@ -47,7 +47,7 @@ static int CeedOperatorDestroy_Opt(CeedOperator op) {
 /*
   Setup infields or outfields
  */
-static int CeedOperatorSetupFields_Opt(struct CeedQFunctionField qfields[16],
+static int CeedOperatorSetupFields_Blocked(struct CeedQFunctionField qfields[16],
                                        struct CeedOperatorField ofields[16],
                                        CeedElemRestriction *blkrestr,
                                        CeedVector *evecs, CeedScalar **qdata,
@@ -111,9 +111,9 @@ static int CeedOperatorSetupFields_Opt(struct CeedQFunctionField qfields[16],
   CeedOperator needs to connect all the named fields (be they active or passive)
   to the named inputs and outputs of its CeedQFunction.
  */
-static int CeedOperatorSetup_Opt(CeedOperator op) {
+static int CeedOperatorSetup_Blocked(CeedOperator op) {
   if (op->setupdone) return 0;
-  CeedOperator_Opt *impl = op->data;
+  CeedOperator_Blocked *impl = op->data;
   CeedQFunction qf = op->qf;
   CeedInt Q = op->numqpoints, numinputfields, numoutputfields;
   int ierr;
@@ -150,14 +150,14 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
   ierr = CeedCalloc(16, &impl->outdata); CeedChk(ierr);
   // Set up infield and outfield pointer arrays
   // Infields
-  ierr = CeedOperatorSetupFields_Opt(qf->inputfields, op->inputfields,
+  ierr = CeedOperatorSetupFields_Blocked(qf->inputfields, op->inputfields,
                                      impl->blkrestr, impl->evecs,
                                      impl->qdata, impl->qdata_alloc,
                                      impl->indata, 0,
                                      0, numinputfields, Q);
   CeedChk(ierr);
   // Outfields
-  ierr = CeedOperatorSetupFields_Opt(qf->outputfields, op->outputfields,
+  ierr = CeedOperatorSetupFields_Blocked(qf->outputfields, op->outputfields,
                                      impl->blkrestr, impl->evecs,
                                      impl->qdata, impl->qdata_alloc,
                                      impl->indata, numinputfields,
@@ -181,9 +181,9 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
   return 0;
 }
 
-static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
+static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
                                  CeedVector outvec, CeedRequest *request) {
-  CeedOperator_Opt *impl = op->data;
+  CeedOperator_Blocked *impl = op->data;
   const CeedInt blksize = 8;
   CeedInt Q = op->numqpoints, elemsize, numinputfields, numoutputfields,
           nblks = (op->numelements/blksize) + !!(op->numelements%blksize);
@@ -192,7 +192,7 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
   CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   // Setup
-  ierr = CeedOperatorSetup_Opt(op); CeedChk(ierr);
+  ierr = CeedOperatorSetup_Blocked(op); CeedChk(ierr);
   ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
   CeedChk(ierr);
 
@@ -345,13 +345,13 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
   return 0;
 }
 
-int CeedOperatorCreate_Opt(CeedOperator op) {
-  CeedOperator_Opt *impl;
+int CeedOperatorCreate_Blocked(CeedOperator op) {
+  CeedOperator_Blocked *impl;
   int ierr;
 
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   op->data = impl;
-  op->Destroy = CeedOperatorDestroy_Opt;
-  op->Apply = CeedOperatorApply_Opt;
+  op->Destroy = CeedOperatorDestroy_Blocked;
+  op->Apply = CeedOperatorApply_Blocked;
   return 0;
 }

--- a/backends/blocked/ceed-blocked-qfunction.c
+++ b/backends/blocked/ceed-blocked-qfunction.c
@@ -16,11 +16,11 @@
 
 #include <ceed-impl.h>
 #include <string.h>
-#include "ceed-opt.h"
+#include "ceed-blocked.h"
 
-int CeedQFunctionCreate_Opt(CeedQFunction qf) {
+int CeedQFunctionCreate_Blocked(CeedQFunction qf) {
   int ierr;
-  Ceed_Opt *impl = qf->ceed->data;
+  Ceed_Blocked *impl = qf->ceed->data;
   Ceed ceedref = impl->ceedref;
   ierr = ceedref->QFunctionCreate(qf);
   CeedChk(ierr);

--- a/backends/blocked/ceed-blocked-restrict.c
+++ b/backends/blocked/ceed-blocked-restrict.c
@@ -16,13 +16,13 @@
 
 #include <ceed-impl.h>
 #include <string.h>
-#include "ceed-opt.h"
+#include "ceed-blocked.h"
 
-int CeedElemRestrictionCreate_Opt(CeedElemRestriction r,
+int CeedElemRestrictionCreate_Blocked(CeedElemRestriction r,
                                   CeedMemType mtype,
                                   CeedCopyMode cmode, const CeedInt *indices) {
   int ierr;
-  Ceed_Opt *impl = r->ceed->data;
+  Ceed_Blocked *impl = r->ceed->data;
   Ceed ceedref = impl->ceedref;
   ierr = ceedref->ElemRestrictionCreate(r, mtype, cmode, indices);
   CeedChk(ierr);

--- a/backends/blocked/ceed-blocked-vector.c
+++ b/backends/blocked/ceed-blocked-vector.c
@@ -16,11 +16,11 @@
 
 #include <ceed-impl.h>
 #include <string.h>
-#include "ceed-opt.h"
+#include "ceed-blocked.h"
 
-int CeedVectorCreate_Opt(Ceed ceed, CeedInt n, CeedVector vec) {
+int CeedVectorCreate_Blocked(Ceed ceed, CeedInt n, CeedVector vec) {
   int ierr;
-  Ceed_Opt *impl = ceed->data;
+  Ceed_Blocked *impl = ceed->data;
   Ceed ceedref = impl->ceedref;
   ierr = ceedref->VecCreate(ceed, n, vec); CeedChk(ierr);
 

--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -16,24 +16,24 @@
 
 #include <ceed-impl.h>
 #include <string.h>
-#include "ceed-opt.h"
+#include "ceed-blocked.h"
 
-static int CeedDestroy_Opt(Ceed ceed) {
+static int CeedDestroy_Blocked(Ceed ceed) {
   int ierr;
-  Ceed_Opt *impl = ceed->data;
+  Ceed_Blocked *impl = ceed->data;
   Ceed ceedref = impl->ceedref;
   ierr = CeedFree(&ceedref); CeedChk(ierr);
   ierr = CeedFree(&impl); CeedChk(ierr);
   return 0;
 }
 
-static int CeedInit_Opt(const char *resource, Ceed ceed) {
+static int CeedInit_Blocked(const char *resource, Ceed ceed) {
   if (strcmp(resource, "/cpu/self")
-      && strcmp(resource, "/cpu/self/opt"))
-    return CeedError(ceed, 1, "Opt backend cannot use resource: %s", resource);
+      && strcmp(resource, "/cpu/self/blocked"))
+    return CeedError(ceed, 1, "Blocked backend cannot use resource: %s", resource);
 
   int ierr;
-  Ceed_Opt *impl;
+  Ceed_Blocked *impl;
   Ceed ceedref;
 
   // Create refrence CEED that implementation will be dispatched
@@ -43,19 +43,19 @@ static int CeedInit_Opt(const char *resource, Ceed ceed) {
   ceed->data = impl;
   impl->ceedref = ceedref;
 
-  ceed->VecCreate = CeedVectorCreate_Opt;
-  ceed->BasisCreateTensorH1 = CeedBasisCreateTensorH1_Opt;
-  ceed->BasisCreateH1 = CeedBasisCreateH1_Opt;
-  ceed->ElemRestrictionCreate = CeedElemRestrictionCreate_Opt;
-  ceed->ElemRestrictionCreateBlocked = CeedElemRestrictionCreate_Opt;
-  ceed->QFunctionCreate = CeedQFunctionCreate_Opt;
-  ceed->OperatorCreate = CeedOperatorCreate_Opt;
-  ceed->Destroy = CeedDestroy_Opt;
+  ceed->VecCreate = CeedVectorCreate_Blocked;
+  ceed->BasisCreateTensorH1 = CeedBasisCreateTensorH1_Blocked;
+  ceed->BasisCreateH1 = CeedBasisCreateH1_Blocked;
+  ceed->ElemRestrictionCreate = CeedElemRestrictionCreate_Blocked;
+  ceed->ElemRestrictionCreateBlocked = CeedElemRestrictionCreate_Blocked;
+  ceed->QFunctionCreate = CeedQFunctionCreate_Blocked;
+  ceed->OperatorCreate = CeedOperatorCreate_Blocked;
+  ceed->Destroy = CeedDestroy_Blocked;
 
   return 0;
 }
 
 __attribute__((constructor))
 static void Register(void) {
-  CeedRegister("/cpu/self/opt", CeedInit_Opt, 10);
+  CeedRegister("/cpu/self/blocked", CeedInit_Blocked, 10);
 }

--- a/backends/blocked/ceed-blocked.h
+++ b/backends/blocked/ceed-blocked.h
@@ -19,14 +19,14 @@
 
 typedef struct {
   Ceed ceedref;
-} Ceed_Opt;
+} Ceed_Blocked;
 
 typedef struct {
   CeedScalar *colograd1d;
-} CeedBasis_Opt;
+} CeedBasis_Blocked;
 
 typedef struct {
-  CeedElemRestriction *blkrestr; /// Block versions of restrictions
+  CeedElemRestriction *blkrestr; /// Blocked versions of restrictions
   CeedVector
   *evecs;   /// E-vectors needed to apply operator (input followed by outputs)
   CeedScalar **edata;
@@ -39,15 +39,15 @@ typedef struct {
   CeedInt    numeout;
   CeedInt    numqin;
   CeedInt    numqout;
-} CeedOperator_Opt;
+} CeedOperator_Blocked;
 
-CEED_INTERN int CeedVectorCreate_Opt(Ceed ceed, CeedInt n, CeedVector vec);
+CEED_INTERN int CeedVectorCreate_Blocked(Ceed ceed, CeedInt n, CeedVector vec);
 
-CEED_INTERN int CeedElemRestrictionCreate_Opt(CeedElemRestriction r,
+CEED_INTERN int CeedElemRestrictionCreate_Blocked(CeedElemRestriction r,
     CeedMemType mtype,
     CeedCopyMode cmode, const CeedInt *indices);
 
-CEED_INTERN int CeedBasisCreateTensorH1_Opt(Ceed ceed, CeedInt dim,
+CEED_INTERN int CeedBasisCreateTensorH1_Blocked(Ceed ceed, CeedInt dim,
     CeedInt P1d,
     CeedInt Q1d, const CeedScalar *interp1d,
     const CeedScalar *grad1d,
@@ -55,7 +55,7 @@ CEED_INTERN int CeedBasisCreateTensorH1_Opt(Ceed ceed, CeedInt dim,
     const CeedScalar *qweight1d,
     CeedBasis basis);
 
-CEED_INTERN int CeedBasisCreateH1_Opt(Ceed ceed, CeedElemTopology topo,
+CEED_INTERN int CeedBasisCreateH1_Blocked(Ceed ceed, CeedElemTopology topo,
                                       CeedInt dim,
                                       CeedInt ndof, CeedInt nqpts,
                                       const CeedScalar *interp,
@@ -64,6 +64,6 @@ CEED_INTERN int CeedBasisCreateH1_Opt(Ceed ceed, CeedElemTopology topo,
                                       const CeedScalar *qweight,
                                       CeedBasis basis);
 
-CEED_INTERN int CeedQFunctionCreate_Opt(CeedQFunction qf);
+CEED_INTERN int CeedQFunctionCreate_Blocked(CeedQFunction qf);
 
-CEED_INTERN int CeedOperatorCreate_Opt(CeedOperator op);
+CEED_INTERN int CeedOperatorCreate_Blocked(CeedOperator op);

--- a/tests/tap.sh
+++ b/tests/tap.sh
@@ -7,7 +7,7 @@ export CEED_ERROR_HANDLER=exit
 
 output=$(mktemp $1.XXXX)
 
-backends=(${BACKENDS:?Variable must be set, e.g., \"/cpu/self/ref /cpu/self/opt\"})
+backends=(${BACKENDS:?Variable must be set, e.g., \"/cpu/self/ref /cpu/self/blocked\"})
 printf "1..$[3*${#backends[@]}]\n";
 
 # for examples/ceed petsc*, mfem*, or ex* grep the code to fetch arguments from a TESTARGS line


### PR DESCRIPTION
This PR renames `cpu/self/opt` to `cpu/self/vec`, to be more specific and to align with the fact that there will be other optimized CPU backends.