### PR TITLE
Drop simd OPT flag for CEED 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 # export LSAN_OPTIONS=suppressions=.asanignore
 AFLAGS = -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
-OPT    = -O -g -march=native -ffp-contract=fast -fopenmp-simd
+OPT    = -O -g -march=native -ffp-contract=fast #-fopenmp-simd
 CFLAGS = -std=c99 $(OPT) -Wall -Wextra -Wno-unused-parameter -fPIC -MMD -MP
 NVCCFLAGS = -Xcompiler "$(OPT)" -Xcompiler -fPIC
 # If using the IBM XL Fortran (xlf) replace FFLAGS appropriately:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ can be built using
 
 or, with optimization flags
 
-    make OPT='-O3 -march=skylake-avx512 -ffp-contract=fast'
+    make OPT='-O3 -march=skylake-avx512 -ffp-contract=fast -fopenmp-simd'
 
 These optimization flags are used by all languages (C, C++, Fortran) and this
 makefile variable can also be set for testing and examples (below).


### PR DESCRIPTION
This PR drops the `-fopenmp-simd` `OPT` flag from the default `OPT` flag list for Ceed 2.0. This flag was causing troubles in some of the Spack environments. (see: https://github.com/spack/spack/pull/10903)