### PR TITLE
Make Style Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,12 +407,10 @@ doc :
 	doxygen Doxyfile
 
 style :
-	astyle --style=google --indent=spaces=2 --max-code-length=80 \
-            --keep-one-line-statements --keep-one-line-blocks --lineend=linux \
-            --suffix=none --preserve-date --formatted \
-            --exclude=include/ceedf.h --exclude=tests/t310-basis-f.h \
-            include/*.h interface/*.[ch] tests/*.[ch] backends/*/*.[ch] \
-            examples/*/*.[ch] examples/*/*.[ch]pp -i
+	@astyle --options=.astylerc \
+          $(filter-out include/ceedf.h tests/t310-basis-f.h, \
+            $(wildcard include/*.h interface/*.[ch] tests/*.[ch] backends/*/*.[ch] \
+              examples/*/*.[ch] examples/*/*.[ch]pp))
 
 print :
 	@echo $(VAR)=$($(VAR))

--- a/backends/avx/ceed-avx-basis.c
+++ b/backends/avx/ceed-avx-basis.c
@@ -57,7 +57,8 @@ static int CeedTensorContract8_Avx(Ceed ceed, CeedInt A, CeedInt B,
   }
 
   const int JJ = 4, CC=8;
-  if (C % CC) return CeedError(ceed, 2, "Tensor [%d, %d, %d]: last dimension not divisible by %d", A, B, C, CC);
+  if (C % CC) return CeedError(ceed, 2,
+                                 "Tensor [%d, %d, %d]: last dimension not divisible by %d", A, B, C, CC);
 
   if (!Add) {
     for (CeedInt q=0; q<A*J*C; q++) {
@@ -79,7 +80,7 @@ static int CeedTensorContract8_Avx(Ceed ceed, CeedInt A, CeedInt B,
             __m256d tqv = _mm256_set1_pd(t[(j+jj)*tstride0 + b*tstride1]);
             for (CeedInt cc=0; cc<CC/4; cc++) { // unroll
               vv[jj][cc] += _mm256_mul_pd(tqv,
-                              _mm256_loadu_pd(&u[(a*B+b)*C+c+cc*4]));
+                                          _mm256_loadu_pd(&u[(a*B+b)*C+c+cc*4]));
             }
           }
         }
@@ -176,7 +177,7 @@ static int CeedBasisApply_Avx(CeedBasis basis, CeedInt nelem,
         P = Q1d, Q = Q1d;
       }
       CeedBasis_Avx *impl;
-      ierr = CeedBasisGetData(basis, (void*)&impl); CeedChk(ierr);
+      ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
       CeedScalar interp[nelem*ncomp*Q*CeedIntPow(P>Q?P:Q, dim-1)];
       CeedInt pre = ncomp*CeedIntPow(P, dim-1), post = nelem;
       CeedScalar tmp[2][nelem*ncomp*Q*CeedIntPow(P>Q?P:Q, dim-1)];
