### PR TITLE
Add LMode field to CeedOperatorSetField

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
   - osx
 
+dist: xenial
+
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,15 +45,26 @@ install:
   - export CURR_DIR=$PWD
   - cd $HOME/install
   - if [[ -d mfem ]]; then
-        git -C mfem pull --depth 1
-        && git -C mfem gc --prune=all;
+        git -C mfem pull --depth 1 --allow-unrelated-histories;
+        if [[ $? -eq 0 ]]; then
+          git -C mfem gc --prune=all;
+        else 
+          rm -rf mfem
+          && git clone --depth 1 https://github.com/mfem/mfem.git;
+        fi
     else
         git clone --depth 1 https://github.com/mfem/mfem.git;
     fi
   - make -C mfem -j2 serial MFEM_CXXFLAGS=-O
   - if [[ -d occa ]]; then
-        git -C occa pull
-        && git -C occa reset --hard $OCCA_HEAD;
+        git -C occa pull --allow-unrelated-histories;
+        if [[ $? -eq 0 ]]; then
+          git -C occa reset --hard $OCCA_HEAD;
+        else
+          rm -rf occa
+          && git clone https://github.com/libocca/occa.git
+          && git -C occa reset --hard $OCCA_HEAD;
+        fi
     else
         git clone https://github.com/libocca/occa.git
         && git -C occa reset --hard $OCCA_HEAD;

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -225,7 +225,7 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
   ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
   CeedChk(ierr);
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedTransposeMode lmode;
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -251,6 +251,7 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
       if (vec == CEED_VECTOR_ACTIVE)
         vec = invec;
       // Restrict
+      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionApply(impl->blkrestr[i], CEED_NOTRANSPOSE,
                                       lmode, vec, impl->evecs[i],
                                       request); CeedChk(ierr); CeedChk(ierr);
@@ -388,6 +389,7 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
     if (vec == CEED_VECTOR_ACTIVE)
       vec = outvec;
     // Restrict
+    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
     ierr = CeedElemRestrictionApply(impl->blkrestr[i+impl->numein], CEED_TRANSPOSE,
                                       lmode, impl->evecs[i+impl->numein], vec,
                                       request); CeedChk(ierr);

--- a/backends/magma/ceed-magma.c
+++ b/backends/magma/ceed-magma.c
@@ -877,7 +877,6 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
   CeedInt Q = op->numqpoints, elemsize;
   int ierr;
   CeedQFunction qf = op->qf;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedScalar *vec_temp;
 
   // Setup
@@ -898,7 +897,7 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
       if (op->inputfields[i].vec == CEED_VECTOR_ACTIVE) {
         // Restrict
         ierr = CeedElemRestrictionApply(op->inputfields[i].Erestrict, CEED_NOTRANSPOSE,
-                                        lmode, invec, opmagma->evecs[ieiin],
+                                        op->inputfields[i].lmode, invec, opmagma->evecs[ieiin],
                                         request); CeedChk(ierr);
         // Get evec
         ierr = CeedVectorGetArrayRead(opmagma->evecs[i], CEED_MEM_HOST,
@@ -907,7 +906,7 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
         // Passive
         // Restrict
         ierr = CeedElemRestrictionApply(op->inputfields[i].Erestrict, CEED_NOTRANSPOSE,
-                                        lmode, op->inputfields[i].vec, opmagma->evecs[i],
+                                        op->inputfields[i].lmode, op->inputfields[i].vec, opmagma->evecs[i],
                                         request); CeedChk(ierr);
         // Get evec
         ierr = CeedVectorGetArrayRead(opmagma->evecs[i], CEED_MEM_HOST,
@@ -1012,7 +1011,7 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
       ierr = CeedVectorRestoreArray(outvec, &vec_temp); CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
-                                      lmode, opmagma->evecs[i+opmagma->numein], outvec, request); CeedChk(ierr);
+                                      op->outputfields[i].lmode, opmagma->evecs[i+opmagma->numein], outvec, request); CeedChk(ierr);
     } else {
       // Passive
       // Restore evec
@@ -1027,7 +1026,7 @@ static int CeedOperatorApply_Magma(CeedOperator op, CeedVector invec,
       CeedChk(ierr);
       // Restrict
       ierr = CeedElemRestrictionApply(op->outputfields[i].Erestrict, CEED_TRANSPOSE,
-                                      lmode, opmagma->evecs[i+opmagma->numein], op->outputfields[i].vec,
+                                      op->outputfields[i].lmode, opmagma->evecs[i+opmagma->numein], op->outputfields[i].vec,
                                       request); CeedChk(ierr);
     }
   }

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -366,7 +366,7 @@ static int CeedOperatorApply_Occa(CeedOperator op,
   ierr = CeedOperatorGetNumElements(op, &numelements); CeedChk(ierr);
   CeedQFunction qf;
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedTransposeMode lmode;
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -404,6 +404,7 @@ static int CeedOperatorApply_Occa(CeedOperator op,
       // Restrict
       ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict);
       CeedChk(ierr);
+      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionApply(Erestrict, CEED_NOTRANSPOSE,
                                       lmode, vec, data->Evecs[i],
                                       request); CeedChk(ierr);
@@ -587,6 +588,7 @@ static int CeedOperatorApply_Occa(CeedOperator op,
     // Restrict
     ierr = CeedOperatorFieldGetElemRestriction(opoutputfields[i], &Erestrict);
     CeedChk(ierr);
+    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
     ierr = CeedElemRestrictionApply(Erestrict, CEED_TRANSPOSE,
                                     lmode, data->Evecs[i+data->numein], vec,
                                     request); CeedChk(ierr);

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -83,12 +83,12 @@ int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
         // v is (ndof x ncomp), column-major
         dbg("[CeedElemRestriction][Apply] kRestrict[4]");
         // occaKernelRun(data->kRestrict[4], occaInt(ncomp), id, ud, vd);
-        occaKernelRun(data->kRestrict[7], occaInt(ncomp), id, od,ud, vd);
+        occaKernelRun(data->kRestrict[7], occaInt(ncomp), tid, od,ud, vd);
       } else {
         // v is (ncomp x ndof), column-major
         dbg("[CeedElemRestriction][Apply] kRestrict[5]");
         // occaKernelRun(data->kRestrict[5], occaInt(ncomp), id, ud, vd);
-        // occaKernelRun(data->kRestrict[8], occaInt(ncomp), id, od,ud, vd);
+        occaKernelRun(data->kRestrict[8], occaInt(ncomp), tid, od,ud, vd);
       }
     }
   }
@@ -232,7 +232,7 @@ int CeedElemRestrictionCreate_Occa(const CeedMemType mtype,
   // data->kRestrict[5] = occaDeviceBuildKernel(dev, oklPath, "kRestrict5", pKR);
   data->kRestrict[6] = occaDeviceBuildKernel(dev, oklPath, "kRestrict3b", pKR);
   data->kRestrict[7] = occaDeviceBuildKernel(dev, oklPath, "kRestrict4b", pKR);
-  // data->kRestrict[8] = occaDeviceBuildKernel(dev, oklPath, "kRestrict5b", pKR);
+  data->kRestrict[8] = occaDeviceBuildKernel(dev, oklPath, "kRestrict5b", pKR);
   // free local usage **********************************************************
   occaFree(pKR);
   ierr = CeedFree(&oklPath); CeedChk(ierr);

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -81,8 +81,31 @@
     const int rngN = toffsets[i+1];
     for (int d = 0; d < ncomp; ++d) {
       double value = 0.0;
-      for (int j=rng1; j<rngN; ++j)
-        value += uu[d+tindices[j]*ncomp];
+      for (int j=rng1; j<rngN; ++j) {
+        int n = tindices[j] % elemsize;
+        int e = tindices[j] / elemsize;
+        value += uu[(e*ncomp + d)*elemsize + n];
+      }
+      vv[d*ndof+i] = value;
+    }
+  }
+}
+// *****************************************************************************
+@kernel void kRestrict5b(const int ncomp,
+                         const int *tindices,
+                         const int *toffsets,
+                         const double* uu,
+                         double* vv) {
+  for (int i=0; i<ndof; i++; @tile(TILE_SIZE,@outer,@inner)){
+    const int rng1 = toffsets[i];
+    const int rngN = toffsets[i+1];
+    for (int d = 0; d < ncomp; ++d) {
+      double value = 0.0;
+      for (int j=rng1; j<rngN; ++j) {
+        int n = tindices[j] % elemsize;
+        int e = tindices[j] / elemsize;
+        value += uu[(e*ncomp + d)*elemsize + n];
+      }
       vv[d+i*ncomp] = value;
     }
   }

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -202,7 +202,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   ierr = CeedOperatorGetNumElements(op, &numelements); CeedChk(ierr);
   ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
   CeedChk(ierr);
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedTransposeMode lmode;
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -230,6 +230,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
       // Restrict
       ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict);
       CeedChk(ierr);
