### PR TITLE
Fix PETSC BPs make ordering

### DIFF
--- a/examples/petsc/Makefile
+++ b/examples/petsc/Makefile
@@ -9,7 +9,7 @@ LDFLAGS = $(call pkgconf, --libs-only-L --libs-only-other $(PETSc.pc) $(ceed.pc)
 LDFLAGS += $(patsubst -L%, $(call pkgconf, --variable=ldflag_rpath $(PETSc.pc))%, $(call pkgconf, --libs-only-L $(PETSc.pc) $(ceed.pc)))
 LDLIBS = $(call pkgconf, --libs-only-l $(PETSc.pc) $(ceed.pc)) -lm
 
-bp.c := $(wildcard bp*.c)
+bp.c := $(sort $(wildcard bp*.c))
 bp := $(bp.c:%.c=%)
 
 all: $(bp)


### PR DESCRIPTION
Minor - PETSc examples makefile did bp3 before bp1 and it annoyed me.