### PR TITLE
Simple Cuda backend using one thread per element

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ ref.c      := $(sort $(wildcard backends/ref/*.c))
 template.c := $(sort $(wildcard backends/template/*.c))
 cuda.c     := $(sort $(wildcard backends/cuda/*.c))
 cuda.cu    := $(sort $(wildcard backends/cuda/*.cu))
+cuda-reg.c := $(sort $(wildcard backends/cuda-reg/*.c))
+cuda-reg.cu:= $(sort $(wildcard backends/cuda-reg/*.cu))
 blocked.c  := $(sort $(wildcard backends/blocked/*.c))
 avx.c      := $(sort $(wildcard backends/avx/*.c))
 xsmm.c     := $(sort $(wildcard backends/xsmm/*.c))
@@ -263,9 +265,9 @@ ifneq ($(CUDA_LIB_DIR),)
   $(libceed) : CFLAGS += -I$(CUDA_DIR)/include
   $(libceed) : LDFLAGS += -L$(CUDA_LIB_DIR) -Wl,-rpath,$(abspath $(CUDA_LIB_DIR))
   $(libceed) : LDLIBS += -lcudart -lnvrtc -lcuda
-  libceed.c  += $(cuda.c)
-  libceed.cu += $(cuda.cu)
-  BACKENDS += /gpu/cuda
+  libceed.c  += $(cuda.c) $(cuda-reg.c)
+  libceed.cu += $(cuda.cu) $(cuda-reg.cu)
+  BACKENDS += /gpu/cuda/ref /gpu/cuda/reg
 endif
 
 # MAGMA Backend

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ There are multiple supported backends, which can be selected at runtime in the e
 | `/gpu/occa`              | CUDA OCCA kernels                                 |
 | `/omp/occa`              | OpenMP OCCA kernels                               |
 | `/ocl/occa`              | OpenCL OCCA kernels                               |
-| `/gpu/cuda/ref`          | Pure CUDA kernels                                 |
-| `/gpu/cuda/reg`          | Pure CUDA kernels                                 |
+| `/gpu/cuda/ref`          | Reference pure CUDA kernels                       |
+| `/gpu/cuda/reg`          | Pure CUDA kernels using one thread per element    |
 | `/gpu/magma`             | CUDA MAGMA kernels                                |
 
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ There are multiple supported backends, which can be selected at runtime in the e
 | `/gpu/occa`              | CUDA OCCA kernels                                 |
 | `/omp/occa`              | OpenMP OCCA kernels                               |
 | `/ocl/occa`              | OpenCL OCCA kernels                               |
-| `/gpu/cuda`              | Pure CUDA kernels                                 |
+| `/gpu/cuda/ref`          | Pure CUDA kernels                                 |
+| `/gpu/cuda/reg`          | Pure CUDA kernels                                 |
 | `/gpu/magma`             | CUDA MAGMA kernels                                |
 
 
@@ -116,7 +117,7 @@ to provide vectorized CPU performance.
 The `/*/occa` backends rely upon the [OCCA](http://github.com/libocca/occa) package to provide
 cross platform performance.
 
-The `/gpu/cuda` backend provides GPU performance strictly using CUDA.
+The `/gpu/cuda/*` backends provide GPU performance strictly using CUDA.
 
 The `/gpu/magma` backend relies upon the [MAGMA](https://bitbucket.org/icl/magma) package.
 

--- a/backends/cuda-reg/ceed-cuda-reg-basis.c
+++ b/backends/cuda-reg/ceed-cuda-reg-basis.c
@@ -23,43 +23,52 @@
 // reg kernels
 static const char *kernels3dreg = QUOTE(
 
-typedef CeedScalar real;
+                                    typedef CeedScalar real;
 
 //TODO remove the magic number 32
 
 //Read non interleaved dofs
-inline __device__ void readDofs(const int bid, const int tid, const int comp, const int size, const int nelem, const CeedScalar* d_U, real* r_U) {
+                                    inline __device__ void readDofs(const int bid, const int tid, const int comp,
+const int size, const int nelem, const CeedScalar *d_U, real *r_U) {
 #pragma unroll
-      for (int i = 0; i < size; i++)
-        //r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem ];
-        r_U[i] = d_U[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ];
+  for (int i = 0; i < size; i++)
+    //r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem ];
+    r_U[i] = d_U[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ];
 }
 
 //read interleaved quads
-inline __device__ void readQuads(const int bid, const int tid, const int comp, const int dim, const int size, const int nelem, const CeedScalar* d_U, real* r_U) {
+inline __device__ void readQuads(const int bid, const int tid, const int comp,
+                                 const int dim, const int size, const int nelem, const CeedScalar *d_U,
+                                 real *r_U) {
 #pragma unroll
-      for (int i = 0; i < size; i++)
-        r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem + dim*BASIS_NCOMP*nelem*size];
-        //r_U[i] = d_U[tid + i*32 + bid*32*size + comp*nelem*size + dim*BASIS_NCOMP*nelem*size];
+  for (int i = 0; i < size; i++)
+    r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem +
+                 dim*BASIS_NCOMP*nelem*size];
+  //r_U[i] = d_U[tid + i*32 + bid*32*size + comp*nelem*size + dim*BASIS_NCOMP*nelem*size];
 }
 
 //Write non interleaved dofs
-inline __device__ void writeDofs(const int bid, const int tid, const int comp, const int size, const int nelem, const CeedScalar* r_V, real* d_V) {
-#pragma unroll 
-      for (int i = 0; i < size; i++)
-        //d_V[i + tid*size + bid*32*size + comp*size*nelem ] = r_V[i]; 
-        d_V[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ] = r_V[i];
+inline __device__ void writeDofs(const int bid, const int tid, const int comp,
+                                 const int size, const int nelem, const CeedScalar *r_V, real *d_V) {
+#pragma unroll
+  for (int i = 0; i < size; i++)
+    //d_V[i + tid*size + bid*32*size + comp*size*nelem ] = r_V[i];
+    d_V[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ] = r_V[i];
 }
 
 //Write interleaved quads
-inline __device__ void writeQuads(const int bid, const int tid, const int comp, const int dim, const int size, const int nelem, const CeedScalar* r_V, real* d_V) {
+inline __device__ void writeQuads(const int bid, const int tid, const int comp,
+                                  const int dim, const int size, const int nelem, const CeedScalar *r_V,
+                                  real *d_V) {
 #pragma unroll
-      for (int i = 0; i < size; i++)
-        d_V[i + tid*size + bid*32*size + comp*size*nelem + dim*BASIS_NCOMP*nelem*size ] = r_V[i];
-        //d_V[tid + i*32 + bid*32*size + comp*nelem*size + dim*BASIS_NCOMP*nelem*size] = r_V[i]; 
+  for (int i = 0; i < size; i++)
+    d_V[i + tid*size + bid*32*size + comp*size*nelem + dim*BASIS_NCOMP*nelem*size ]
+      = r_V[i];
+  //d_V[tid + i*32 + bid*32*size + comp*nelem*size + dim*BASIS_NCOMP*nelem*size] = r_V[i];
 }
 
-inline __device__ void add(const int size, CeedScalar* r_V, const CeedScalar* r_U) {
+inline __device__ void add(const int size, CeedScalar *r_V,
+                           const CeedScalar *r_U) {
   for (int i = 0; i < size; i++)
     r_V[i] += r_U[i];
 }
@@ -67,9 +76,8 @@ inline __device__ void add(const int size, CeedScalar* r_V, const CeedScalar* r_
 //****
 // 1D
 inline __device__ void Contract1d(const real *A, const real *B,
-                                 int nA1,
-                                 int nB1, int nB2, real *T)
-{
+                                  int nA1,
+                                  int nB1, int nB2, real *T) {
 #pragma unroll
   for (int l = 0; l < nB2; l++) T[l] = 0.0;
 #pragma unroll
@@ -81,9 +89,8 @@ inline __device__ void Contract1d(const real *A, const real *B,
 }
 
 inline __device__ void ContractTranspose1d(const real *A, const real *B,
-                                         int nA1,
-                                         int nB1, int nB2, real *T)
-{
+    int nA1,
+    int nB1, int nB2, real *T) {
 #pragma unroll
   for (int l = 0; l < nB1; l++) T[l] = 0.0;
 #pragma unroll
@@ -94,17 +101,18 @@ inline __device__ void ContractTranspose1d(const real *A, const real *B,
     }
 }
 
-inline __device__ void interp1d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+inline __device__ void interp1d(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B, const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V) {
   real r_V[Q1D];
   real r_t[Q1D];
 
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
 
-  if(bid*32+tid<nelem){
+  if(bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose){
+      if(!transpose) {
         const int sizeU = P1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
         Contract1d(r_V, c_B, P1D, P1D, Q1D, r_t);
@@ -121,8 +129,9 @@ inline __device__ void interp1d(const CeedInt nelem, const int transpose, const 
   }
 }
 
-inline __device__ void grad1d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+inline __device__ void grad1d(const CeedInt nelem, const int transpose,
+                              const CeedScalar *c_B, const CeedScalar *c_G,
+                              const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
   //use P1D for one of these
   real r_U[Q1D];
   real r_V[Q1D];
@@ -131,9 +140,9 @@ inline __device__ void grad1d(const CeedInt nelem, const int transpose, const Ce
   const int bid = blockIdx.x;
   int dim;
 
-  if(bid*32+tid<nelem){
+  if(bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose){
+      if(!transpose) {
         const int sizeU = P1D;
         const int sizeV = Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
@@ -155,48 +164,45 @@ inline __device__ void grad1d(const CeedInt nelem, const int transpose, const Ce
 //****
 // 2D
 inline __device__ void Contract2d(const real *A, const real *B,
-                                 int nA1, int nA2,
-                                 int nB1, int nB2, real *T)
-{
+                                  int nA1, int nA2,
+                                  int nB1, int nB2, real *T) {
 #pragma unroll
-    for (int l = 0; l < nA2*nB2; l++) T[l] = 0.0;
+  for (int l = 0; l < nA2*nB2; l++) T[l] = 0.0;
 #pragma unroll
-    for (int a2 = 0; a2 < nA2; a2++)
+  for (int a2 = 0; a2 < nA2; a2++)
 #pragma unroll
-            for (int b2 = 0; b2 < nB2; b2++)
+    for (int b2 = 0; b2 < nB2; b2++)
 #pragma unroll
-                for (int t = 0; t < nB1; t++)
-                {
-                    T[a2 + b2*nA2] += B[b2*nB1 + t] * A[a2*nA1 + t];
-                }
+      for (int t = 0; t < nB1; t++) {
+        T[a2 + b2*nA2] += B[b2*nB1 + t] * A[a2*nA1 + t];
+      }
 }
 
 inline __device__ void ContractTranspose2d(const real *A, const real *B,
-                                         int nA1, int nA2,
-                                         int nB1, int nB2, real *T)
-{
+    int nA1, int nA2,
+    int nB1, int nB2, real *T) {
 #pragma unroll
-    for (int l = 0; l < nA2*nB1; l++) T[l] = 0.0;
+  for (int l = 0; l < nA2*nB1; l++) T[l] = 0.0;
 #pragma unroll
-    for (int a2 = 0; a2 < nA2; a2++)
+  for (int a2 = 0; a2 < nA2; a2++)
 #pragma unroll
-            for (int b1 = 0; b1 < nB1; b1++)
+    for (int b1 = 0; b1 < nB1; b1++)
 #pragma unroll
-                for (int t = 0; t < nB2; t++)
-                {
-                    T[a2 + b1*nA2] += B[t*nB1 + b1] * A[a2*nA1 + t];
-                }
+      for (int t = 0; t < nB2; t++) {
+        T[a2 + b1*nA2] += B[t*nB1 + b1] * A[a2*nA1 + t];
+      }
 }
 
-inline __device__ void interp2d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+inline __device__ void interp2d(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B, const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V) {
   real r_V[Q1D*Q1D];
   real r_t[Q1D*Q1D];
 
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
 
-  if(bid*32+tid<nelem){
+  if(bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
       if(!transpose) {
         const int sizeU = P1D*P1D;
@@ -214,11 +220,12 @@ inline __device__ void interp2d(const CeedInt nelem, const int transpose, const 
         writeDofs(bid, tid, comp, sizeV, nelem, r_V, d_V);
       }
     }
-  }  
+  }
 }
 
-inline __device__ void grad2d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+inline __device__ void grad2d(const CeedInt nelem, const int transpose,
+                              const CeedScalar *c_B, const CeedScalar *c_G,
+                              const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
   //use P1D for one of these
   real r_U[Q1D*Q1D];
   real r_V[Q1D*Q1D];
@@ -228,18 +235,18 @@ inline __device__ void grad2d(const CeedInt nelem, const int transpose, const Ce
   const int bid = blockIdx.x;
   int dim;
 
-  if(bid*32+tid<nelem){
+  if(bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose){
+      if(!transpose) {
         const int sizeU = P1D*P1D;
         const int sizeV = Q1D*Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
         Contract2d(r_U, c_G, P1D, P1D, P1D, Q1D, r_t);
-        Contract2d(r_t, c_B, P1D, Q1D, P1D, Q1D, r_V); 
+        Contract2d(r_t, c_B, P1D, Q1D, P1D, Q1D, r_V);
         dim = 0;
         writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
         Contract2d(r_U, c_B, P1D, P1D, P1D, Q1D, r_t);
-        Contract2d(r_t, c_G, P1D, Q1D, P1D, Q1D, r_V); 
+        Contract2d(r_t, c_G, P1D, Q1D, P1D, Q1D, r_V);
         dim = 1;
         writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
       } else {
@@ -263,59 +270,56 @@ inline __device__ void grad2d(const CeedInt nelem, const int transpose, const Ce
 //****
 // 3D
 inline __device__ void Contract3d(const real *A, const real *B,
-                                 int nA1, int nA2, int nA3,
-                                 int nB1, int nB2, real *T)
-{
+                                  int nA1, int nA2, int nA3,
+                                  int nB1, int nB2, real *T) {
 #pragma unroll
-    for (int l = 0; l < nA2*nA3*nB2; l++) T[l] = 0.0;
+  for (int l = 0; l < nA2*nA3*nB2; l++) T[l] = 0.0;
 #pragma unroll
-    for (int a2 = 0; a2 < nA2; a2++)
+  for (int a2 = 0; a2 < nA2; a2++)
 #pragma unroll
-        for (int a3 = 0; a3 < nA3; a3++)
+    for (int a3 = 0; a3 < nA3; a3++)
 #pragma unroll
-            for (int b2 = 0; b2 < nB2; b2++)
+      for (int b2 = 0; b2 < nB2; b2++)
 #pragma unroll
-                for (int t = 0; t < nB1; t++)
-                {
-                    T[a2 + a3*nA2 + b2*nA2*nA3] += B[b2*nB1 + t] * A[a3*nA2*nA1 + a2*nA1 + t];
-                }
+        for (int t = 0; t < nB1; t++) {
+          T[a2 + a3*nA2 + b2*nA2*nA3] += B[b2*nB1 + t] * A[a3*nA2*nA1 + a2*nA1 + t];
+        }
 }
 
 inline __device__ void ContractTranspose3d(const real *A, const real *B,
-                                         int nA1, int nA2, int nA3,
-                                         int nB1, int nB2, real *T)
-{
+    int nA1, int nA2, int nA3,
+    int nB1, int nB2, real *T) {
 #pragma unroll
-    for (int l = 0; l < nA2*nA3*nB1; l++) T[l] = 0.0;
+  for (int l = 0; l < nA2*nA3*nB1; l++) T[l] = 0.0;
 #pragma unroll
-    for (int a2 = 0; a2 < nA2; a2++)
+  for (int a2 = 0; a2 < nA2; a2++)
 #pragma unroll
-        for (int a3 = 0; a3 < nA3; a3++)
+    for (int a3 = 0; a3 < nA3; a3++)
 #pragma unroll
-            for (int b1 = 0; b1 < nB1; b1++)
+      for (int b1 = 0; b1 < nB1; b1++)
 #pragma unroll
-                for (int t = 0; t < nB2; t++)
-                {
-                    T[a2 + a3*nA2 + b1*nA2*nA3] += B[t*nB1 + b1] * A[a3*nA2*nA1 + a2*nA1 + t];
-                }
+        for (int t = 0; t < nB2; t++) {
+          T[a2 + a3*nA2 + b1*nA2*nA3] += B[t*nB1 + b1] * A[a3*nA2*nA1 + a2*nA1 + t];
+        }
 }
 
-inline __device__ void interp3d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+inline __device__ void interp3d(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B, const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V) {
   real r_V[Q1D*Q1D*Q1D];
   real r_t[Q1D*Q1D*Q1D];
 
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
 
-  if(bid*32+tid<nelem){
+  if(bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose){
+      if(!transpose) {
         const int sizeU = P1D*P1D*P1D;
         const int sizeV = Q1D*Q1D*Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
         Contract3d(r_V, c_B, P1D, P1D, P1D, P1D, Q1D, r_t);
-        Contract3d(r_t, c_B, P1D, P1D, Q1D, P1D, Q1D, r_V); 
+        Contract3d(r_t, c_B, P1D, P1D, Q1D, P1D, Q1D, r_V);
         Contract3d(r_V, c_B, P1D, Q1D, Q1D, P1D, Q1D, r_t);
         writeQuads(bid, tid, comp, 0, sizeV, nelem, r_t, d_V);
       } else {
@@ -331,8 +335,9 @@ inline __device__ void interp3d(const CeedInt nelem, const int transpose, const 
   }
 }
 
-inline __device__ void grad3d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+inline __device__ void grad3d(const CeedInt nelem, const int transpose,
+                              const CeedScalar *c_B, const CeedScalar *c_G,
+                              const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
   //use P1D for one of these
   real r_U[Q1D*Q1D*Q1D];
   real r_V[Q1D*Q1D*Q1D];
@@ -342,24 +347,24 @@ inline __device__ void grad3d(const CeedInt nelem, const int transpose, const Ce
   const int bid = blockIdx.x;
   int dim;
 
-  if(bid*32+tid<nelem){
+  if(bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose){
+      if(!transpose) {
         const int sizeU = P1D*P1D*P1D;
         const int sizeV = Q1D*Q1D*Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
         Contract3d(r_U, c_G, P1D, P1D, P1D, P1D, Q1D, r_V);
-        Contract3d(r_V, c_B, P1D, P1D, Q1D, P1D, Q1D, r_t); 
+        Contract3d(r_V, c_B, P1D, P1D, Q1D, P1D, Q1D, r_t);
         Contract3d(r_t, c_B, P1D, Q1D, Q1D, P1D, Q1D, r_V);
         dim = 0;
         writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
         Contract3d(r_U, c_B, P1D, P1D, P1D, P1D, Q1D, r_V);
-        Contract3d(r_V, c_G, P1D, P1D, Q1D, P1D, Q1D, r_t); 
+        Contract3d(r_V, c_G, P1D, P1D, Q1D, P1D, Q1D, r_t);
         Contract3d(r_t, c_B, P1D, Q1D, Q1D, P1D, Q1D, r_V);
         dim = 1;
         writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
         Contract3d(r_U, c_B, P1D, P1D, P1D, P1D, Q1D, r_V);
-        Contract3d(r_V, c_B, P1D, P1D, Q1D, P1D, Q1D, r_t); 
+        Contract3d(r_V, c_B, P1D, P1D, Q1D, P1D, Q1D, r_t);
         Contract3d(r_t, c_G, P1D, Q1D, Q1D, P1D, Q1D, r_V);
         dim = 2;
         writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
@@ -389,8 +394,9 @@ inline __device__ void grad3d(const CeedInt nelem, const int transpose, const Ce
   }
 }
 
-extern "C" __global__ void interp(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+extern "C" __global__ void interp(const CeedInt nelem, const int transpose,
+                                  const CeedScalar *c_B, const CeedScalar *__restrict__ d_U,
+                                  CeedScalar *__restrict__ d_V) {
   if (BASIS_DIM==1) {
     interp1d(nelem, transpose, c_B, d_U, d_V);
   } else if (BASIS_DIM==2) {
@@ -398,10 +404,11 @@ extern "C" __global__ void interp(const CeedInt nelem, const int transpose, cons
   } else if (BASIS_DIM==3) {
     interp3d(nelem, transpose, c_B, d_U, d_V);
   }
-}   
+}
 
-extern "C" __global__ void grad(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
-{
+extern "C" __global__ void grad(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B, const CeedScalar *c_G,
+                                const CeedScalar *__restrict__ d_U, CeedScalar *__restrict__ d_V) {
   if (BASIS_DIM==1) {
     grad1d(nelem, transpose, c_B, c_G, d_U, d_V);
   } else if (BASIS_DIM==2) {
@@ -411,17 +418,16 @@ extern "C" __global__ void grad(const CeedInt nelem, const int transpose, const 
   }
 }
 
-__device__ void weight1d(const CeedInt nelem, const CeedScalar * qweight1d, CeedScalar* w){
+__device__ void weight1d(const CeedInt nelem, const CeedScalar *qweight1d,
+                         CeedScalar *w) {
   CeedScalar w1d[Q1D];
-  for (int i = 0; i < Q1D; ++i)
-  {
+  for (int i = 0; i < Q1D; ++i) {
     w1d[i] = qweight1d[i];
   }
   for (int e = blockIdx.x * blockDim.x + threadIdx.x;
        e < nelem;
        e += blockDim.x * gridDim.x) {
-    for (int i = 0; i < Q1D; ++i)
-    {
+    for (int i = 0; i < Q1D; ++i) {
       //const int ind = e + i*nelem;//interleaved
       const int ind = e*Q1D + i;//sequential
       w[ind] = w1d[i];
@@ -429,19 +435,17 @@ __device__ void weight1d(const CeedInt nelem, const CeedScalar * qweight1d, Ceed
   }
 }
 
-__device__ void weight2d(const CeedInt nelem, const CeedScalar * qweight1d, CeedScalar* w){
+__device__ void weight2d(const CeedInt nelem, const CeedScalar *qweight1d,
+                         CeedScalar *w) {
   CeedScalar w1d[Q1D];
-  for (int i = 0; i < Q1D; ++i)
-  {
+  for (int i = 0; i < Q1D; ++i) {
     w1d[i] = qweight1d[i];
   }
   for (int e = blockIdx.x * blockDim.x + threadIdx.x;
        e < nelem;
        e += blockDim.x * gridDim.x) {
-    for (int i = 0; i < Q1D; ++i)
-    {
-      for (int j = 0; j < Q1D; ++j)
-      {
+    for (int i = 0; i < Q1D; ++i) {
+      for (int j = 0; j < Q1D; ++j) {
         //const int ind = e + i*nelem + j*Q1D*nelem;//interleaved
         const int ind = e*Q1D*Q1D + i + j*Q1D;//sequential
         w[ind] = w1d[i]*w1d[j];
@@ -450,21 +454,18 @@ __device__ void weight2d(const CeedInt nelem, const CeedScalar * qweight1d, Ceed
   }
 }
 
-__device__ void weight3d(const CeedInt nelem, const CeedScalar * qweight1d, CeedScalar* w){
+__device__ void weight3d(const CeedInt nelem, const CeedScalar *qweight1d,
+                         CeedScalar *w) {
   CeedScalar w1d[Q1D];
-  for (int i = 0; i < Q1D; ++i)
-  {
+  for (int i = 0; i < Q1D; ++i) {
     w1d[i] = qweight1d[i];
   }
   for (int e = blockIdx.x * blockDim.x + threadIdx.x;
        e < nelem;
        e += blockDim.x * gridDim.x) {
-    for (int i = 0; i < Q1D; ++i)
-    {
-      for (int j = 0; j < Q1D; ++j)
-      {
-        for (int k = 0; k < Q1D; ++k)
-        {
+    for (int i = 0; i < Q1D; ++i) {
+      for (int j = 0; j < Q1D; ++j) {
+        for (int k = 0; k < Q1D; ++k) {
           //const int ind = e + i*nelem + j*Q1D*nelem + k*Q1D*Q1D*nelem;//interleaved
           const int ind = e*Q1D*Q1D*Q1D + i + j*Q1D + k*Q1D*Q1D;//sequential
           w[ind] = w1d[i]*w1d[j]*w1d[k];
@@ -474,7 +475,8 @@ __device__ void weight3d(const CeedInt nelem, const CeedScalar * qweight1d, Ceed
   }
 }
 
-extern "C" __global__ void weight(const CeedInt nelem, const CeedScalar * __restrict__ qweight1d, CeedScalar * __restrict__ v){ 
+extern "C" __global__ void weight(const CeedInt nelem,
+                                  const CeedScalar *__restrict__ qweight1d, CeedScalar *__restrict__ v) {
   if (BASIS_DIM==1) {
     weight1d(nelem, qweight1d, v);
   } else if (BASIS_DIM==2) {
@@ -484,28 +486,32 @@ extern "C" __global__ void weight(const CeedInt nelem, const CeedScalar * __rest
   }
 }
 
-);
+                                  );
 
-int CeedCudaRegInitInterp(CeedScalar* d_B, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B);
-int CeedCudaRegInitInterpGrad(CeedScalar* d_B, CeedScalar* d_G, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B_ptr, CeedScalar** c_G_ptr);
+int CeedCudaRegInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
+                          CeedScalar **c_B);
+int CeedCudaRegInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G, CeedInt P1d,
+                              CeedInt Q1d, CeedScalar **c_B_ptr, CeedScalar **c_G_ptr);
 
-int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem, CeedTransposeMode tmode,
-    CeedEvalMode emode, CeedVector u, CeedVector v) {
+int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem,
+                            CeedTransposeMode tmode,
+                            CeedEvalMode emode, CeedVector u, CeedVector v) {
   int ierr;
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
-  Ceed_Cuda_reg* ceed_Cuda;
-  CeedGetData(ceed, (void*) &ceed_Cuda); CeedChk(ierr);
+  Ceed_Cuda_reg *ceed_Cuda;
+  CeedGetData(ceed, (void *) &ceed_Cuda); CeedChk(ierr);
   CeedBasis_Cuda_reg *data;
-  CeedBasisGetData(basis, (void*)&data); CeedChk(ierr);
+  CeedBasisGetData(basis, (void *)&data); CeedChk(ierr);
   const CeedInt transpose = tmode == CEED_TRANSPOSE;
   const int warpsize  = 32;
   const int blocksize = warpsize;
-  const int gridsize  = nelem/warpsize + ( (nelem/warpsize*warpsize<nelem)? 1 : 0 );
+  const int gridsize  = nelem/warpsize + ( (nelem/warpsize*warpsize<nelem)? 1 :
+                        0 );
 
   const CeedScalar *d_u;
   CeedScalar *d_v;
-  if(emode!=CEED_EVAL_WEIGHT){
+  if(emode!=CEED_EVAL_WEIGHT) {
     ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
@@ -515,17 +521,21 @@ int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem, CeedTransposeM
   }
   if (emode == CEED_EVAL_INTERP) {
     //TODO: check performance difference between c_B and d_B
-    ierr = CeedCudaRegInitInterp(data->d_interp1d, basis->P1d, basis->Q1d, &data->c_B);
+    ierr = CeedCudaRegInitInterp(data->d_interp1d, basis->P1d, basis->Q1d,
+                                 &data->c_B);
     CeedChk(ierr);
-    void *interpargs[] = {(void*)&nelem, (void*)&transpose, &data->c_B, &d_u, &d_v};
-    ierr = run_kernel(ceed, data->interp, gridsize, blocksize, interpargs); CeedChk(ierr);
+    void *interpargs[] = {(void *) &nelem, (void *) &transpose, &data->c_B, &d_u, &d_v};
+    ierr = run_kernel(ceed, data->interp, gridsize, blocksize, interpargs);
+    CeedChk(ierr);
   } else if (emode == CEED_EVAL_GRAD) {
-    ierr = CeedCudaRegInitInterpGrad(data->d_interp1d, data->d_grad1d, basis->P1d, basis->Q1d, &data->c_B, &data->c_G);
+    ierr = CeedCudaRegInitInterpGrad(data->d_interp1d, data->d_grad1d, basis->P1d,
+                                     basis->Q1d, &data->c_B, &data->c_G);
     CeedChk(ierr);
-    void *gradargs[] = {(void*)&nelem, (void*)&transpose, &data->c_B, &data->c_G, &d_u, &d_v};
-    ierr = run_kernel(ceed, data->grad, gridsize, blocksize, gradargs); CeedChk(ierr);
+    void *gradargs[] = {(void *) &nelem, (void *) &transpose, &data->c_B, &data->c_G, &d_u, &d_v};
+    ierr = run_kernel(ceed, data->grad, gridsize, blocksize, gradargs);
+    CeedChk(ierr);
   } else if (emode == CEED_EVAL_WEIGHT) {
-    void *weightargs[] = {(void*)&nelem, (void*)&data->d_qweight1d, &d_v};
+    void *weightargs[] = {(void *) &nelem, (void *) &data->d_qweight1d, &d_v};
     const int blocksize = 32;
     int gridsize = nelem/32;
     if (blocksize * gridsize < nelem)
@@ -533,7 +543,7 @@ int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem, CeedTransposeM
     ierr = run_kernel(ceed, data->weight, gridsize, blocksize, weightargs);
   }
 
-  if(emode!=CEED_EVAL_WEIGHT){
+  if(emode!=CEED_EVAL_WEIGHT) {
     ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);
@@ -545,7 +555,7 @@ static int CeedBasisDestroy_Cuda_reg(CeedBasis basis) {
   int ierr;
 
   CeedBasis_Cuda_reg *data;
-  ierr = CeedBasisGetData(basis, (void*) &data); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *) &data); CeedChk(ierr);
 
   CeedChk_Cu(basis->ceed, cuModuleUnload(data->module));
 
@@ -559,26 +569,26 @@ static int CeedBasisDestroy_Cuda_reg(CeedBasis basis) {
 }
 
 int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d, CeedInt Q1d,
-                                 const CeedScalar *interp1d,
-                                 const CeedScalar *grad1d,
-                                 const CeedScalar *qref1d,
-                                 const CeedScalar *qweight1d,
-                                 CeedBasis basis) {
+                                     const CeedScalar *interp1d,
+                                     const CeedScalar *grad1d,
+                                     const CeedScalar *qref1d,
+                                     const CeedScalar *qweight1d,
+                                     CeedBasis basis) {
   int ierr;
   CeedBasis_Cuda_reg *data;
   ierr = CeedCalloc(1, &data); CeedChk(ierr);
 
   const CeedInt qBytes = basis->Q1d * sizeof(CeedScalar);
-  ierr = cudaMalloc((void**)&data->d_qweight1d, qBytes); CeedChk(ierr);
+  ierr = cudaMalloc((void **)&data->d_qweight1d, qBytes); CeedChk(ierr);
   ierr = cudaMemcpy(data->d_qweight1d, basis->qweight1d, qBytes,
                     cudaMemcpyHostToDevice); CeedChk(ierr);
 
   const CeedInt iBytes = qBytes * basis->P1d;
-  ierr = cudaMalloc((void**)&data->d_interp1d, iBytes); CeedChk(ierr);
+  ierr = cudaMalloc((void **)&data->d_interp1d, iBytes); CeedChk(ierr);
   ierr = cudaMemcpy(data->d_interp1d, basis->interp1d, iBytes,
                     cudaMemcpyHostToDevice); CeedChk(ierr);
 
-  ierr = cudaMalloc((void**)&data->d_grad1d, iBytes); CeedChk(ierr);
+  ierr = cudaMalloc((void **)&data->d_grad1d, iBytes); CeedChk(ierr);
   ierr = cudaMemcpy(data->d_grad1d, basis->grad1d, iBytes,
                     cudaMemcpyHostToDevice); CeedChk(ierr);
 
@@ -601,9 +611,10 @@ int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d, CeedInt Q1d,
 
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
-  ierr = CeedBasisSetData(basis, (void*)&data);
+  ierr = CeedBasisSetData(basis, (void *)&data);
   CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApply_Cuda_reg);
+  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
+                                CeedBasisApply_Cuda_reg);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Destroy",
                                 CeedBasisDestroy_Cuda_reg);
@@ -612,12 +623,12 @@ int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d, CeedInt Q1d,
 }
 
 int CeedBasisCreateH1_Cuda_reg(CeedElemTopology topo, CeedInt dim,
-                           CeedInt ndof, CeedInt nqpts,
-                           const CeedScalar *interp,
-                           const CeedScalar *grad,
-                           const CeedScalar *qref,
-                           const CeedScalar *qweight,
-                           CeedBasis basis) {
+                               CeedInt ndof, CeedInt nqpts,
+                               const CeedScalar *interp,
+                               const CeedScalar *grad,
+                               const CeedScalar *qref,
+                               const CeedScalar *qweight,
+                               CeedBasis basis) {
   int ierr;
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);

--- a/backends/cuda-reg/ceed-cuda-reg-basis.c
+++ b/backends/cuda-reg/ceed-cuda-reg-basis.c
@@ -1,0 +1,625 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <ceed-impl.h>
+#include "../include/ceed.h"
+#include "ceed-cuda-reg.h"
+#include "../cuda/ceed-cuda.h"
+
+//*********************
+// reg kernels
+static const char *kernels3dreg = QUOTE(
+
+typedef CeedScalar real;
+
+//TODO remove the magic number 32
+
+//Read non interleaved dofs
+inline __device__ void readDofs(const int bid, const int tid, const int comp, const int size, const int nelem, const CeedScalar* d_U, real* r_U) {
+#pragma unroll
+      for (int i = 0; i < size; i++)
+        //r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem ];
+        r_U[i] = d_U[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ];
+}
+
+//read interleaved quads
+inline __device__ void readQuads(const int bid, const int tid, const int comp, const int dim, const int size, const int nelem, const CeedScalar* d_U, real* r_U) {
+#pragma unroll
+      for (int i = 0; i < size; i++)
+        r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem + dim*BASIS_NCOMP*nelem*size];
+        //r_U[i] = d_U[tid + i*32 + bid*32*size + comp*nelem*size + dim*BASIS_NCOMP*nelem*size];
+}
+
+//Write non interleaved dofs
+inline __device__ void writeDofs(const int bid, const int tid, const int comp, const int size, const int nelem, const CeedScalar* r_V, real* d_V) {
+#pragma unroll 
+      for (int i = 0; i < size; i++)
+        //d_V[i + tid*size + bid*32*size + comp*size*nelem ] = r_V[i]; 
+        d_V[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ] = r_V[i];
+}
+
+//Write interleaved quads
+inline __device__ void writeQuads(const int bid, const int tid, const int comp, const int dim, const int size, const int nelem, const CeedScalar* r_V, real* d_V) {
+#pragma unroll
+      for (int i = 0; i < size; i++)
+        d_V[i + tid*size + bid*32*size + comp*size*nelem + dim*BASIS_NCOMP*nelem*size ] = r_V[i];
+        //d_V[tid + i*32 + bid*32*size + comp*nelem*size + dim*BASIS_NCOMP*nelem*size] = r_V[i]; 
+}
+
+inline __device__ void add(const int size, CeedScalar* r_V, const CeedScalar* r_U) {
+  for (int i = 0; i < size; i++)
+    r_V[i] += r_U[i];
+}
+
+//****
+// 1D
+inline __device__ void Contract1d(const real *A, const real *B,
+                                 int nA1,
+                                 int nB1, int nB2, real *T)
+{
+#pragma unroll
+  for (int l = 0; l < nB2; l++) T[l] = 0.0;
+#pragma unroll
+  for (int b2 = 0; b2 < nB2; b2++)
+#pragma unroll
+    for (int t = 0; t < nB1; t++) {
+      T[b2] += B[b2*nB1 + t] * A[t];
+    }
+}
+
+inline __device__ void ContractTranspose1d(const real *A, const real *B,
+                                         int nA1,
+                                         int nB1, int nB2, real *T)
+{
+#pragma unroll
+  for (int l = 0; l < nB1; l++) T[l] = 0.0;
+#pragma unroll
+  for (int b1 = 0; b1 < nB1; b1++)
+#pragma unroll
+    for (int t = 0; t < nB2; t++) {
+      T[b1] += B[t*nB1 + b1] * A[t];
+    }
+}
+
+inline __device__ void interp1d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  real r_V[Q1D];
+  real r_t[Q1D];
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+
+  if(bid*32+tid<nelem){
+    for(int comp=0; comp<BASIS_NCOMP; comp++) {
+      if(!transpose){
+        const int sizeU = P1D;
+        readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
+        Contract1d(r_V, c_B, P1D, P1D, Q1D, r_t);
+        const int sizeV = Q1D;
+        writeQuads(bid, tid, comp, 0, sizeV, nelem, r_t, d_V);
+      } else {
+        const int sizeU = Q1D;
+        readQuads(bid, tid, comp, 0, sizeU, nelem, d_U, r_V);
+        ContractTranspose1d(r_V, c_B, Q1D, P1D, Q1D, r_t);
+        const int sizeV = P1D;
+        writeDofs(bid, tid, comp, sizeV, nelem, r_t, d_V);
+      }
+    }
+  }
+}
+
+inline __device__ void grad1d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  //use P1D for one of these
+  real r_U[Q1D];
+  real r_V[Q1D];
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  int dim;
+
+  if(bid*32+tid<nelem){
+    for(int comp=0; comp<BASIS_NCOMP; comp++) {
+      if(!transpose){
+        const int sizeU = P1D;
+        const int sizeV = Q1D;
+        readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
+        Contract1d(r_U, c_G, P1D, P1D, Q1D, r_V);
+        dim = 0;
+        writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
+      } else {
+        const int sizeU = Q1D;
+        const int sizeV = P1D;
+        dim = 0;
+        readQuads(bid, tid, comp, dim, sizeU, nelem, d_U, r_U);
+        ContractTranspose1d(r_U, c_G, Q1D, P1D, Q1D, r_V);
+        writeDofs(bid, tid, comp, sizeV, nelem, r_V, d_V);
+      }
+    }
+  }
+}
+
+//****
+// 2D
+inline __device__ void Contract2d(const real *A, const real *B,
+                                 int nA1, int nA2,
+                                 int nB1, int nB2, real *T)
+{
+#pragma unroll
+    for (int l = 0; l < nA2*nB2; l++) T[l] = 0.0;
+#pragma unroll
+    for (int a2 = 0; a2 < nA2; a2++)
+#pragma unroll
+            for (int b2 = 0; b2 < nB2; b2++)
+#pragma unroll
+                for (int t = 0; t < nB1; t++)
+                {
+                    T[a2 + b2*nA2] += B[b2*nB1 + t] * A[a2*nA1 + t];
+                }
+}
+
+inline __device__ void ContractTranspose2d(const real *A, const real *B,
+                                         int nA1, int nA2,
+                                         int nB1, int nB2, real *T)
+{
+#pragma unroll
+    for (int l = 0; l < nA2*nB1; l++) T[l] = 0.0;
+#pragma unroll
+    for (int a2 = 0; a2 < nA2; a2++)
+#pragma unroll
+            for (int b1 = 0; b1 < nB1; b1++)
+#pragma unroll
+                for (int t = 0; t < nB2; t++)
+                {
+                    T[a2 + b1*nA2] += B[t*nB1 + b1] * A[a2*nA1 + t];
+                }
+}
+
+inline __device__ void interp2d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  real r_V[Q1D*Q1D];
+  real r_t[Q1D*Q1D];
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+
+  if(bid*32+tid<nelem){
+    for(int comp=0; comp<BASIS_NCOMP; comp++) {
+      if(!transpose) {
+        const int sizeU = P1D*P1D;
+        readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
+        Contract2d(r_V, c_B, P1D, P1D, P1D, Q1D, r_t);
+        Contract2d(r_t, c_B, P1D, Q1D, P1D, Q1D, r_V);
+        const int sizeV = Q1D*Q1D;
+        writeQuads(bid, tid, comp, 0, sizeV, nelem, r_V, d_V);
+      } else {
+        const int sizeU = Q1D*Q1D;
+        readQuads(bid, tid, comp, 0, sizeU, nelem, d_U, r_V);
+        ContractTranspose2d(r_V, c_B, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose2d(r_t, c_B, Q1D, P1D, P1D, Q1D, r_V);
+        const int sizeV = P1D*P1D;
+        writeDofs(bid, tid, comp, sizeV, nelem, r_V, d_V);
+      }
+    }
+  }  
+}
+
+inline __device__ void grad2d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  //use P1D for one of these
+  real r_U[Q1D*Q1D];
+  real r_V[Q1D*Q1D];
+  real r_t[Q1D*Q1D];
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  int dim;
+
+  if(bid*32+tid<nelem){
+    for(int comp=0; comp<BASIS_NCOMP; comp++) {
+      if(!transpose){
+        const int sizeU = P1D*P1D;
+        const int sizeV = Q1D*Q1D;
+        readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
+        Contract2d(r_U, c_G, P1D, P1D, P1D, Q1D, r_t);
+        Contract2d(r_t, c_B, P1D, Q1D, P1D, Q1D, r_V); 
+        dim = 0;
+        writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
+        Contract2d(r_U, c_B, P1D, P1D, P1D, Q1D, r_t);
+        Contract2d(r_t, c_G, P1D, Q1D, P1D, Q1D, r_V); 
+        dim = 1;
+        writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
+      } else {
+        const int sizeU = Q1D*Q1D;
+        const int sizeV = P1D*P1D;
+        dim = 0;
+        readQuads(bid, tid, comp, dim, sizeU, nelem, d_U, r_U);
+        ContractTranspose2d(r_U, c_G, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose2d(r_t, c_B, Q1D, P1D, P1D, Q1D, r_V);
+        dim = 1;
+        readQuads(bid, tid, comp, dim, sizeU, nelem, d_U, r_U);
+        ContractTranspose2d(r_U, c_B, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose2d(r_t, c_G, Q1D, P1D, P1D, Q1D, r_U);
+        add(sizeV, r_V, r_U);
+        writeDofs(bid, tid, comp, sizeV, nelem, r_V, d_V);
+      }
+    }
+  }
+}
+
+//****
+// 3D
+inline __device__ void Contract3d(const real *A, const real *B,
+                                 int nA1, int nA2, int nA3,
+                                 int nB1, int nB2, real *T)
+{
+#pragma unroll
+    for (int l = 0; l < nA2*nA3*nB2; l++) T[l] = 0.0;
+#pragma unroll
+    for (int a2 = 0; a2 < nA2; a2++)
+#pragma unroll
+        for (int a3 = 0; a3 < nA3; a3++)
+#pragma unroll
+            for (int b2 = 0; b2 < nB2; b2++)
+#pragma unroll
+                for (int t = 0; t < nB1; t++)
+                {
+                    T[a2 + a3*nA2 + b2*nA2*nA3] += B[b2*nB1 + t] * A[a3*nA2*nA1 + a2*nA1 + t];
+                }
+}
+
+inline __device__ void ContractTranspose3d(const real *A, const real *B,
+                                         int nA1, int nA2, int nA3,
+                                         int nB1, int nB2, real *T)
+{
+#pragma unroll
+    for (int l = 0; l < nA2*nA3*nB1; l++) T[l] = 0.0;
+#pragma unroll
+    for (int a2 = 0; a2 < nA2; a2++)
+#pragma unroll
+        for (int a3 = 0; a3 < nA3; a3++)
+#pragma unroll
+            for (int b1 = 0; b1 < nB1; b1++)
+#pragma unroll
+                for (int t = 0; t < nB2; t++)
+                {
+                    T[a2 + a3*nA2 + b1*nA2*nA3] += B[t*nB1 + b1] * A[a3*nA2*nA1 + a2*nA1 + t];
+                }
+}
+
+inline __device__ void interp3d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  real r_V[Q1D*Q1D*Q1D];
+  real r_t[Q1D*Q1D*Q1D];
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+
+  if(bid*32+tid<nelem){
+    for(int comp=0; comp<BASIS_NCOMP; comp++) {
+      if(!transpose){
+        const int sizeU = P1D*P1D*P1D;
+        const int sizeV = Q1D*Q1D*Q1D;
+        readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
+        Contract3d(r_V, c_B, P1D, P1D, P1D, P1D, Q1D, r_t);
+        Contract3d(r_t, c_B, P1D, P1D, Q1D, P1D, Q1D, r_V); 
+        Contract3d(r_V, c_B, P1D, Q1D, Q1D, P1D, Q1D, r_t);
+        writeQuads(bid, tid, comp, 0, sizeV, nelem, r_t, d_V);
+      } else {
+        const int sizeU = Q1D*Q1D*Q1D;
+        const int sizeV = P1D*P1D*P1D;
+        readQuads(bid, tid, comp, 0, sizeU, nelem, d_U, r_V);
+        ContractTranspose3d(r_V, c_B, Q1D, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose3d(r_t, c_B, Q1D, Q1D, P1D, P1D, Q1D, r_V);
+        ContractTranspose3d(r_V, c_B, Q1D, P1D, P1D, P1D, Q1D, r_t);
+        writeDofs(bid, tid, comp, sizeV, nelem, r_t, d_V);
+      }
+    }
+  }
+}
+
+inline __device__ void grad3d(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  //use P1D for one of these
+  real r_U[Q1D*Q1D*Q1D];
+  real r_V[Q1D*Q1D*Q1D];
+  real r_t[Q1D*Q1D*Q1D];
+
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  int dim;
+
+  if(bid*32+tid<nelem){
+    for(int comp=0; comp<BASIS_NCOMP; comp++) {
+      if(!transpose){
+        const int sizeU = P1D*P1D*P1D;
+        const int sizeV = Q1D*Q1D*Q1D;
+        readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
+        Contract3d(r_U, c_G, P1D, P1D, P1D, P1D, Q1D, r_V);
+        Contract3d(r_V, c_B, P1D, P1D, Q1D, P1D, Q1D, r_t); 
+        Contract3d(r_t, c_B, P1D, Q1D, Q1D, P1D, Q1D, r_V);
+        dim = 0;
+        writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
+        Contract3d(r_U, c_B, P1D, P1D, P1D, P1D, Q1D, r_V);
+        Contract3d(r_V, c_G, P1D, P1D, Q1D, P1D, Q1D, r_t); 
+        Contract3d(r_t, c_B, P1D, Q1D, Q1D, P1D, Q1D, r_V);
+        dim = 1;
+        writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
+        Contract3d(r_U, c_B, P1D, P1D, P1D, P1D, Q1D, r_V);
+        Contract3d(r_V, c_B, P1D, P1D, Q1D, P1D, Q1D, r_t); 
+        Contract3d(r_t, c_G, P1D, Q1D, Q1D, P1D, Q1D, r_V);
+        dim = 2;
+        writeQuads(bid, tid, comp, dim, sizeV, nelem, r_V, d_V);
+      } else {
+        const int sizeU = Q1D*Q1D*Q1D;
+        const int sizeV = P1D*P1D*P1D;
+        dim = 0;
+        readQuads(bid, tid, comp, dim, sizeU, nelem, d_U, r_U);
+        ContractTranspose3d(r_U, c_G, Q1D, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose3d(r_t, c_B, Q1D, Q1D, P1D, P1D, Q1D, r_U);
+        ContractTranspose3d(r_U, c_B, Q1D, P1D, P1D, P1D, Q1D, r_V);
+        dim = 1;
+        readQuads(bid, tid, comp, dim, sizeU, nelem, d_U, r_U);
+        ContractTranspose3d(r_U, c_B, Q1D, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose3d(r_t, c_G, Q1D, Q1D, P1D, P1D, Q1D, r_U);
+        ContractTranspose3d(r_U, c_B, Q1D, P1D, P1D, P1D, Q1D, r_t);
+        add(sizeV, r_V, r_t);
+        dim = 2;
+        readQuads(bid, tid, comp, dim, sizeU, nelem, d_U, r_U);
+        ContractTranspose3d(r_U, c_B, Q1D, Q1D, Q1D, P1D, Q1D, r_t);
+        ContractTranspose3d(r_t, c_B, Q1D, Q1D, P1D, P1D, Q1D, r_U);
+        ContractTranspose3d(r_U, c_G, Q1D, P1D, P1D, P1D, Q1D, r_t);
+        add(sizeV, r_V, r_t);
+        writeDofs(bid, tid, comp, sizeV, nelem, r_V, d_V);
+      }
+    }
+  }
+}
+
+extern "C" __global__ void interp(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  if (BASIS_DIM==1) {
+    interp1d(nelem, transpose, c_B, d_U, d_V);
+  } else if (BASIS_DIM==2) {
+    interp2d(nelem, transpose, c_B, d_U, d_V);
+  } else if (BASIS_DIM==3) {
+    interp3d(nelem, transpose, c_B, d_U, d_V);
+  }
+}   
+
+extern "C" __global__ void grad(const CeedInt nelem, const int transpose, const CeedScalar *c_B, const CeedScalar *c_G, const CeedScalar * __restrict__ d_U, CeedScalar *__restrict__ d_V)
+{
+  if (BASIS_DIM==1) {
+    grad1d(nelem, transpose, c_B, c_G, d_U, d_V);
+  } else if (BASIS_DIM==2) {
+    grad2d(nelem, transpose, c_B, c_G, d_U, d_V);
+  } else if (BASIS_DIM==3) {
+    grad3d(nelem, transpose, c_B, c_G, d_U, d_V);
+  }
+}
+
+__device__ void weight1d(const CeedInt nelem, const CeedScalar * qweight1d, CeedScalar* w){
+  CeedScalar w1d[Q1D];
+  for (int i = 0; i < Q1D; ++i)
+  {
+    w1d[i] = qweight1d[i];
+  }
+  for (int e = blockIdx.x * blockDim.x + threadIdx.x;
+       e < nelem;
+       e += blockDim.x * gridDim.x) {
+    for (int i = 0; i < Q1D; ++i)
+    {
+      //const int ind = e + i*nelem;//interleaved
+      const int ind = e*Q1D + i;//sequential
+      w[ind] = w1d[i];
+    }
+  }
+}
+
+__device__ void weight2d(const CeedInt nelem, const CeedScalar * qweight1d, CeedScalar* w){
+  CeedScalar w1d[Q1D];
+  for (int i = 0; i < Q1D; ++i)
+  {
+    w1d[i] = qweight1d[i];
+  }
+  for (int e = blockIdx.x * blockDim.x + threadIdx.x;
+       e < nelem;
+       e += blockDim.x * gridDim.x) {
+    for (int i = 0; i < Q1D; ++i)
+    {
+      for (int j = 0; j < Q1D; ++j)
+      {
+        //const int ind = e + i*nelem + j*Q1D*nelem;//interleaved
+        const int ind = e*Q1D*Q1D + i + j*Q1D;//sequential
+        w[ind] = w1d[i]*w1d[j];
+      }
+    }
+  }
+}
+
+__device__ void weight3d(const CeedInt nelem, const CeedScalar * qweight1d, CeedScalar* w){
+  CeedScalar w1d[Q1D];
+  for (int i = 0; i < Q1D; ++i)
+  {
+    w1d[i] = qweight1d[i];
+  }
+  for (int e = blockIdx.x * blockDim.x + threadIdx.x;
+       e < nelem;
+       e += blockDim.x * gridDim.x) {
+    for (int i = 0; i < Q1D; ++i)
+    {
+      for (int j = 0; j < Q1D; ++j)
+      {
+        for (int k = 0; k < Q1D; ++k)
+        {
+          //const int ind = e + i*nelem + j*Q1D*nelem + k*Q1D*Q1D*nelem;//interleaved
+          const int ind = e*Q1D*Q1D*Q1D + i + j*Q1D + k*Q1D*Q1D;//sequential
+          w[ind] = w1d[i]*w1d[j]*w1d[k];
+        }
+      }
+    }
+  }
+}
+
+extern "C" __global__ void weight(const CeedInt nelem, const CeedScalar * __restrict__ qweight1d, CeedScalar * __restrict__ v){ 
+  if (BASIS_DIM==1) {
+    weight1d(nelem, qweight1d, v);
+  } else if (BASIS_DIM==2) {
+    weight2d(nelem, qweight1d, v);
+  } else if (BASIS_DIM==3) {
+    weight3d(nelem, qweight1d, v);
+  }
+}
+
+);
+
+int CeedCudaRegInitInterp(CeedScalar* d_B, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B);
+int CeedCudaRegInitInterpGrad(CeedScalar* d_B, CeedScalar* d_G, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B_ptr, CeedScalar** c_G_ptr);
+
+int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem, CeedTransposeMode tmode,
+    CeedEvalMode emode, CeedVector u, CeedVector v) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
+  Ceed_Cuda_reg* ceed_Cuda;
+  CeedGetData(ceed, (void*) &ceed_Cuda); CeedChk(ierr);
+  CeedBasis_Cuda_reg *data;
+  CeedBasisGetData(basis, (void*)&data); CeedChk(ierr);
+  const CeedInt transpose = tmode == CEED_TRANSPOSE;
+  const int warpsize  = 32;
+  const int blocksize = warpsize;
+  const int gridsize  = nelem/warpsize + ( (nelem/warpsize*warpsize<nelem)? 1 : 0 );
+
+  const CeedScalar *d_u;
+  CeedScalar *d_v;
+  if(emode!=CEED_EVAL_WEIGHT){
+    ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
+  }
+  ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
+
+  if (tmode == CEED_TRANSPOSE) {
+    ierr = cudaMemset(d_v, 0, v->length * sizeof(CeedScalar)); CeedChk(ierr);
+  }
+  if (emode == CEED_EVAL_INTERP) {
+    //TODO: check performance difference between c_B and d_B
+    ierr = CeedCudaRegInitInterp(data->d_interp1d, basis->P1d, basis->Q1d, &data->c_B);
+    CeedChk(ierr);
+    void *interpargs[] = {(void*)&nelem, (void*)&transpose, &data->c_B, &d_u, &d_v};
+    ierr = run_kernel(ceed, data->interp, gridsize, blocksize, interpargs); CeedChk(ierr);
+  } else if (emode == CEED_EVAL_GRAD) {
+    ierr = CeedCudaRegInitInterpGrad(data->d_interp1d, data->d_grad1d, basis->P1d, basis->Q1d, &data->c_B, &data->c_G);
+    CeedChk(ierr);
+    void *gradargs[] = {(void*)&nelem, (void*)&transpose, &data->c_B, &data->c_G, &d_u, &d_v};
+    ierr = run_kernel(ceed, data->grad, gridsize, blocksize, gradargs); CeedChk(ierr);
+  } else if (emode == CEED_EVAL_WEIGHT) {
+    void *weightargs[] = {(void*)&nelem, (void*)&data->d_qweight1d, &d_v};
+    const int blocksize = 32;
+    int gridsize = nelem/32;
+    if (blocksize * gridsize < nelem)
+      gridsize += 1;
+    ierr = run_kernel(ceed, data->weight, gridsize, blocksize, weightargs);
+  }
+
+  if(emode!=CEED_EVAL_WEIGHT){
+    ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
+  }
+  ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);
+
+  return 0;
+}
+
+static int CeedBasisDestroy_Cuda_reg(CeedBasis basis) {
+  int ierr;
+
+  CeedBasis_Cuda_reg *data;
+  ierr = CeedBasisGetData(basis, (void*) &data); CeedChk(ierr);
+
+  CeedChk_Cu(basis->ceed, cuModuleUnload(data->module));
+
+  ierr = cudaFree(data->d_qweight1d); CeedChk(ierr);
+  ierr = cudaFree(data->d_interp1d); CeedChk(ierr);
+  ierr = cudaFree(data->d_grad1d); CeedChk(ierr);
+
+  ierr = CeedFree(&data); CeedChk(ierr);
+
+  return 0;
+}
+
+int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d, CeedInt Q1d,
+                                 const CeedScalar *interp1d,
+                                 const CeedScalar *grad1d,
+                                 const CeedScalar *qref1d,
+                                 const CeedScalar *qweight1d,
+                                 CeedBasis basis) {
+  int ierr;
+  CeedBasis_Cuda_reg *data;
+  ierr = CeedCalloc(1, &data); CeedChk(ierr);
+
+  const CeedInt qBytes = basis->Q1d * sizeof(CeedScalar);
+  ierr = cudaMalloc((void**)&data->d_qweight1d, qBytes); CeedChk(ierr);
+  ierr = cudaMemcpy(data->d_qweight1d, basis->qweight1d, qBytes,
+                    cudaMemcpyHostToDevice); CeedChk(ierr);
+
+  const CeedInt iBytes = qBytes * basis->P1d;
+  ierr = cudaMalloc((void**)&data->d_interp1d, iBytes); CeedChk(ierr);
+  ierr = cudaMemcpy(data->d_interp1d, basis->interp1d, iBytes,
+                    cudaMemcpyHostToDevice); CeedChk(ierr);
+
+  ierr = cudaMalloc((void**)&data->d_grad1d, iBytes); CeedChk(ierr);
+  ierr = cudaMemcpy(data->d_grad1d, basis->grad1d, iBytes,
+                    cudaMemcpyHostToDevice); CeedChk(ierr);
+
+  ierr = compile(basis->ceed, kernels3dreg, &data->module, 7,
+                 "Q1D", basis->Q1d,
+                 "P1D", basis->P1d,
+                 "BASIS_BUF_LEN", basis->ncomp * CeedIntPow(basis->Q1d > basis->P1d ?
+                     basis->Q1d : basis->P1d, basis->dim),
+                 "BASIS_DIM", basis->dim,
+                 "BASIS_NCOMP", basis->ncomp,
+                 "BASIS_ELEMSIZE", CeedIntPow(basis->P1d, basis->dim),
+                 "BASIS_NQPT", CeedIntPow(basis->Q1d, basis->dim)
+                ); CeedChk(ierr);
+  ierr = get_kernel(basis->ceed, data->module, "interp", &data->interp);
+  CeedChk(ierr);
+  ierr = get_kernel(basis->ceed, data->module, "grad", &data->grad);
+  CeedChk(ierr);
+  ierr = get_kernel(basis->ceed, data->module, "weight", &data->weight);
+  CeedChk(ierr);
+
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
+  ierr = CeedBasisSetData(basis, (void*)&data);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApply_Cuda_reg);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Destroy",
+                                CeedBasisDestroy_Cuda_reg);
+  CeedChk(ierr);
+  return 0;
+}
+
+int CeedBasisCreateH1_Cuda_reg(CeedElemTopology topo, CeedInt dim,
+                           CeedInt ndof, CeedInt nqpts,
+                           const CeedScalar *interp,
+                           const CeedScalar *grad,
+                           const CeedScalar *qref,
+                           const CeedScalar *qweight,
+                           CeedBasis basis) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement generic H1 basis");
+}

--- a/backends/cuda-reg/ceed-cuda-reg-basis.c
+++ b/backends/cuda-reg/ceed-cuda-reg-basis.c
@@ -23,15 +23,16 @@
 // reg kernels
 static const char *kernels3dreg = QUOTE(
 
-                                    typedef CeedScalar real;
+typedef CeedScalar real;
 
 //TODO remove the magic number 32
 
 //Read non interleaved dofs
-                                    inline __device__ void readDofs(const int bid, const int tid, const int comp,
+inline __device__ void readDofs(const int bid, const int tid, const int comp,
 const int size, const int nelem, const CeedScalar *d_U, real *r_U) {
 #pragma unroll
   for (int i = 0; i < size; i++)
+    //r_U[i] = d_U[tid + i*32 + bid*32*size + comp*size*nelem];
     //r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem ];
     r_U[i] = d_U[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ];
 }

--- a/backends/cuda-reg/ceed-cuda-reg-basis.c
+++ b/backends/cuda-reg/ceed-cuda-reg-basis.c
@@ -30,7 +30,6 @@ typedef CeedScalar real;
 //Read non interleaved dofs
 inline __device__ void readDofs(const int bid, const int tid, const int comp,
 const int size, const int nelem, const CeedScalar *d_U, real *r_U) {
-#pragma unroll
   for (int i = 0; i < size; i++)
     //r_U[i] = d_U[tid + i*32 + bid*32*size + comp*size*nelem];
     //r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem ];
@@ -41,7 +40,6 @@ const int size, const int nelem, const CeedScalar *d_U, real *r_U) {
 inline __device__ void readQuads(const int bid, const int tid, const int comp,
                                  const int dim, const int size, const int nelem, const CeedScalar *d_U,
                                  real *r_U) {
-#pragma unroll
   for (int i = 0; i < size; i++)
     r_U[i] = d_U[i + tid*size + bid*32*size + comp*size*nelem +
                  dim*BASIS_NCOMP*nelem*size];
@@ -51,7 +49,6 @@ inline __device__ void readQuads(const int bid, const int tid, const int comp,
 //Write non interleaved dofs
 inline __device__ void writeDofs(const int bid, const int tid, const int comp,
                                  const int size, const int nelem, const CeedScalar *r_V, real *d_V) {
-#pragma unroll
   for (int i = 0; i < size; i++)
     //d_V[i + tid*size + bid*32*size + comp*size*nelem ] = r_V[i];
     d_V[i + comp*size + tid*BASIS_NCOMP*size + bid*32*BASIS_NCOMP*size ] = r_V[i];
@@ -61,7 +58,6 @@ inline __device__ void writeDofs(const int bid, const int tid, const int comp,
 inline __device__ void writeQuads(const int bid, const int tid, const int comp,
                                   const int dim, const int size, const int nelem, const CeedScalar *r_V,
                                   real *d_V) {
-#pragma unroll
   for (int i = 0; i < size; i++)
     d_V[i + tid*size + bid*32*size + comp*size*nelem + dim*BASIS_NCOMP*nelem*size ]
       = r_V[i];
@@ -79,11 +75,11 @@ inline __device__ void add(const int size, CeedScalar *r_V,
 inline __device__ void Contract1d(const real *A, const real *B,
                                   int nA1,
                                   int nB1, int nB2, real *T) {
-#pragma unroll
+//_Pragma("unroll")
   for (int l = 0; l < nB2; l++) T[l] = 0.0;
-#pragma unroll
+//_Pragma("unroll")
   for (int b2 = 0; b2 < nB2; b2++)
-#pragma unroll
+//_Pragma("unroll")
     for (int t = 0; t < nB1; t++) {
       T[b2] += B[b2*nB1 + t] * A[t];
     }
@@ -92,11 +88,11 @@ inline __device__ void Contract1d(const real *A, const real *B,
 inline __device__ void ContractTranspose1d(const real *A, const real *B,
     int nA1,
     int nB1, int nB2, real *T) {
-#pragma unroll
+//_Pragma("unroll")
   for (int l = 0; l < nB1; l++) T[l] = 0.0;
-#pragma unroll
+//_Pragma("unroll")
   for (int b1 = 0; b1 < nB1; b1++)
-#pragma unroll
+//_Pragma("unroll")
     for (int t = 0; t < nB2; t++) {
       T[b1] += B[t*nB1 + b1] * A[t];
     }
@@ -167,13 +163,13 @@ inline __device__ void grad1d(const CeedInt nelem, const int transpose,
 inline __device__ void Contract2d(const real *A, const real *B,
                                   int nA1, int nA2,
                                   int nB1, int nB2, real *T) {
-#pragma unroll
+//_Pragma("unroll")
   for (int l = 0; l < nA2*nB2; l++) T[l] = 0.0;
-#pragma unroll
+//_Pragma("unroll")
   for (int a2 = 0; a2 < nA2; a2++)
-#pragma unroll
+//_Pragma("unroll")
     for (int b2 = 0; b2 < nB2; b2++)
-#pragma unroll
+//_Pragma("unroll")
       for (int t = 0; t < nB1; t++) {
         T[a2 + b2*nA2] += B[b2*nB1 + t] * A[a2*nA1 + t];
       }
@@ -182,13 +178,13 @@ inline __device__ void Contract2d(const real *A, const real *B,
 inline __device__ void ContractTranspose2d(const real *A, const real *B,
     int nA1, int nA2,
     int nB1, int nB2, real *T) {
-#pragma unroll
+//_Pragma("unroll")
   for (int l = 0; l < nA2*nB1; l++) T[l] = 0.0;
-#pragma unroll
+//_Pragma("unroll")
   for (int a2 = 0; a2 < nA2; a2++)
-#pragma unroll
+//_Pragma("unroll")
     for (int b1 = 0; b1 < nB1; b1++)
-#pragma unroll
+//_Pragma("unroll")
       for (int t = 0; t < nB2; t++) {
         T[a2 + b1*nA2] += B[t*nB1 + b1] * A[a2*nA1 + t];
       }
@@ -273,15 +269,15 @@ inline __device__ void grad2d(const CeedInt nelem, const int transpose,
 inline __device__ void Contract3d(const real *A, const real *B,
                                   int nA1, int nA2, int nA3,
                                   int nB1, int nB2, real *T) {
-#pragma unroll
+//_Pragma("unroll")
   for (int l = 0; l < nA2*nA3*nB2; l++) T[l] = 0.0;
-#pragma unroll
+//_Pragma("unroll")
   for (int a2 = 0; a2 < nA2; a2++)
-#pragma unroll
+//_Pragma("unroll")
     for (int a3 = 0; a3 < nA3; a3++)
-#pragma unroll
+//_Pragma("unroll")
       for (int b2 = 0; b2 < nB2; b2++)
-#pragma unroll
+//_Pragma("unroll")
         for (int t = 0; t < nB1; t++) {
           T[a2 + a3*nA2 + b2*nA2*nA3] += B[b2*nB1 + t] * A[a3*nA2*nA1 + a2*nA1 + t];
         }
@@ -290,15 +286,15 @@ inline __device__ void Contract3d(const real *A, const real *B,
 inline __device__ void ContractTranspose3d(const real *A, const real *B,
     int nA1, int nA2, int nA3,
     int nB1, int nB2, real *T) {
-#pragma unroll
+//_Pragma("unroll")
   for (int l = 0; l < nA2*nA3*nB1; l++) T[l] = 0.0;
-#pragma unroll
+//_Pragma("unroll")
   for (int a2 = 0; a2 < nA2; a2++)
-#pragma unroll
+//_Pragma("unroll")
     for (int a3 = 0; a3 < nA3; a3++)
-#pragma unroll
+//_Pragma("unroll")
       for (int b1 = 0; b1 < nB1; b1++)
-#pragma unroll
+//_Pragma("unroll")
         for (int t = 0; t < nB2; t++) {
           T[a2 + a3*nA2 + b1*nA2*nA3] += B[t*nB1 + b1] * A[a3*nA2*nA1 + a2*nA1 + t];
         }

--- a/backends/cuda-reg/ceed-cuda-reg-restriction.c
+++ b/backends/cuda-reg/ceed-cuda-reg-restriction.c
@@ -1,0 +1,471 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <ceed-impl.h>
+#include "ceed-cuda-reg.h"
+#include "../cuda/ceed-cuda.h"
+
+static const char *restrictionkernels = QUOTE(
+// extern "C" __global__ void noTrNoTr(const CeedInt nelem,
+//                                     const CeedInt *__restrict__ indices,
+//                                     const CeedScalar *__restrict__ u,
+//                                     CeedScalar *__restrict__ v) {
+//   if (indices) {
+//     const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+//     for(CeedInt i = blockIdx.x * blockDim.x + threadIdx.x;
+//         i < esize;
+//         i += blockDim.x * gridDim.x) {
+//       const CeedInt ind = indices[i];
+//       for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+//       {
+//         v[i + d*esize] = u[ind + RESTRICTION_NDOF * d];
+//         // v[i*RESTRICTION_NCOMP + d] = u[ind + RESTRICTION_NDOF * d];
+//       }
+//     }
+//   } else {
+//     const CeedInt esize = RESTRICTION_ELEMSIZE * RESTRICTION_NCOMP * nelem;
+//     for(CeedInt i = blockIdx.x * blockDim.x + threadIdx.x;
+//         i < esize;
+//         i += blockDim.x * gridDim.x) {
+//       v[i] = u[i];
+//     }
+//   }
+// }
+
+extern "C" __global__ void noTrNoTr(const CeedInt nelem,
+                                    const CeedInt *__restrict__ indices,
+                                    const CeedScalar *__restrict__ u,
+                                    CeedScalar *__restrict__ v) {
+  if (indices) {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = indices[dof + e * RESTRICTION_ELEMSIZE];//could be interesting to reorder this to coalesce
+        for(CeedInt comp = 0; comp < RESTRICTION_NCOMP; ++comp)
+        {
+          v[dof + comp*RESTRICTION_ELEMSIZE + e*RESTRICTION_ELEMSIZE*RESTRICTION_NCOMP] = u[ind + RESTRICTION_NDOF * comp];
+        }
+      }
+    }
+  } else {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = dof + e * RESTRICTION_ELEMSIZE;
+        for(CeedInt comp = 0; comp < RESTRICTION_NCOMP; ++comp)
+        {
+          v[dof + comp*RESTRICTION_ELEMSIZE + e*RESTRICTION_ELEMSIZE*RESTRICTION_NCOMP] = u[ind + RESTRICTION_NDOF * comp];
+        }
+      }
+    }
+  }
+}
+
+extern "C" __global__ void noTrNoTrInterleaved(const CeedInt nelem,
+                                    const CeedInt *__restrict__ indices,
+                                    const CeedScalar *__restrict__ u,
+                                    CeedScalar *__restrict__ v) {
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  if (indices) {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = indices[e * RESTRICTION_ELEMSIZE + dof];
+        for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+        {
+          v[tid + dof*32 + bid*32*RESTRICTION_ELEMSIZE + d*esize] = u[ind + RESTRICTION_NDOF * d]; // TODO: make sure at least 32 elements
+        }
+      }
+    }
+  } else {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = e * RESTRICTION_ELEMSIZE + dof;
+        for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+        {
+          v[tid + dof*32 + bid*32*RESTRICTION_ELEMSIZE + d*esize] = u[ind + RESTRICTION_NDOF * d];
+        }
+      }
+    }
+  }
+}
+
+// extern "C" __global__ void noTrTr(const CeedInt nelem,
+//                                   const CeedInt *__restrict__ indices,
+//                                   const CeedScalar *__restrict__ u,
+//                                   CeedScalar *__restrict__ v) {
+//   if (indices) {
+//     const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+//     for(CeedInt i = blockIdx.x * blockDim.x + threadIdx.x;
+//         i < esize;
+//         i += blockDim.x * gridDim.x) {
+//       const CeedInt ind = indices[i];
+//       for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+//       {
+//         v[i + d*esize] = u[ind * RESTRICTION_NCOMP + d];
+//       }
+//     }
+//   } else {
+//     const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+//     for(CeedInt i = blockIdx.x * blockDim.x + threadIdx.x;
+//         i < esize;
+//         i += blockDim.x * gridDim.x) {
+//       for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+//       {
+//         v[i + d*esize] = u[i * RESTRICTION_NCOMP + d];        
+//       }
+//     }
+//   }
+// }
+
+extern "C" __global__ void noTrTr(const CeedInt nelem,
+                                    const CeedInt *__restrict__ indices,
+                                    const CeedScalar *__restrict__ u,
+                                    CeedScalar *__restrict__ v) {
+  if (indices) {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = indices[dof + e * RESTRICTION_ELEMSIZE];//could be interesting to reorder this to coalesce
+        for(CeedInt comp = 0; comp < RESTRICTION_NCOMP; ++comp)
+        {
+          v[dof + comp*RESTRICTION_ELEMSIZE + e*RESTRICTION_ELEMSIZE*RESTRICTION_NCOMP] = u[ind * RESTRICTION_NCOMP + comp];
+        }
+      }
+    }
+  } else {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = dof + e * RESTRICTION_ELEMSIZE;
+        for(CeedInt comp = 0; comp < RESTRICTION_NCOMP; ++comp)
+        {
+          v[dof + comp*RESTRICTION_ELEMSIZE + e*RESTRICTION_ELEMSIZE*RESTRICTION_NCOMP] = u[ind * RESTRICTION_NCOMP + comp];
+        }
+      }
+    }
+  }
+}
+
+
+extern "C" __global__ void noTrTrInterleaved(const CeedInt nelem,
+                                    const CeedInt *__restrict__ indices,
+                                    const CeedScalar *__restrict__ u,
+                                    CeedScalar *__restrict__ v) {
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  if (indices) {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = indices[e * RESTRICTION_ELEMSIZE + dof];
+        for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+        {
+          v[tid + dof*32 + bid*32*RESTRICTION_ELEMSIZE + d*esize] = u[ind * RESTRICTION_NCOMP + d]; // TODO: make sure at least 32 elements
+        }
+      }
+    }
+  } else {
+    const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+    for(CeedInt e = blockIdx.x * blockDim.x + threadIdx.x;
+        e < nelem;
+        e += blockDim.x * gridDim.x) {
+      for (CeedInt dof = 0; dof < RESTRICTION_ELEMSIZE; ++dof)
+      {
+        const CeedInt ind = e * RESTRICTION_ELEMSIZE + dof;
+        for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
+        {
+          v[tid + dof*32 + bid*32*RESTRICTION_ELEMSIZE + d*esize] = u[ind * RESTRICTION_NCOMP + d];
+        }
+      }
+    }
+  }
+}
+
+extern "C" __global__ void trNoTr(const CeedInt nelem,
+                                  const CeedInt * __restrict__ tindices,
+                                  const CeedInt * __restrict__ toffsets,
+                                  const CeedScalar *__restrict__ u,
+                                  CeedScalar *__restrict__ v) {
+  double value[RESTRICTION_NCOMP];
+  const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+  for (CeedInt i = blockIdx.x * blockDim.x + threadIdx.x;
+       i < RESTRICTION_NDOF;
+       i += blockDim.x * gridDim.x) {
+    const int rng1 = toffsets[i];
+    const int rngN = toffsets[i+1];
+    for (int d = 0; d < RESTRICTION_NCOMP; ++d)
+      value[d] = 0.0;
+    for (int j=rng1; j<rngN; ++j) {
+      const int tind = tindices[j];
+      int n = tind % RESTRICTION_ELEMSIZE;
+      int e = tind / RESTRICTION_ELEMSIZE;
+      for (int d = 0; d < RESTRICTION_NCOMP; ++d)
+        // value[d] += u[tind + d*esize];
+        value[d] += u[(e*RESTRICTION_NCOMP + d)*RESTRICTION_ELEMSIZE + n];
+    }
+    for (int d = 0; d < RESTRICTION_NCOMP; ++d)
+      v[d*RESTRICTION_NDOF+i] = value[d];
+  }
+}
+
+extern "C" __global__ void trTr(const CeedInt nelem,
+                                const CeedInt * __restrict__ tindices,
+                                const CeedInt * __restrict__ toffsets,
+                                const CeedScalar *__restrict__ u,
+                                CeedScalar *__restrict__ v) {
+  double value[RESTRICTION_NCOMP];
+  const CeedInt esize = RESTRICTION_ELEMSIZE * nelem;
+  for (CeedInt i = blockIdx.x * blockDim.x + threadIdx.x;
+       i < RESTRICTION_NDOF;
+       i += blockDim.x * gridDim.x) {
+    const int rng1 = toffsets[i];
+    const int rngN = toffsets[i+1];
+    for (int d = 0; d < RESTRICTION_NCOMP; ++d)
+      value[d] = 0.0;
+    for (int j=rng1; j<rngN; ++j) {
+      const int tind = tindices[j];
+      int n = tind % RESTRICTION_ELEMSIZE;
+      int e = tind / RESTRICTION_ELEMSIZE;
+      for (int d = 0; d < RESTRICTION_NCOMP; ++d)
+        // value[d] += u[tind + d*esize];
+        value[d] += u[(e*RESTRICTION_NCOMP + d)*RESTRICTION_ELEMSIZE + n];
+    }
+    for (int d = 0; d < RESTRICTION_NCOMP; ++d)
+      v[d+RESTRICTION_NCOMP*i] = value[d];
+  }
+}
+
+);
+
+static int CeedElemRestrictionApply_Cuda_reg(CeedElemRestriction r,
+    CeedTransposeMode tmode, CeedTransposeMode lmode,
+    CeedVector u, CeedVector v, CeedRequest *request) {
+  int ierr;
+  CeedElemRestriction_Cuda_reg *impl;
+  ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
+  Ceed ceed;
+  ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  Ceed_Cuda_reg *data;
+  ierr = CeedGetData(ceed, (void *)&data); CeedChk(ierr);
+  const CeedScalar *d_u;
+  CeedScalar *d_v;
+  ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
+  ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
+  const CeedInt blocksize = 32;
+  CeedInt nelem, elemsize, ndof;
+  CeedElemRestrictionGetNumElements(r, &nelem);
+  ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetNumDoF(r, &ndof); CeedChk(ierr);
+  CUfunction kernel;
+  if (tmode == CEED_NOTRANSPOSE) {
+    if (lmode == CEED_NOTRANSPOSE) {
+      kernel = impl->noTrNoTr;
+    } else {
+      kernel = impl->noTrTr;
+    }
+    void *args[] = {&nelem, &impl->d_ind, &d_u, &d_v};
+    ierr = run_kernel(ceed, kernel, CeedDivUpInt(nelem, blocksize), blocksize,
+                      args); CeedChk(ierr);
+  } else {
+    if (lmode == CEED_NOTRANSPOSE) {
+      kernel = impl->trNoTr;
+    } else {
+      kernel = impl->trTr;
+    }
+    void *args[] = {&nelem, &impl->d_tindices, &impl->d_toffsets, &d_u, &d_v};
+    ierr = run_kernel(ceed, kernel, CeedDivUpInt(ndof, blocksize), blocksize,
+                      args); CeedChk(ierr);
+  }
+  if (request != CEED_REQUEST_IMMEDIATE && request != CEED_REQUEST_ORDERED)
+    *request = NULL;
+
+  ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
+  ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);
+  return 0;
+}
+
+static int CeedElemRestrictionDestroy_Cuda_reg(CeedElemRestriction r) {
+  CeedElemRestriction_Cuda *impl = (CeedElemRestriction_Cuda *)r->data;
+  int ierr;
+
+  Ceed ceed;
+  ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  ierr = cuModuleUnload(impl->module); CeedChk_Cu(ceed, ierr);
+  ierr = CeedFree(&impl->h_ind_allocated); CeedChk(ierr);
+  ierr = cudaFree(impl->d_ind_allocated); CeedChk_Cu(ceed, ierr);
+  ierr = CeedFree(&r->data); CeedChk(ierr);
+  return 0;
+}
+
+static int CeedElemRestrictionOffset_Cuda_reg(const CeedElemRestriction r,
+                                              const CeedInt *indices) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  CeedElemRestriction_Cuda_reg *impl;
+  ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
+  CeedInt nelem, elemsize, ndof;
+  ierr = CeedElemRestrictionGetNumElements(r, &nelem); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetNumDoF(r, &ndof); CeedChk(ierr);
+  CeedInt toffsets[ndof+1];
+  CeedInt tindices[nelem*elemsize];
+  for (int i=0; i<=ndof; ++i) toffsets[i]=0;
+  for (int e=0; e < nelem; ++e)
+    for (int i=0; i < elemsize; ++i)
+      ++toffsets[indices[elemsize*e+i]+1];
+  for (int i = 1; i <= ndof; ++i)
+    toffsets[i] += toffsets[i-1];
+  for (int e = 0; e < nelem; ++e) {
+    for (int i = 0; i < elemsize; ++i) {
+      const int lid = elemsize*e+i;
+      const int gid = indices[lid];
+      tindices[toffsets[gid]++] = lid;
+    }
+  }
+  for (int i = ndof; i > 0; --i)
+    toffsets[i] = toffsets[i - 1];
+  toffsets[0] = 0;
+  CeedInt size = (1+ndof) * sizeof(CeedInt);
+  ierr = cudaMalloc((void**)&impl->d_toffsets, size);CeedChk_Cu(ceed, ierr);
+  ierr = cudaMemcpy(impl->d_toffsets, toffsets, size, cudaMemcpyHostToDevice);
+  CeedChk_Cu(ceed, ierr);
+  size = nelem * elemsize * sizeof(CeedInt);
+  ierr = cudaMalloc((void**)&impl->d_tindices, size);CeedChk_Cu(ceed, ierr);
+  ierr = cudaMemcpy(impl->d_tindices, tindices, size, cudaMemcpyHostToDevice);
+  CeedChk_Cu(ceed, ierr);
+  return 0;
+}
+
+int CeedElemRestrictionCreate_Cuda_reg(CeedMemType mtype,
+                                       CeedCopyMode cmode,
+                                       const CeedInt *indices,
+                                       CeedElemRestriction r) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  CeedElemRestriction_Cuda_reg *impl;
+  ierr = CeedCalloc(1, &impl); CeedChk(ierr);
+  CeedInt nelem, elemsize;
+  ierr = CeedElemRestrictionGetNumElements(r, &nelem); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
+  CeedInt size = nelem * elemsize;
+
+  ierr = CeedCalloc(1, &impl); CeedChk(ierr);
+  impl->h_ind           = NULL;
+  impl->h_ind_allocated = NULL;
+  impl->d_ind           = NULL;
+  impl->d_ind_allocated = NULL;
+  impl->d_tindices      = NULL;
+  impl->d_toffsets      = NULL;
+  ierr = CeedElemRestrictionSetData(r, (void *)&impl); CeedChk(ierr);
+
+  if (mtype == CEED_MEM_HOST) {
+    switch (cmode) {
+    case CEED_OWN_POINTER:
+      impl->h_ind_allocated = (CeedInt *)indices;
+      impl->h_ind = (CeedInt *)indices;
+      break;
+    case CEED_USE_POINTER:
+      impl->h_ind = (CeedInt *)indices;
+      break;
+    case CEED_COPY_VALUES:
+      break;
+    }
+    if (indices != NULL) {
+      ierr = cudaMalloc( (void **)&impl->d_ind, size * sizeof(CeedInt));
+      CeedChk_Cu(ceed, ierr);
+      impl->d_ind_allocated = impl->d_ind;//We own the device memory
+      ierr = cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt),
+                        cudaMemcpyHostToDevice);
+      CeedChk_Cu(ceed, ierr);
+      ierr = CeedElemRestrictionOffset_Cuda_reg(r, indices); CeedChk(ierr);
+    }
+  } else if (mtype == CEED_MEM_DEVICE) {
+    switch (cmode) {
+    case CEED_COPY_VALUES:
+      if (indices != NULL) {
+        ierr = cudaMalloc( (void **)&impl->d_ind, size * sizeof(CeedInt));
+        CeedChk_Cu(ceed, ierr);
+        impl->d_ind_allocated = impl->d_ind;//We own the device memory
+        ierr = cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt),
+                          cudaMemcpyDeviceToDevice);
+        CeedChk_Cu(ceed, ierr);
+        ierr = CeedElemRestrictionOffset_Cuda_reg(r, indices); CeedChk(ierr);
+      }
+      break;
+    case CEED_OWN_POINTER:
+      impl->d_ind = (CeedInt *)indices;
+      impl->d_ind_allocated = impl->d_ind;
+      break;
+    case CEED_USE_POINTER:
+      impl->d_ind = (CeedInt *)indices;
+    }
+  } else
+    return CeedError(ceed, 1, "Only MemType = HOST or DEVICE supported");
+
+  CeedInt ncomp, ndof;
+  ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetNumDoF(r, &ndof); CeedChk(ierr);
+  ierr = compile(ceed, restrictionkernels, &impl->module, 3,
+                 "RESTRICTION_ELEMSIZE", elemsize,
+                 "RESTRICTION_NCOMP", ncomp,
+                 "RESTRICTION_NDOF", ndof); CeedChk(ierr);
+  ierr = get_kernel(ceed, impl->module, "noTrNoTr", &impl->noTrNoTr); CeedChk(ierr);
+  ierr = get_kernel(ceed, impl->module, "noTrTr", &impl->noTrTr); CeedChk(ierr);
+  ierr = get_kernel(ceed, impl->module, "trNoTr", &impl->trNoTr); CeedChk(ierr);
+  ierr = get_kernel(ceed, impl->module, "trTr", &impl->trTr); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "ElemRestriction", r, "Apply",
+                                CeedElemRestrictionApply_Cuda_reg); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "ElemRestriction", r, "Destroy",
+                                CeedElemRestrictionDestroy_Cuda_reg); CeedChk(ierr);
+  return 0;
+}
+
+int CeedElemRestrictionCreateBlocked_Cuda_reg(const CeedMemType mtype,
+                                              const CeedCopyMode cmode,
+                                              const CeedInt *indices,
+                                              const CeedElemRestriction r) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement blocked restrictions");
+}

--- a/backends/cuda-reg/ceed-cuda-reg.c
+++ b/backends/cuda-reg/ceed-cuda-reg.c
@@ -53,5 +53,5 @@ static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
 
 __attribute__((constructor))
 static void Register(void) {
-  CeedRegister("/gpu/cuda/reg", CeedInit_Cuda_reg, 20);
+  CeedRegister("/gpu/cuda/reg", CeedInit_Cuda_reg, 30);
 }

--- a/backends/cuda-reg/ceed-cuda-reg.c
+++ b/backends/cuda-reg/ceed-cuda-reg.c
@@ -43,6 +43,11 @@ static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
                                 CeedBasisCreateTensorH1_Cuda_reg); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateH1",
                                 CeedBasisCreateH1_Cuda_reg); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "ElemRestrictionCreate",
+                                CeedElemRestrictionCreate_Cuda_reg); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed,
+                                "ElemRestrictionCreateBlocked",
+                                CeedElemRestrictionCreateBlocked_Cuda_reg); CeedChk(ierr);
   return 0;
 }
 

--- a/backends/cuda-reg/ceed-cuda-reg.c
+++ b/backends/cuda-reg/ceed-cuda-reg.c
@@ -1,0 +1,52 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <ceed-impl.h>
+#include <string.h>
+#include <stdarg.h>
+#include "ceed-cuda-reg.h"
+
+static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
+  int ierr;
+  const int nrc = 9; // number of characters in resource
+  if (strncmp(resource, "/gpu/cuda/reg", nrc))
+    return CeedError(ceed, 1, "Cuda backend cannot use resource: %s", resource);
+
+  Ceed ceedref;
+  CeedInit("/gpu/cuda/ref", &ceedref);
+  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+
+  const int rlen = strlen(resource);
+  const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;
+  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : 0;
+
+  ierr = cudaSetDevice(deviceID); CeedChk(ierr);
+
+  Ceed_Cuda_reg *data;
+  ierr = CeedCalloc(1,&data); CeedChk(ierr);
+
+  ierr = CeedSetData(ceed,(void *)&data); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
+                                CeedBasisCreateTensorH1_Cuda_reg); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateH1",
+                                CeedBasisCreateH1_Cuda_reg); CeedChk(ierr);
+  return 0;
+}
+
+__attribute__((constructor))
+static void Register(void) {
+  CeedRegister("/gpu/cuda/reg", CeedInit_Cuda_reg, 20);
+}

--- a/backends/cuda-reg/ceed-cuda-reg.h
+++ b/backends/cuda-reg/ceed-cuda-reg.h
@@ -44,5 +44,5 @@ CEED_INTERN int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d,
     CeedBasis basis);
 
 CEED_INTERN int CeedBasisCreateH1_Cuda_reg(CeedElemTopology, CeedInt, CeedInt,
-                                       CeedInt, const CeedScalar *,
-                                       const CeedScalar *, const CeedScalar *, const CeedScalar *, CeedBasis);
+    CeedInt, const CeedScalar *,
+    const CeedScalar *, const CeedScalar *, const CeedScalar *, CeedBasis);

--- a/backends/cuda-reg/ceed-cuda-reg.h
+++ b/backends/cuda-reg/ceed-cuda-reg.h
@@ -33,6 +33,20 @@ typedef struct {
 } CeedBasis_Cuda_reg;
 
 typedef struct {
+  CUmodule module;
+  CUfunction noTrNoTr;
+  CUfunction noTrTr;
+  CUfunction trNoTr;
+  CUfunction trTr;
+  CeedInt *h_ind;
+  CeedInt *h_ind_allocated;
+  CeedInt *d_ind;
+  CeedInt *d_ind_allocated;
+  CeedInt *d_toffsets;
+  CeedInt *d_tindices;
+} CeedElemRestriction_Cuda_reg;
+
+typedef struct {
 } Ceed_Cuda_reg;
 
 CEED_INTERN int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d,
@@ -46,3 +60,13 @@ CEED_INTERN int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d,
 CEED_INTERN int CeedBasisCreateH1_Cuda_reg(CeedElemTopology, CeedInt, CeedInt,
     CeedInt, const CeedScalar *,
     const CeedScalar *, const CeedScalar *, const CeedScalar *, CeedBasis);
+
+CEED_INTERN int CeedElemRestrictionCreate_Cuda_reg(CeedMemType mtype,
+                                                   CeedCopyMode cmode,
+                                                   const CeedInt *indices,
+                                                   CeedElemRestriction r);
+
+CEED_INTERN int CeedElemRestrictionCreateBlocked_Cuda_reg(const CeedMemType mtype,
+                                                          const CeedCopyMode cmode,
+                                                          const CeedInt *indices,
+                                                          const CeedElemRestriction r);

--- a/backends/cuda-reg/ceed-cuda-reg.h
+++ b/backends/cuda-reg/ceed-cuda-reg.h
@@ -38,6 +38,8 @@ typedef struct {
   CUfunction noTrTr;
   CUfunction trNoTr;
   CUfunction trTr;
+  CUfunction trNoTrIdentity;
+  CUfunction trTrIdentity;
   CeedInt *h_ind;
   CeedInt *h_ind_allocated;
   CeedInt *d_ind;

--- a/backends/cuda-reg/ceed-cuda-reg.h
+++ b/backends/cuda-reg/ceed-cuda-reg.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+#include <ceed-backend.h>
+#include "../include/ceed.h"
+#include <ceed-impl.h>
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#define CUDA_MAX_PATH 256
+
+#define CeedChk_Nvrtc(ceed, x) \
+do { \
+  nvrtcResult result = x; \
+  if (result != NVRTC_SUCCESS) \
+    return CeedError((ceed), result, nvrtcGetErrorString(result)); \
+} while (0)
+
+#define CeedChk_Cu(ceed, x) \
+do { \
+  CUresult result = x; \
+  if (result != CUDA_SUCCESS) { \
+    const char *msg; \
+    cuGetErrorName(result, &msg); \
+    return CeedError((ceed), result, msg); \
+  } \
+} while (0)
+
+#define QUOTE(...) #__VA_ARGS__
+
+typedef struct {
+  CUmodule module;
+  CUfunction interp;
+  CUfunction grad;
+  CUfunction weight;
+  CeedScalar *d_interp1d;
+  CeedScalar *d_grad1d;
+  CeedScalar *d_qweight1d;
+  CeedScalar *c_B;
+  CeedScalar *c_G;
+} CeedBasis_Cuda_reg;
+
+typedef struct {
+} Ceed_Cuda_reg;
+
+CEED_INTERN int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d,
+    CeedInt Q1d,
+    const CeedScalar *interp1d,
+    const CeedScalar *grad1d,
+    const CeedScalar *qref1d,
+    const CeedScalar *qweight1d,
+    CeedBasis basis);
+
+CEED_INTERN int CeedBasisCreateH1_Cuda_reg(CeedElemTopology, CeedInt, CeedInt,
+                                       CeedInt, const CeedScalar *,
+                                       const CeedScalar *, const CeedScalar *, const CeedScalar *, CeedBasis);

--- a/backends/cuda-reg/ceed-cuda-reg.h
+++ b/backends/cuda-reg/ceed-cuda-reg.h
@@ -20,27 +20,6 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#define CUDA_MAX_PATH 256
-
-#define CeedChk_Nvrtc(ceed, x) \
-do { \
-  nvrtcResult result = x; \
-  if (result != NVRTC_SUCCESS) \
-    return CeedError((ceed), result, nvrtcGetErrorString(result)); \
-} while (0)
-
-#define CeedChk_Cu(ceed, x) \
-do { \
-  CUresult result = x; \
-  if (result != CUDA_SUCCESS) { \
-    const char *msg; \
-    cuGetErrorName(result, &msg); \
-    return CeedError((ceed), result, msg); \
-  } \
-} while (0)
-
-#define QUOTE(...) #__VA_ARGS__
-
 typedef struct {
   CUmodule module;
   CUfunction interp;

--- a/backends/cuda-reg/cuda-reg-basis.cu
+++ b/backends/cuda-reg/cuda-reg-basis.cu
@@ -1,0 +1,37 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+#include "../include/ceed.h"
+#include <cuda.h>
+
+const int sizeMax = 16;
+__constant__ double c_B[sizeMax*sizeMax];
+__constant__ double c_G[sizeMax*sizeMax];
+
+extern "C" int CeedCudaRegInitInterp(CeedScalar* d_B, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B_ptr) {
+  const int Bsize = P1d*Q1d*sizeof(CeedScalar);
+  cudaMemcpyToSymbol(c_B, d_B, Bsize, 0, cudaMemcpyDeviceToDevice);
+  cudaGetSymbolAddress((void**)c_B_ptr, c_B);
+  return 0;
+}
+
+extern "C" int CeedCudaRegInitInterpGrad(CeedScalar* d_B, CeedScalar* d_G, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B_ptr, CeedScalar** c_G_ptr) {
+  const int Bsize = P1d*Q1d*sizeof(CeedScalar);
+  cudaMemcpyToSymbol(c_B, d_B, Bsize, 0, cudaMemcpyDeviceToDevice);
+  cudaGetSymbolAddress((void**)c_B_ptr, c_B);
+  cudaMemcpyToSymbol(c_G, d_G, Bsize, 0, cudaMemcpyDeviceToDevice);
+  cudaGetSymbolAddress((void**)c_G_ptr, c_G);
+  return 0;
+}

--- a/backends/cuda-reg/cuda-reg-basis.cu
+++ b/backends/cuda-reg/cuda-reg-basis.cu
@@ -20,18 +20,20 @@ const int sizeMax = 16;
 __constant__ double c_B[sizeMax*sizeMax];
 __constant__ double c_G[sizeMax*sizeMax];
 
-extern "C" int CeedCudaRegInitInterp(CeedScalar* d_B, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B_ptr) {
+extern "C" int CeedCudaRegInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
+                                     CeedScalar **c_B_ptr) {
   const int Bsize = P1d*Q1d*sizeof(CeedScalar);
   cudaMemcpyToSymbol(c_B, d_B, Bsize, 0, cudaMemcpyDeviceToDevice);
-  cudaGetSymbolAddress((void**)c_B_ptr, c_B);
+  cudaGetSymbolAddress((void **)c_B_ptr, c_B);
   return 0;
 }
 
-extern "C" int CeedCudaRegInitInterpGrad(CeedScalar* d_B, CeedScalar* d_G, CeedInt P1d, CeedInt Q1d, CeedScalar** c_B_ptr, CeedScalar** c_G_ptr) {
+extern "C" int CeedCudaRegInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G,
+    CeedInt P1d, CeedInt Q1d, CeedScalar **c_B_ptr, CeedScalar **c_G_ptr) {
   const int Bsize = P1d*Q1d*sizeof(CeedScalar);
   cudaMemcpyToSymbol(c_B, d_B, Bsize, 0, cudaMemcpyDeviceToDevice);
-  cudaGetSymbolAddress((void**)c_B_ptr, c_B);
+  cudaGetSymbolAddress((void **)c_B_ptr, c_B);
   cudaMemcpyToSymbol(c_G, d_G, Bsize, 0, cudaMemcpyDeviceToDevice);
-  cudaGetSymbolAddress((void**)c_G_ptr, c_G);
+  cudaGetSymbolAddress((void **)c_G_ptr, c_G);
   return 0;
 }

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -386,3 +386,10 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
                                 CeedOperatorDestroy_Cuda); CeedChk(ierr);
   return 0;
 }
+
+int CeedCompositeOperatorCreate_Cuda(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not support composite operators");
+}

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -136,6 +136,8 @@ static int CeedInit_Cuda(const char *resource, Ceed ceed) {
                                 CeedQFunctionCreate_Cuda); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Cuda); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "CompositeOperatorCreate",
+                                CeedCompositeOperatorCreate_Cuda); CeedChk(ierr);
   return 0;
 }
 

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -46,7 +46,16 @@ int compile(Ceed ceed, const char *source, CUmodule *module,
   opts[numopts]     = "-DCeedScalar=double";
   opts[numopts + 1] = "-DCeedInt=int";
   struct cudaDeviceProp prop;
-  cudaGetDeviceProperties(&prop, 0);
+  Ceed_Cuda *ceed_data;
+  Ceed delegate;
+  CeedGetDelegate(ceed, &delegate);
+  //We assume that the delegate is always the Cuda one
+  if (delegate){
+    ierr = CeedGetData(delegate, (void *)&ceed_data); CeedChk(ierr);
+  }else{
+    ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
+  }
+  cudaGetDeviceProperties(&prop, ceed_data->deviceId);
   char buff[optslen];
   snprintf(buff, optslen,"-arch=compute_%d%d", prop.major, prop.minor);
   opts[numopts + 2] = buff;

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -93,7 +93,7 @@ int run_kernel(Ceed ceed, CUfunction kernel, const int gridSize,
 static int CeedInit_Cuda(const char *resource, Ceed ceed) {
   int ierr;
   const int nrc = 9; // number of characters in resource
-  if (strncmp(resource, "/gpu/cuda", nrc))
+  if (strncmp(resource, "/gpu/cuda/ref", nrc))
     return CeedError(ceed, 1, "Cuda backend cannot use resource: %s", resource);
 
   const int rlen = strlen(resource);
@@ -104,6 +104,7 @@ static int CeedInit_Cuda(const char *resource, Ceed ceed) {
 
   Ceed_Cuda *data;
   ierr = CeedCalloc(1,&data); CeedChk(ierr);
+  data->deviceId = deviceID;
 
   struct cudaDeviceProp deviceProp;
   cudaGetDeviceProperties(&deviceProp, deviceID);
@@ -131,5 +132,5 @@ static int CeedInit_Cuda(const char *resource, Ceed ceed) {
 
 __attribute__((constructor))
 static void Register(void) {
-  CeedRegister("/gpu/cuda", CeedInit_Cuda, 20);
+  CeedRegister("/gpu/cuda/ref", CeedInit_Cuda, 20);
 }

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -45,8 +45,11 @@ int compile(Ceed ceed, const char *source, CUmodule *module,
   }
   opts[numopts]     = "-DCeedScalar=double";
   opts[numopts + 1] = "-DCeedInt=int";
-  opts[numopts + 2] = "-arch=compute_60";//FIXME: Should take into account GPU CC
-
+  struct cudaDeviceProp prop;
+  cudaGetDeviceProperties(&prop, 0);
+  char buff[optslen];
+  snprintf(buff, optslen,"-arch=compute_%d%d", prop.major, prop.minor);
+  opts[numopts + 2] = buff;
 
   nvrtcResult result = nvrtcCompileProgram(prog, numopts + optsextra, opts);
   if (result != NVRTC_SUCCESS) {

--- a/backends/cuda/ceed-cuda.h
+++ b/backends/cuda/ceed-cuda.h
@@ -100,6 +100,7 @@ typedef struct {
 
 typedef struct {
   int optblocksize;
+  int deviceId;
 } Ceed_Cuda;
 
 static inline CeedInt CeedDivUpInt(CeedInt numer, CeedInt denom) {

--- a/backends/cuda/ceed-cuda.h
+++ b/backends/cuda/ceed-cuda.h
@@ -146,3 +146,5 @@ CEED_INTERN int CeedBasisCreateH1_Cuda(CeedElemTopology, CeedInt, CeedInt,
 CEED_INTERN int CeedQFunctionCreate_Cuda(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Cuda(CeedOperator op);
+
+CEED_INTERN int CeedCompositeOperatorCreate_Cuda(CeedOperator op);

--- a/tests/t401-qfunction-f.cu
+++ b/tests/t401-qfunction-f.cu
@@ -40,30 +40,3 @@ extern "C" __global__ void mass(void *ctx, CeedInt Q, Fields_Cuda fields) {
     v[i] = val * qdata[i] * u[i];
   }
 }
-
-// // *****************************************************************************
-// extern "C" __global__ void setup(void *ctx, CeedInt Q, const CeedScalar *const *in,
-//                       CeedScalar *const *out) {
-//   const CeedScalar *w = in[0];
-//   CeedScalar *qdata = out[0];
-//   for (int i = blockIdx.x * blockDim.x + threadIdx.x;
-//     i < Q;
-//     i += blockDim.x * gridDim.x)
-//   {
-//     qdata[i] = w[i];
-//   }
-// }
-
-// // *****************************************************************************
-// extern "C" __global__ void mass(void *ctx, CeedInt Q, const CeedScalar *const *in,
-//                      CeedScalar *const *out) {
-//   const CeedScalar *qdata = in[0], *u = in[1];
-//   CeedScalar *v = out[0];
-//   for (int i = blockIdx.x * blockDim.x + threadIdx.x;
-//     i < Q;
-//     i += blockDim.x * gridDim.x)
-//   {
-//     v[i] = qdata[i] * u[i];
-//   }
-// }
-

--- a/tests/t401-qfunction.cu
+++ b/tests/t401-qfunction.cu
@@ -40,30 +40,3 @@ extern "C" __global__ void mass(void *ctx, CeedInt Q, Fields_Cuda fields) {
     v[i] = val * qdata[i] * u[i];
   }
 }
-
-// // *****************************************************************************
-// extern "C" __global__ void setup(void *ctx, CeedInt Q, const CeedScalar *const *in,
-//                       CeedScalar *const *out) {
-//   const CeedScalar *w = in[0];
-//   CeedScalar *qdata = out[0];
-//   for (int i = blockIdx.x * blockDim.x + threadIdx.x;
-//     i < Q;
-//     i += blockDim.x * gridDim.x)
-//   {
-//     qdata[i] = w[i];
-//   }
-// }
-
-// // *****************************************************************************
-// extern "C" __global__ void mass(void *ctx, CeedInt Q, const CeedScalar *const *in,
-//                      CeedScalar *const *out) {
-//   const CeedScalar *qdata = in[0], *u = in[1];
-//   CeedScalar *v = out[0];
-//   for (int i = blockIdx.x * blockDim.x + threadIdx.x;
-//     i < Q;
-//     i += blockDim.x * gridDim.x)
-//   {
-//     v[i] = qdata[i] * u[i];
-//   }
-// }
-


### PR DESCRIPTION
This backend uses a simple approach where each element is processed by one GPU thread. This approach is expected to be efficient for 1D and 2D problems, but very inefficient as soon as the kernels start to spill data out of registers, which should arise around `Q1D=4` for 3D problems.