### PR TITLE
In Makefile: replace '-' with '_' in a variable name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,11 +346,11 @@ examples : $(allexamples)
 
 # Benchmarks
 allbenchmarks = petsc-bp1 petsc-bp3
-bench-targets = $(addprefix bench-,$(allbenchmarks))
-.PHONY: $(bench-targets) benchmarks
-$(bench-targets): bench-%: $(OBJDIR)/%
+bench_targets = $(addprefix bench-,$(allbenchmarks))
+.PHONY: $(bench_targets) benchmarks
+$(bench_targets): bench-%: $(OBJDIR)/%
 	cd benchmarks && ./benchmark.sh --ceed "$(BACKENDS)" -r $(*).sh
-benchmarks: $(bench-targets)
+benchmarks: $(bench_targets)
 
 $(ceed.pc) : pkgconfig-prefix = $(abspath .)
 $(OBJDIR)/ceed.pc : pkgconfig-prefix = $(prefix)


### PR DESCRIPTION
Technically, having dashes is allowed but it is [not recommended](https://www.gnu.org/software/make/manual/make.html#Using-Variables).

This came up in #200 but it was not the cause for that issue.