### PR TITLE
Strcpy fix

### DIFF
--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -250,7 +250,7 @@ int main(int argc, char **argv) {
   User user;
   char ceedresource[4096] = "/cpu/self";
   PetscFunctionList icsflist = NULL, qflist = NULL;
-  char problemtype[256] = "advection";
+  char problemtype[PETSC_MAX_PATH_LEN] = "advection";
   PetscInt degree, qextra, localNelem, lsize, outputfreq,
            steps, melem[3], mdof[3], p[3], irank[3], ldof[3], contsteps;
   PetscMPIInt size, rank;
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
   qextra = 2;
   ierr = PetscOptionsInt("-qextra", "Number of extra quadrature points",
                          NULL, qextra, &qextra, NULL); CHKERRQ(ierr);
-  PetscStrcpy(user->outputfolder, ".");
+  PetscStrncpy(user->outputfolder, ".", 2);
   ierr = PetscOptionsString("-of", "Output folder",
                             NULL, user->outputfolder, user->outputfolder,
                             sizeof(user->outputfolder), NULL); CHKERRQ(ierr);
@@ -646,8 +646,8 @@ int main(int argc, char **argv) {
   PetscFunctionListFind(icsflist, problemtype, &icsfp);
   if (!icsfp)
       return CeedError(ceed, 1, "Function not found in the list");
-  char str[256] = __FILE__":ICs";
-  strcat(str, problemtype);
+  char str[PETSC_MAX_PATH_LEN] = __FILE__":ICs";
+  PetscStrlcat(str, problemtype, PETSC_MAX_PATH_LEN);
   CeedQFunctionCreateInterior(ceed, 1,
                               (int(*)(void *, CeedInt, const CeedScalar *const *, CeedScalar *const *))icsfp,
                               str, &qf_ics);
@@ -660,8 +660,8 @@ int main(int argc, char **argv) {
   PetscFunctionListFind(qflist, problemtype, &fp);
   if (!fp)
       return CeedError(ceed, 1, "Function not found in the list");
-  strcpy(str, __FILE__":");
-  strcat(str, problemtype);
+  PetscStrncpy(str, __FILE__":", PETSC_MAX_PATH_LEN);
+  PetscStrlcat(str, problemtype, PETSC_MAX_PATH_LEN);
   CeedQFunctionCreateInterior(ceed, 1,
                               (int(*)(void *, CeedInt, const CeedScalar *const *, CeedScalar *const *))fp,
                               str, &qf);

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -67,7 +67,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
   (*qf)->vlength = vlength;
   (*qf)->function = f;
   ierr = CeedCalloc(strlen(focca)+1, &focca_copy); CeedChk(ierr);
-  strcpy(focca_copy, focca);
+  strncpy(focca_copy, focca, strlen(focca)+1);
   (*qf)->focca = focca_copy;
   ierr = CeedCalloc(16, &(*qf)->inputfields); CeedChk(ierr);
   ierr = CeedCalloc(16, &(*qf)->outputfields); CeedChk(ierr);

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -450,11 +450,11 @@ int CeedSetDelegate(Ceed ceed, Ceed *delegate) {
 int CeedSetBackendFunction(Ceed ceed,
                            const char *type, void *object,
                            const char *fname, int (*f)()) {
-  char lookupname[100];
-  strcpy(lookupname, "");
+  char lookupname[CEED_MAX_RESOURCE_LEN+1] = "";
 
   // Build lookup name
-  strcat(strcat(lookupname, type), fname);
+  strncat(lookupname, type, CEED_MAX_RESOURCE_LEN);
+  strncat(lookupname, fname, CEED_MAX_RESOURCE_LEN);
 
   // Find and use offset
   for (CeedInt i = 0; i < CEED_NUM_BACKEND_FUNCTIONS; i++) {


### PR DESCRIPTION
This PR changes a few instances of strcpy and strcat to strncpy and strncat. See Issue #193.

After this, I think that all that remains on clang-tidy is "issues that it can't show statically are actually fine".