### PR TITLE
Add CeedVectorSyncArray

### DIFF
--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -255,10 +255,6 @@ class CeedMassOperator : public mfem::Operator {
     CeedVectorSetArray(u, CEED_MEM_HOST, CEED_USE_POINTER, x.GetData());
     CeedVectorSetArray(v, CEED_MEM_HOST, CEED_USE_POINTER, y.GetData());
     CeedOperatorApply(oper, u, v, CEED_REQUEST_IMMEDIATE);
-
-    //TODO replace this by SyncArray when available
-    const CeedScalar *array;
-    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &array);
-    CeedVectorRestoreArrayRead(v, &array);
+    CeedVectorSyncArray(v, CEED_MEM_HOST);
   }
 };

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -315,10 +315,6 @@ class CeedDiffusionOperator : public mfem::Operator {
     CeedVectorSetArray(v, CEED_MEM_HOST, CEED_USE_POINTER, y.GetData());
 
     CeedOperatorApply(oper, u, v, CEED_REQUEST_IMMEDIATE);
-
-    //TODO replace this by SyncArray when available
-    const CeedScalar *array;
-    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &array);
-    CeedVectorRestoreArrayRead(v, &array);
+    CeedVectorSyncArray(v, CEED_MEM_HOST);
   }
 };

--- a/examples/nek5000/bp1.usr
+++ b/examples/nek5000/bp1.usr
@@ -1434,8 +1434,6 @@ C     Output: ap1
       real*8    h1(lx,lelt),h2(lx,lelt)
       integer ceed,ceed_op,vec_ap1,vec_p1,err
       integer i,e
-C TODO replace this by SyncArray when available
-      integer*8 offset
 
       call ceedvectorsetarray(vec_p1,ceed_mem_host,ceed_use_pointer,
      $  p1,err)
@@ -1445,9 +1443,7 @@ C TODO replace this by SyncArray when available
       call ceedoperatorapply(ceed_op,vec_p1,vec_ap1,
      $  ceed_request_immediate,err)
 
-C TODO replace this by SyncArray when available
-      call ceedvectorgetarrayread(vec_ap1,ceed_mem_host,ap1,offset,err)
-      call ceedvectorrestorearrayread(vec_ap1,ap1,offset,err)
+      call ceedvectorsyncarray(vec_ap1,ceed_mem_host,err)
 
       pap(1)=0.
 

--- a/examples/nek5000/bp3.usr
+++ b/examples/nek5000/bp3.usr
@@ -1434,8 +1434,6 @@ C     Output: ap1
       real*8    h1(lx,lelt),h2(lx,lelt)
       integer ceed,ceed_op,vec_ap1,vec_p1,err
       integer i,e
-C TODO replace this by SyncArray when available
-      integer*8 offset
 
       call ceedvectorsetarray(vec_p1,ceed_mem_host,ceed_use_pointer,
      $  p1,err)
@@ -1445,9 +1443,7 @@ C TODO replace this by SyncArray when available
       call ceedoperatorapply(ceed_op,vec_p1,vec_ap1,
      $  ceed_request_immediate,err)
 
-C TODO replace this by SyncArray when available
-      call ceedvectorgetarrayread(vec_ap1,ceed_mem_host,ap1,offset,err)
-      call ceedvectorrestorearrayread(vec_ap1,ap1,offset,err)
+      call ceedvectorsyncarray(vec_ap1,ceed_mem_host,err)
 
       pap(1)=0.
 

