### PR TITLE
Add print number of global dofs for PETSc BPs

### DIFF
--- a/examples/petsc/bp1.c
+++ b/examples/petsc/bp1.c
@@ -243,7 +243,14 @@ int main(int argc, char **argv) {
 
   GlobalDof(p, irank, degree, melem, mdof);
 
+  ierr = VecCreate(comm, &X); CHKERRQ(ierr);
+  ierr = VecSetSizes(X, mdof[0] * mdof[1] * mdof[2], PETSC_DECIDE); CHKERRQ(ierr);
+  ierr = VecSetUp(X); CHKERRQ(ierr);
+
   if (!test_mode) {
+    CeedInt gsize;
+    ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
+    ierr = PetscPrintf(comm, "Global dofs: %D\n", gsize); CHKERRQ(ierr);
     ierr = PetscPrintf(comm, "Process decomposition: %D %D %D\n",
                        p[0], p[1], p[2]); CHKERRQ(ierr);
     ierr = PetscPrintf(comm, "Local elements: %D = %D %D %D\n", localelem,
@@ -253,10 +260,6 @@ int main(int argc, char **argv) {
   }
 
   {
-    ierr = VecCreate(comm, &X); CHKERRQ(ierr);
-    ierr = VecSetSizes(X, mdof[0] * mdof[1] * mdof[2], PETSC_DECIDE); CHKERRQ(ierr);
-    ierr = VecSetUp(X); CHKERRQ(ierr);
-
     lsize = 1;
     for (int d=0; d<3; d++) {
       ldof[d] = melem[d]*degree + 1;

--- a/examples/petsc/bp1.c
+++ b/examples/petsc/bp1.c
@@ -469,6 +469,7 @@ int main(int argc, char **argv) {
   }
 
   ierr = VecDestroy(&rhs); CHKERRQ(ierr);
+  ierr = VecDestroy(&rhsloc); CHKERRQ(ierr);
   ierr = VecDestroy(&X); CHKERRQ(ierr);
   ierr = VecDestroy(&user->Xloc); CHKERRQ(ierr);
   ierr = VecDestroy(&user->Yloc); CHKERRQ(ierr);

--- a/examples/petsc/bp3.c
+++ b/examples/petsc/bp3.c
@@ -249,7 +249,14 @@ int main(int argc, char **argv) {
 
   GlobalDof(p, irank, degree, melem, mdof);
 
+  ierr = VecCreate(comm, &X); CHKERRQ(ierr);
+  ierr = VecSetSizes(X, mdof[0] * mdof[1] * mdof[2], PETSC_DECIDE); CHKERRQ(ierr);
+  ierr = VecSetUp(X); CHKERRQ(ierr);
+
   if (!test_mode) {
+    CeedInt gsize;
+    ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
+    ierr = PetscPrintf(comm, "Global dofs: %D\n", gsize); CHKERRQ(ierr);
     ierr = PetscPrintf(comm, "Process decomposition: %D %D %D\n",
                        p[0], p[1], p[2]); CHKERRQ(ierr);
     ierr = PetscPrintf(comm, "Local elements: %D = %D %D %D\n", localelem,
@@ -259,10 +266,6 @@ int main(int argc, char **argv) {
   }
 
   {
-    ierr = VecCreate(comm, &X); CHKERRQ(ierr);
-    ierr = VecSetSizes(X, mdof[0] * mdof[1] * mdof[2], PETSC_DECIDE); CHKERRQ(ierr);
-    ierr = VecSetUp(X); CHKERRQ(ierr);
-
     lsize = 1;
     for (int d=0; d<3; d++) {
       ldof[d] = melem[d]*degree + 1;

--- a/examples/petsc/bp3.c
+++ b/examples/petsc/bp3.c
@@ -323,10 +323,22 @@ int main(int argc, char **argv) {
     ierr = VecScatterCreate(Xloc, locis, X, ltogis0, &ltog0); CHKERRQ(ierr);
     { // Create global-to-global scatter for Dirichlet values (everything not in
       // ltogis0, which is the range of ltog0)
-      PetscInt xstart, xend;
+      PetscInt xstart, xend, *indD, countD = 0;
       IS isD;
+      const PetscScalar *x;
+      ierr = VecZeroEntries(Xloc); CHKERRQ(ierr);
+      ierr = VecSet(X, 1.0); CHKERRQ(ierr);
+      ierr = VecScatterBegin(ltog0, Xloc, X, INSERT_VALUES, SCATTER_FORWARD); CHKERRQ(ierr);
+      ierr = VecScatterEnd(ltog0, Xloc, X, INSERT_VALUES, SCATTER_FORWARD); CHKERRQ(ierr);
       ierr = VecGetOwnershipRange(X, &xstart, &xend); CHKERRQ(ierr);
-      ierr = ISComplement(ltogis0, xstart, xend, &isD); CHKERRQ(ierr);
+      ierr = PetscMalloc1(xend-xstart, &indD); CHKERRQ(ierr);
+      ierr = VecGetArrayRead(X, &x);CHKERRQ(ierr);
+      for (PetscInt i=0; i<xend-xstart; i++) {
+        if (x[i] == 1.) indD[countD++] = xstart + i;
+      }
+      ierr = VecRestoreArrayRead(X, &x); CHKERRQ(ierr);
+      ierr = ISCreateGeneral(comm, countD, indD, PETSC_COPY_VALUES, &isD); CHKERRQ(ierr);
+      ierr = PetscFree(indD); CHKERRQ(ierr);
       ierr = VecScatterCreate(X, isD, X, isD, &gtogD); CHKERRQ(ierr);
       ierr = ISDestroy(&isD); CHKERRQ(ierr);
     }


### PR DESCRIPTION
I added a printout of the number of global dofs for the PETSc BPs.

Sample output:

```
[jeth8984@shas0136 petsc]$ mpiexec -n 2 ./bp1 -ksp_view
Global dofs: 2541
Process decomposition: 2 1 1
Local elements: 1000 = 10 10 10
Owned dofs: 1210 = 10 11 11
KSP Object: 2 MPI processes
  type: cg
  maximum iterations=10000, initial guess is zero
  tolerances:  relative=1e-10, absolute=1e-50, divergence=10000.
  left preconditioning
  using PRECONDITIONED norm type for convergence test
PC Object: 2 MPI processes
  type: jacobi
  linear system matrix = precond matrix:
  Mat Object: 2 MPI processes
    type: shell
    rows=2541, cols=2541
KSP cg CONVERGED_RTOL iterations 34 rnorm 3.992091e-09
Pointwise error (max) 1.267540e-02
[jeth8984@shas0136 petsc]$ mpiexec -n 8 ./bp1 -ksp_view
Global dofs: 9261
Process decomposition: 2 2 2
Local elements: 1000 = 10 10 10
Owned dofs: 1000 = 10 10 10
KSP Object: 8 MPI processes
  type: cg
  maximum iterations=10000, initial guess is zero
  tolerances:  relative=1e-10, absolute=1e-50, divergence=10000.
  left preconditioning
  using PRECONDITIONED norm type for convergence test
PC Object: 8 MPI processes
  type: jacobi
  linear system matrix = precond matrix:
  Mat Object: 8 MPI processes
    type: shell
    rows=9261, cols=9261
KSP cg CONVERGED_RTOL iterations 31 rnorm 8.744846e-09
Pointwise error (max) 5.198906e-03
```