### PR TITLE
Drop array argument from backend RestoreArray

### DIFF
--- a/backends/cuda/ceed-cuda-vec.c
+++ b/backends/cuda/ceed-cuda-vec.c
@@ -280,14 +280,11 @@ static int CeedVectorGetArray_Cuda(const CeedVector vec,
 // *****************************************************************************
 // * Restore an array obtained using CeedVectorGetArray()
 // *****************************************************************************
-static int CeedVectorRestoreArrayRead_Cuda(const CeedVector vec,
-    const CeedScalar **array) {
+static int CeedVectorRestoreArrayRead_Cuda(const CeedVector vec) {
   return 0;
 }
 // *****************************************************************************
-static int CeedVectorRestoreArray_Cuda(const CeedVector vec,
-                                       CeedScalar **array) {
-  *array = NULL;
+static int CeedVectorRestoreArray_Cuda(const CeedVector vec) {
   return 0;
 }
 

--- a/backends/magma/ceed-magma.c
+++ b/backends/magma/ceed-magma.c
@@ -231,26 +231,14 @@ static int CeedVectorGetArrayRead_Magma(CeedVector vec, CeedMemType mtype,
 // * Restore vector vec with values from array, where array received its values
 // * from vec and possibly modified them.
 // *****************************************************************************
-static int CeedVectorRestoreArray_Magma(CeedVector vec, CeedScalar **array) {
+static int CeedVectorRestoreArray_Magma(CeedVector vec) {
   CeedVector_Magma *impl = vec->data;
 
-  // Check if the array is a CPU pointer
-  if (*array == impl->array) {
-    // Update device, if the device pointer is not NULL
-    if (impl->darray != NULL) {
-      magma_setvector(vec->length, sizeof(*array[0]),
-                      *array, 1, impl->darray, 1);
-    } else {
-      // nothing to do (case of CPU use pointer)
-    }
-
-  } else if (impl->down_) {
+  if (impl->down_) {
     // nothing to do if array is on GPU, except if down_=1(case CPU use pointer)
     magma_getvector(vec->length, sizeof(*array[0]),
                     impl->darray, 1, impl->array, 1);
   }
-
-  *array = NULL;
   return 0;
 }
 
@@ -262,27 +250,14 @@ static int CeedVectorRestoreArray_Magma(CeedVector vec, CeedScalar **array) {
 // * from vec to only read them; in this case vec may have been modified meanwhile
 // * and needs to be restored here.
 // *****************************************************************************
-static int CeedVectorRestoreArrayRead_Magma(CeedVector vec,
-    const CeedScalar **array) {
+static int CeedVectorRestoreArrayRead_Magma(CeedVector vec) {
   CeedVector_Magma *impl = vec->data;
 
-  // Check if the array is a CPU pointer
-  if (*array == impl->array) {
-    // Update device, if the device pointer is not NULL
-    if (impl->darray != NULL) {
-      magma_setvector(vec->length, sizeof(*array[0]),
-                      *array, 1, impl->darray, 1);
-    } else {
-      // nothing to do (case of CPU use pointer)
-    }
-
-  } else if (impl->down_) {
+  if (impl->down_) {
     // nothing to do if array is on GPU, except if down_=1(case CPU use pointer)
     magma_getvector(vec->length, sizeof(*array[0]),
                     impl->darray, 1, impl->array, 1);
   }
-
-  *array = NULL;
   return 0;
 }
 

--- a/backends/occa/ceed-occa-vector.c
+++ b/backends/occa/ceed-occa-vector.c
@@ -133,8 +133,11 @@ static int CeedVectorGetArray_Occa(const CeedVector vec,
 // *****************************************************************************
 // * Restore an array obtained using CeedVectorGetArray()
 // *****************************************************************************
-static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec,
-    const CeedScalar **array) {
+static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec) {
+  return 0;
+}
+// *****************************************************************************
+static int CeedVectorRestoreArray_Occa(const CeedVector vec) {
   int ierr;
   Ceed ceed;
   ierr = CeedVectorGetCeed(vec, &ceed); CeedChk(ierr);
@@ -142,15 +145,8 @@ static int CeedVectorRestoreArrayRead_Occa(const CeedVector vec,
   CeedVector_Occa *data;
   ierr = CeedVectorGetData(vec, (void *)&data); CeedChk(ierr);
   assert((data)->h_array);
-  assert(*array);
   CeedSyncH2D_Occa(vec); // sync Host to Device
-  *array = NULL;
   return 0;
-}
-// *****************************************************************************
-static int CeedVectorRestoreArray_Occa(const CeedVector vec,
-                                       CeedScalar **array) {
-  return CeedVectorRestoreArrayRead_Occa(vec,(const CeedScalar **)array);
 }
 
 // *****************************************************************************

--- a/backends/ref/ceed-ref-vec.c
+++ b/backends/ref/ceed-ref-vec.c
@@ -82,14 +82,11 @@ static int CeedVectorGetArrayRead_Ref(CeedVector vec, CeedMemType mtype,
   return 0;
 }
 
-static int CeedVectorRestoreArray_Ref(CeedVector vec, CeedScalar **array) {
-  *array = NULL;
+static int CeedVectorRestoreArray_Ref(CeedVector vec) {
   return 0;
 }
 
-static int CeedVectorRestoreArrayRead_Ref(CeedVector vec,
-    const CeedScalar **array) {
-  *array = NULL;
+static int CeedVectorRestoreArrayRead_Ref(CeedVector vec) {
   return 0;
 }
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -70,8 +70,8 @@ struct CeedVector_private {
   int (*SetValue)(CeedVector, CeedScalar);
   int (*GetArray)(CeedVector, CeedMemType, CeedScalar **);
   int (*GetArrayRead)(CeedVector, CeedMemType, const CeedScalar **);
-  int (*RestoreArray)(CeedVector, CeedScalar **);
-  int (*RestoreArrayRead)(CeedVector, const CeedScalar **);
+  int (*RestoreArray)(CeedVector);
+  int (*RestoreArrayRead)(CeedVector);
   int (*Destroy)(CeedVector);
   int refcount;
   CeedInt length;

--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -216,7 +216,8 @@ int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
     return CeedError(vec->ceed, 1,
                      "Cannot restore CeedVector array access, access was not granted");
 
-  ierr = vec->RestoreArray(vec, array); CeedChk(ierr);
+  ierr = vec->RestoreArray(vec); CeedChk(ierr);
+  *array = NULL;
   vec->state += 1;
 
   return 0;
@@ -238,7 +239,8 @@ int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
   if (!vec || !vec->RestoreArrayRead)
     return CeedError(vec ? vec->ceed : NULL, 1, "Not supported");
 
-  ierr = vec->RestoreArrayRead(vec, array); CeedChk(ierr);
+  ierr = vec->RestoreArrayRead(vec); CeedChk(ierr);
+  *array = NULL;
   vec->numreaders--;
 
   return 0;


### PR DESCRIPTION
This PR drops the `array` argument from the backend functions for `CeedVectorRestoreArray` and `CeedVectorRestoreArrayRead`. Currently the MAGMA backend appears to use this argument but does not appear to actually need it.

The library has no way of enforcing that the correct array argument was returned and the user is truly relinquishing access, so to me the inclusion of this argument is mostly for us to help 'obliging' users by setting it to `NULL`.

See Issue #184.