### PR TITLE
[WIP] [Discussion] QFunction Gallery

### DIFF
--- a/gallery/bp1mass.h
+++ b/gallery/bp1mass.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+/// @file
+/// libCEED QFunctions for setting up BP1 mass operator
+
+// *****************************************************************************
+static int Fields(Ceed ceed, CeedQFunction *qf) {
+
+  // Create the Q-function that defines the action of the mass operator.
+  CeedQFunctionCreateInterior(ceed, 1, Mass, __FILE__ ":Mass", &qf);
+  CeedQFunctionAddInput(qf, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf, "v", 1, CEED_EVAL_INTERP);
+}
+// *****************************************************************************
+static int Mass(void *ctx, CeedInt Q,
+                const CeedScalar *const *in, CeedScalar *const *out) {
+  const CeedScalar *u = in[0], *rho = in[1];
+  CeedScalar *v = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    v[i] = rho[i] * u[i];
+  }
+  return 0;
+}
+// *****************************************************************************

--- a/gallery/bp1masssetup.h
+++ b/gallery/bp1masssetup.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+/// @file
+/// libCEED QFunctions for BP1 mass operator
+
+// *****************************************************************************
+static int Fields(Ceed ceed, CeedQFunction *qf) {
+  // Create the Q-function that builds the mass operator. (i.e. computes its
+  // quadrature data)
+  CeedQFunctionCreateInterior(ceed, 1, Setup, __FILE__ ":Setup", &qf);
+  CeedQFunctionAddInput(qf, "dx", 3, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf, "rho", 1, CEED_EVAL_NONE);
+}
+// *****************************************************************************
+static int Setup(void *ctx, CeedInt Q,
+                 const CeedScalar *const *in, CeedScalar *const *out) {
+  const CeedScalar *J = in[0], *w = in[1];
+  CeedScalar *rho = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    CeedScalar det = (+J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7])
+                      -J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6])
+                      +J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6]));
+    rho[i] = det * w[i];
+  }
+  return 0;
+}
+// *****************************************************************************

--- a/gallery/bp3diffusion.h
+++ b/gallery/bp3diffusion.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+/// @file
+/// libCEED QFunctions for BP3 diffusion operator
+
+// *****************************************************************************
+static int Fields(Ceed ceed, CeedQFunction *qf) {
+  // Create the Q-function that defines the action of the diff operator.
+  CeedQFunctionCreateInterior(ceed, 1, Diff, __FILE__ ":Diff", &qf);
+  CeedQFunctionAddInput(qf, "u", 1, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf, "rho", 6, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf, "v", 1, CEED_EVAL_GRAD);
+  return 0;
+}
+// *****************************************************************************
+static int Diff(void *ctx, CeedInt Q,
+                const CeedScalar *const *in, CeedScalar *const *out) {
+  const CeedScalar *ug = in[0], *qd = in[1];
+  CeedScalar *vg = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    const CeedScalar ug0 = ug[i+Q*0];
+    const CeedScalar ug1 = ug[i+Q*1];
+    const CeedScalar ug2 = ug[i+Q*2];
+    vg[i+Q*0] = qd[i+Q*0]*ug0 + qd[i+Q*1]*ug1 + qd[i+Q*2]*ug2;
+    vg[i+Q*1] = qd[i+Q*1]*ug0 + qd[i+Q*3]*ug1 + qd[i+Q*4]*ug2;
+    vg[i+Q*2] = qd[i+Q*2]*ug0 + qd[i+Q*4]*ug1 + qd[i+Q*5]*ug2;
+  }
+  return 0;
+}
+// *****************************************************************************

