### PR TITLE
Simplify accessing of inner context

### DIFF
--- a/backends/occa/ceed-occa-qfunction.c
+++ b/backends/occa/ceed-occa-qfunction.c
@@ -134,13 +134,7 @@ static int CeedQFunctionApply_Occa(CeedQFunction qf, CeedInt Q,
   // ***************************************************************************
   void *ctx;
   if (cbytes>0) {
-    bool fortranstatus;
-    ierr = CeedQFunctionGetFortranStatus(qf, &fortranstatus); CeedChk(ierr);
-    if (fortranstatus) {
-      ierr = CeedQFunctionGetFortranContext(qf, &ctx); CeedChk(ierr);
-    } else {
-      ierr = CeedQFunctionGetContext(qf, &ctx); CeedChk(ierr);
-    }
+    ierr = CeedQFunctionGetInnerContext(qf, &ctx); CeedChk(ierr);
     occaCopyPtrToMem(d_ctx,ctx,cbytes,0,NO_PROPS);
   }
 

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -110,9 +110,9 @@ CEED_EXTERN int CeedQFunctionGetUserFunction(CeedQFunction qf,
     int (**f)());
 CEED_EXTERN int CeedQFunctionGetContextSize(CeedQFunction qf, size_t *ctxsize);
 CEED_EXTERN int CeedQFunctionGetContext(CeedQFunction qf, void* *ctx);
+CEED_EXTERN int CeedQFunctionGetInnerContext(CeedQFunction qf, void* *ctx);
 CEED_EXTERN int CeedQFunctionGetFortranStatus(CeedQFunction qf,
     bool *fortranstatus);
-CEED_EXTERN int CeedQFunctionGetFortranContext(CeedQFunction qf, void* *ctx);
 CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void* *data);
 CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void* *data);
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -299,7 +299,7 @@ int CeedQFunctionGetFortranStatus(CeedQFunction qf, bool *fortranstatus) {
 }
 
 /**
-  @brief Get Fortran global context for a CeedQFunction
+  @brief Get true user context for a CeedQFunction
 
   @param qf              CeedQFunction
   @param[out] ctx        Variable to store context data values
@@ -309,13 +309,14 @@ int CeedQFunctionGetFortranStatus(CeedQFunction qf, bool *fortranstatus) {
   @ref Advanced
 **/
 
-int CeedQFunctionGetFortranContext(CeedQFunction qf, void* *ctx) {
-  if (!qf->fortranstatus)
-    return CeedError(qf->ceed, 1,
-                     "QFunction was not set using Fortran");
+int CeedQFunctionGetInnerContext(CeedQFunction qf, void* *ctx) {
+  if (qf->fortranstatus) {
+    fContext *fctx = qf->ctx;
+    *ctx = fctx->innerctx;
+  } else {
+    *ctx = qf->ctx;
+  }
 
-  fContext *fctx = qf->ctx;
- *ctx = fctx->innerctx;
   return 0;
 }
 


### PR DESCRIPTION
This PR simplifies access to the 'true' user context for backends that do not call through the C/Fortran user interface when using user QFunctions written in Fortran (such as CUDA and OCCA).