### PR TITLE
lWIP] Improve LIBXSMM Backend Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ ceed.pc
 *.gcno
 *.gcda
 *.gcov
+
+# Debugging
+vgcore*

--- a/backends/avx/ceed-avx-tensor.c
+++ b/backends/avx/ceed-avx-tensor.c
@@ -293,7 +293,7 @@ static int CeedTensorContractDestroy_Avx(CeedTensorContract contract) {
   return 0;
 }
 
-int CeedTensorContractCreate_Avx(CeedTensorContract contract) {
+int CeedTensorContractCreate_Avx(CeedBasis basis, CeedTensorContract contract) {
   int ierr;
   Ceed ceed;
   ierr = CeedTensorContractGetCeed(contract, &ceed); CeedChk(ierr);

--- a/backends/avx/ceed-avx.h
+++ b/backends/avx/ceed-avx.h
@@ -17,4 +17,5 @@
 #include <ceed-backend.h>
 #include <string.h>
 
-CEED_INTERN int CeedTensorContractCreate_Avx(CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Avx(CeedBasis basis,
+     CeedTensorContract contract);

--- a/backends/avx/ceed-avx.h
+++ b/backends/avx/ceed-avx.h
@@ -18,4 +18,4 @@
 #include <string.h>
 
 CEED_INTERN int CeedTensorContractCreate_Avx(CeedBasis basis,
-     CeedTensorContract contract);
+    CeedTensorContract contract);

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -263,7 +263,7 @@ int CeedBasisCreateTensorH1_Ref(CeedInt dim, CeedInt P1d,
   Ceed parent;
   ierr = CeedGetParent(ceed, &parent); CeedChk(ierr);
   CeedTensorContract contract;
-  ierr = CeedTensorContractCreate(parent, &contract); CeedChk(ierr);
+  ierr = CeedTensorContractCreate(parent, basis, &contract); CeedChk(ierr);
   ierr = CeedBasisSetTensorContract(basis, &contract); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
@@ -286,8 +286,10 @@ int CeedBasisCreateH1_Ref(CeedElemTopology topo, CeedInt dim,
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
 
+  Ceed parent;
+  ierr = CeedGetParent(ceed, &parent); CeedChk(ierr);
   CeedTensorContract contract;
-  ierr = CeedTensorContractCreate(ceed, &contract); CeedChk(ierr);
+  ierr = CeedTensorContractCreate(parent, basis, &contract); CeedChk(ierr);
   ierr = CeedBasisSetTensorContract(basis, &contract); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",

--- a/backends/ref/ceed-ref-tensor.c
+++ b/backends/ref/ceed-ref-tensor.c
@@ -46,7 +46,7 @@ static int CeedTensorContractDestroy_Ref(CeedTensorContract contract) {
   return 0;
 }
 
-int CeedTensorContractCreate_Ref(CeedTensorContract contract) {
+int CeedTensorContractCreate_Ref(CeedBasis basis, CeedTensorContract contract) {
   int ierr;
   Ceed ceed;
   ierr = CeedTensorContractGetCeed(contract, &ceed); CeedChk(ierr);

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -71,8 +71,8 @@ CEED_INTERN int CeedBasisCreateH1_Ref(CeedElemTopology topo,
                                       const CeedScalar *qweight,
                                       CeedBasis basis);
 
-CEED_INTERN int CeedTensorContractCreate_Ref(CeedBasis basis, 
-     CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Ref(CeedBasis basis,
+    CeedTensorContract contract);
 
 CEED_INTERN int CeedQFunctionCreate_Ref(CeedQFunction qf);
 

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -71,7 +71,8 @@ CEED_INTERN int CeedBasisCreateH1_Ref(CeedElemTopology topo,
                                       const CeedScalar *qweight,
                                       CeedBasis basis);
 
-CEED_INTERN int CeedTensorContractCreate_Ref(CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Ref(CeedBasis basis, 
+     CeedTensorContract contract);
 
 CEED_INTERN int CeedQFunctionCreate_Ref(CeedQFunction qf);
 

--- a/backends/xsmm/ceed-xsmm-tensor.c
+++ b/backends/xsmm/ceed-xsmm-tensor.c
@@ -14,33 +14,26 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
+#include <math.h>
 #include <string.h>
-#include <libxsmm.h>
 #include "ceed-xsmm.h"
 
-// Blocked Tensor Contract
-static int CeedTensorContract_Xsmm_Blocked(CeedTensorContract contract,
-    CeedInt A, CeedInt B, CeedInt C, CeedInt J, const CeedScalar *restrict t,
-    CeedTransposeMode tmode, const CeedInt Add, const CeedScalar *restrict u,
-    CeedScalar *restrict v) {
-  CeedScalar alpha = 1.0, beta = 1.0;
-  char transu = 'N', transt = 'N';
-  if (tmode == CEED_TRANSPOSE)
-    transt = 'T';
-
-  if (!Add)
-    beta = 0.0;
-
-  for (CeedInt a=0; a<A; a++)
-    // libXSMM GEMM
-    libxsmm_dgemm(&transu, &transt, &C, &J, &B,
-                  &alpha, &u[a*B*C], NULL, &t[0], NULL,
-                  &beta, &v[a*J*C], NULL);
-  return 0;
+// Utility functions for index in pointer array
+int CeedGetXsmmInd_Tensor(CeedInt nelem, CeedInt add, CeedTransposeMode tmode,
+                          CeedInt B, CeedInt C, CeedInt J, CeedInt currdim,
+                          CeedInt dim) {
+  return (nelem == 8 ? 1:0)*4*2*dim + (add ? 1:0)*4*dim +
+         (tmode ? 1:0)*2*dim + (B == J ? 1:0)*dim + currdim;
 }
 
-// Serial Tensor Contact
-static int CeedTensorContract_Xsmm_Serial(CeedTensorContract contract,
+int CeedGetXsmmInd_NonTensor(CeedInt add, CeedInt P, CeedInt Q, CeedInt B,
+                             CeedInt C, CeedInt J) {
+  return (C == 8 ? 1:0)*4*2 + (add ? 1:0)*4 +
+         (B == P ? (J == Q ? 0:1) : (B == Q ? 2:3));
+}
+
+// Default Tensor Contact
+static int CeedTensorContract_Xsmm_Default(CeedTensorContract contract,
     CeedInt A, CeedInt B, CeedInt C, CeedInt J, const CeedScalar *restrict t,
     CeedTransposeMode tmode, const CeedInt Add, const CeedScalar *restrict u,
     CeedScalar *restrict v) {
@@ -73,27 +66,115 @@ static int CeedTensorContractApply_Xsmm(CeedTensorContract contract, CeedInt A,
                                         CeedInt B, CeedInt C, CeedInt J,
                                         const CeedScalar *restrict t,
                                         CeedTransposeMode tmode,
-                                        const CeedInt Add,
+                                        const CeedInt add,
                                         const CeedScalar *restrict u,
                                         CeedScalar *restrict v) {
-  CeedInt blksize = 8;
+  int ierr;
+  CeedInt blksize = 8, ind, nelem;
+  CeedTensorContract_Xsmm *impl;
+  ierr = CeedTensorContractGetData(contract, (void *)&impl); CeedChk(ierr);
 
-  if (C % blksize)
-    CeedTensorContract_Xsmm_Serial(contract, A, B, C, J, t, tmode, Add, u, v);
+  // Get nelem and current dim
+  CeedScalar currdim = log(C/blksize) / log(J);
+  if (!(C % blksize) && currdim - (int)currdim < 1e-15)
+    nelem = blksize;
+  else {
+    nelem = 1;
+    currdim = log(C) / log(J);
+  }
+
+  // Get kernel index
+  if (impl->tensorbasis)
+    ind = CeedGetXsmmInd_Tensor(nelem, add, tmode==CEED_TRANSPOSE?1:0, B, C,
+                                J, (CeedInt)currdim, impl->dim);
   else
-    CeedTensorContract_Xsmm_Blocked(contract, A, B, C, J, t, tmode, Add, u, v);
+    ind = CeedGetXsmmInd_NonTensor(add, impl->P, impl->Q, B, C, J);
+
+  // Run kernel or fallback to default implementation
+  if (C != 1 && impl->kernels[ind])
+    for (CeedInt a=0; a<A; a++)
+      impl->kernels[ind](&u[a*B*C], &t[0], &v[a*J*C], NULL, NULL, NULL);
+  else
+    CeedTensorContract_Xsmm_Default(contract, A, B, C, J, t, tmode, add, u, v);
 
   return 0;
 }
 
 static int CeedTensorContractDestroy_Xsmm(CeedTensorContract contract) {
+  int ierr;
+  CeedTensorContract_Xsmm *impl;
+  ierr = CeedTensorContractGetData(contract, (void *)&impl); CeedChk(ierr);
+  ierr = CeedFree(&impl->kernels); CeedChk(ierr);
+  ierr = CeedFree(&impl); CeedChk(ierr);
+
   return 0;
 }
 
-int CeedTensorContractCreate_Xsmm(CeedBasis basis, CeedTensorContract contract) {
+int CeedTensorContractCreate_Xsmm(CeedBasis basis,
+                                  CeedTensorContract contract) {
   int ierr;
   Ceed ceed;
   ierr = CeedTensorContractGetCeed(contract, &ceed); CeedChk(ierr);
+  CeedTensorContract_Xsmm *impl;
+  ierr = CeedCalloc(1, &impl); CeedChk(ierr);
+
+  // Set up pointers to kernels
+  ierr = CeedBasisGetTensorStatus(basis, &impl->tensorbasis); CeedChk(ierr);
+  if (impl->tensorbasis) {
+    ierr = CeedBasisGetNumNodes1D(basis, &impl->P); CeedChk(ierr);
+    ierr = CeedBasisGetNumQuadraturePoints1D(basis, &impl->Q); CeedChk(ierr);
+    ierr = CeedBasisGetDimension(basis, &impl->dim); CeedChk(ierr);
+    // Set up kernel pointer array
+    impl->numkernels = 2*2*4*impl->dim;
+    ierr = CeedCalloc(impl->numkernels, &impl->kernels); CeedChk(ierr);
+    for (CeedInt nelem = 1; nelem <= 8; nelem+=7) {
+      for (CeedInt add = 0; add <= 1; add++) {
+        for (CeedInt tmode = 0; tmode <= 1; tmode++) {
+          for (CeedInt grad = 0; grad <=1; grad++) {
+            for (CeedInt dim = 0; dim < impl->dim; dim++) {
+              const int flags = LIBXSMM_GEMM_FLAGS('N', tmode ? 'T' : 'N');
+              CeedInt B = grad ? impl->Q : (tmode ? impl->Q : impl->P),
+                      J = grad ? impl->Q : (tmode ? impl->P : impl->Q),
+                      C = nelem*CeedIntPow(J, dim);
+              int ind = CeedGetXsmmInd_Tensor(nelem, add, tmode, B, C, J, dim,
+                                              impl->dim);
+              CeedScalar alpha = 1.0, beta = 1.0;
+              if (!add) beta = 0.0;
+              impl->kernels[ind] = libxsmm_dmmdispatch(C, J, B,
+                                   NULL, NULL, NULL, &alpha,
+                                   &beta, &flags, NULL);
+            }
+          }
+        }
+      }
+    }
+  } else {
+    ierr = CeedBasisGetNumNodes(basis, &impl->P); CeedChk(ierr);
+    ierr = CeedBasisGetNumQuadraturePoints(basis, &impl->Q); CeedChk(ierr);
+    ierr = CeedBasisGetDimension(basis, &impl->dim); CeedChk(ierr);
+    // Set up kernel pointer array
+    impl->numkernels = 4*2*2;
+    ierr = CeedCalloc(impl->numkernels, &impl->kernels); CeedChk(ierr);
+    for (CeedInt nelem = 1; nelem <= 8; nelem+=7) {
+      for (CeedInt add = 0; add <= 1; add++) {
+        for (CeedInt tmode = 0; tmode <= 1; tmode++) {
+          for (CeedInt grad = 1; grad <= impl->dim; grad+=impl->dim-1) {
+            const int flags = LIBXSMM_GEMM_FLAGS('N', tmode ? 'T' : 'N');
+            CeedInt B = tmode ? grad*impl->Q : impl->P,
+                    J = tmode ? impl->P : grad*impl->Q;
+            int ind = CeedGetXsmmInd_NonTensor(add, impl->P, impl->Q, B, nelem,
+                                               J);
+            CeedScalar alpha = 1.0, beta = 1.0;
+            if (!add) beta = 0.0;
+            impl->kernels[ind] = libxsmm_dmmdispatch(nelem, J, B,
+                                 NULL, NULL, NULL, &alpha,
+                                 &beta, &flags, NULL);
+          }
+        }
+      }
+    }
+  }
+  ierr = CeedTensorContractSetData(contract, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Apply",
                                 CeedTensorContractApply_Xsmm); CeedChk(ierr);

--- a/backends/xsmm/ceed-xsmm-tensor.c
+++ b/backends/xsmm/ceed-xsmm-tensor.c
@@ -90,7 +90,7 @@ static int CeedTensorContractDestroy_Xsmm(CeedTensorContract contract) {
   return 0;
 }
 
-int CeedTensorContractCreate_Xsmm(CeedTensorContract contract) {
+int CeedTensorContractCreate_Xsmm(CeedBasis basis, CeedTensorContract contract) {
   int ierr;
   Ceed ceed;
   ierr = CeedTensorContractGetCeed(contract, &ceed); CeedChk(ierr);

--- a/backends/xsmm/ceed-xsmm-tensor.c
+++ b/backends/xsmm/ceed-xsmm-tensor.c
@@ -143,6 +143,9 @@ int CeedTensorContractCreate_Xsmm(CeedBasis basis,
               impl->kernels[ind] = libxsmm_dmmdispatch(C, J, B,
                                    NULL, NULL, NULL, &alpha,
                                    &beta, &flags, NULL);
+              if (!impl->kernels[ind])
+                return CeedError(ceed, 1,
+                                 "LIBXSMM kernel failed to build.");
             }
           }
         }
@@ -169,6 +172,9 @@ int CeedTensorContractCreate_Xsmm(CeedBasis basis,
             impl->kernels[ind] = libxsmm_dmmdispatch(nelem, J, B,
                                  NULL, NULL, NULL, &alpha,
                                  &beta, &flags, NULL);
+            if (!impl->kernels[ind])
+              return CeedError(ceed, 1,
+                               "LIBXSMM kernel failed to build.");
           }
         }
       }

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -17,4 +17,5 @@
 #include <ceed-backend.h>
 #include <string.h>
 
-CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedBasis basis,
+     CeedTensorContract contract);

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -15,7 +15,14 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 
 #include <ceed-backend.h>
+#include <libxsmm.h>
 #include <string.h>
 
+typedef struct {
+  libxsmm_dmmfunction *kernels;
+  bool tensorbasis;
+  CeedInt P, Q, dim, nelem, numkernels;
+} CeedTensorContract_Xsmm;
+
 CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedBasis basis,
-     CeedTensorContract contract);
+    CeedTensorContract contract);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -109,7 +109,7 @@ CEED_EXTERN int CeedBasisGetTensorContract(CeedBasis basis,
     CeedTensorContract *contract);
 CEED_EXTERN int CeedBasisSetTensorContract(CeedBasis basis,
     CeedTensorContract *contract);
-CEED_EXTERN int CeedTensorContractCreate(Ceed ceed,
+CEED_EXTERN int CeedTensorContractCreate(Ceed ceed, CeedBasis basis,
     CeedTensorContract *contract);
 CEED_EXTERN int CeedTensorContractApply(CeedTensorContract contract, CeedInt A,
                                         CeedInt B, CeedInt C, CeedInt J, const CeedScalar *restrict t,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -55,7 +55,7 @@ struct Ceed_private {
                        const CeedScalar *,
                        const CeedScalar *, const CeedScalar *,
                        const CeedScalar *, CeedBasis);
-  int (*TensorContractCreate)(CeedTensorContract);
+  int (*TensorContractCreate)(CeedBasis, CeedTensorContract);
   int (*QFunctionCreate)(CeedQFunction);
   int (*OperatorCreate)(CeedOperator);
   int (*CompositeOperatorCreate)(CeedOperator);

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -34,7 +34,8 @@
 
   @ref Advanced
 **/
-int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
+int CeedTensorContractCreate(Ceed ceed, CeedBasis basis,
+                             CeedTensorContract *contract) {
   int ierr;
 
   if (!ceed->TensorContractCreate) {
@@ -45,7 +46,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
       return CeedError(ceed, 1,
                        "Backend does not support TensorContractCreate");
 
-    ierr = CeedTensorContractCreate(delegate, contract);
+    ierr = CeedTensorContractCreate(delegate, basis, contract);
     CeedChk(ierr);
     return 0;
   }
@@ -54,7 +55,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
 
   (*contract)->ceed = ceed;
   ceed->refcount++;
-  ierr = ceed->TensorContractCreate(*contract);
+  ierr = ceed->TensorContractCreate(basis, *contract);
   CeedChk(ierr);
   return 0;
 };


### PR DESCRIPTION
This PR increases the performance of the LIBXSMM backend by creating an of array kernel pointers when the TensorContract object is created.