### PR TITLE
Add MKL optional flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,13 @@ endif
 # libXSMM Backends
 ifneq ($(wildcard $(XSMM_DIR)/lib/libxsmm.*),)
   $(libceed) : LDFLAGS += -L$(XSMM_DIR)/lib -Wl,-rpath,$(abspath $(XSMM_DIR)/lib)
-  $(libceed) : LDLIBS += -lxsmm -ldl -lblas
+  $(libceed) : LDLIBS += -lxsmm -ldl
+  MKL ?= 0
+  ifneq (0,$(MKL))
+    $(libceed) : LDLIBS += -mkl
+  else
+    $(libceed) : LDLIBS += -lblas
+  endif
   libceed.c += $(xsmm.c)
   $(xsmm.c:%.c=$(OBJDIR)/%.o) : CFLAGS += -I$(XSMM_DIR)/include
   BACKENDS += /cpu/self/xsmm/serial /cpu/self/xsmm/blocked

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ The `/cpu/self/ref/*` backends are written in pure C and provide basic functiona
 The `/cpu/self/avx/*` backends rely upon AVX instructions to provide vectorized CPU performance.
 
 The `/cpu/self/xsmm/*` backends rely upon the [LIBXSMM](http://github.com/hfp/libxsmm) package
-to provide vectorized CPU performance.
+to provide vectorized CPU performance. The LIBXSMM backend does not use BLAS or MKL; however,
+if LIBXSMM was linked to MKL, this can be specified with the compilation flag `MKL=1`.
 
 The `/*/occa` backends rely upon the [OCCA](http://github.com/libocca/occa) package to provide
 cross platform performance.


### PR DESCRIPTION
Adds option to link against MKL instead of BLAS (default) for LIBXSMM. See Issue #199. I've verified that `MKL=1 make` works on CU Summit.