@@ -311,7 +312,7 @@ static int CeedBasisDestroyNonTensor_Avx(CeedBasis basis) {
 static int CeedBasisDestroyTensor_Avx(CeedBasis basis) {
   int ierr;
   CeedBasis_Avx *impl;
-  ierr = CeedBasisGetData(basis, (void*)&impl); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedFree(&impl->colograd1d); CeedChk(ierr);
   ierr = CeedFree(&impl); CeedChk(ierr);
@@ -332,7 +333,7 @@ int CeedBasisCreateTensorH1_Avx(CeedInt dim, CeedInt P1d,
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedMalloc(Q1d*Q1d, &impl->colograd1d); CeedChk(ierr);
   ierr = CeedBasisGetCollocatedGrad(basis, impl->colograd1d); CeedChk(ierr);
-  ierr = CeedBasisSetData(basis, (void*)&impl); CeedChk(ierr);
+  ierr = CeedBasisSetData(basis, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
                                 CeedBasisApply_Avx); CeedChk(ierr);

--- a/backends/avx/ceed-avx.h
+++ b/backends/avx/ceed-avx.h
@@ -29,9 +29,9 @@ CEED_INTERN int CeedBasisCreateTensorH1_Avx(CeedInt dim, CeedInt P1d,
     CeedBasis basis);
 
 CEED_INTERN int CeedBasisCreateH1_Avx(CeedElemTopology topo, CeedInt dim,
-    CeedInt ndof, CeedInt nqpts,
-    const CeedScalar *interp,
-    const CeedScalar *grad,
-    const CeedScalar *qref,
-    const CeedScalar *qweight,
-    CeedBasis basis);
+                                      CeedInt ndof, CeedInt nqpts,
+                                      const CeedScalar *interp,
+                                      const CeedScalar *grad,
+                                      const CeedScalar *qref,
+                                      const CeedScalar *qweight,
+                                      CeedBasis basis);

--- a/backends/blocked/ceed-blocked-basis.c
+++ b/backends/blocked/ceed-blocked-basis.c
@@ -112,7 +112,7 @@ static int CeedBasisApply_Blocked(CeedBasis basis, CeedInt nelem,
         P = Q1d, Q = Q1d;
       }
       CeedBasis_Blocked *impl;
-      ierr = CeedBasisGetData(basis, (void*)&impl); CeedChk(ierr);
+      ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
       CeedScalar interp[nelem*ncomp*Q*CeedIntPow(P>Q?P:Q, dim-1)];
       CeedInt pre = ncomp*CeedIntPow(P, dim-1), post = nelem;
       CeedScalar tmp[2][nelem*ncomp*Q*CeedIntPow(P>Q?P:Q, dim-1)];
@@ -247,7 +247,7 @@ static int CeedBasisDestroyNonTensor_Blocked(CeedBasis basis) {
 static int CeedBasisDestroyTensor_Blocked(CeedBasis basis) {
   int ierr;
   CeedBasis_Blocked *impl;
-  ierr = CeedBasisGetData(basis, (void*)&impl); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedFree(&impl->colograd1d); CeedChk(ierr);
   ierr = CeedFree(&impl); CeedChk(ierr);
@@ -268,7 +268,7 @@ int CeedBasisCreateTensorH1_Blocked(CeedInt dim, CeedInt P1d,
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedMalloc(Q1d*Q1d, &impl->colograd1d); CeedChk(ierr);
   ierr = CeedBasisGetCollocatedGrad(basis, impl->colograd1d); CeedChk(ierr);
-  ierr = CeedBasisSetData(basis, (void*)&impl); CeedChk(ierr);
+  ierr = CeedBasisSetData(basis, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
                                 CeedBasisApply_Blocked); CeedChk(ierr);

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -21,7 +21,7 @@
 static int CeedOperatorDestroy_Blocked(CeedOperator op) {
   int ierr;
   CeedOperator_Blocked *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
 
   for (CeedInt i=0; i<impl->numein+impl->numeout; i++) {
     ierr = CeedElemRestrictionDestroy(&impl->blkrestr[i]); CeedChk(ierr);
@@ -157,7 +157,7 @@ static int CeedOperatorSetup_Blocked(CeedOperator op) {
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   CeedOperator_Blocked *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
   CeedQFunction qf;
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
   CeedInt Q, numinputfields, numoutputfields;
@@ -210,7 +210,7 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
                                      CeedVector outvec, CeedRequest *request) {
   int ierr;
   CeedOperator_Blocked *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
   const CeedInt blksize = 8;
   CeedInt Q, elemsize, numinputfields, numoutputfields, numelements, ncomp;
   ierr = CeedOperatorGetNumElements(op, &numelements); CeedChk(ierr);

--- a/backends/blocked/ceed-blocked.h
+++ b/backends/blocked/ceed-blocked.h
@@ -25,7 +25,7 @@ typedef struct {
   CeedElemRestriction *blkrestr; /// Blocked versions of restrictions
   CeedVector
   *evecs;   /// E-vectors needed to apply operator (input followed by outputs)
-  CeedScalar ** edata;
+  CeedScalar **edata;
   uint64_t *inputstate;  /// State counter of inputs
   CeedVector *evecsin;   /// Input E-vectors needed to apply operator
   CeedVector *evecsout;  /// Output E-vectors needed to apply operator

--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -24,10 +24,10 @@ static int CeedBasisBuildKernel(CeedBasis basis) {
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice dev = ceed_data->device;
   CeedBasis_Occa *data;
-  ierr = CeedBasisGetData(basis, (void*)&data); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *)&data); CeedChk(ierr);
   // ***************************************************************************
   CeedInt dim, P1d, Q1d, ncomp;
   ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
@@ -138,7 +138,7 @@ int CeedBasisApplyElems_Occa(CeedBasis basis, CeedInt QnD,
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
   CeedBasis_Occa *data;
-  ierr = CeedBasisGetData(basis, (void*)&data); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *)&data); CeedChk(ierr);
   const CeedInt ready =  data->ready;
   // ***************************************************************************
   // We were waiting for the CeedElemRestriction to fill nelem and elemsize
@@ -342,7 +342,7 @@ static int CeedBasisDestroy_Occa(CeedBasis basis) {
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
   CeedBasis_Occa *data;
-  ierr = CeedBasisGetData(basis, (void*)&data); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *)&data); CeedChk(ierr);
   dbg("[CeedBasis][Destroy]");
   occaFree(data->kZero);
   occaFree(data->kInterp);
@@ -370,7 +370,7 @@ int CeedBasisCreateTensorH1_Occa(CeedInt dim, CeedInt P1d, CeedInt Q1d,
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice dev = ceed_data->device;
   dbg("[CeedBasis][CreateTensorH1]");
   // ***************************************************************************

--- a/backends/occa/ceed-occa-okl.c
+++ b/backends/occa/ceed-occa-okl.c
@@ -76,7 +76,7 @@ int CeedOklDladdr_Occa(Ceed ceed) {
   Ceed_Occa *data;
   ierr = CeedGetData(ceed, (void *)&data); CeedChk(ierr);
   memset(&info,0,sizeof(info));
-  ierr = dladdr((void*)&CeedInit,&info);
+  ierr = dladdr((void *)&CeedInit,&info);
   dbg("[CeedOklDladdr] libceed -> %s", info.dli_fname);
   if (ierr==0)
     return CeedError(ceed, 1, "OCCA backend cannot fetch dladdr");

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -22,7 +22,7 @@
 static int CeedOperatorDestroy_Occa(CeedOperator op) {
   int ierr;
   CeedOperator_Occa *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
 
   for (CeedInt i=0; i<impl->numein+impl->numeout; i++) {
     if (impl->Evecs[i]) {
@@ -93,7 +93,7 @@ static int CeedOperatorSetupFields_Occa(CeedQFunction qf, CeedOperator op,
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *qf_data;
-  ierr = CeedQFunctionGetData(qf, (void*)&qf_data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&qf_data); CeedChk(ierr);
   CeedBasis basis;
   CeedElemRestriction Erestrict;
   CeedOperatorField *opfields;
@@ -186,7 +186,7 @@ static int CeedOperatorSetup_Occa(CeedOperator op) {
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   CeedOperator_Occa *data;
-  ierr = CeedOperatorGetData(op, (void*)&data); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&data); CeedChk(ierr);
   CeedQFunction qf;
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
   CeedInt Q, numinputfields, numoutputfields;
@@ -274,7 +274,7 @@ static int CeedOperatorApply_Occa(CeedOperator op,
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   dbg("[CeedOperator][Apply]");
   CeedOperator_Occa *data;
-  ierr = CeedOperatorGetData(op, (void*)&data); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&data); CeedChk(ierr);
   //CeedVector *E = data->Evecs, *D = data->D, outvec;
   CeedInt Q, elemsize, numelements, numinputfields, numoutputfields, ncomp;
   ierr = CeedOperatorGetNumQuadraturePoints(op, &Q); CeedChk(ierr);
@@ -537,7 +537,7 @@ int CeedOperatorCreate_Occa(CeedOperator op) {
 
   dbg("[CeedOperator][Create]");
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
-  ierr = CeedOperatorSetData(op, (void*)&impl);
+  ierr = CeedOperatorSetData(op, (void *)&impl);
 
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Occa); CeedChk(ierr);

--- a/backends/occa/ceed-occa-qfunction-noop.c
+++ b/backends/occa/ceed-occa-qfunction-noop.c
@@ -27,9 +27,9 @@ int CeedQFunctionAllocNoOpIn_Occa(CeedQFunction qf, CeedInt Q,
   Ceed ceed;
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *data;
-  ierr = CeedQFunctionGetData(qf, (void*)&data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&data); CeedChk(ierr);
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice device = ceed_data->device;
   int nIn;
   ierr = CeedQFunctionGetNumArgs(qf, &nIn, NULL);
@@ -106,9 +106,9 @@ int CeedQFunctionAllocNoOpOut_Occa(CeedQFunction qf, CeedInt Q,
   Ceed ceed;
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *data;
-  ierr = CeedQFunctionGetData(qf, (void*)&data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&data); CeedChk(ierr);
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice device = ceed_data->device;
   const CeedInt bytes = sizeof(CeedScalar);
   const CeedInt dim = 1; // !?

--- a/backends/occa/ceed-occa-qfunction-op.c
+++ b/backends/occa/ceed-occa-qfunction-op.c
@@ -27,10 +27,10 @@ int CeedQFunctionAllocOpIn_Occa(CeedQFunction qf, CeedInt Q,
   Ceed ceed;
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *qf_data;
-  ierr = CeedQFunctionGetData(qf, (void*)&qf_data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&qf_data); CeedChk(ierr);
   CeedOperator op = qf_data->op;
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice device = ceed_data->device;
   CeedInt nIn;
   ierr = CeedQFunctionGetNumArgs(qf, &nIn, NULL); CeedChk(ierr);
@@ -111,10 +111,10 @@ int CeedQFunctionAllocOpOut_Occa(CeedQFunction qf, CeedInt Q,
   Ceed ceed;
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *data;
-  ierr = CeedQFunctionGetData(qf, (void*)&data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&data); CeedChk(ierr);
   CeedOperator op = data->op;
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice device = ceed_data->device;
   const CeedInt bytes = sizeof(CeedScalar);
   CeedInt nOut;

--- a/backends/occa/ceed-occa-qfunction.c
+++ b/backends/occa/ceed-occa-qfunction.c
@@ -19,18 +19,19 @@
 // *****************************************************************************
 // * functions for the 'no-operator' case
 // *****************************************************************************
-int CeedQFunctionAllocNoOpIn_Occa(CeedQFunction, CeedInt, CeedInt*, CeedInt*);
-int CeedQFunctionAllocNoOpOut_Occa(CeedQFunction, CeedInt, CeedInt*, CeedInt*) ;
+int CeedQFunctionAllocNoOpIn_Occa(CeedQFunction, CeedInt, CeedInt *, CeedInt *);
+int CeedQFunctionAllocNoOpOut_Occa(CeedQFunction, CeedInt, CeedInt *,
+                                   CeedInt *) ;
 int CeedQFunctionFillNoOp_Occa(CeedQFunction, CeedInt, occaMemory,
-                               CeedInt*, CeedInt*, const CeedScalar*const*);
+                               CeedInt *, CeedInt *, const CeedScalar *const *);
 
 // *****************************************************************************
 // * functions for the 'operator' case
 // *****************************************************************************
-int CeedQFunctionAllocOpIn_Occa(CeedQFunction, CeedInt, CeedInt*, CeedInt*);
-int CeedQFunctionAllocOpOut_Occa(CeedQFunction, CeedInt, CeedInt*, CeedInt*) ;
+int CeedQFunctionAllocOpIn_Occa(CeedQFunction, CeedInt, CeedInt *, CeedInt *);
+int CeedQFunctionAllocOpOut_Occa(CeedQFunction, CeedInt, CeedInt *, CeedInt *) ;
 int CeedQFunctionFillOp_Occa(CeedQFunction, CeedInt, occaMemory,
-                             CeedInt*, CeedInt*, const CeedScalar*const*);
+                             CeedInt *, CeedInt *, const CeedScalar *const *);
 
 // *****************************************************************************
 // * buildKernel
@@ -40,9 +41,9 @@ static int CeedQFunctionBuildKernel(CeedQFunction qf, const CeedInt Q) {
   Ceed ceed;
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *data;
-  ierr = CeedQFunctionGetData(qf, (void*)&data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&data); CeedChk(ierr);
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const bool ocl = ceed_data->ocl;
   assert(ceed_data);
   const occaDevice dev = ceed_data->device;
@@ -83,7 +84,7 @@ static int CeedQFunctionApply_Occa(CeedQFunction qf, CeedInt Q,
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   dbg("[CeedQFunction][Apply]");
   CeedQFunction_Occa *data;
-  ierr = CeedQFunctionGetData(qf, (void*)&data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&data); CeedChk(ierr);
   const bool from_operator_apply = data->op;
   //Ceed_Occa *ceed_data = qf->ceed->data;
   //const occaDevice device = ceed_data->device;
@@ -203,7 +204,7 @@ static int CeedQFunctionDestroy_Occa(CeedQFunction qf) {
   Ceed ceed;
   ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
   CeedQFunction_Occa *data;
-  ierr = CeedQFunctionGetData(qf, (void*)&data); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&data); CeedChk(ierr);
   const bool operator_setup = data->op;
   free(data->oklPath);
   dbg("[CeedQFunction][Destroy]");

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -43,7 +43,7 @@ int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   dbg("[CeedElemRestriction][Apply]");
   CeedElemRestriction_Occa *data;
-  ierr = CeedElemRestrictionGetData(r, (void*)&data); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetData(r, (void *)&data); CeedChk(ierr);
   const occaMemory id = data->d_indices;
   const occaMemory tid = data->d_tindices;
   const occaMemory od = data->d_toffsets;
@@ -106,7 +106,7 @@ static int CeedElemRestrictionDestroy_Occa(CeedElemRestriction r) {
   Ceed ceed;
   ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
   CeedElemRestriction_Occa *data;
-  ierr = CeedElemRestrictionGetData(r, (void*)&data); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetData(r, (void *)&data); CeedChk(ierr);
   dbg("[CeedElemRestriction][Destroy]");
   for (int i=0; i<7; i++) {
     occaFree(data->kRestrict[i]);
@@ -164,7 +164,7 @@ int CeedElemRestrictionCreate_Occa(const CeedMemType mtype,
   dbg("[CeedElemRestriction][Create]");
   CeedElemRestriction_Occa *data;
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const bool ocl = ceed_data->ocl;
   const occaDevice dev = ceed_data->device;
   // ***************************************************************************
@@ -204,7 +204,7 @@ int CeedElemRestrictionCreate_Occa(const CeedMemType mtype,
   for (int i = 0; i < CEED_OCCA_NUM_RESTRICTION_KERNELS; ++i) {
     data->kRestrict[i] = occaUndefined;
   }
-  ierr = CeedElemRestrictionSetData(r, (void*)&data); CeedChk(ierr);
+  ierr = CeedElemRestrictionSetData(r, (void *)&data); CeedChk(ierr);
   dbg("[CeedElemRestriction][Create] nelem=%d",nelem);
   occaProperties pKR = occaCreateProperties();
   occaPropertiesSet(pKR, "defines/ndof", occaInt(ndof));

--- a/backends/occa/ceed-occa-vector.c
+++ b/backends/occa/ceed-occa-vector.c
@@ -31,7 +31,7 @@ static inline size_t bytes(const CeedVector vec) {
 // *****************************************************************************
 static inline void CeedSyncH2D_Occa(const CeedVector vec) {
   CeedVector_Occa *data;
-  CeedVectorGetData(vec, (void*)&data);
+  CeedVectorGetData(vec, (void *)&data);
 
   assert(data);
   assert(data->h_array);
@@ -41,7 +41,7 @@ static inline void CeedSyncH2D_Occa(const CeedVector vec) {
 // *****************************************************************************
 static inline void CeedSyncD2H_Occa(const CeedVector vec) {
   CeedVector_Occa *data;
-  CeedVectorGetData(vec, (void*)&data);
+  CeedVectorGetData(vec, (void *)&data);
 
   assert(data);
   assert(data->h_array);
@@ -63,7 +63,7 @@ static int CeedVectorSetArray_Occa(const CeedVector vec,
   CeedInt length;
   ierr = CeedVectorGetLength(vec, &length); CeedChk(ierr);
   CeedVector_Occa *data;
-  ierr = CeedVectorGetData(vec, (void*)&data); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&data); CeedChk(ierr);
   dbg("[CeedVector][Set]");
   if (mtype != CEED_MEM_HOST)
     return CeedError(ceed, 1, "Only MemType = HOST supported");
@@ -110,7 +110,7 @@ static int CeedVectorGetArrayRead_Occa(const CeedVector vec,
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
   dbg("[CeedVector][Get]");
   CeedVector_Occa *data;
-  ierr = CeedVectorGetData(vec, (void*)&data); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&data); CeedChk(ierr);
   if (mtype != CEED_MEM_HOST)
     return CeedError(ceed, 1, "Can only provide to HOST memory");
   if (!data->h_array) { // Allocate if array was not allocated yet
@@ -127,7 +127,7 @@ static int CeedVectorGetArrayRead_Occa(const CeedVector vec,
 static int CeedVectorGetArray_Occa(const CeedVector vec,
                                    const CeedMemType mtype,
                                    CeedScalar **array) {
-  return CeedVectorGetArrayRead_Occa(vec,mtype,(const CeedScalar**)array);
+  return CeedVectorGetArrayRead_Occa(vec,mtype,(const CeedScalar **)array);
 }
 
 // *****************************************************************************
@@ -140,7 +140,7 @@ static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec,
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
   dbg("[CeedVector][Restore]");
   CeedVector_Occa *data;
-  ierr = CeedVectorGetData(vec, (void*)&data); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&data); CeedChk(ierr);
   assert((data)->h_array);
   assert(*array);
   CeedSyncH2D_Occa(vec); // sync Host to Device
@@ -150,7 +150,7 @@ static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec,
 // *****************************************************************************
 static int CeedVectorRestoreArray_Occa(const CeedVector vec,
                                        CeedScalar **array) {
-  return CeedVectorRestoreArrayRead_Occa(vec,(const CeedScalar**)array);
+  return CeedVectorRestoreArrayRead_Occa(vec,(const CeedScalar **)array);
 }
 
 // *****************************************************************************
@@ -161,7 +161,7 @@ static int CeedVectorDestroy_Occa(const CeedVector vec) {
   Ceed ceed;
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
   CeedVector_Occa *data;
-  ierr = CeedVectorGetData(vec, (void*)&data); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&data); CeedChk(ierr);
   dbg("[CeedVector][Destroy]");
   ierr = CeedFree(&data->h_array_allocated); CeedChk(ierr);
   occaFree(data->d_array);
@@ -177,7 +177,7 @@ int CeedVectorCreate_Occa(const CeedInt n, CeedVector vec) {
   Ceed ceed;
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
   Ceed_Occa *ceed_data;
-  ierr = CeedGetData(ceed, (void*)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   CeedVector_Occa *data;
   dbg("[CeedVector][Create] n=%d", n);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "SetArray",

--- a/backends/occa/ceed-occa.h
+++ b/backends/occa/ceed-occa.h
@@ -116,7 +116,8 @@ typedef struct {
 } Ceed_Occa;
 
 // *****************************************************************************
-CEED_INTERN int CeedOklPath_Occa(const Ceed, const char*, const char*, char **);
+CEED_INTERN int CeedOklPath_Occa(const Ceed, const char *, const char *,
+                                 char **);
 
 // *****************************************************************************
 CEED_INTERN int CeedOklDladdr_Occa(Ceed);
@@ -127,8 +128,8 @@ CEED_INTERN int CeedOklDladdr_Occa(Ceed);
 #ifndef CEED_DEBUG_COLOR
 #define CEED_DEBUG_COLOR 0
 #endif
-void CeedDebugImpl(const Ceed,const char*,...);
-void CeedDebugImpl256(const Ceed,const unsigned char,const char*,...);
+void CeedDebugImpl(const Ceed,const char *,...);
+void CeedDebugImpl256(const Ceed,const unsigned char,const char *,...);
 #define CeedDebug(ceed,format, ...) CeedDebugImpl(ceed,format, ## __VA_ARGS__)
 #define CeedDebug256(ceed,color, ...) CeedDebugImpl256(ceed,color, ## __VA_ARGS__)
 #define dbg(...) CeedDebug256(ceed,(unsigned char)CEED_DEBUG_COLOR, ## __VA_ARGS__)

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -20,7 +20,7 @@
 static int CeedOperatorDestroy_Ref(CeedOperator op) {
   int ierr;
   CeedOperator_Ref *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
 
   for (CeedInt i=0; i<impl->numein+impl->numeout; i++) {
     ierr = CeedVectorDestroy(&impl->evecs[i]); CeedChk(ierr);
@@ -137,7 +137,7 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   CeedOperator_Ref *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
   CeedQFunction qf;
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
   CeedInt Q, numinputfields, numoutputfields;
@@ -187,7 +187,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
                                  CeedVector outvec, CeedRequest *request) {
   int ierr;
   CeedOperator_Ref *impl;
-  ierr = CeedOperatorGetData(op, (void*)&impl); CeedChk(ierr);
+  ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
   CeedQFunction qf;
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
   CeedInt Q, numelements, elemsize, numinputfields, numoutputfields, ncomp;
@@ -410,7 +410,7 @@ int CeedOperatorCreate_Ref(CeedOperator op) {
   CeedOperator_Ref *impl;
 
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
-  ierr = CeedOperatorSetData(op, (void*)&impl);
+  ierr = CeedOperatorSetData(op, (void *)&impl);
 
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Ref); CeedChk(ierr);

--- a/backends/ref/ceed-ref-qfunction.c
+++ b/backends/ref/ceed-ref-qfunction.c
@@ -21,13 +21,13 @@ static int CeedQFunctionApply_Ref(CeedQFunction qf, CeedInt Q,
                                   CeedVector *U, CeedVector *V) {
   int ierr;
   CeedQFunction_Ref *impl;
-  ierr = CeedQFunctionGetData(qf, (void*)&impl); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&impl); CeedChk(ierr);
 
   void *ctx;
   ierr = CeedQFunctionGetContext(qf, &ctx); CeedChk(ierr);
 
   int (*f)() = NULL;
-  ierr = CeedQFunctionGetUserFunction(qf, (int (**)())&f); CeedChk(ierr);
+  ierr = CeedQFunctionGetUserFunction(qf, (int (* *)())&f); CeedChk(ierr);
 
   CeedInt nIn, nOut;
   ierr = CeedQFunctionGetNumArgs(qf, &nIn, &nOut); CeedChk(ierr);
@@ -56,7 +56,7 @@ static int CeedQFunctionApply_Ref(CeedQFunction qf, CeedInt Q,
 static int CeedQFunctionDestroy_Ref(CeedQFunction qf) {
   int ierr;
   CeedQFunction_Ref *impl;
-  ierr = CeedQFunctionGetData(qf, (void*)&impl); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedFree(&impl->inputs); CeedChk(ierr);
   ierr = CeedFree(&impl->outputs); CeedChk(ierr);
@@ -74,7 +74,7 @@ int CeedQFunctionCreate_Ref(CeedQFunction qf) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedCalloc(16, &impl->inputs); CeedChk(ierr);
   ierr = CeedCalloc(16, &impl->outputs); CeedChk(ierr);
-  ierr = CeedQFunctionSetData(qf, (void*)&impl); CeedChk(ierr);
+  ierr = CeedQFunctionSetData(qf, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "QFunction", qf, "Apply",
                                 CeedQFunctionApply_Ref); CeedChk(ierr);

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -23,7 +23,7 @@ static int CeedElemRestrictionApply_Ref(CeedElemRestriction r,
                                         CeedVector v, CeedRequest *request) {
   int ierr;
   CeedElemRestriction_Ref *impl;
-  ierr = CeedElemRestrictionGetData(r, (void*)&impl); CeedChk(ierr);;
+  ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);;
   const CeedScalar *uu;
   CeedScalar *vv;
   CeedInt nblk, blksize, nelem, elemsize, ndof, ncomp;
@@ -93,7 +93,7 @@ static int CeedElemRestrictionApply_Ref(CeedElemRestriction r,
 static int CeedElemRestrictionDestroy_Ref(CeedElemRestriction r) {
   int ierr;
   CeedElemRestriction_Ref *impl;
-  ierr = CeedElemRestrictionGetData(r, (void*)&impl); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedFree(&impl->indices_allocated); CeedChk(ierr);
   ierr = CeedFree(&impl); CeedChk(ierr);
@@ -129,7 +129,7 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mtype, CeedCopyMode cmode,
     impl->indices = indices;
   }
 
-  ierr = CeedElemRestrictionSetData(r, (void*)&impl); CeedChk(ierr);
+  ierr = CeedElemRestrictionSetData(r, (void *)&impl); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "ElemRestriction", r, "Apply",
                                 CeedElemRestrictionApply_Ref); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "ElemRestriction", r, "Destroy",

--- a/backends/ref/ceed-ref-vec.c
+++ b/backends/ref/ceed-ref-vec.c
@@ -21,7 +21,7 @@ static int CeedVectorSetArray_Ref(CeedVector vec, CeedMemType mtype,
                                   CeedCopyMode cmode, CeedScalar *array) {
   int ierr;
   CeedVector_Ref *impl;
-  ierr = CeedVectorGetData(vec, (void*)&impl); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&impl); CeedChk(ierr);
   CeedInt length;
   ierr = CeedVectorGetLength(vec, &length); CeedChk(ierr);
   Ceed ceed;
@@ -50,7 +50,7 @@ static int CeedVectorGetArray_Ref(CeedVector vec, CeedMemType mtype,
                                   CeedScalar **array) {
   int ierr;
   CeedVector_Ref *impl;
-  ierr = CeedVectorGetData(vec, (void*)&impl); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&impl); CeedChk(ierr);
   Ceed ceed;
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
 
@@ -68,7 +68,7 @@ static int CeedVectorGetArrayRead_Ref(CeedVector vec, CeedMemType mtype,
                                       const CeedScalar **array) {
   int ierr;
   CeedVector_Ref *impl;
-  ierr = CeedVectorGetData(vec, (void*)&impl); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&impl); CeedChk(ierr);
   Ceed ceed;
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
 
@@ -96,7 +96,7 @@ static int CeedVectorRestoreArrayRead_Ref(CeedVector vec,
 static int CeedVectorDestroy_Ref(CeedVector vec) {
   int ierr;
   CeedVector_Ref *impl;
-  ierr = CeedVectorGetData(vec, (void*)&impl); CeedChk(ierr);
+  ierr = CeedVectorGetData(vec, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedFree(&impl->array_allocated); CeedChk(ierr);
   ierr = CeedFree(&impl); CeedChk(ierr);
@@ -122,6 +122,6 @@ int CeedVectorCreate_Ref(CeedInt n, CeedVector vec) {
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "Destroy",
                                 CeedVectorDestroy_Ref); CeedChk(ierr);
   ierr = CeedCalloc(1,&impl); CeedChk(ierr);
-  ierr = CeedVectorSetData(vec, (void*)&impl);
+  ierr = CeedVectorSetData(vec, (void *)&impl);
   return 0;
 }

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -36,7 +36,7 @@ typedef struct {
 typedef struct {
   CeedVector
   *evecs;   /// E-vectors needed to apply operator (input followed by outputs)
-  CeedScalar ** edata;
+  CeedScalar **edata;
   uint64_t *inputstate;  /// State counter of inputs
   CeedVector *evecsin;   /// Input E-vectors needed to apply operator
   CeedVector *evecsout;  /// Output E-vectors needed to apply operator

--- a/backends/xsmm/ceed-xsmm-basis.c
+++ b/backends/xsmm/ceed-xsmm-basis.c
@@ -23,12 +23,12 @@
 // TRANSPOSE:   V_ajc = T_bj U_abc
 // If Add != 0, "=" is replaced by "+="
 static int CeedTensorContract_Xsmm_Blocked(Ceed ceed, CeedInt A, CeedInt B,
-                                           CeedInt C, CeedInt J,
-                                           const CeedScalar *restrict t,
-                                           CeedTransposeMode tmode,
-                                           const CeedInt Add,
-                                           const CeedScalar *restrict u,
-                                           CeedScalar *restrict v) {
+    CeedInt C, CeedInt J,
+    const CeedScalar *restrict t,
+    CeedTransposeMode tmode,
+    const CeedInt Add,
+    const CeedScalar *restrict u,
+    CeedScalar *restrict v) {
   CeedScalar alpha = 1.0, beta = 1.0;
   char transu = 'N', transt = 'N';
   if (tmode == CEED_TRANSPOSE)
@@ -46,12 +46,12 @@ static int CeedTensorContract_Xsmm_Blocked(Ceed ceed, CeedInt A, CeedInt B,
 }
 
 static int CeedTensorContract_Xsmm_Serial(Ceed ceed, CeedInt A, CeedInt B,
-                                          CeedInt C, CeedInt J,
-                                          const CeedScalar *restrict t,
-                                          CeedTransposeMode tmode,
-                                          const CeedInt Add,
-                                          const CeedScalar *restrict u,
-                                          CeedScalar *restrict v) {
+    CeedInt C, CeedInt J,
+    const CeedScalar *restrict t,
+    CeedTransposeMode tmode,
+    const CeedInt Add,
+    const CeedScalar *restrict u,
+    CeedScalar *restrict v) {
   CeedScalar alpha = 1.0, beta = 1.0;
   char transu = 'N', transt = 'N';
   if ((tmode == CEED_TRANSPOSE && C != 1)
@@ -67,11 +67,11 @@ static int CeedTensorContract_Xsmm_Serial(Ceed ceed, CeedInt A, CeedInt B,
       libxsmm_dgemm(&transu, &transt, &C, &J, &B,
                     &alpha, &u[a*B*C], NULL, &t[0], NULL,
                     &beta, &v[a*J*C], NULL);
-   else
-      // libXSMM GEMM
-      libxsmm_dgemm(&transt, &transu, &J, &A, &B,
-                    &alpha, &t[0], NULL, &u[0], NULL,
-                    &beta, &v[0], NULL);
+  else
+    // libXSMM GEMM
+    libxsmm_dgemm(&transt, &transu, &J, &A, &B,
+                  &alpha, &t[0], NULL, &u[0], NULL,
+                  &beta, &v[0], NULL);
 
   return 0;
 }
@@ -151,7 +151,7 @@ static int CeedBasisApply_Xsmm(CeedBasis basis, CeedInt nelem,
         P = Q1d, Q = Q1d;
       }
       CeedBasis_Xsmm *impl;
-      ierr = CeedBasisGetData(basis, (void*)&impl); CeedChk(ierr);
+      ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
       CeedScalar interp[nelem*ncomp*Q*CeedIntPow(P>Q?P:Q, dim-1)];
       CeedInt pre = ncomp*CeedIntPow(P, dim-1), post = nelem;
       CeedScalar tmp[2][nelem*ncomp*Q*CeedIntPow(P>Q?P:Q, dim-1)];
@@ -286,7 +286,7 @@ static int CeedBasisDestroyNonTensor_Xsmm(CeedBasis basis) {
 static int CeedBasisDestroyTensor_Xsmm(CeedBasis basis) {
   int ierr;
   CeedBasis_Xsmm *impl;
-  ierr = CeedBasisGetData(basis, (void*)&impl); CeedChk(ierr);
+  ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedFree(&impl->colograd1d); CeedChk(ierr);
   ierr = CeedFree(&impl); CeedChk(ierr);
@@ -307,7 +307,7 @@ int CeedBasisCreateTensorH1_Xsmm(CeedInt dim, CeedInt P1d, CeedInt Q1d,
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedMalloc(Q1d*Q1d, &impl->colograd1d); CeedChk(ierr);
   ierr = CeedBasisGetCollocatedGrad(basis, impl->colograd1d); CeedChk(ierr);
-  ierr = CeedBasisSetData(basis, (void*)&impl); CeedChk(ierr);
+  ierr = CeedBasisSetData(basis, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
                                 CeedBasisApply_Xsmm); CeedChk(ierr);

--- a/backends/xsmm/ceed-xsmm-blocked.c
+++ b/backends/xsmm/ceed-xsmm-blocked.c
@@ -21,7 +21,7 @@ static int CeedInit_Xsmm_Blocked(const char *resource, Ceed ceed) {
   int ierr;
   if (strcmp(resource, "/cpu/self/xsmm/blocked"))
     return CeedError(ceed, 1, "blocked libXSMM backend cannot use resource: %s",
-      resource);
+                     resource);
 
   Ceed ceedref;
 

--- a/backends/xsmm/ceed-xsmm-serial.c
+++ b/backends/xsmm/ceed-xsmm-serial.c
@@ -21,7 +21,7 @@ static int CeedInit_Xsmm_Serial(const char *resource, Ceed ceed) {
   int ierr;
   if (strcmp(resource, "/cpu/self/xsmm/serial"))
     return CeedError(ceed, 1, "serial libXSMM backend cannot use resource: %s",
-      resource);
+                     resource);
 
   Ceed ceedref;
 

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -29,9 +29,9 @@ CEED_INTERN int CeedBasisCreateTensorH1_Xsmm(CeedInt dim, CeedInt P1d,
     CeedBasis basis);
 
 CEED_INTERN int CeedBasisCreateH1_Xsmm(CeedElemTopology topo, CeedInt dim,
-    CeedInt ndof, CeedInt nqpts,
-    const CeedScalar *interp,
-    const CeedScalar *grad,
-    const CeedScalar *qref,
-    const CeedScalar *qweight,
-    CeedBasis basis);
+                                       CeedInt ndof, CeedInt nqpts,
+                                       const CeedScalar *interp,
+                                       const CeedScalar *grad,
+                                       const CeedScalar *qref,
+                                       const CeedScalar *qweight,
+                                       CeedBasis basis);

--- a/examples/ceed/ex1.c
+++ b/examples/ceed/ex1.c
@@ -43,7 +43,7 @@ static int f_build_mass(void *ctx, CeedInt Q,
                         const CeedScalar *const *in, CeedScalar *const *out) {
   // in[0] is Jacobians with shape [dim, nc=dim, Q]
   // in[1] is quadrature weights, size (Q)
-  struct BuildContext *bc = (struct BuildContext*)ctx;
+  struct BuildContext *bc = (struct BuildContext *)ctx;
   const CeedScalar *J = in[0], *qw = in[1];
   CeedScalar *qd = out[0];
   switch (bc->dim + 10*bc->space_dim) {

--- a/examples/mfem/bp1.cpp
+++ b/examples/mfem/bp1.cpp
@@ -47,11 +47,11 @@ double solution(const mfem::Vector &pt) {
 int main(int argc, char *argv[]) {
   // 1. Parse command-line options.
   const char *ceed_spec = "/cpu/self";
-#ifndef MFEM_DIR
+  #ifndef MFEM_DIR
   const char *mesh_file = "../../../mfem/data/star.mesh";
-#else
+  #else
   const char *mesh_file = MFEM_DIR "/data/star.mesh";
-#endif
+  #endif
   int order = 1;
   bool visualization = true;
   bool test = false;

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -27,7 +27,7 @@ static int f_build_mass(void *ctx, CeedInt Q,
                         const CeedScalar *const *in, CeedScalar *const *out) {
   // in[0] is Jacobians with shape [dim, nc=dim, Q]
   // in[1] is quadrature weights, size (Q)
-  BuildContext *bc = (BuildContext*)ctx;
+  BuildContext *bc = (BuildContext *)ctx;
   const CeedScalar *J = in[0], *qw = in[1];
   CeedScalar *rho = out[0];
   switch (bc->dim + 10*bc->space_dim) {
@@ -95,21 +95,21 @@ class CeedMassOperator : public mfem::Operator {
     switch (mesh->Dimension()) {
     case 1: {
       const mfem::H1_SegmentElement *h1_fe =
-        dynamic_cast<const mfem::H1_SegmentElement*>(fe);
+        dynamic_cast<const mfem::H1_SegmentElement *>(fe);
       MFEM_VERIFY(h1_fe, "invalid FE");
       h1_fe->GetDofMap().Copy(dof_map);
       break;
     }
     case 2: {
       const mfem::H1_QuadrilateralElement *h1_fe =
-        dynamic_cast<const mfem::H1_QuadrilateralElement*>(fe);
+        dynamic_cast<const mfem::H1_QuadrilateralElement *>(fe);
       MFEM_VERIFY(h1_fe, "invalid FE");
       h1_fe->GetDofMap().Copy(dof_map);
       break;
     }
     case 3: {
       const mfem::H1_HexahedronElement *h1_fe =
-        dynamic_cast<const mfem::H1_HexahedronElement*>(fe);
+        dynamic_cast<const mfem::H1_HexahedronElement *>(fe);
       MFEM_VERIFY(h1_fe, "invalid FE");
       h1_fe->GetDofMap().Copy(dof_map);
       break;
@@ -123,7 +123,7 @@ class CeedMassOperator : public mfem::Operator {
     mfem::Vector shape_i(shape1d.Height());
     mfem::DenseMatrix grad_i(grad1d.Height(), 1);
     const mfem::H1_SegmentElement *h1_fe1d =
-      dynamic_cast<const mfem::H1_SegmentElement*>(fe1d);
+      dynamic_cast<const mfem::H1_SegmentElement *>(fe1d);
     MFEM_VERIFY(h1_fe1d, "invalid FE");
     const mfem::Array<int> &dof_map_1d = h1_fe1d->GetDofMap();
     for (int i = 0; i < ir.GetNPoints(); i++) {
@@ -257,7 +257,7 @@ class CeedMassOperator : public mfem::Operator {
     CeedOperatorApply(oper, u, v, CEED_REQUEST_IMMEDIATE);
 
     //TODO replace this by SyncArray when available
-    const CeedScalar* array;
+    const CeedScalar *array;
     CeedVectorGetArrayRead(v, CEED_MEM_HOST, &array);
     CeedVectorRestoreArrayRead(v, &array);
   }

--- a/examples/mfem/bp3.cpp
+++ b/examples/mfem/bp3.cpp
@@ -66,11 +66,11 @@ double rhs(const mfem::Vector &pt) {
 int main(int argc, char *argv[]) {
   // 1. Parse command-line options.
   const char *ceed_spec = "/cpu/self";
-#ifndef MFEM_DIR
+  #ifndef MFEM_DIR
   const char *mesh_file = "../../../mfem/data/star.mesh";
-#else
+  #else
   const char *mesh_file = MFEM_DIR "/data/star.mesh";
-#endif
+  #endif
   int order = 2;
   bool visualization = true;
   bool test = false;

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -25,7 +25,7 @@ struct BuildContext { CeedInt dim, space_dim; };
 /// libCEED Q-function for building quadrature data for a diffusion operator
 static int f_build_diff(void *ctx, CeedInt Q,
                         const CeedScalar *const *in, CeedScalar *const *out) {
-  BuildContext *bc = (BuildContext*)ctx;
+  BuildContext *bc = (BuildContext *)ctx;
   // in[0] is Jacobians with shape [dim, nc=dim, Q]
   // in[1] is quadrature weights, size (Q)
   //
@@ -95,7 +95,7 @@ static int f_build_diff(void *ctx, CeedInt Q,
 /// libCEED Q-function for applying a diff operator
 static int f_apply_diff(void *ctx, CeedInt Q,
                         const CeedScalar *const *in, CeedScalar *const *out) {
-  BuildContext *bc = (BuildContext*)ctx;
+  BuildContext *bc = (BuildContext *)ctx;
   // in[0], out[0] have shape [dim, nc=1, Q]
   const CeedScalar *ug = in[0], *qd = in[1];
   CeedScalar *vg = out[0];
@@ -154,21 +154,21 @@ class CeedDiffusionOperator : public mfem::Operator {
     switch (mesh->Dimension()) {
     case 1: {
       const mfem::H1_SegmentElement *h1_fe =
-        dynamic_cast<const mfem::H1_SegmentElement*>(fe);
+        dynamic_cast<const mfem::H1_SegmentElement *>(fe);
       MFEM_VERIFY(h1_fe, "invalid FE");
       h1_fe->GetDofMap().Copy(dof_map);
       break;
     }
     case 2: {
       const mfem::H1_QuadrilateralElement *h1_fe =
-        dynamic_cast<const mfem::H1_QuadrilateralElement*>(fe);
+        dynamic_cast<const mfem::H1_QuadrilateralElement *>(fe);
       MFEM_VERIFY(h1_fe, "invalid FE");
       h1_fe->GetDofMap().Copy(dof_map);
       break;
     }
     case 3: {
       const mfem::H1_HexahedronElement *h1_fe =
-        dynamic_cast<const mfem::H1_HexahedronElement*>(fe);
+        dynamic_cast<const mfem::H1_HexahedronElement *>(fe);
       MFEM_VERIFY(h1_fe, "invalid FE");
       h1_fe->GetDofMap().Copy(dof_map);
       break;
@@ -182,7 +182,7 @@ class CeedDiffusionOperator : public mfem::Operator {
     mfem::Vector shape_i(shape1d.Height());
     mfem::DenseMatrix grad_i(grad1d.Height(), 1);
     const mfem::H1_SegmentElement *h1_fe1d =
-      dynamic_cast<const mfem::H1_SegmentElement*>(fe1d);
+      dynamic_cast<const mfem::H1_SegmentElement *>(fe1d);
     MFEM_VERIFY(h1_fe1d, "invalid FE");
     const mfem::Array<int> &dof_map_1d = h1_fe1d->GetDofMap();
     for (int i = 0; i < ir.GetNPoints(); i++) {
@@ -317,7 +317,7 @@ class CeedDiffusionOperator : public mfem::Operator {
     CeedOperatorApply(oper, u, v, CEED_REQUEST_IMMEDIATE);
 
     //TODO replace this by SyncArray when available
-    const CeedScalar* array;
+    const CeedScalar *array;
     CeedVectorGetArrayRead(v, CEED_MEM_HOST, &array);
     CeedVectorRestoreArrayRead(v, &array);
   }

--- a/examples/petsc/bp1.c
+++ b/examples/petsc/bp1.c
@@ -128,7 +128,7 @@ static PetscErrorCode MatMult_Mass(Mat A, Vec X, Vec Y) {
   CHKERRQ(ierr);
   ierr = VecZeroEntries(user->Yloc); CHKERRQ(ierr);
 
-  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   ierr = VecGetArray(user->Yloc, &y); CHKERRQ(ierr);
   CeedVectorSetArray(user->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorSetArray(user->yceed, CEED_MEM_HOST, CEED_USE_POINTER, y);
@@ -136,13 +136,13 @@ static PetscErrorCode MatMult_Mass(Mat A, Vec X, Vec Y) {
   CeedOperatorApply(user->op, user->xceed, user->yceed,
                     CEED_REQUEST_IMMEDIATE);
   //TODO replace this by SyncArray when available
-  const CeedScalar* array;
+  const CeedScalar *array;
   ierr = CeedVectorGetArrayRead(user->yceed, CEED_MEM_HOST, &array);
   CHKERRQ(ierr);
   ierr = CeedVectorRestoreArrayRead(user->yceed, &array); CHKERRQ(ierr);
 
 
-  ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   ierr = VecRestoreArray(user->Yloc, &y); CHKERRQ(ierr);
 
   if (Y) {
@@ -169,11 +169,11 @@ static PetscErrorCode ComputeErrorMax(User user, CeedOperator op_error, Vec X,
                          SCATTER_REVERSE); CHKERRQ(ierr);
   ierr = VecScatterEnd(user->ltog, X, user->Xloc, INSERT_VALUES, SCATTER_REVERSE);
   CHKERRQ(ierr);
-  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   CeedVectorSetArray(user->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedOperatorApply(op_error, user->xceed, collocated_error,
                     CEED_REQUEST_IMMEDIATE);
-  VecRestoreArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
 
   *maxerror = 0;
   const CeedScalar *e;
@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
   // Find my location in the process grid
   ierr = MPI_Comm_rank(comm, &rank); CHKERRQ(ierr);
   for (int d=0,rankleft=rank; d<3; d++) {
-    const int pstride[3] = {p[1]*p[2], p[2], 1};
+    const int pstride[3] = {p[1] *p[2], p[2], 1};
     irank[d] = rankleft / pstride[d];
     rankleft -= irank[d] * pstride[d];
   }
@@ -444,7 +444,7 @@ int main(int argc, char **argv) {
   // Setup rho, rhs, and target
   CeedOperatorApply(op_setup, xcoord, rho, CEED_REQUEST_IMMEDIATE);
   //TODO replace this by SyncArray when available
-  const CeedScalar* array;
+  const CeedScalar *array;
   ierr = CeedVectorGetArrayRead(rhsceed, CEED_MEM_HOST, &array); CHKERRQ(ierr);
   ierr = CeedVectorRestoreArrayRead(rhsceed, &array); CHKERRQ(ierr);
   CeedVectorDestroy(&xcoord);

--- a/examples/petsc/bp3.c
+++ b/examples/petsc/bp3.c
@@ -132,7 +132,7 @@ static PetscErrorCode MatMult_Diff(Mat A, Vec X, Vec Y) {
   CHKERRQ(ierr);
   ierr = VecZeroEntries(user->Yloc); CHKERRQ(ierr);
 
-  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   ierr = VecGetArray(user->Yloc, &y); CHKERRQ(ierr);
   CeedVectorSetArray(user->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorSetArray(user->yceed, CEED_MEM_HOST, CEED_USE_POINTER, y);
@@ -140,12 +140,12 @@ static PetscErrorCode MatMult_Diff(Mat A, Vec X, Vec Y) {
   CeedOperatorApply(user->op, user->xceed, user->yceed,
                     CEED_REQUEST_IMMEDIATE);
   //TODO replace this by SyncArray when available
-  const CeedScalar* array;
+  const CeedScalar *array;
   ierr = CeedVectorGetArrayRead(user->yceed, CEED_MEM_HOST, &array);
   CHKERRQ(ierr);
   ierr = CeedVectorRestoreArrayRead(user->yceed, &array); CHKERRQ(ierr);
 
-  ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   ierr = VecRestoreArray(user->Yloc, &y); CHKERRQ(ierr);
 
   ierr = VecZeroEntries(Y); CHKERRQ(ierr);
@@ -174,11 +174,11 @@ static PetscErrorCode ComputeErrorMax(User user, CeedOperator op_error, Vec X,
                          SCATTER_REVERSE); CHKERRQ(ierr);
   ierr = VecScatterEnd(user->ltog, X, user->Xloc, INSERT_VALUES, SCATTER_REVERSE);
   CHKERRQ(ierr);
-  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   CeedVectorSetArray(user->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedOperatorApply(op_error, user->xceed, collocated_error,
                     CEED_REQUEST_IMMEDIATE);
-  VecRestoreArrayRead(user->Xloc, (const PetscScalar**)&x); CHKERRQ(ierr);
+  VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
 
   *maxerror = 0;
   const CeedScalar *e;
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
   // Find my location in the process grid
   ierr = MPI_Comm_rank(comm, &rank); CHKERRQ(ierr);
   for (int d=0,rankleft=rank; d<3; d++) {
-    const int pstride[3] = {p[1]*p[2], p[2], 1};
+    const int pstride[3] = {p[1] *p[2], p[2], 1};
     irank[d] = rankleft / pstride[d];
     rankleft -= irank[d] * pstride[d];
   }
@@ -500,7 +500,7 @@ int main(int argc, char **argv) {
   // Setup rho, rhs, and target
   CeedOperatorApply(op_setup, xcoord, rho, CEED_REQUEST_IMMEDIATE);
   //TODO replace this by SyncArray when available
-  const CeedScalar* array;
+  const CeedScalar *array;
   ierr = CeedVectorGetArrayRead(rhsceed, CEED_MEM_HOST, &array); CHKERRQ(ierr);
   ierr = CeedVectorRestoreArrayRead(rhsceed, &array); CHKERRQ(ierr);
   CeedVectorDestroy(&xcoord);

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -23,9 +23,9 @@
 // *****************************************************************************
 static int Setup(void *ctx, CeedInt Q,
                  const CeedScalar *const *in, CeedScalar *const *out) {
-#ifndef M_PI
+  #ifndef M_PI
 #define M_PI    3.14159265358979323846
-#endif
+  #endif
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
   CeedScalar *qd = out[0], *true_soln = out[1], *rhs = out[2];
   for (CeedInt i=0; i<Q; i++) {

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -48,8 +48,8 @@ CEED_EXTERN int CeedRegister(const char *prefix,
 CEED_EXTERN int CeedGetDelegate(Ceed ceed, Ceed *delegate);
 CEED_EXTERN int CeedSetDelegate(Ceed ceed, Ceed *delegate);
 CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
-                                       const char * type, void *object,
-                                       const char * fname, int (*f)());
+                                       const char *type, void *object,
+                                       const char *fname, int (*f)());
 CEED_EXTERN int CeedGetData(Ceed ceed, void* *data);
 CEED_EXTERN int CeedSetData(Ceed ceed, void* *data);
 

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -322,7 +322,7 @@ CEED_EXTERN int CeedQFunctionAddOutput(CeedQFunction qf, const char *fieldname,
 CEED_EXTERN int CeedQFunctionSetContext(CeedQFunction qf, void *ctx,
                                         size_t ctxsize);
 CEED_EXTERN int CeedQFunctionApply(CeedQFunction qf, CeedInt Q,
-                                   CeedVector* u, CeedVector* v);
+                                   CeedVector *u, CeedVector *v);
 CEED_EXTERN int CeedQFunctionDestroy(CeedQFunction *qf);
 
 CEED_EXTERN int CeedOperatorCreate(Ceed ceed, CeedQFunction qf,

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -609,7 +609,7 @@ int CeedBasisApply(CeedBasis basis, CeedInt nelem, CeedTransposeMode tmode,
   int ierr;
   CeedInt ulength = 0, vlength, ndof, nqpt;
   if (!basis->Apply) return CeedError(basis->ceed, 1,
-                                      "Backend does not support BasisApply");
+                                        "Backend does not support BasisApply");
   // check compatibility of topological and geometrical dimensions
   ierr = CeedBasisGetNumNodes(basis, &ndof); CeedChk(ierr);
   ierr = CeedBasisGetNumQuadraturePoints(basis, &nqpt); CeedChk(ierr);
@@ -619,10 +619,11 @@ int CeedBasisApply(CeedBasis basis, CeedInt nelem, CeedTransposeMode tmode,
     ierr = CeedVectorGetLength(u, &ulength); CeedChk(ierr);
   }
 
-  if ((tmode == CEED_TRANSPOSE   && (vlength % ndof != 0 || ulength % nqpt != 0)) ||
+  if ((tmode == CEED_TRANSPOSE   && (vlength % ndof != 0 || ulength % nqpt != 0))
+      ||
       (tmode == CEED_NOTRANSPOSE && (ulength % ndof != 0 || vlength % nqpt != 0)))
-        return CeedError(basis->ceed, 1,
-                         "Length of input/output vectors incompatible with basis dimensions");
+    return CeedError(basis->ceed, 1,
+                     "Length of input/output vectors incompatible with basis dimensions");
 
   ierr = basis->Apply(basis, nelem, tmode, emode, u, v); CeedChk(ierr);
   return 0;

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -47,7 +47,7 @@ typedef int fortran_charlen_t;
   Splice(stringname, _c)[Splice(stringname, _len)] = 0;                 \
 
 #define fCeedInit FORTRAN_NAME(ceedinit,CEEDINIT)
-void fCeedInit(const char* resource, int *ceed, int *err,
+void fCeedInit(const char *resource, int *ceed, int *err,
                fortran_charlen_t resource_len) {
   FIX_STRING(resource);
   if (Ceed_count == Ceed_count_max) {
@@ -90,7 +90,7 @@ void fCeedVectorCreate(int *ceed, int *length, int *vec, int *err) {
     CeedRealloc(CeedVector_count_max, &CeedVector_dict);
   }
 
-  CeedVector* vec_ = &CeedVector_dict[CeedVector_count];
+  CeedVector *vec_ = &CeedVector_dict[CeedVector_count];
   *err = CeedVectorCreate(Ceed_dict[*ceed], *length, vec_);
 
   if (*err == 0) {
@@ -444,7 +444,7 @@ static int CeedQFunctionFortranStub(void *ctx, int nq,
   int ierr;
 
   CeedScalar *ctx_ = (CeedScalar *) fctx->innerctx;
-  fctx->f((void*)ctx_,&nq,u[0],u[1],u[2],u[3],u[4],u[5],u[6],
+  fctx->f((void *)ctx_,&nq,u[0],u[1],u[2],u[3],u[4],u[5],u[6],
           u[7],u[8],u[9],u[10],u[11],u[12],u[13],u[14],u[15],
           v[0],v[1],v[2],v[3],v[4],v[5],v[6],v[7],v[8],v[9],
           v[10],v[11],v[12],v[13],v[14],v[15],&ierr);
@@ -453,7 +453,7 @@ static int CeedQFunctionFortranStub(void *ctx, int nq,
 
 #define fCeedQFunctionCreateInterior \
     FORTRAN_NAME(ceedqfunctioncreateinterior, CEEDQFUNCTIONCREATEINTERIOR)
-void fCeedQFunctionCreateInterior(int* ceed, int* vlength,
+void fCeedQFunctionCreateInterior(int *ceed, int *vlength,
                                   void (*f)(void *ctx, int *nq,
                                       const CeedScalar *u,const CeedScalar *u1,
                                       const CeedScalar *u2,const CeedScalar *u3,
@@ -613,8 +613,8 @@ static int CeedOperator_count_max = 0;
 
 #define fCeedOperatorCreate \
     FORTRAN_NAME(ceedoperatorcreate, CEEDOPERATORCREATE)
-void fCeedOperatorCreate(int* ceed,
-                         int* qf, int* dqf, int* dqfT, int *op, int *err) {
+void fCeedOperatorCreate(int *ceed,
+                         int *qf, int *dqf, int *dqfT, int *op, int *err) {
   if (CeedOperator_count == CeedOperator_count_max)
     CeedOperator_count_max += CeedOperator_count_max/2 + 1,
                               CeedOperator_dict =

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -216,7 +216,7 @@ int CeedQFunctionGetNumArgs(CeedQFunction qf, CeedInt *numinput,
 **/
 
 int CeedQFunctionGetFOCCA(CeedQFunction qf, char* *focca) {
-  *focca = (char*) qf->focca;
+  *focca = (char *) qf->focca;
   return 0;
 }
 
@@ -374,7 +374,7 @@ int CeedQFunctionSetContext(CeedQFunction qf, void *ctx, size_t ctxsize) {
   @ref Advanced
 **/
 int CeedQFunctionApply(CeedQFunction qf, CeedInt Q,
-                       CeedVector* u, CeedVector* v) {
+                       CeedVector *u, CeedVector *v) {
   int ierr;
   if (!qf->Apply)
     return CeedError(qf->ceed, 1, "Backend does not support QFunctionApply");

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -329,7 +329,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
 
   // Setup Ceed
   ierr = CeedCalloc(1,ceed); CeedChk(ierr);
-  const char * ceed_error_handler = getenv("CEED_ERROR_HANDLER");
+  const char *ceed_error_handler = getenv("CEED_ERROR_HANDLER");
   if (!ceed_error_handler) ceed_error_handler = "abort";
   if (!strcmp(ceed_error_handler, "exit"))
     (*ceed)->Error = CeedErrorExit;


### PR DESCRIPTION
This PR adds Jed's branch fixing `make style`.

```
astyle --exclude options are evidently broken and were generating
confusing output.  The Makefile version also missed
--align-pointer=name from .astylerc and that led to an inconsistency.
```