### PR TITLE
Small clang-tidy fixes

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -88,7 +88,7 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf, CeedOperator op,
       ierr = CeedOperatorFieldGetElemRestriction(opfields[i], &r);
       CeedChk(ierr);
       CeedElemRestriction_Ref *data;
-      ierr = CeedElemRestrictionGetData(r, (void *)&data);
+      ierr = CeedElemRestrictionGetData(r, (void *)&data); CeedChk(ierr);
       Ceed ceed;
       ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
       CeedInt nelem, elemsize, ndof;
@@ -123,6 +123,7 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf, CeedOperator op,
     case CEED_EVAL_GRAD:
       ierr = CeedOperatorFieldGetBasis(opfields[i], &basis); CeedChk(ierr);
       ierr = CeedQFunctionFieldGetNumComponents(qffields[i], &ncomp);
+      CeedChk(ierr);
       ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
       ierr = CeedElemRestrictionGetElementSize(r, &P);
       CeedChk(ierr);
@@ -355,6 +356,7 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
         ierr = CeedVectorSetArray(impl->evecsout[i], CEED_MEM_HOST,
                                   CEED_USE_POINTER,
                                   &impl->edata[i + numinputfields][e*elemsize*ncomp]);
+        CeedChk(ierr);
         ierr = CeedBasisApply(basis, blksize, CEED_TRANSPOSE,
                               CEED_EVAL_INTERP, impl->qvecsout[i],
                               impl->evecsout[i]); CeedChk(ierr);
@@ -365,6 +367,7 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
         ierr = CeedVectorSetArray(impl->evecsout[i], CEED_MEM_HOST,
                                   CEED_USE_POINTER,
                                   &impl->edata[i + numinputfields][e*elemsize*ncomp]);
+        CeedChk(ierr);
         ierr = CeedBasisApply(basis, blksize, CEED_TRANSPOSE,
                               CEED_EVAL_GRAD, impl->qvecsout[i],
                               impl->evecsout[i]); CeedChk(ierr);
