### PR TITLE
Check QFunction Output Vecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,14 @@ addons:
     - gfortran
     - liblapack-dev
     - libopenblas-dev
+    - valgrind-dbg
   homebrew:
     packages:
     - ccache
     - gcc
     - lapack
     - openblas
+    - valgrind
 
 env:
   - FC=gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
     - gcc
     - lapack
     - openblas
-    - valgrind
 
 env:
   - FC=gfortran

--- a/Makefile
+++ b/Makefile
@@ -139,17 +139,18 @@ petscexamples  := $(petscexamples.c:examples/petsc/%.c=$(OBJDIR)/petsc-%)
 navierstokesexample.c := $(sort $(wildcard examples/navier-stokes/*.c))
 navierstokesexample  := $(navierstokesexample.c:examples/navier-stokes/%.c=$(OBJDIR)/navier-stokes-%)
 
-# backends/[ref, template, blocked, avx, occa, magma]
-ref.c      := $(sort $(wildcard backends/ref/*.c))
-template.c := $(sort $(wildcard backends/template/*.c))
-cuda.c     := $(sort $(wildcard backends/cuda/*.c))
-cuda.cu    := $(sort $(wildcard backends/cuda/*.cu))
-cuda-reg.c := $(sort $(wildcard backends/cuda-reg/*.c))
-cuda-reg.cu:= $(sort $(wildcard backends/cuda-reg/*.cu))
-blocked.c  := $(sort $(wildcard backends/blocked/*.c))
-avx.c      := $(sort $(wildcard backends/avx/*.c))
-xsmm.c     := $(sort $(wildcard backends/xsmm/*.c))
-occa.c     := $(sort $(wildcard backends/occa/*.c))
+# backends/[ref, template, blocked, memcheck, avx, occa, magma]
+ref.c          := $(sort $(wildcard backends/ref/*.c))
+template.c     := $(sort $(wildcard backends/template/*.c))
+cuda.c         := $(sort $(wildcard backends/cuda/*.c))
+cuda.cu        := $(sort $(wildcard backends/cuda/*.cu))
+cuda-reg.c     := $(sort $(wildcard backends/cuda-reg/*.c))
+cuda-reg.cu    := $(sort $(wildcard backends/cuda-reg/*.cu))
+blocked.c      := $(sort $(wildcard backends/blocked/*.c))
+ceedmemcheck.c := $(sort $(wildcard backends/memcheck/*.c))
+avx.c          := $(sort $(wildcard backends/avx/*.c))
+xsmm.c         := $(sort $(wildcard backends/xsmm/*.c))
+occa.c         := $(sort $(wildcard backends/occa/*.c))
 magma_preprocessor := python backends/magma/gccm.py
 magma_pre_src  := $(filter-out %_tmp.c, $(wildcard backends/magma/ceed-*.c))
 magma_dsrc     := $(wildcard backends/magma/magma_d*.c)
@@ -234,6 +235,12 @@ $(libceed) : LDFLAGS += $(if $(DARWIN), -install_name @rpath/$(notdir $(libceed)
 libceed.c += $(ref.c)
 libceed.c += $(template.c)
 libceed.c += $(blocked.c)
+
+# Memcheck Backend
+ifneq ($(shell which valgrind 2> /dev/null),)
+  libceed.c += $(ceedmemcheck.c)
+  BACKENDS += /cpu/self/ref/memcheck
+endif
 
 # AVX Backed
 AVX_STATUS = Disabled

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ There are multiple supported backends, which can be selected at runtime in the e
 | `/cpu/self/ref/serial`   | Serial reference implementation                   |
 | `/cpu/self/ref/blocked`  | Blocked refrence implementation                   |
 | `/cpu/self/tmpl`         | Backend template, delegates to `/cpu/self/ref/blocked` |
+| `/cpu/self/ref/memcheck` | Memcheck backend, undefined value checks          |
 | `/cpu/self/avx/serial`   | Serial AVX implementation                         |
 | `/cpu/self/avx/blocked`  | Blocked AVX implementation                        |
 | `/cpu/self/xsmm/serial`  | Serial LIBXSMM implementation                     |
@@ -114,6 +115,10 @@ The `/cpu/self/avx/*` backends rely upon AVX instructions to provide vectorized 
 The `/cpu/self/xsmm/*` backends rely upon the [LIBXSMM](http://github.com/hfp/libxsmm) package
 to provide vectorized CPU performance. The LIBXSMM backend does not use BLAS or MKL; however,
 if LIBXSMM was linked to MKL, this can be specified with the compilation flag `MKL=1`.
+
+The `/cpu/self/ref/memcheck` backend relies upon the [Valgrind](http://valgrind.org/) Memcheck tool
+to help verify that user QFunctions have no undefined values. To use, run your code with
+Valgrind and the Memcheck backend, e.g. `valgrind ./build/ex1 -ceed /cpu/self/ref/memcheck`.
 
 The `/*/occa` backends rely upon the [OCCA](http://github.com/libocca/occa) package to provide
 cross platform performance.

--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -14,8 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <ceed-backend.h>
-#include <string.h>
 #include "ceed-avx.h"
 
 static int CeedInit_Avx(const char *resource, Ceed ceed) {

--- a/backends/avx/ceed-avx-serial.c
+++ b/backends/avx/ceed-avx-serial.c
@@ -14,8 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <ceed-backend.h>
-#include <string.h>
 #include "ceed-avx.h"
 
 static int CeedInit_Avx(const char *resource, Ceed ceed) {

--- a/backends/avx/ceed-avx-tensor.c
+++ b/backends/avx/ceed-avx-tensor.c
@@ -14,8 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
-#include <immintrin.h>
 #include "ceed-avx.h"
 
 // Blocked Tensor Contact

--- a/backends/avx/ceed-avx.h
+++ b/backends/avx/ceed-avx.h
@@ -16,6 +16,7 @@
 
 #include <ceed-backend.h>
 #include <string.h>
+#include <immintrin.h>
 
 CEED_INTERN int CeedTensorContractCreate_Avx(CeedBasis basis,
     CeedTensorContract contract);

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-blocked.h"
 #include "../ref/ceed-ref.h"
 

--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-blocked.h"
 
 static int CeedInit_Blocked(const char *resource, Ceed ceed) {

--- a/backends/memcheck/ceed-memcheck.c
+++ b/backends/memcheck/ceed-memcheck.c
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <string.h>
+#include "ceed-memcheck.h"
+
+static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
+  int ierr;
+  if (strcmp(resource, "/cpu/self/ref/memcheck"))
+    return CeedError(ceed, 1, "Valgrind Memcheck backend cannot use resource: %s",
+                     resource);
+
+  Ceed ceedref;
+
+  // Create refrence CEED that implementation will be dispatched
+  //   through unless overridden
+  CeedInit("/cpu/self/ref/blocked", &ceedref);
+  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",
+                                CeedQFunctionCreate_Memcheck); CeedChk(ierr);
+
+  return 0;
+}
+
+__attribute__((constructor))
+static void Register(void) {
+  CeedRegister("/cpu/self/ref/memcheck", CeedInit_Memcheck, 100);
+}

--- a/backends/memcheck/ceed-memcheck.c
+++ b/backends/memcheck/ceed-memcheck.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-memcheck.h"
 
 static int CeedInit_Memcheck(const char *resource, Ceed ceed) {

--- a/backends/memcheck/ceed-memcheck.h
+++ b/backends/memcheck/ceed-memcheck.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <string.h>
+#include <ceed-backend.h>
+#include <valgrind/memcheck.h>
+
+typedef struct {
+  const CeedScalar **inputs;
+  CeedScalar **outputs;
+  bool setupdone;
+} CeedQFunction_Memcheck;
+
+CEED_INTERN int CeedQFunctionCreate_Memcheck(CeedQFunction qf);

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-ref.h"
 
 static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-ref.h"
 
 static int CeedOperatorDestroy_Ref(CeedOperator op) {

--- a/backends/ref/ceed-ref-qfunction.c
+++ b/backends/ref/ceed-ref-qfunction.c
@@ -14,8 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
-#include <stdio.h>
 #include "ceed-ref.h"
 
 static int CeedQFunctionApply_Ref(CeedQFunction qf, CeedInt Q,

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-ref.h"
 
 static int CeedElemRestrictionApply_Ref(CeedElemRestriction r,

--- a/backends/ref/ceed-ref-tensor.c
+++ b/backends/ref/ceed-ref-tensor.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-ref.h"
 
 int CeedTensorContractApply_Ref(CeedTensorContract contract, CeedInt A,

--- a/backends/ref/ceed-ref-vec.c
+++ b/backends/ref/ceed-ref-vec.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-ref.h"
 
 static int CeedVectorSetArray_Ref(CeedVector vec, CeedMemType mtype,

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-ref.h"
 
 static int CeedInit_Ref(const char *resource, Ceed ceed) {

--- a/backends/xsmm/ceed-xsmm-blocked.c
+++ b/backends/xsmm/ceed-xsmm-blocked.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-xsmm.h"
 
 static int CeedInit_Xsmm_Blocked(const char *resource, Ceed ceed) {

--- a/backends/xsmm/ceed-xsmm-serial.c
+++ b/backends/xsmm/ceed-xsmm-serial.c
@@ -14,7 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <string.h>
 #include "ceed-xsmm.h"
 
 static int CeedInit_Xsmm_Serial(const char *resource, Ceed ceed) {

--- a/backends/xsmm/ceed-xsmm-tensor.c
+++ b/backends/xsmm/ceed-xsmm-tensor.c
@@ -14,8 +14,6 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include <math.h>
-#include <string.h>
 #include "ceed-xsmm.h"
 
 // Utility functions for index in pointer array

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -17,6 +17,7 @@
 #include <ceed-backend.h>
 #include <libxsmm.h>
 #include <string.h>
+#include <math.h>
 
 typedef struct {
   libxsmm_dmmfunction *kernels;


### PR DESCRIPTION
This PR is a minor change to ~~zero~~ *set* QFunction output vecs *as undefined* prior to use in the CPU backends. See Issue #181.