--- a/examples/petsc/bp1.c
+++ b/examples/petsc/bp1.c
@@ -135,12 +135,7 @@ static PetscErrorCode MatMult_Mass(Mat A, Vec X, Vec Y) {
 
   CeedOperatorApply(user->op, user->xceed, user->yceed,
                     CEED_REQUEST_IMMEDIATE);
-  //TODO replace this by SyncArray when available
-  const CeedScalar *array;
-  ierr = CeedVectorGetArrayRead(user->yceed, CEED_MEM_HOST, &array);
-  CHKERRQ(ierr);
-  ierr = CeedVectorRestoreArrayRead(user->yceed, &array); CHKERRQ(ierr);
-
+  ierr = CeedVectorSyncArray(user->yceed, CEED_MEM_HOST); CHKERRQ(ierr);
 
   ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   ierr = VecRestoreArray(user->Yloc, &y); CHKERRQ(ierr);
@@ -443,10 +438,7 @@ int main(int argc, char **argv) {
 
   // Setup rho, rhs, and target
   CeedOperatorApply(op_setup, xcoord, rho, CEED_REQUEST_IMMEDIATE);
-  //TODO replace this by SyncArray when available
-  const CeedScalar *array;
-  ierr = CeedVectorGetArrayRead(rhsceed, CEED_MEM_HOST, &array); CHKERRQ(ierr);
-  ierr = CeedVectorRestoreArrayRead(rhsceed, &array); CHKERRQ(ierr);
+  ierr = CeedVectorSyncArray(rhsceed, CEED_MEM_HOST); CHKERRQ(ierr);
   CeedVectorDestroy(&xcoord);
 
   // Gather RHS

--- a/examples/petsc/bp3.c
+++ b/examples/petsc/bp3.c
@@ -139,11 +139,7 @@ static PetscErrorCode MatMult_Diff(Mat A, Vec X, Vec Y) {
 
   CeedOperatorApply(user->op, user->xceed, user->yceed,
                     CEED_REQUEST_IMMEDIATE);
-  //TODO replace this by SyncArray when available
-  const CeedScalar *array;
-  ierr = CeedVectorGetArrayRead(user->yceed, CEED_MEM_HOST, &array);
-  CHKERRQ(ierr);
-  ierr = CeedVectorRestoreArrayRead(user->yceed, &array); CHKERRQ(ierr);
+  ierr = CeedVectorSyncArray(user->yceed, CEED_MEM_HOST); CHKERRQ(ierr);
 
   ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
   ierr = VecRestoreArray(user->Yloc, &y); CHKERRQ(ierr);
@@ -499,10 +495,7 @@ int main(int argc, char **argv) {
 
   // Setup rho, rhs, and target
   CeedOperatorApply(op_setup, xcoord, rho, CEED_REQUEST_IMMEDIATE);
-  //TODO replace this by SyncArray when available
-  const CeedScalar *array;
-  ierr = CeedVectorGetArrayRead(rhsceed, CEED_MEM_HOST, &array); CHKERRQ(ierr);
-  ierr = CeedVectorRestoreArrayRead(rhsceed, &array); CHKERRQ(ierr);
+  ierr = CeedVectorSyncArray(rhsceed, CEED_MEM_HOST); CHKERRQ(ierr);
   CeedVectorDestroy(&xcoord);
 
   // Gather RHS

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -68,6 +68,7 @@ struct CeedVector_private {
   Ceed ceed;
   int (*SetArray)(CeedVector, CeedMemType, CeedCopyMode, CeedScalar *);
   int (*SetValue)(CeedVector, CeedScalar);
+  int (*SyncArray)(CeedVector, CeedMemType);
   int (*GetArray)(CeedVector, CeedMemType, CeedScalar **);
   int (*GetArrayRead)(CeedVector, CeedMemType, const CeedScalar **);
   int (*RestoreArray)(CeedVector);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -154,6 +154,7 @@ CEED_EXTERN int CeedVectorCreate(Ceed ceed, CeedInt len, CeedVector *vec);
 CEED_EXTERN int CeedVectorSetArray(CeedVector vec, CeedMemType mtype,
                                    CeedCopyMode cmode, CeedScalar *array);
 CEED_EXTERN int CeedVectorSetValue(CeedVector vec, CeedScalar value);
+CEED_EXTERN int CeedVectorSyncArray(CeedVector vec, CeedMemType mtype);
 CEED_EXTERN int CeedVectorGetArray(CeedVector vec, CeedMemType mtype,
                                    CeedScalar **array);
 CEED_EXTERN int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mtype,

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -105,6 +105,11 @@ void fCeedVectorSetArray(int *vec, int *memtype, int *copymode,
   *err = CeedVectorSetArray(CeedVector_dict[*vec], *memtype, *copymode, array);
 }
 
+#define fCeedVectorSyncArray FORTRAN_NAME(ceedvectorsyncarray,CEEDVECTORSYNCARRAY)
+void fCeedVectorSyncArray(int *vec, int *memtype, int *err) {
+  *err = CeedVectorSyncArray(CeedVector_dict[*vec], *memtype);
+}
+
 #define fCeedVectorSetValue FORTRAN_NAME(ceedvectorsetvalue,CEEDVECTORSETVALUE)
 void fCeedVectorSetValue(int *vec, CeedScalar *value, int *err) {
   *err = CeedVectorSetValue(CeedVector_dict[*vec], *value);

--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -129,6 +129,34 @@ int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
 }
 
 /**
+  @brief Sync the CeedVector to a specified memtype
+
+  @param vec        CeedVector
+  @param mtype      Memtype to be synced
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Basic
+**/
+int CeedVectorSyncArray(CeedVector vec, CeedMemType mtype) {
+  int ierr;
+
+  if (vec && (vec->state % 2) == 1)
+    return CeedError(vec->ceed, 1,
+                     "Cannot sync CeedVector, the access lock is already in use");
+
+  if (vec->SyncArray) {
+    ierr = vec->SyncArray(vec, mtype); CeedChk(ierr);
+  } else {
+    const CeedScalar *array;
+    ierr = CeedVectorGetArrayRead(vec, mtype, &array); CeedChk(ierr);
+    ierr = CeedVectorRestoreArrayRead(vec, &array); CeedChk(ierr);
+  }
+
+  return 0;
+}
+
+/**
   @brief Get read/write access to a CeedVector via the specified memory type
 
   @param vec        CeedVector to access


### PR DESCRIPTION
This PR adds a minor function - CeedVectorSyncArray. This function signals to the backend to update the memory `mtype` associated with a CeedVector `vec`. The default implementation is to call `CeedVectorGetArrayRead` followed by `CeedVectorRestoreArrayRead`, but a backend can override this.

See Issue #162