+      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionApply(Erestrict, CEED_NOTRANSPOSE,
                                       lmode, vec, impl->evecs[i],
                                       request); CeedChk(ierr);
@@ -366,6 +367,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
     // Restrict
     ierr = CeedOperatorFieldGetElemRestriction(opoutputfields[i], &Erestrict);
     CeedChk(ierr);
+    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
     ierr = CeedElemRestrictionApply(Erestrict, CEED_TRANSPOSE,
                                     lmode, impl->evecs[i+impl->numein], vec,
                                     request); CeedChk(ierr);

--- a/examples/ceed/ex1.c
+++ b/examples/ceed/ex1.c
@@ -214,11 +214,11 @@ int main(int argc, const char *argv[]) {
   // Create the operator that builds the quadrature data for the mass operator.
   CeedOperator build_oper;
   CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
-  CeedOperatorSetField(build_oper, "dx", mesh_restr, mesh_basis,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(build_oper, "weights", mesh_restr_i,
+  CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
+                       mesh_basis,CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
                        mesh_basis, CEED_VECTOR_NONE);
-  CeedOperatorSetField(build_oper, "rho", sol_restr_i,
+  CeedOperatorSetField(build_oper, "rho", sol_restr_i, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Compute the quadrature data for the mass operator.
@@ -249,10 +249,12 @@ int main(int argc, const char *argv[]) {
   // Create the mass operator.
   CeedOperator oper;
   CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
-  CeedOperatorSetField(oper, "u", sol_restr, sol_basis, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(oper, "rho", sol_restr_i,
+  CeedOperatorSetField(oper, "u", sol_restr, CEED_NOTRANSPOSE,
+                       sol_basis, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(oper, "rho", sol_restr_i, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, rho);
-  CeedOperatorSetField(oper, "v", sol_restr, sol_basis, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(oper, "v", sol_restr, CEED_NOTRANSPOSE,
+                       sol_basis, CEED_VECTOR_ACTIVE);
 
   // Compute the mesh volume using the mass operator: vol = 1^T.M.1.
   if (!test) {

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -201,11 +201,11 @@ class CeedMassOperator : public mfem::Operator {
 
     // Create the operator that builds the quadrature data for the mass operator.
     CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
-    CeedOperatorSetField(build_oper, "dx", mesh_restr, mesh_basis,
-                         CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(build_oper, "weights", mesh_restr_i,
+    CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
+                         mesh_basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
                          mesh_basis, CEED_VECTOR_NONE);
-    CeedOperatorSetField(build_oper, "rho", restr_i,
+    CeedOperatorSetField(build_oper, "rho", restr_i, CEED_NOTRANSPOSE,
                          CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
     // Compute the quadrature data for the mass operator.
@@ -221,10 +221,12 @@ class CeedMassOperator : public mfem::Operator {
 
     // Create the mass operator.
     CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
-    CeedOperatorSetField(oper, "u", restr, basis, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(oper, "rho", restr_i,
+    CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
+                         basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(oper, "rho", restr_i, CEED_NOTRANSPOSE,
                          CEED_BASIS_COLLOCATED, rho);
-    CeedOperatorSetField(oper, "v", restr, basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(oper, "v", restr, CEED_NOTRANSPOSE,
+                         basis, CEED_VECTOR_ACTIVE);
 
     CeedVectorCreate(ceed, fes->GetNDofs(), &u);
     CeedVectorCreate(ceed, fes->GetNDofs(), &v);

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -259,11 +259,11 @@ class CeedDiffusionOperator : public mfem::Operator {
 
     // Create the operator that builds the quadrature data for the diff operator.
     CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
-    CeedOperatorSetField(build_oper, "dx", mesh_restr, mesh_basis,
-                         CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(build_oper, "weights", mesh_restr_i,
+    CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
+                         mesh_basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
                          mesh_basis, CEED_VECTOR_NONE);
-    CeedOperatorSetField(build_oper, "rho", restr_i,
+    CeedOperatorSetField(build_oper, "rho", restr_i, CEED_NOTRANSPOSE,
                          CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
     // Compute the quadrature data for the diff operator.
@@ -280,10 +280,12 @@ class CeedDiffusionOperator : public mfem::Operator {
 
     // Create the diff operator.
     CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
-    CeedOperatorSetField(oper, "u", restr, basis, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(oper, "rho", restr_i,
+    CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
+                         basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(oper, "rho", restr_i, CEED_NOTRANSPOSE,
                          CEED_BASIS_COLLOCATED, rho);
-    CeedOperatorSetField(oper, "v", restr, basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(oper, "v", restr, CEED_NOTRANSPOSE,
+                         basis, CEED_VECTOR_ACTIVE);
 
     CeedVectorCreate(ceed, fes->GetNDofs(), &u);
     CeedVectorCreate(ceed, fes->GetNDofs(), &v);

--- a/examples/nek5000/bp1.usr
+++ b/examples/nek5000/bp1.usr
@@ -868,21 +868,21 @@ c     Create ceed qfunctions for setupf and massf
 c     Create a ceed operator
       call ceedoperatorcreate(ceed,qf_setup,
      $  ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorsetfield(op_setup,'_weight',
-     $  erstrctx,basisx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'rho',
-     $  erstrctx,ceed_basis_collocated,
+      call ceedoperatorsetfield(op_setup,'_weight',erstrctx,
+     $  ceed_notranspose,basisx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'rho',erstrctx,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
 
       call ceedoperatorcreate(ceed,qf_mass,
      $  ceed_null,ceed_null,op_mass,err)
-      call ceedoperatorsetfield(op_mass,'rho',
-     $  erstrctx,ceed_basis_collocated,
+      call ceedoperatorsetfield(op_mass,'rho',erstrctx,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  vec_qdata,err)
       call ceedoperatorsetfield(op_mass,'u',erstrctu,
-     $  basisu,ceed_vector_active,err)
+     $  ceed_notranspose,basisu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'v',erstrctu,
-     $  basisu,ceed_vector_active,err)
+     $  ceed_notranspose,basisu,ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,ceed_null,vec_qdata,
      $  ceed_request_immediate,err)

--- a/examples/nek5000/bp3.usr
+++ b/examples/nek5000/bp3.usr
@@ -612,22 +612,22 @@ c     Create ceed qfunctions for setupf and diffusionf
 c     Create a ceed operator
       call ceedoperatorcreate(ceed,qf_setup,
      $  ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorsetfield(op_setup,'weight',
-     $  erstrctu,basisx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',
-     $  erstrctx,basisx,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_setup,'rho',
-     $  erstrctw,ceed_basis_collocated,
+      call ceedoperatorsetfield(op_setup,'weight',erstrctu,
+     $  ceed_notranspose,basisx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erstrctx,
+     $  ceed_notranspose,basisx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erstrctw,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
 
       call ceedoperatorcreate(ceed,qf_diffusion,
      $  ceed_null,ceed_null,op_diffusion,err)
-      call ceedoperatorsetfield(op_diffusion,'u',
-     $  erstrctu,basisu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_diffusion,'rho',
-     $  erstrctw,ceed_basis_collocated,vec_qdata,err)
-      call ceedoperatorsetfield(op_diffusion,'v',
-     $  erstrctu,basisu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_diffusion,'u',erstrctu,
+     $  ceed_notranspose,basisu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_diffusion,'rho',erstrctw,
+     $  ceed_notranspose,ceed_basis_collocated,vec_qdata,err)
+      call ceedoperatorsetfield(op_diffusion,'v',erstrctu,
+     $  ceed_notranspose,basisu,ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,vec_coords,vec_qdata,
      $  ceed_request_immediate,err)

--- a/examples/petsc/bp1.c
+++ b/examples/petsc/bp1.c
@@ -375,29 +375,35 @@ int main(int argc, char **argv) {
 
   // Create the operator that builds the quadrature data for the mass operator.
   CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "weight", Erestrictxi, basisx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui,
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       basisx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
+                       basisx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       basisx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "true_soln", Erestrictui,
+  CeedOperatorSetField(op_setup, "true_soln", Erestrictui, CEED_NOTRANSPOSE, 
                        CEED_BASIS_COLLOCATED, target);
-  CeedOperatorSetField(op_setup, "rhs", Erestrictu, basisu, rhsceed);
+  CeedOperatorSetField(op_setup, "rhs", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, rhsceed);
 
   // Create the mass operator.
   CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "rho", Erestrictui,
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, rho);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, CEED_VECTOR_ACTIVE);
 
   // Create the error operator
   CeedOperatorCreate(ceed, qf_error, NULL, NULL, &op_error);
-  CeedOperatorSetField(op_error, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_error, "true_soln", Erestrictui,
+  CeedOperatorSetField(op_error, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_error, "true_soln", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, target);
-  CeedOperatorSetField(op_error, "error", Erestrictui,
+  CeedOperatorSetField(op_error, "error", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
 

--- a/examples/petsc/bp3.c
+++ b/examples/petsc/bp3.c
@@ -424,29 +424,35 @@ int main(int argc, char **argv) {
 
   // Create the operator that builds the quadrature data for the diff operator.
   CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "weight", Erestrictxi, basisx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictqdi,
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       basisx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
+                       basisx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       basisx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictqdi, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "true_soln", Erestrictui,
+  CeedOperatorSetField(op_setup, "true_soln", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, target);
-  CeedOperatorSetField(op_setup, "rhs", Erestrictu, basisu, rhsceed);
+  CeedOperatorSetField(op_setup, "rhs", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, rhsceed);
 
   // Create the diff operator.
   CeedOperatorCreate(ceed, qf_diff, NULL, NULL, &op_diff);
-  CeedOperatorSetField(op_diff, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diff, "rho", Erestrictqdi,
+  CeedOperatorSetField(op_diff, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "rho", Erestrictqdi, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, rho);
-  CeedOperatorSetField(op_diff, "v", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, CEED_VECTOR_ACTIVE);
 
   // Create the error operator
   CeedOperatorCreate(ceed, qf_error, NULL, NULL, &op_error);
-  CeedOperatorSetField(op_error, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_error, "true_soln", Erestrictui,
+  CeedOperatorSetField(op_error, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_error, "true_soln", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, target);
-  CeedOperatorSetField(op_error, "error", Erestrictui,
+  CeedOperatorSetField(op_error, "error", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
 

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -122,6 +122,8 @@ CEED_EXTERN int CeedOperatorFieldGetElemRestriction(CeedOperatorField opfield,
                                                     CeedElemRestriction *rstr);
 CEED_EXTERN int CeedOperatorFieldGetBasis(CeedOperatorField opfield,
                                           CeedBasis *basis);
+CEED_EXTERN int CeedOperatorFieldGetLMode(CeedOperatorField opfield,
+                                          CeedTransposeMode *lmode);
 CEED_EXTERN int CeedOperatorFieldGetVector(CeedOperatorField opfield,
                                            CeedVector *vec);
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -130,6 +130,7 @@ struct CeedQFunction_private {
 
 struct CeedOperatorField_private {
   CeedElemRestriction Erestrict; /// Restriction from L-vector or NULL if identity
+  CeedTransposeMode lmode;       /// Transpose mode for lvector ordering
   CeedBasis basis;               /// Basis or NULL for collocated fields
   CeedVector
   vec;                /// State vector for passive fields, NULL for active fields

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -307,7 +307,8 @@ CEED_EXTERN int CeedOperatorCreate(Ceed ceed, CeedQFunction qf,
                                    CeedQFunction dqf, CeedQFunction dqfT,
                                    CeedOperator *op);
 CEED_EXTERN int CeedOperatorSetField(CeedOperator op, const char *fieldname,
-                                     CeedElemRestriction r, CeedBasis b,
+                                     CeedElemRestriction r,
+                                     CeedTransposeMode lmode, CeedBasis b,
                                      CeedVector v);
 CEED_EXTERN int CeedOperatorApply(CeedOperator op, CeedVector in,
                                   CeedVector out, CeedRequest *request);

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -639,7 +639,7 @@ void fCeedOperatorCreate(int* ceed,
 #define fCeedOperatorSetField \
     FORTRAN_NAME(ceedoperatorsetfield,CEEDOPERATORSETFIELD)
 void fCeedOperatorSetField(int *op, const char *fieldname,
-                           int *r, int *b, int *v, int *err,
+                           int *r, int *lmode, int *b, int *v, int *err,
                            fortran_charlen_t fieldname_len) {
   FIX_STRING(fieldname);
   CeedElemRestriction r_;
@@ -653,6 +653,7 @@ void fCeedOperatorSetField(int *op, const char *fieldname,
   } else {
     r_ = CeedElemRestriction_dict[*r];
   }
+  
   if (*b == FORTRAN_NULL) {
     b_ = NULL;
   } else if (*b == FORTRAN_BASIS_COLLOCATED) {
@@ -670,7 +671,7 @@ void fCeedOperatorSetField(int *op, const char *fieldname,
     v_ = CeedVector_dict[*v];
   }
 
-  *err = CeedOperatorSetField(op_, fieldname_c, r_, b_, v_);
+  *err = CeedOperatorSetField(op_, fieldname_c, r_, *lmode, b_, v_);
 }
 
 #define fCeedOperatorApply FORTRAN_NAME(ceedoperatorapply, CEEDOPERATORAPPLY)

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -82,6 +82,11 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
   @param op         Ceedoperator on which to provide the field
   @param fieldname  Name of the field (to be matched with the name used by CeedQFunction)
   @param r          CeedElemRestriction
+  @param lmode      CeedTransposeMode which specifies the ordering of the
+                      components of the l-vector used by this CeedOperatorField,
+                      CEED_NOTRANSPOSE indicates the component is the
+                      outermost index and CEED_TRANSPOSE indicates the component
+                      is the innermost index in ordering of the l-vector
   @param b          CeedBasis in which the field resides or CEED_BASIS_COLLOCATED
                       if collocated with quadrature points
   @param v          CeedVector to be used by CeedOperator or CEED_VECTOR_ACTIVE

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -93,8 +93,8 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
   @ref Basic
 **/
 int CeedOperatorSetField(CeedOperator op, const char *fieldname,
-                         CeedElemRestriction r, CeedBasis b,
-                         CeedVector v) {
+                         CeedElemRestriction r, CeedTransposeMode lmode,
+                         CeedBasis b, CeedVector v) {
   int ierr;
   CeedInt numelements;
   ierr = CeedElemRestrictionGetNumElements(r, &numelements); CeedChk(ierr);
@@ -130,6 +130,7 @@ int CeedOperatorSetField(CeedOperator op, const char *fieldname,
                    fieldname);
 found:
   ofield->Erestrict = r;
+  ofield->lmode = lmode;
   ofield->basis = b;
   ofield->vec = v;
   op->nfields += 1;
@@ -320,6 +321,21 @@ int CeedOperatorGetFields(CeedOperator op,
 }
 
 /**
+  @brief Get the L vector CeedTransposeMode of a CeedOperatorField
+
+  @param opfield         CeedOperatorField
+  @param[out] lmode      Variable to store CeedTransposeMode
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+
+int CeedOperatorFieldGetLMode(CeedOperatorField opfield,
+                              CeedTransposeMode *lmode) {
+  *lmode = (&opfield)->lmode;
+  return 0;
+}/**
   @brief Get the CeedElemRestriction of a CeedOperatorField
 
   @param opfield         CeedOperatorField

--- a/tests/t200-elemrestriction.c
+++ b/tests/t200-elemrestriction.c
@@ -1,6 +1,6 @@
 /// @file
-/// Test creation, use, and destruction of a element restriction
-/// \test Test creation, use, and destruction of a element restriction
+/// Test creation, use, and destruction of an element restriction
+/// \test Test creation, use, and destruction of an element restriction
 #include <ceed.h>
 
 int main(int argc, char **argv) {
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 1, CEED_MEM_HOST, CEED_USE_POINTER,
                             ind, &r);
   CeedVectorCreate(ceed, ne*2, &y);
-  CeedVectorSetArray(y, CEED_MEM_HOST, CEED_COPY_VALUES, NULL); // Allocates array
+  CeedVectorSetValue(y, 0); // Allocates array
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
                            CEED_REQUEST_IMMEDIATE);
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);

--- a/tests/t201-elemrestriction-f.f
+++ b/tests/t201-elemrestriction-f.f
@@ -31,8 +31,7 @@ c-----------------------------------------------------------------------
       call ceedelemrestrictioncreateidentity(ceed,ne,2,2*ne,1,r,err)
 
       call ceedvectorcreate(ceed,2*ne,y,err);
-      call ceedvectorsetarray(y,ceed_mem_host,ceed_copy_values,%val(0),
-     $  err);
+      call ceedvectorsetvalue(y,0.d0,err);
       call ceedelemrestrictionapply(r,ceed_notranspose,
      $  ceed_notranspose,x,y,ceed_request_immediate,err)
 

--- a/tests/t201-elemrestriction.c
+++ b/tests/t201-elemrestriction.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
 
   CeedElemRestrictionCreateIdentity(ceed, ne, 2, ne*2, 1, &r);
   CeedVectorCreate(ceed, ne*2, &y);
-  CeedVectorSetArray(y, CEED_MEM_HOST, CEED_COPY_VALUES, NULL); // Allocates array
+  CeedVectorSetValue(y, 0); // Allocates array
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
                            CEED_REQUEST_IMMEDIATE);
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);

--- a/tests/t202-elemrestriction-f.f
+++ b/tests/t202-elemrestriction-f.f
@@ -38,8 +38,7 @@ c-----------------------------------------------------------------------
      $  ceed_mem_host,ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,2*blksize*2,y,err);
-      call ceedvectorsetarray(y,ceed_mem_host,ceed_copy_values,%val(0),
-     $  err);
+      call ceedvectorsetvalue(y,0.d0,err);
 
 c    No Transpose
       call ceedelemrestrictionapply(r,ceed_notranspose,

--- a/tests/t202-elemrestriction.c
+++ b/tests/t202-elemrestriction.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreateBlocked(ceed, ne, 2, blksize, ne+1, 1, CEED_MEM_HOST,
                                    CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2, &y);
-  CeedVectorSetArray(y, CEED_MEM_HOST, CEED_COPY_VALUES, NULL); // Allocates array
+  CeedVectorSetValue(y, 0); // Allocates array
 
   // NoTranspose
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,

--- a/tests/t203-elemrestriction-f.f
+++ b/tests/t203-elemrestriction-f.f
@@ -43,8 +43,7 @@ c-----------------------------------------------------------------------
      $  ncomp,ceed_mem_host,ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,2*blksize*2*ncomp,y,err);
-      call ceedvectorsetarray(y,ceed_mem_host,ceed_copy_values,%val(0),
-     $  err);
+      call ceedvectorsetvalue(y,0.d0,err);
 
 c    No Transpose
       call ceedelemrestrictionapply(r,ceed_notranspose,

--- a/tests/t203-elemrestriction.c
+++ b/tests/t203-elemrestriction.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
                                    CEED_MEM_HOST,
                                    CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2*ncomp, &y);
-  CeedVectorSetArray(y, CEED_MEM_HOST, CEED_COPY_VALUES, NULL); // Allocates array
+  CeedVectorSetValue(y, 0); // Allocates array
 
   // NoTranspose
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,

--- a/tests/t204-elemrestriction-f.f
+++ b/tests/t204-elemrestriction-f.f
@@ -6,15 +6,15 @@ c-----------------------------------------------------------------------
       integer ceed,err
       integer x,y
       integer r
-      integer i
+      integer i,n
       integer*8 offset
 
       integer ne
       parameter(ne=3)
 
       integer*4 ind(2*ne)
-      real*8 a(ne+1)
-      real*8 yy(2*ne)
+      real*8 a(2*(ne+1))
+      real*8 yy(4*ne)
       real*8 diff
 
       character arg*32
@@ -22,10 +22,11 @@ c-----------------------------------------------------------------------
       call getarg(1,arg)
       call ceedinit(trim(arg)//char(0),ceed,err)
 
-      call ceedvectorcreate(ceed,ne+1,x,err)
+      call ceedvectorcreate(ceed,2*(ne+1),x,err)
 
       do i=1,ne+1
         a(i)=10+i-1
+        a(i+ne+1)=20+i-1
       enddo
 
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,err)
@@ -35,20 +36,28 @@ c-----------------------------------------------------------------------
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,1,ceed_mem_host,
+      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,2,ceed_mem_host,
      $  ceed_use_pointer,ind,r,err)
 
-      call ceedvectorcreate(ceed,2*ne,y,err);
+      call ceedvectorcreate(ceed,2*(2*ne),y,err);
       call ceedvectorsetvalue(y,0.d0,err);
       call ceedelemrestrictionapply(r,ceed_notranspose,
      $  ceed_notranspose,x,y,ceed_request_immediate,err)
 
       call ceedvectorgetarrayread(y,ceed_mem_host,yy,offset,err)
-      do i=1,ne*2
-        diff=10+i/2-yy(i+offset)
-        if (abs(diff) > 1.0D-15) then
-          write(*,*) 'Error in restricted array y(',i,')=',yy(i+offset)
-        endif
+      do i=0,ne-1
+        do n=1,2
+          diff=10+(2*i+n)/2-yy(i*4+n+offset)
+          if (abs(diff) > 1.0D-15) then
+            write(*,*) 'Error in restricted array y(',i*4+n,')=',
+     $  yy(i*4+n+offset),'!=',10+(2*i+n)/2
+          endif
+          diff=20+(2*i+n)/2-yy(i*4+n+2+offset)
+          if (abs(diff) > 1.0D-15) then
+            write(*,*) 'Error in restricted array y(',i*4+n+2,')=',
+     $  yy(i*4+n+2+offset),'!=',20+(2*i+n)/2
+          endif
+        enddo
       enddo
       call ceedvectorrestorearrayread(y,yy,offset,err)
 

--- a/tests/t204-elemrestriction.c
+++ b/tests/t204-elemrestriction.c
@@ -1,0 +1,57 @@
+/// @file
+/// Test creation, use, and destruction of a multicomponent element restriction
+/// \test Test creation, use, and destruction of a multicomponent element restriction
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector x, y;
+  CeedInt ne = 3;
+  CeedInt ind[2*ne];
+  CeedScalar a[2*(ne+1)];
+  const CeedScalar *yy;
+  CeedElemRestriction r;
+
+  CeedInit(argv[1], &ceed);
+
+  // Setup
+  CeedVectorCreate(ceed, 2*(ne+1), &x);
+  for (CeedInt i=0; i<ne+1; i++) {
+    a[i] = 10 + i;
+    a[i+ne+1] = 20 + i;
+  }
+  CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
+
+  for (CeedInt i=0; i<ne; i++) {
+    ind[2*i+0] = i;
+    ind[2*i+1] = i+1;
+  }
+  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST, CEED_USE_POINTER,
+                            ind, &r);
+  CeedVectorCreate(ceed, 2*(ne*2), &y);
+  CeedVectorSetValue(y, 0); // Allocates array
+
+  // Restrict
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
+                           CEED_REQUEST_IMMEDIATE);
+
+  // Check
+  CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
+  for (CeedInt i=0; i<ne; i++) {
+    for (CeedInt n=0; n<2; n++) {
+        if (yy[i*4+n] != 10+(2*i+n+1)/2)
+           printf("Error in restricted array y[%d] = %f != %f\n",
+                           i*4+n, (double)yy[i*4+n], 10.+(2*i+n+1)/2);
+        if (yy[i*4+n+2] != 20+(2*i+n+1)/2)
+          printf("Error in restricted array y[%d] = %f != %f\n",
+                           i*4+n+2, (double)yy[i*4+n+2], 20.+(2*i+n+1)/2);
+    }
+  }
+
+  CeedVectorRestoreArrayRead(y, &yy);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&y);
+  CeedElemRestrictionDestroy(&r);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t205-elemrestriction-f.f
+++ b/tests/t205-elemrestriction-f.f
@@ -6,15 +6,15 @@ c-----------------------------------------------------------------------
       integer ceed,err
       integer x,y
       integer r
-      integer i
+      integer i,n
       integer*8 offset
 
       integer ne
       parameter(ne=3)
 
       integer*4 ind(2*ne)
-      real*8 a(ne+1)
-      real*8 yy(2*ne)
+      real*8 a(2*(ne+1))
+      real*8 yy(4*ne)
       real*8 diff
 
       character arg*32
@@ -22,10 +22,11 @@ c-----------------------------------------------------------------------
       call getarg(1,arg)
       call ceedinit(trim(arg)//char(0),ceed,err)
 
-      call ceedvectorcreate(ceed,ne+1,x,err)
+      call ceedvectorcreate(ceed,2*(ne+1),x,err)
 
       do i=1,ne+1
-        a(i)=10+i-1
+        a(2*i-1)=10+i-1
+        a(2*i)=20+i-1
       enddo
 
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,err)
@@ -35,20 +36,28 @@ c-----------------------------------------------------------------------
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,1,ceed_mem_host,
+      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,2,ceed_mem_host,
      $  ceed_use_pointer,ind,r,err)
 
-      call ceedvectorcreate(ceed,2*ne,y,err);
+      call ceedvectorcreate(ceed,2*(2*ne),y,err);
       call ceedvectorsetvalue(y,0.d0,err);
       call ceedelemrestrictionapply(r,ceed_notranspose,
-     $  ceed_notranspose,x,y,ceed_request_immediate,err)
+     $  ceed_transpose,x,y,ceed_request_immediate,err)
 
       call ceedvectorgetarrayread(y,ceed_mem_host,yy,offset,err)
-      do i=1,ne*2
-        diff=10+i/2-yy(i+offset)
-        if (abs(diff) > 1.0D-15) then
-          write(*,*) 'Error in restricted array y(',i,')=',yy(i+offset)
-        endif
+      do i=0,ne-1
+        do n=1,2
+          diff=10+(2*i+n)/2-yy(i*4+n+offset)
+          if (abs(diff) > 1.0D-15) then
+            write(*,*) 'Error in restricted array y(',i*4+n,')=',
+     $  yy(i*4+n+offset),'!=',10+(2*i+n)/2
+          endif
+          diff=20+(2*i+n)/2-yy(i*4+n+2+offset)
+          if (abs(diff) > 1.0D-15) then
+            write(*,*) 'Error in restricted array y(',i*4+n+2,')=',
+     $  yy(i*4+n+2+offset),'!=',20+(2*i+n)/2
+          endif
+        enddo
       enddo
       call ceedvectorrestorearrayread(y,yy,offset,err)
 

--- a/tests/t205-elemrestriction.c
+++ b/tests/t205-elemrestriction.c
@@ -1,0 +1,57 @@
+/// @file
+/// Test creation, use, and destruction of an interlaced multicomponent element restriction
+/// \test Test creation, use, and destruction of an interlaced multicomponent element restriction
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector x, y;
+  CeedInt ne = 3;
+  CeedInt ind[2*ne];
+  CeedScalar a[2*(ne+1)];
+  const CeedScalar *yy;
+  CeedElemRestriction r;
+
+  CeedInit(argv[1], &ceed);
+
+  // Setup
+  CeedVectorCreate(ceed, 2*(ne+1), &x);
+  for (CeedInt i=0; i<ne+1; i++) {
+    a[2*i] = 10 + i;
+    a[2*i+1] = 20 + i;
+  }
+  CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
+
+  for (CeedInt i=0; i<ne; i++) {
+    ind[2*i+0] = i;
+    ind[2*i+1] = i+1;
+  }
+  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST, CEED_USE_POINTER,
+                            ind, &r);
+  CeedVectorCreate(ceed, 2*(ne*2), &y);
+  CeedVectorSetValue(y, 0); // Allocates array
+
+  // Restrict
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_TRANSPOSE, x, y,
+                           CEED_REQUEST_IMMEDIATE);
+
+  // Check
+  CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
+  for (CeedInt i=0; i<ne; i++) {
+    for (CeedInt n=0; n<2; n++) {
+        if (yy[i*4+n] != 10+(2*i+n+1)/2)
+           printf("Error in restricted array y[%d] = %f != %f\n",
+                           i*2+n, (double)yy[i*4+n], 10.+(2*i+n+1)/2);
+        if (yy[i*4+n+2] != 20+(2*i+n+1)/2)
+          printf("Error in restricted array y[%d] = %f != %f\n",
+                           i*4+n+2, (double)yy[i*4+n+2], 20.+(2*i+n+1)/2);
+    }
+  }
+
+  CeedVectorRestoreArrayRead(y, &yy);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&y);
+  CeedElemRestrictionDestroy(&r);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t206-elemrestriction.c
+++ b/tests/t206-elemrestriction.c
@@ -1,0 +1,58 @@
+/// @file
+/// Test creation, transpose use, and destruction of a multicomponent element restriction
+/// \test Test creation, transpose use, and destruction of a multicomponent element restriction
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector x, y;
+  CeedInt ne = 5, mult;
+  CeedInt ind[2*ne];
+  CeedScalar a[2*(ne*2)];
+  const CeedScalar *yy;
+  CeedElemRestriction r;
+
+  CeedInit(argv[1], &ceed);
+
+  // Setup
+  CeedVectorCreate(ceed, 2*(ne*2), &x);
+  for (CeedInt i=0; i<ne; i++) {
+    for (CeedInt n=0; n<2; n++) {
+        a[i*4+n] = 10+(2*i+n+1)/2;
+        a[i*4+n+2] = 20+(2*i+n+1)/2;
+    }
+  }
+  CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
+
+  for (CeedInt i=0; i<ne; i++) {
+    ind[2*i+0] = i;
+    ind[2*i+1] = i+1;
+  }
+  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST, CEED_USE_POINTER,
+                            ind, &r);
+  CeedVectorCreate(ceed, 2*(ne+1), &y);
+  CeedVectorSetValue(y, 0); // Allocates array
+
+  // Restrict
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_NOTRANSPOSE, x, y,
+                           CEED_REQUEST_IMMEDIATE);
+
+  // Check
+  CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
+  for (CeedInt i=0; i<ne+1; i++) {
+    mult = i>0&&i<ne ? 2 : 1;
+    if (yy[i] != (10+i)*mult)
+       printf("Error in restricted array y[%d] = %f != %f\n",
+                       i, (double)yy[i], (10.+i)*mult);
+    if (yy[i+ne+1] != (20+i)*mult)
+      printf("Error in restricted array y[%d] = %f != %f\n",
+                       i+ne+1, (double)yy[i+ne+1], (20.+i)*mult);
+  }
+
+  CeedVectorRestoreArrayRead(y, &yy);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&y);
+  CeedElemRestrictionDestroy(&r);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t207-elemrestriction-f.f
+++ b/tests/t207-elemrestriction-f.f
@@ -6,15 +6,15 @@ c-----------------------------------------------------------------------
       integer ceed,err
       integer x,y
       integer r
-      integer i
+      integer i,n,mult
       integer*8 offset
 
       integer ne
       parameter(ne=3)
 
       integer*4 ind(2*ne)
-      real*8 a(ne+1)
-      real*8 yy(2*ne)
+      real*8 a(2*(ne*2))
+      real*8 yy(2*(ne+1))
       real*8 diff
 
       character arg*32
@@ -22,10 +22,13 @@ c-----------------------------------------------------------------------
       call getarg(1,arg)
       call ceedinit(trim(arg)//char(0),ceed,err)
 
-      call ceedvectorcreate(ceed,ne+1,x,err)
+      call ceedvectorcreate(ceed,2*(ne*2),x,err)
 
-      do i=1,ne+1
-        a(i)=10+i-1
+      do i=0,ne-1
+        do n=1,2
+          a(i*4+n)=10+(2*i+n)/2
+          a(i*4+n+2)=20+(2*i+n)/2
+        enddo
       enddo
 
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,err)
@@ -35,19 +38,30 @@ c-----------------------------------------------------------------------
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,1,ceed_mem_host,
+      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,2,ceed_mem_host,
      $  ceed_use_pointer,ind,r,err)
 
-      call ceedvectorcreate(ceed,2*ne,y,err);
+      call ceedvectorcreate(ceed,2*(ne+1),y,err);
       call ceedvectorsetvalue(y,0.d0,err);
-      call ceedelemrestrictionapply(r,ceed_notranspose,
-     $  ceed_notranspose,x,y,ceed_request_immediate,err)
+      call ceedelemrestrictionapply(r,ceed_transpose,
+     $  ceed_transpose,x,y,ceed_request_immediate,err)
 
       call ceedvectorgetarrayread(y,ceed_mem_host,yy,offset,err)
-      do i=1,ne*2
-        diff=10+i/2-yy(i+offset)
+      do i=0,ne
+        if (i > 0 .and. i < ne) then
+          mult = 2
+        else
+          mult = 1
+        endif
+        diff=(10+i)*mult-yy(2*i+1+offset)
         if (abs(diff) > 1.0D-15) then
-          write(*,*) 'Error in restricted array y(',i,')=',yy(i+offset)
+          write(*,*) 'Error in restricted array y(',2*i+1,')=',
+     $  yy(2*i+1+offset),'!=',(10+i)*mult
+        endif
+        diff=(20+i)*mult-yy(2*i+2+offset)
+        if (abs(diff) > 1.0D-15) then
+          write(*,*) 'Error in restricted array y(',2*i+2,')=',
+     $  yy(2*i+2+offset),'!=',(20+i)*mult
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,offset,err)

--- a/tests/t207-elemrestriction.c
+++ b/tests/t207-elemrestriction.c
@@ -1,0 +1,58 @@
+/// @file
+/// Test creation, transpose use, and destruction of an interlaced multicomponent element restriction
+/// \test Test creation, transpose use, and destruction of an interlaced multicomponent element restriction
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector x, y;
+  CeedInt ne = 5, mult;
+  CeedInt ind[2*ne];
+  CeedScalar a[2*(ne*2)];
+  const CeedScalar *yy;
+  CeedElemRestriction r;
+
+  CeedInit(argv[1], &ceed);
+
+  // Setup
+  CeedVectorCreate(ceed, 2*(ne*2), &x);
+  for (CeedInt i=0; i<ne; i++) {
+    for (CeedInt n=0; n<2; n++) {
+        a[i*4+n] = 10+(2*i+n+1)/2;
+        a[i*4+n+2] = 20+(2*i+n+1)/2;
+    }
+  }
+  CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
+
+  for (CeedInt i=0; i<ne; i++) {
+    ind[2*i+0] = i;
+    ind[2*i+1] = i+1;
+  }
+  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST, CEED_USE_POINTER,
+                            ind, &r);
+  CeedVectorCreate(ceed, 2*(ne+1), &y);
+  CeedVectorSetValue(y, 0); // Allocates array
+
+  // Restrict
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_TRANSPOSE, x, y,
+                           CEED_REQUEST_IMMEDIATE);
+
+  // Check
+  CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
+  for (CeedInt i=0; i<ne+1; i++) {
+    mult = i>0&&i<ne ? 2 : 1;
+    if (yy[2*i] != (10+i)*mult)
+       printf("Error in restricted array y[%d] = %f != %f\n",
+                       2*i, (double)yy[2*i], (10.+i)*mult);
+    if (yy[2*i+1] != (20+i)*mult)
+      printf("Error in restricted array y[%d] = %f != %f\n",
+                       2*i+1, (double)yy[2*i+1], (20.+i)*mult);
+  }
+
+  CeedVectorRestoreArrayRead(y, &yy);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&y);
+  CeedElemRestrictionDestroy(&r);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t500-operator-f.f
+++ b/tests/t500-operator-f.f
@@ -119,20 +119,19 @@ c     $  't30-operator-f.f:mass',qf_mass,err)
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',
-     $  erestrictxi,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,
+     $  ceed_notranspose,bx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,
+     $  ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_setup,'rho',
-     $  erestrictui,ceed_basis_collocated,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'rho',
-     $  erestrictui,ceed_basis_collocated,
-     $  qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,
-     $  ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,
      $  ceed_request_immediate,err)

--- a/tests/t500-operator.c
+++ b/tests/t500-operator.c
@@ -3,6 +3,7 @@
 /// \test Test creation creation, action, and destruction for mass matrix operator
 #include <ceed.h>
 #include <stdlib.h>
+#include <math.h>
 
 //! [QFunction User Code]
 static int setup(void *ctx, CeedInt Q, const CeedScalar *const *in,
@@ -99,18 +100,21 @@ int main(int argc, char **argv) {
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
 //! [Setup Set]
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui,
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 //! [Setup Set]
 
 //! [Operator Set]
-  CeedOperatorSetField(op_mass, "rho", Erestrictui,
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
 //! [Operator Set]
 
 //! [Setup Apply]
@@ -126,7 +130,7 @@ int main(int argc, char **argv) {
 
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
   for (CeedInt i=0; i<Nu; i++)
-    if (hv[i] != 0.0) printf("[%d] v %g != 0.0\n",i, hv[i]);
+    if (fabs(hv[i]) > 1e-14) printf("[%d] v %g != 0.0\n",i, hv[i]);
   CeedVectorRestoreArrayRead(V, &hv);
 
   CeedQFunctionDestroy(&qf_setup);

--- a/tests/t501-operator-f.f
+++ b/tests/t501-operator-f.f
@@ -120,20 +120,20 @@ c     $  't30-operator-f.f:mass',qf_mass,err)
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',
-     $  erestrictxi,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,
+     $  ceed_notranspose,bx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,
+     $  ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_setup,'rho',
-     $  erestrictui,ceed_basis_collocated,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'rho',
-     $  erestrictui,ceed_basis_collocated,
+      call ceedoperatorsetfield(op_mass,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,
-     $  ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,
      $  ceed_request_immediate,err)

--- a/tests/t501-operator.c
+++ b/tests/t501-operator.c
@@ -88,16 +88,19 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui,
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui,
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t502-operator-f.f
+++ b/tests/t502-operator-f.f
@@ -1,0 +1,182 @@
+c-----------------------------------------------------------------------
+      subroutine setup(ctx,q,u1,u2,u3,u4,u5,u6,u7,
+     $  u8,u9,u10,u11,u12,u13,u14,u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,
+     $  v9,v10,v11,v12,v13,v14,v15,v16,ierr)
+      real*8 ctx
+      real*8 u1(1)
+      real*8 u2(1)
+      real*8 v1(1)
+      integer q,ierr
+
+      do i=1,q
+        v1(i)=u1(i)*u2(i)
+      enddo
+
+      ierr=0
+      end
+c-----------------------------------------------------------------------
+      subroutine mass(ctx,q,u1,u2,u3,u4,u5,u6,u7,
+     $  u8,u9,u10,u11,u12,u13,u14,u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,
+     $  v9,v10,v11,v12,v13,v14,v15,v16,ierr)
+      real*8 ctx
+      real*8 u1(1)
+      real*8 u2(1)
+      real*8 v1(1)
+      integer q,ierr
+
+      do i=1,q
+        v1(i)=u2(i)*u1(i)
+        v1(q+i)=u2(q+i)*u1(i)
+      enddo
+
+      ierr=0
+      end
+c-----------------------------------------------------------------------
+      program test
+
+      include 'ceedf.h'
+
+      integer ceed,err,i,j
+      integer erestrictx,erestrictu,erestrictxi,erestrictui
+      integer bx,bu
+      integer qf_setup,qf_mass
+      integer op_setup,op_mass
+      integer qdata,x,u,v
+      integer nelem,p,q
+      parameter(nelem=15)
+      parameter(p=5)
+      parameter(q=8)
+      integer nx,nu
+      parameter(nx=nelem+1)
+      parameter(nu=nelem*(p-1)+1)
+      integer indx(nelem*2)
+      integer indu(nelem*p)
+      real*8 arrx(nx)
+      integer*8 voffset
+
+      real*8 hu(nu*2),hv(nu*2)
+      real*8 total1,total2
+
+      character arg*32
+
+      external setup,mass
+
+      call getarg(1,arg)
+      call ceedinit(trim(arg)//char(0),ceed,err)
+
+      do i=0,nx-1
+        arrx(i+1)=i/(nx-1.d0)
+      enddo
+      do i=0,nelem-1
+        indx(2*i+1)=i
+        indx(2*i+2)=i+1
+      enddo
+
+      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,
+     $  ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,
+     $  erestrictxi,err)
+
+      do i=0,nelem-1
+        do j=0,p-1
+          indu(p*i+j+1)=i*(p-1)+j
+        enddo
+      enddo
+
+      call ceedelemrestrictioncreate(ceed,nelem,p,nu,2,
+     $  ceed_mem_host,ceed_use_pointer,indu,erestrictu,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,
+     $  erestrictui,err)
+
+      call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,
+     $  bx,err)
+      call ceedbasiscreatetensorh1lagrange(ceed,1,2,p,q,ceed_gauss,
+     $  bu,err)
+
+      call ceedqfunctioncreateinterior(ceed,1,setup,
+c     __FILE__ should not be more than the 72 characters, -ffree-line-length-none ?
+     $__FILE__ 
+     $     //':setup'//char(0),qf_setup,err)
+c     $  't30-operator-f.f:setup',qf_setup,err)
+      call ceedqfunctionaddinput(qf_setup,'_weight',1,
+     $  ceed_eval_weight,err)
+      call ceedqfunctionaddinput(qf_setup,'x',1,ceed_eval_grad,err)
+      call ceedqfunctionaddoutput(qf_setup,'rho',1,
+     $  ceed_eval_none,err)
+
+      call ceedqfunctioncreateinterior(ceed,1,mass,
+     $__FILE__ 
+     $     //':mass'//char(0),qf_mass,err)
+c     $  't30-operator-f.f:mass',qf_mass,err)
+      call ceedqfunctionaddinput(qf_mass,'rho',1,ceed_eval_none,err)
+      call ceedqfunctionaddinput(qf_mass,'u',2,ceed_eval_interp,err)
+      call ceedqfunctionaddoutput(qf_mass,'v',2,ceed_eval_interp,err)
+
+      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,
+     $  op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,
+     $  op_mass,err)
+
+      call ceedvectorcreate(ceed,nx,x,err)
+      call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,err)
+      call ceedvectorcreate(ceed,nelem*q,qdata,err)
+
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,
+     $  ceed_notranspose,bx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,
+     $  ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
+     $  ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
+     $  qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,
+     $  ceed_transpose,bu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,
+     $  ceed_transpose,bu,ceed_vector_active,err)
+
+      call ceedoperatorapply(op_setup,x,qdata,
+     $  ceed_request_immediate,err)
+
+      call ceedvectorcreate(ceed,2*nu,u,err)
+      call ceedvectorgetarray(u,ceed_mem_host,hu,voffset,err)
+      do i=1,nu
+        hu(voffset+2*i-1)=1.
+        hu(voffset+2*i)=2.
+      enddo
+      call ceedvectorrestorearray(u,hu,voffset,err)
+      call ceedvectorcreate(ceed,2*nu,v,err)
+      call ceedoperatorapply(op_mass,u,v,ceed_request_immediate,err)
+
+      call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
+      total1=0.
+      total2=0.
+      do i=1,nu
+        total1=total1+hv(voffset+2*i-1)
+        total2=total2+hv(voffset+2*i)
+      enddo
+      if (abs(total1-1.)>1.0d-10) then
+        write(*,*) 'Computed Area: ',total1,' != True Area: 1.0'
+      endif
+      if (abs(total2-2.)>1.0d-10) then
+        write(*,*) 'Computed Area: ',total2,' != True Area: 2.0'
+      endif
+      call ceedvectorrestorearrayread(v,hv,voffset,err)
+
+      call ceedvectordestroy(x,err)
+      call ceedvectordestroy(u,err)
+      call ceedvectordestroy(v,err)
+      call ceedoperatordestroy(op_mass,err)
+      call ceedoperatordestroy(op_setup,err)
+      call ceedqfunctiondestroy(qf_mass,err)
+      call ceedqfunctiondestroy(qf_setup,err)
+      call ceedbasisdestroy(bu,err)
+      call ceedbasisdestroy(bx,err)
+      call ceedelemrestrictiondestroy(erestrictu,err)
+      call ceedelemrestrictiondestroy(erestrictx,err)
+      call ceedelemrestrictiondestroy(erestrictui,err)
+      call ceedelemrestrictiondestroy(erestrictxi,err)
+      call ceeddestroy(ceed,err)
+      end
+c-----------------------------------------------------------------------

--- a/tests/t502-operator-f.okl
+++ b/tests/t502-operator-f.okl
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+// *****************************************************************************
+typedef int CeedInt;
+typedef double CeedScalar;
+// OCCA parser doesn't like __global here
+//typedef __global double gCeedScalar;
+
+// *****************************************************************************
+@kernel void setup(void *ctx, CeedInt Q,
+                   const int *iOf7, const int *oOf7, 
+                   const CeedScalar *in, CeedScalar *out) {
+  for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
+    // OCCA parser can't insert an __global here
+    /*const CeedScalar *weight = in + iOf7[0];
+    const CeedScalar *dxdX = in + iOf7[1];
+    CeedScalar *rho = out + oOf7[0];
+    rho[i] = weight[i] * dxdX[i];*/
+    out[oOf7[0]+i] = in[iOf7[0]+i] * in[iOf7[1]+i];
+  }
+}
+
+// *****************************************************************************
+@kernel void mass(void *ctx, CeedInt Q,
+                  const int *iOf7, const int *oOf7,
+                  const CeedScalar *in, CeedScalar *out) {
+  for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
+    // OCCA parser can't insert an __global here
+    /*const CeedScalar *rho = in + iOf7[0];
+    const CeedScalar *u = in + iOf7[1];
+    CeedScalar *v = out + oOf7[0];
+    v[i] = rho[i] * u[i];*/
+    out[oOf7[0]+i] = in[iOf7[0]+i] * in[iOf7[1]+i];
+    out[oOf7[0]+i+Q] = in[iOf7[0]+i] * in[iOf7[1]+i+Q];
+  }
+}

--- a/tests/t502-operator.c
+++ b/tests/t502-operator.c
@@ -1,0 +1,146 @@
+/// @file
+/// Test creation creation, action, and destruction for mass matrix operator
+/// \test Test creation creation, action, and destruction for mass matrix operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+
+static int setup(void *ctx, CeedInt Q, const CeedScalar *const *in,
+                 CeedScalar *const *out);
+static int mass(void *ctx, CeedInt Q, const CeedScalar *const *in,
+                CeedScalar *const *out);
+
+static int setup(void *ctx, CeedInt Q, const CeedScalar *const *in,
+                 CeedScalar *const *out) {
+  const CeedScalar *weight = in[0], *dxdX = in[1];
+  CeedScalar *rho = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    rho[i] = weight[i] * dxdX[i];
+  }
+  return 0;
+}
+
+static int mass(void *ctx, CeedInt Q, const CeedScalar *const *in,
+                CeedScalar *const *out) {
+  const CeedScalar *rho = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    v[i]   = rho[i] * u[i];
+    v[Q+i] = rho[i] * u[Q+i];
+  }
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup, qf_mass;
+  CeedOperator op_setup, op_mass;
+  CeedVector qdata, X, U, V;
+  CeedScalar *hu;
+  const CeedScalar *hv;
+  CeedInt nelem = 15, P = 5, Q = 8;
+  CeedInt Nx = nelem+1, Nu = nelem*(P-1)+1;
+  CeedInt indx[nelem*2], indu[nelem*P];
+  CeedScalar x[Nx];
+  CeedScalar sum1, sum2;
+
+  CeedInit(argv[1], &ceed);
+  for (CeedInt i=0; i<Nx; i++) x[i] = (CeedScalar) i / (Nx - 1);
+  for (CeedInt i=0; i<nelem; i++) {
+    indx[2*i+0] = i;
+    indx[2*i+1] = i+1;
+  }
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictx);
+  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+
+  for (CeedInt i=0; i<nelem; i++) {
+    for (CeedInt j=0; j<P; j++) {
+      indu[P*i+j] = i*(P-1) + j;
+    }
+  }
+  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 2, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indu, &Erestrictu);
+  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, 1, 2, P, Q, CEED_GAUSS, &bu);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, __FILE__ ":setup", &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "x", 1, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, __FILE__ ":mass", &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", 2, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", 2, CEED_EVAL_INTERP);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+
+  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+
+  CeedVectorCreate(ceed, Nx, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+  CeedVectorCreate(ceed, nelem*Q, &qdata);
+
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_TRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_TRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
+
+  CeedVectorCreate(ceed, 2*Nu, &U);
+  CeedVectorGetArray(U, CEED_MEM_HOST, &hu);
+  for (int i = 0; i < Nu; i++) {
+    hu[2*i] = 1.0;
+    hu[2*i+1] = 2.0;
+  }
+  CeedVectorRestoreArray(U, &hu);
+  CeedVectorCreate(ceed, 2*Nu, &V);
+  CeedOperatorApply(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+  // Check output
+  CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
+  sum1 = 0.; sum2 = 0.;
+  for (CeedInt i=0; i<Nu; i++) {
+    sum1 += hv[2*i];
+    sum2 += hv[2*i+1];
+  }
+  if (fabs(sum1-1.)>1e-10) printf("Computed Area: %f != True Area: 1.0\n", sum1);
+  if (fabs(sum2-2.)>1e-10) printf("Computed Area: %f != True Area: 2.0\n", sum2);
+  CeedVectorRestoreArrayRead(V, &hv);
+
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedElemRestrictionDestroy(&Erestrictxi);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedVectorDestroy(&qdata);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t502-operator.okl
+++ b/tests/t502-operator.okl
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+// *****************************************************************************
+typedef int CeedInt;
+typedef double CeedScalar;
+// OCCA parser doesn't like __global here
+//typedef __global double gCeedScalar;
+
+// *****************************************************************************
+@kernel void setup(void *ctx, CeedInt Q,
+                   const int *iOf7, const int *oOf7, 
+                   const CeedScalar *in, CeedScalar *out) {
+  for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
+    // OCCA parser can't insert an __global here
+    /*const CeedScalar *weight = in + iOf7[0];
+    const CeedScalar *dxdX = in + iOf7[1];
+    CeedScalar *rho = out + oOf7[0];
+    rho[i] = weight[i] * dxdX[i];*/
+    out[oOf7[0]+i] = in[iOf7[0]+i] * in[iOf7[1]+i];
+  }
+}
+
+// *****************************************************************************
+@kernel void mass(void *ctx, CeedInt Q,
+                  const int *iOf7, const int *oOf7,
+                  const CeedScalar *in, CeedScalar *out) {
+  for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
+    // OCCA parser can't insert an __global here
+    /*const CeedScalar *rho = in + iOf7[0];
+    const CeedScalar *u = in + iOf7[1];
+    CeedScalar *v = out + oOf7[0];
+    v[i] = rho[i] * u[i];*/
+    out[oOf7[0]+i] = in[iOf7[0]+i] * in[iOf7[1]+i];
+    out[oOf7[0]+i+Q] = in[iOf7[0]+i] * in[iOf7[1]+i+Q];
+  }
+}

--- a/tests/t510-operator-f.f
+++ b/tests/t510-operator-f.f
@@ -147,20 +147,20 @@ c     $  't30-operator-f.f:mass',qf_mass,err)
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,err)
       call ceedvectorcreate(ceed,nqpts,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',
-     $  erestrictxi,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,
+     $  ceed_notranspose,bx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,
+     $  ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_setup,'rho',
-     $  erestrictui,ceed_basis_collocated,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'rho',
-     $  erestrictui,ceed_basis_collocated,
+      call ceedoperatorsetfield(op_mass,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,
-     $  ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,
      $  ceed_request_immediate,err)

--- a/tests/t510-operator.c
+++ b/tests/t510-operator.c
@@ -3,6 +3,7 @@
 /// \test Test creation creation, action, and destruction for mass matrix operator
 #include <ceed.h>
 #include <stdlib.h>
+#include <math.h>
 #include "t310-basis.h"
 
 static int setup(void *ctx, CeedInt Q, const CeedScalar *const *in,
@@ -112,16 +113,19 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, Nqpts, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui,
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui,
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 
@@ -134,7 +138,7 @@ int main(int argc, char **argv) {
   // Check output
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
   for (CeedInt i=0; i<Ndofs; i++)
-    if (hv[i] != 0.0) printf("[%d] v %g != 0.0\n",i, hv[i]);
+    if (fabs(hv[i]) > 1e-14) printf("[%d] v %g != 0.0\n",i, hv[i]);
   CeedVectorRestoreArrayRead(V, &hv);
 
   CeedQFunctionDestroy(&qf_setup);

--- a/tests/t511-operator-f.f
+++ b/tests/t511-operator-f.f
@@ -148,20 +148,20 @@ c     $  't30-operator-f.f:mass',qf_mass,err)
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,err)
       call ceedvectorcreate(ceed,nqpts,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',
-     $  erestrictxi,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,
+     $  ceed_notranspose,bx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,
+     $  ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_setup,'rho',
-     $  erestrictui,ceed_basis_collocated,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'rho',
-     $  erestrictui,ceed_basis_collocated,
+      call ceedoperatorsetfield(op_mass,'rho',erestrictui,
+     $  ceed_notranspose,ceed_basis_collocated,
      $  qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,
-     $  ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,
-     $  ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,
+     $  ceed_notranspose,bu,ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,
      $  ceed_request_immediate,err)

--- a/tests/t511-operator.c
+++ b/tests/t511-operator.c
@@ -114,16 +114,19 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, Nqpts, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui,
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui,
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 


### PR DESCRIPTION
This PR addes the LMode field to CeedOperatorSetField. Previously lmode=CEED_NOTRANSPOSE was hardcoded into CeedOperatorApply.

This PR should follow PR #167.