@@ -438,7 +441,7 @@ int CeedOperatorCreate_Blocked(CeedOperator op) {
   CeedOperator_Blocked *impl;
 
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
-  ierr = CeedOperatorSetData(op, (void *)&impl);
+  ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Blocked); CeedChk(ierr);

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -261,7 +261,7 @@ int CeedBasisCreateTensorH1_Ref(CeedInt dim, CeedInt P1d,
   ierr = CeedBasisSetData(basis, (void *)&impl); CeedChk(ierr);
 
   Ceed parent;
-  ierr = CeedGetParent(ceed, &parent);
+  ierr = CeedGetParent(ceed, &parent); CeedChk(ierr);
   CeedTensorContract contract;
   ierr = CeedTensorContractCreate(parent, &contract); CeedChk(ierr);
   ierr = CeedBasisSetTensorContract(basis, &contract); CeedChk(ierr);

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -104,6 +104,7 @@ static int CeedOperatorSetupFields_Ref(CeedQFunction qf, CeedOperator op,
     case CEED_EVAL_GRAD:
       ierr = CeedOperatorFieldGetBasis(opfields[i], &basis); CeedChk(ierr);
       ierr = CeedQFunctionFieldGetNumComponents(qffields[i], &ncomp);
+      CeedChk(ierr);
       ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
       ierr = CeedElemRestrictionGetElementSize(Erestrict, &P);
       CeedChk(ierr);
@@ -331,6 +332,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
         ierr = CeedVectorSetArray(impl->evecsout[i], CEED_MEM_HOST,
                                   CEED_USE_POINTER,
                                   &impl->edata[i + numinputfields][e*elemsize*ncomp]);
+        CeedChk(ierr);
         ierr = CeedBasisApply(basis, 1, CEED_TRANSPOSE,
                               CEED_EVAL_INTERP, impl->qvecsout[i],
                               impl->evecsout[i]); CeedChk(ierr);
@@ -341,6 +343,7 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
         ierr = CeedVectorSetArray(impl->evecsout[i], CEED_MEM_HOST,
                                   CEED_USE_POINTER,
                                   &impl->edata[i + numinputfields][e*elemsize*ncomp]);
+        CeedChk(ierr);
         ierr = CeedBasisApply(basis, 1, CEED_TRANSPOSE,
                               CEED_EVAL_GRAD, impl->qvecsout[i],
                               impl->evecsout[i]); CeedChk(ierr);
@@ -424,7 +427,7 @@ static int CeedCompositeOperatorApply_Ref(CeedOperator op, CeedVector invec,
   CeedChk(ierr);
   // Add to outvec with subsequent outputs
   for (CeedInt i=1; i<numsub; i++) {
-    ierr = CeedOperatorGetData(suboperators[i], (void *)&impl);
+    ierr = CeedOperatorGetData(suboperators[i], (void *)&impl); CeedChk(ierr);
     impl->add = true;
     ierr = CeedOperatorApply(suboperators[i], invec, outvec, request);
     CeedChk(ierr);
@@ -441,7 +444,7 @@ int CeedOperatorCreate_Ref(CeedOperator op) {
 
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   impl->add = false;
-  ierr = CeedOperatorSetData(op, (void *)&impl);
+  ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Ref); CeedChk(ierr);

--- a/backends/ref/ceed-ref-vec.c
+++ b/backends/ref/ceed-ref-vec.c
@@ -119,6 +119,6 @@ int CeedVectorCreate_Ref(CeedInt n, CeedVector vec) {
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "Destroy",
                                 CeedVectorDestroy_Ref); CeedChk(ierr);
   ierr = CeedCalloc(1,&impl); CeedChk(ierr);
-  ierr = CeedVectorSetData(vec, (void *)&impl);
+  ierr = CeedVectorSetData(vec, (void *)&impl); CeedChk(ierr);
   return 0;
 }

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -215,7 +215,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem, CeedInt elemsize,
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
 
   if (indices) {
-    ierr = CeedCalloc(nblk*blksize*elemsize, &blkindices);
+    ierr = CeedCalloc(nblk*blksize*elemsize, &blkindices); CeedChk(ierr);
     ierr = CeedPermutePadIndices(indices, blkindices, nblk, nelem, blksize,
                                  elemsize);
     CeedChk(ierr);

--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -80,16 +80,16 @@ int CeedVectorSetArray(CeedVector vec, CeedMemType mtype, CeedCopyMode cmode,
                        CeedScalar *array) {
   int ierr;
 
-  if (vec && (vec->state % 2) == 1)
+  if (!vec->SetArray)
+    return CeedError(vec->ceed, 1, "Not supported");
+
+  if (vec->state % 2 == 1)
     return CeedError(vec->ceed, 1,
                      "Cannot grant CeedVector array access, the access lock is already in use");
 
-  if (vec && vec->numreaders > 0)
+  if (vec->numreaders > 0)
     return CeedError(vec->ceed, 1,
                      "Cannot grant CeedVector array access, a process has read access");
-
-  if (!vec || !vec->SetArray)
-    return CeedError(vec ? vec->ceed : NULL, 1, "Not supported");
 
   ierr = vec->SetArray(vec, mtype, cmode, array); CeedChk(ierr);
   vec->state += 2;
@@ -109,15 +109,15 @@ int CeedVectorSetArray(CeedVector vec, CeedMemType mtype, CeedCopyMode cmode,
 **/
 int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
   int ierr;
-  CeedScalar *array;
 
-  if (vec && (vec->state % 2) == 1)
+  if (vec->state % 2 == 1)
     return CeedError(vec->ceed, 1,
                      "Cannot grant CeedVector array access, the access lock is already in use");
 
   if (vec->SetValue) {
     ierr = vec->SetValue(vec, value); CeedChk(ierr);
   } else {
+    CeedScalar *array;
     ierr = CeedVectorGetArray(vec, CEED_MEM_HOST, &array); CeedChk(ierr);
     for (int i=0; i<vec->length; i++) array[i] = value;
     ierr = CeedVectorRestoreArray(vec, &array); CeedChk(ierr);
@@ -177,16 +177,16 @@ int CeedVectorSyncArray(CeedVector vec, CeedMemType mtype) {
 int CeedVectorGetArray(CeedVector vec, CeedMemType mtype, CeedScalar **array) {
   int ierr;
 
-  if (vec && (vec->state % 2) == 1)
+  if (!vec->GetArray)
+    return CeedError(vec->ceed, 1, "Not supported");
+
+  if (vec->state % 2 == 1)
     return CeedError(vec->ceed, 1,
                      "Cannot grant CeedVector array access, the access lock is already in use");
 
-  if (vec && vec->numreaders > 0)
+  if (vec->numreaders > 0)
     return CeedError(vec->ceed, 1,
                      "Cannot grant CeedVector array access, a process has read access");
-
-  if (!vec || !vec->GetArray)
-    return CeedError(vec ? vec->ceed : NULL, 1, "Not supported");
 
   ierr = vec->GetArray(vec, mtype, array); CeedChk(ierr);
   vec->state += 1;
@@ -211,12 +211,12 @@ int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mtype,
                            const CeedScalar **array) {
   int ierr;
 
-  if (vec && (vec->state % 2) == 1)
+  if (!vec->GetArrayRead)
+    return CeedError(vec->ceed, 1, "Not supported");
+
+  if (vec->state % 2 == 1)
     return CeedError(vec->ceed, 1,
                      "Cannot grant CeedVector read-only array access, the access lock is already in use");
-
-  if (!vec || !vec->GetArrayRead)
-    return CeedError(vec ? vec->ceed : NULL, 1, "Not supported");
 
   ierr = vec->GetArrayRead(vec, mtype, array); CeedChk(ierr);
   vec->numreaders++;
@@ -237,10 +237,10 @@ int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mtype,
 int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
   int ierr;
 
-  if (!vec || !vec->RestoreArray)
-    return CeedError(vec ? vec->ceed : NULL, 1, "Not supported");
+  if (!vec->RestoreArray)
+    return CeedError(vec->ceed, 1, "Not supported");
 
-  if (vec && (vec->state % 2) != 1)
+  if (vec->state % 2 != 1)
     return CeedError(vec->ceed, 1,
                      "Cannot restore CeedVector array access, access was not granted");
 
@@ -264,8 +264,8 @@ int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
 int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
   int ierr;
 
-  if (!vec || !vec->RestoreArrayRead)
-    return CeedError(vec ? vec->ceed : NULL, 1, "Not supported");
+  if (!vec->RestoreArrayRead)
+    return CeedError(vec->ceed, 1, "Not supported");
 
   ierr = vec->RestoreArrayRead(vec); CeedChk(ierr);
   *array = NULL;


### PR DESCRIPTION
These are some small changes from `clang-tidy`.

Not included:
- warnings on strcpy
- notes about following branches
- checking OCCA, MAGMA, and CUDA backends