--- a/gallery/bp3diffusionsetup.h
+++ b/gallery/bp3diffusionsetup.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+/// @file
+/// libCEED QFunctions for BP3 diffusion operator
+
+// *****************************************************************************
+static int Fields(Ceed ceed, CeedQFunction *qf) {
+  // Create the Q-function that builds the diff operator. (i.e. computes its
+  // quadrature data)
+  CeedQFunctionCreateInterior(ceed, 1, Setup, __FILE__ ":Setup", &qf);
+  CeedQFunctionAddInput(qf, "dx", 3, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf, "rho", 6, CEED_EVAL_NONE);
+  return 0;
+}
+// *****************************************************************************
+static int Setup(void *ctx, CeedInt Q,
+                 const CeedScalar *const *in, CeedScalar *const *out) {
+  #ifndef M_PI
+  #define M_PI    3.14159265358979323846
+  #endif
+  const CeedScalar *J = in[0], *w = in[1];
+  CeedScalar *qd = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    const CeedScalar J11 = J[i+Q*0];
+    const CeedScalar J21 = J[i+Q*1];
+    const CeedScalar J31 = J[i+Q*2];
+    const CeedScalar J12 = J[i+Q*3];
+    const CeedScalar J22 = J[i+Q*4];
+    const CeedScalar J32 = J[i+Q*5];
+    const CeedScalar J13 = J[i+Q*6];
+    const CeedScalar J23 = J[i+Q*7];
+    const CeedScalar J33 = J[i+Q*8];
+    const CeedScalar A11 = J22*J33 - J23*J32;
+    const CeedScalar A12 = J13*J32 - J12*J33;
+    const CeedScalar A13 = J12*J23 - J13*J22;
+    const CeedScalar A21 = J23*J31 - J21*J33;
+    const CeedScalar A22 = J11*J33 - J13*J31;
+    const CeedScalar A23 = J13*J21 - J11*J23;
+    const CeedScalar A31 = J21*J32 - J22*J31;
+    const CeedScalar A32 = J12*J31 - J11*J32;
+    const CeedScalar A33 = J11*J22 - J12*J21;
+    const CeedScalar qw = w[i] / (J11*A11 + J21*A12 + J31*A13);
+    qd[i+Q*0] = qw * (A11*A11 + A12*A12 + A13*A13);
+    qd[i+Q*1] = qw * (A11*A21 + A12*A22 + A13*A23);
+    qd[i+Q*2] = qw * (A11*A31 + A12*A32 + A13*A33);
+    qd[i+Q*3] = qw * (A21*A21 + A22*A22 + A23*A23);
+    qd[i+Q*4] = qw * (A21*A31 + A22*A32 + A23*A33);
+    qd[i+Q*5] = qw * (A31*A31 + A32*A32 + A33*A33);
+  }
+  return 0;
+}
+// *****************************************************************************

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -292,6 +292,8 @@ CEED_EXTERN int CeedQRFactorization(CeedScalar *mat, CeedScalar *tau, CeedInt m,
 CEED_EXTERN int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
     int (*f)(void *ctx, CeedInt nq, const CeedScalar *const *u,
              CeedScalar *const *v), const char *focca, CeedQFunction *qf);
+CEED_EXTERN int CeedQFunctionCreateFromGallery(Ceed ceed, const char *name,
+                                               CeedQFunction *qf);
 CEED_EXTERN int CeedQFunctionAddInput(CeedQFunction qf, const char *fieldname,
                                       CeedInt ncomp, CeedEvalMode emode);
 CEED_EXTERN int CeedQFunctionAddOutput(CeedQFunction qf, const char *fieldname,

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -85,6 +85,32 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
 }
 
 /**
+  @brief Create a CeedQFunction from a named CeedQFunction in the gallery
+
+  @param ceed       A Ceed object where the CeedQFunction will be created
+  @param name       Name of the QFuction in the gallery
+  @param[out] qf    Address of the variable where the newly created
+                     CeedQFunction will be stored
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Basic
+**/
+int CeedQFunctionCreateFromGallery(Ceed ceed, const char *name,
+                                   CeedQFunction *qf) {
+  // Find matching QFunction from gallery
+  // -Could have a registered list like with backends, or could
+  // -could search a folder. The latter would make it easy for users to
+  // -add to or modify the gallery without recompilation.
+
+  // Run specified setup information
+  // -Need to setup QFunction and its fields. Right now I have a single headder
+  // -file with the qfunction and the lines of C that set it up.
+
+  return 0;
+}
+
+/**
   @brief Set a CeedQFunction field, used by CeedQFunctionAddInput/Output
 
   @param f          CeedQFunctionField


### PR DESCRIPTION
I am creating this PR as a starting place for us to discuss how we want the gallery to work. As I see it, the gallery needs to do four things

- Streamline setup for common QFunctions
- Facilitate using highly optimized versions of known QFunctions
- Document QFunction requirements: inputs, outputs, data layout, etc
- Provide examples for users to make their own complex QFunctions

I think that we should be careful - this gallery should be based on the QFunction itself, not the bases or geometry, as we get that information from the CeedBasis. We shouldn't have a bunch of different QFunctions for each problem (bp1massp6q8het, bp1massp7q10tet, libparanumalbp1massp5q6tet, etc)

I think we should keep in mind our end goal of only having to write the source of the QFunctions once (rather than a C/Fortran, OCCA, CUDA, one-for-every-backend copy of the code).

Issue #37