### PR TITLE
Add delegates for specific objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ SO_EXT := $(if $(DARWIN),dylib,so)
 ceed.pc := $(LIBDIR)/pkgconfig/ceed.pc
 libceed := $(LIBDIR)/libceed.$(SO_EXT)
 libceed.c := $(wildcard interface/ceed*.c)
-BACKENDS_BUILTIN := /cpu/self/ref/serial /cpu/self/ref/blocked /cpu/self/opt/serial /cpu/self/opt/blocked /cpu/self/tmpl
+BACKENDS_BUILTIN := /cpu/self/ref/serial /cpu/self/ref/blocked /cpu/self/opt/serial /cpu/self/opt/blocked /cpu/self/tmpl /cpu/self/tmpl/sub
 BACKENDS := $(BACKENDS_BUILTIN)
 
 # Tests

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ libceed := $(LIBDIR)/libceed.$(SO_EXT)
 CEED_LIBS = -lceed
 libceed.c := $(wildcard interface/ceed*.c)
 libceed_test := $(LIBDIR)/libceed_test.$(SO_EXT)
+libceeds = $(libceed) $(libceed_test)
 BACKENDS_BUILTIN := /cpu/self/ref/serial /cpu/self/ref/blocked /cpu/self/opt/serial /cpu/self/opt/blocked
 BACKENDS := $(BACKENDS_BUILTIN)
 
@@ -236,6 +237,7 @@ info-backends:
 .PHONY: lib all par info info-backends
 
 $(libceed) : LDFLAGS += $(if $(DARWIN), -install_name @rpath/$(notdir $(libceed)))
+$(libceed_test) : LDFLAGS += $(if $(DARWIN), -install_name @rpath/$(notdir $(libceed_test)))
 
 # Standard Backends
 libceed.c += $(ref.c)
@@ -266,13 +268,13 @@ endif
 
 # libXSMM Backends
 ifneq ($(wildcard $(XSMM_DIR)/lib/libxsmm.*),)
-  $(libceed) : LDFLAGS += -L$(XSMM_DIR)/lib -Wl,-rpath,$(abspath $(XSMM_DIR)/lib)
-  $(libceed) : LDLIBS += -lxsmm -ldl
+  $(libceeds) : LDFLAGS += -L$(XSMM_DIR)/lib -Wl,-rpath,$(abspath $(XSMM_DIR)/lib)
+  $(libceeds) : LDLIBS += -lxsmm -ldl
   MKL ?= 0
   ifneq (0,$(MKL))
-    $(libceed) : LDLIBS += -mkl
+    $(libceeds) : LDLIBS += -mkl
   else
-    $(libceed) : LDLIBS += -lblas
+    $(libceeds) : LDLIBS += -lblas
   endif
   libceed.c += $(xsmm.c)
   $(xsmm.c:%.c=$(OBJDIR)/%.o) $(xsmm.c:%=%.tidy) : CPPFLAGS += -I$(XSMM_DIR)/include
@@ -281,8 +283,8 @@ endif
 
 # OCCA Backends
 ifneq ($(wildcard $(OCCA_DIR)/lib/libocca.*),)
-  $(libceed) : LDFLAGS += -L$(OCCA_DIR)/lib -Wl,-rpath,$(abspath $(OCCA_DIR)/lib)
-  $(libceed) : LDLIBS += -locca
+  $(libceeds) : LDFLAGS += -L$(OCCA_DIR)/lib -Wl,-rpath,$(abspath $(OCCA_DIR)/lib)
+  $(libceeds) : LDLIBS += -locca
   libceed.c += $(occa.c)
   $(occa.c:%.c=$(OBJDIR)/%.o) $(occa.c:%=%.tidy) : CPPFLAGS += -I$(OCCA_DIR)/include
   BACKENDS += /cpu/occa /gpu/occa /omp/occa
@@ -293,9 +295,9 @@ CUDA_LIB_DIR := $(wildcard $(foreach d,lib lib64,$(CUDA_DIR)/$d/libcudart.${SO_E
 CUDA_LIB_DIR := $(patsubst %/,%,$(dir $(firstword $(CUDA_LIB_DIR))))
 CUDA_BACKENDS = /gpu/cuda/ref /gpu/cuda/reg /gpu/cuda/shared
 ifneq ($(CUDA_LIB_DIR),)
-  $(libceed) : CFLAGS += -I$(CUDA_DIR)/include
-  $(libceed) : LDFLAGS += -L$(CUDA_LIB_DIR) -Wl,-rpath,$(abspath $(CUDA_LIB_DIR))
-  $(libceed) : LDLIBS += -lcudart -lnvrtc -lcuda
+  $(libceeds) : CFLAGS += -I$(CUDA_DIR)/include
+  $(libceeds) : LDFLAGS += -L$(CUDA_LIB_DIR) -Wl,-rpath,$(abspath $(CUDA_LIB_DIR))
+  $(libceeds) : LDLIBS += -lcudart -lnvrtc -lcuda
   libceed.c  += $(cuda.c) $(cuda-reg.c) $(cuda-shared.c)
   libceed.cu += $(cuda.cu) $(cuda-reg.cu) $(cuda-shared.cu)
   BACKENDS += $(CUDA_BACKENDS)
@@ -309,7 +311,7 @@ ifneq ($(wildcard $(MAGMA_DIR)/lib/libmagma.*),)
   magma_link_static = -L$(MAGMA_DIR)/lib -lmagma $(cuda_link) $(omp_link)
   magma_link_shared = -L$(MAGMA_DIR)/lib -Wl,-rpath,$(abspath $(MAGMA_DIR)/lib) -lmagma
   magma_link := $(if $(wildcard $(MAGMA_DIR)/lib/libmagma.${SO_EXT}),$(magma_link_shared),$(magma_link_static))
-  $(libceed)           : LDLIBS += $(magma_link)
+  $(libceeds)           : LDLIBS += $(magma_link)
   $(tests) $(examples) : LDLIBS += $(magma_link)
   libceed.c  += $(magma_allsrc.c)
   libceed.cu += $(magma_allsrc.cu)
@@ -364,13 +366,12 @@ $(OBJDIR)/navier-stokes-% : examples/navier-stokes/%.c $(libceed) $(ceed.pc) | $
 	mv examples/navier-stokes/$* $@
 
 libceed_test.o = $(test_backends.c:%.c=$(OBJDIR)/%.o)
-$(libceed_test) : $(libceed)
-$(libceed_test) : $(libceed_test.o) | $$(@D)/.DIR
+$(libceed_test) : $(libceed.o) $(libceed_test.o) | $$(@D)/.DIR
 	$(call quiet,CC) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
 
 $(examples) : $(libceed)
-$(tests) : $(libceed) $(libceed_test)
-$(tests) : CEED_LIBS += -lceed_test
+$(tests) : $(libceed_test)
+$(tests) : CEED_LIBS = -lceed_test
 $(tests) $(examples) : LDFLAGS += -Wl,-rpath,$(abspath $(LIBDIR)) -L$(LIBDIR)
 
 run-t% : BACKENDS += $(TEST_BACKENDS)

--- a/Makefile
+++ b/Makefile
@@ -363,13 +363,13 @@ $(OBJDIR)/navier-stokes-% : examples/navier-stokes/%.c $(libceed) $(ceed.pc) | $
 	  PETSC_DIR="$(abspath $(PETSC_DIR))" $*
 	mv examples/navier-stokes/$* $@
 
-libceed_test.o = $(test_backends.c:%.c=$(OBJDIR)/%.o) $(libceed.o)
+libceed_test.o = $(test_backends.c:%.c=$(OBJDIR)/%.o)
 $(libceed_test) : $(libceed)
 $(libceed_test) : $(libceed_test.o) | $$(@D)/.DIR
 	$(call quiet,CC) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
 
 $(examples) : $(libceed)
-$(tests) : $(libceed_test)
+$(tests) : $(libceed) $(libceed_test)
 $(tests) : CEED_LIBS += -lceed_test
 $(tests) $(examples) : LDFLAGS += -Wl,-rpath,$(abspath $(LIBDIR)) -L$(LIBDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -349,17 +349,17 @@ $(OBJDIR)/% : examples/ceed/%.f | $$(@D)/.DIR
 	$(call quiet,LINK.F) -o $@ $(abspath $<) $(CEED_LIBS) $(LDLIBS)
 
 $(OBJDIR)/mfem-% : examples/mfem/%.cpp $(libceed) | $$(@D)/.DIR
-	$(MAKE) -C examples/mfem CEED_DIR=`pwd` \
+	+$(MAKE) -C examples/mfem CEED_DIR=`pwd` \
 	  MFEM_DIR="$(abspath $(MFEM_DIR))" $*
 	mv examples/mfem/$* $@
 
 $(OBJDIR)/petsc-% : examples/petsc/%.c $(libceed) $(ceed.pc) | $$(@D)/.DIR
-	$(MAKE) -C examples/petsc CEED_DIR=`pwd` \
+	+$(MAKE) -C examples/petsc CEED_DIR=`pwd` \
 	  PETSC_DIR="$(abspath $(PETSC_DIR))" $*
 	mv examples/petsc/$* $@
 
 $(OBJDIR)/navier-stokes-% : examples/navier-stokes/%.c $(libceed) $(ceed.pc) | $$(@D)/.DIR
-	$(MAKE) -C examples/navier-stokes CEED_DIR=`pwd` \
+	+$(MAKE) -C examples/navier-stokes CEED_DIR=`pwd` \
 	  PETSC_DIR="$(abspath $(PETSC_DIR))" $*
 	mv examples/navier-stokes/$* $@
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ SO_EXT := $(if $(DARWIN),dylib,so)
 
 ceed.pc := $(LIBDIR)/pkgconfig/ceed.pc
 libceed := $(LIBDIR)/libceed.$(SO_EXT)
-CEED_LIBS := -lceed
+CEED_LIBS = -lceed
 libceed.c := $(wildcard interface/ceed*.c)
 libceed_test := $(LIBDIR)/libceed_test.$(SO_EXT)
 BACKENDS_BUILTIN := /cpu/self/ref/serial /cpu/self/ref/blocked /cpu/self/opt/serial /cpu/self/opt/blocked

--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ There are multiple supported backends, which can be selected at runtime in the e
 | :----------------------- | :------------------------------------------------ |
 | `/cpu/self/ref/serial`   | Serial reference implementation                   |
 | `/cpu/self/ref/blocked`  | Blocked refrence implementation                   |
+| `/cpu/self/ref/memcheck` | Memcheck backend, undefined value checks          |
 | `/cpu/self/opt/serial`   | Serial optimized C implementation                 |
 | `/cpu/self/opt/blocked`  | Blocked optimized C implementation                |
-| `/cpu/self/tmpl`         | Backend template, delegates to `/cpu/self/ref/blocked` |
-| `/cpu/self/ref/memcheck` | Memcheck backend, undefined value checks          |
 | `/cpu/self/avx/serial`   | Serial AVX implementation                         |
 | `/cpu/self/avx/blocked`  | Blocked AVX implementation                        |
 | `/cpu/self/xsmm/serial`  | Serial LIBXSMM implementation                     |

--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -27,7 +27,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/opt/blocked", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",
                                 CeedTensorContractCreate_Avx); CeedChk(ierr);

--- a/backends/avx/ceed-avx-serial.c
+++ b/backends/avx/ceed-avx-serial.c
@@ -27,7 +27,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/opt/serial", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",

--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -27,7 +27,7 @@ static int CeedInit_Blocked(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/ref/serial", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Blocked); CeedChk(ierr);

--- a/backends/cuda-reg/ceed-cuda-reg.c
+++ b/backends/cuda-reg/ceed-cuda-reg.c
@@ -28,7 +28,7 @@ static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
 
   Ceed ceedref;
   CeedInit("/gpu/cuda/ref", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   const int rlen = strlen(resource);
   const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;

--- a/backends/cuda-shared/ceed-cuda-shared.c
+++ b/backends/cuda-shared/ceed-cuda-shared.c
@@ -30,7 +30,7 @@ static int CeedInit_Cuda_shared(const char *resource, Ceed ceed) {
 
   Ceed ceedreg;
   CeedInit("/gpu/cuda/reg", &ceedreg);
-  ierr = CeedSetDelegate(ceed, &ceedreg); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedreg); CeedChk(ierr);
 
   const int rlen = strlen(resource);
   const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;

--- a/backends/memcheck/ceed-memcheck.c
+++ b/backends/memcheck/ceed-memcheck.c
@@ -27,7 +27,7 @@ static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/ref/blocked", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",
                                 CeedQFunctionCreate_Memcheck); CeedChk(ierr);

--- a/backends/opt/ceed-opt-blocked.c
+++ b/backends/opt/ceed-opt-blocked.c
@@ -37,7 +37,7 @@ static int CeedInit_Opt_Blocked(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/ref/serial", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "Destroy",
                                 CeedDestroy_Opt); CeedChk(ierr);

--- a/backends/opt/ceed-opt-serial.c
+++ b/backends/opt/ceed-opt-serial.c
@@ -37,7 +37,7 @@ static int CeedInit_Opt_Serial(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/ref/serial", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "Destroy",
                                 CeedDestroy_Opt); CeedChk(ierr);

--- a/backends/template/ceed-tmpl-sub.c
+++ b/backends/template/ceed-tmpl-sub.c
@@ -1,0 +1,52 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <ceed-backend.h>
+#include <string.h>
+
+static int CeedInit_Tmpl(const char *resource, Ceed ceed) {
+  int ierr;
+  if (strcmp(resource, "/cpu/self")
+      && strcmp(resource, "/cpu/self/tmpl/sub"))
+    return CeedError(ceed, 1, "Tmpl backend cannot use resource: %s", resource);
+
+  Ceed ceedref;
+  // Create refrence CEED that implementation will be dispatched
+  //   through unless overridden
+  CeedInit("/cpu/self/ref/blocked", &ceedref);
+  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+
+  // Create refrence CEED for objects
+  Ceed basisceedref;
+  CeedInit("/cpu/self/ref/blocked", &basisceedref);
+  ierr = CeedSetObjectDelegate(ceed, &basisceedref, "Basis");
+  CeedChk(ierr);
+  Ceed tensorceedref;
+  CeedInit("/cpu/self/ref/blocked", &tensorceedref);
+  ierr = CeedSetObjectDelegate(ceed, &tensorceedref, "TensorContract");
+  CeedChk(ierr);
+  Ceed opceedref;
+  CeedInit("/cpu/self/ref/blocked", &opceedref);
+  ierr = CeedSetObjectDelegate(ceed, &opceedref, "Operator");
+  CeedChk(ierr);
+
+  return 0;
+}
+
+__attribute__((constructor))
+static void Register(void) {
+  CeedRegister("/cpu/self/tmpl/sub", CeedInit_Tmpl, 70);
+}

--- a/backends/template/ceed-tmpl-sub.c
+++ b/backends/template/ceed-tmpl-sub.c
@@ -27,20 +27,20 @@ static int CeedInit_Tmpl(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/ref/blocked", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   // Create refrence CEED for objects
   Ceed basisceedref;
   CeedInit("/cpu/self/ref/blocked", &basisceedref);
-  ierr = CeedSetObjectDelegate(ceed, &basisceedref, "Basis");
+  ierr = CeedSetObjectDelegate(ceed, basisceedref, "Basis");
   CeedChk(ierr);
   Ceed tensorceedref;
   CeedInit("/cpu/self/ref/blocked", &tensorceedref);
-  ierr = CeedSetObjectDelegate(ceed, &tensorceedref, "TensorContract");
+  ierr = CeedSetObjectDelegate(ceed, tensorceedref, "TensorContract");
   CeedChk(ierr);
   Ceed opceedref;
   CeedInit("/cpu/self/ref/blocked", &opceedref);
-  ierr = CeedSetObjectDelegate(ceed, &opceedref, "Operator");
+  ierr = CeedSetObjectDelegate(ceed, opceedref, "Operator");
   CeedChk(ierr);
 
   return 0;

--- a/backends/template/ceed-tmpl.c
+++ b/backends/template/ceed-tmpl.c
@@ -28,7 +28,7 @@ static int CeedInit_Tmpl(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/ref/blocked", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   return 0;
 }

--- a/backends/xsmm/ceed-xsmm-blocked.c
+++ b/backends/xsmm/ceed-xsmm-blocked.c
@@ -27,7 +27,7 @@ static int CeedInit_Xsmm_Blocked(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/opt/blocked", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",
                                 CeedTensorContractCreate_Xsmm); CeedChk(ierr);

--- a/backends/xsmm/ceed-xsmm-serial.c
+++ b/backends/xsmm/ceed-xsmm-serial.c
@@ -27,7 +27,7 @@ static int CeedInit_Xsmm_Serial(const char *resource, Ceed ceed) {
   // Create refrence CEED that implementation will be dispatched
   //   through unless overridden
   CeedInit("/cpu/self/opt/serial", &ceedref);
-  ierr = CeedSetDelegate(ceed, &ceedref); CeedChk(ierr);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",
                                 CeedTensorContractCreate_Xsmm); CeedChk(ierr);

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -44,7 +44,7 @@ nek:
 		 EXAMPLES=$(NEK5K_EXAMPLES) ./make-nek-examples.sh
 
 prepnektests:
-	cd nek5000 && ./make-nek-tests.sh
+	cd nek5000 && NEK5K_DIR=$(NEK5K_DIR) ./make-nek-tests.sh
 
 mfem:
 	make CEED_DIR=$(CEED_DIR) MFEM_DIR=$(MFEM_DIR) -C mfem all

--- a/examples/nek5000/generate-boxes.sh
+++ b/examples/nek5000/generate-boxes.sh
@@ -22,8 +22,10 @@ max_elem=$2
 ###############################################################################
 # DONT'T TOUCH WHAT FOLLOWS !!!
 ###############################################################################
-# Get the value of NEK5K_DIR which is needed by function genbb
-source make-nek-examples.sh
+if [ -z ${NEK5K_DIR} ]; then
+  echo "ERROR: Must set NEK5K_DIR" 1>&2
+  exit 1
+fi
 
 # Functions needed for creating box meshes
 function xyz()

--- a/examples/nek5000/make-nek-examples.sh
+++ b/examples/nek5000/make-nek-examples.sh
@@ -41,7 +41,7 @@ EXAMPLES=(bp1 bp3)
 # See if its just cleaning and if yes, clean and exit
 if [[ "$#" -eq 1 && "$1" -eq "clean" ]]; then
   if [[ -f ./makenek ]]; then
-    printf "y\n" | ./makenek clean 2>&1 >> /dev/null
+    printf "y\n" | NEK_SOURCE_ROOT=${NEK5K_DIR} ./makenek clean 2>&1 >> /dev/null
   fi
   rm makenek* SESSION.NAME 2> /dev/null
   for i in `seq 1 6`; do

--- a/examples/nek5000/make-nek-tests.sh
+++ b/examples/nek5000/make-nek-tests.sh
@@ -36,4 +36,4 @@ rm -rf ../../build/boxes
 cp -r boxes ../../build/boxes
 
 # Clean
-(./make-nek-examples.sh clean)
+(export NEK5K_DIR && ./make-nek-examples.sh clean)

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -52,10 +52,10 @@ CEED_EXTERN int CeedRegister(const char *prefix,
 
 CEED_EXTERN int CeedGetParent(Ceed ceed, Ceed *parent);
 CEED_EXTERN int CeedGetDelegate(Ceed ceed, Ceed *delegate);
-CEED_EXTERN int CeedSetDelegate(Ceed ceed, Ceed *delegate);
+CEED_EXTERN int CeedSetDelegate(Ceed ceed, Ceed delegate);
 CEED_EXTERN int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate,
                                       const char *objname);
-CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed *delegate,
+CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed delegate,
                                       const char *objname);
 CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
                                        const char *type, void *object,

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -53,6 +53,10 @@ CEED_EXTERN int CeedRegister(const char *prefix,
 CEED_EXTERN int CeedGetParent(Ceed ceed, Ceed *parent);
 CEED_EXTERN int CeedGetDelegate(Ceed ceed, Ceed *delegate);
 CEED_EXTERN int CeedSetDelegate(Ceed ceed, Ceed *delegate);
+CEED_EXTERN int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate,
+                                      const char *objname);
+CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed *delegate,
+                                      const char *objname);
 CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
                                        const char *type, void *object,
                                        const char *fname, int (*f)());

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -36,9 +36,17 @@ typedef struct {
   size_t offset;
 } foffset;
 
+// Lookup table field for object delegates
+typedef struct {
+  char *objname;
+  Ceed delegate;
+} objdelegate;
+
 struct Ceed_private {
   Ceed delegate;
   Ceed parent;
+  objdelegate *objdelegates;
+  int objdelegatecount;
   int (*Error)(Ceed, const char *, int, const char *, int, const char *,
                va_list);
   int (*GetPreferredMemType)(CeedMemType *);

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -62,7 +62,7 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt ncomp, CeedInt P1d,
 
   if (!ceed->BasisCreateTensorH1) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "Basis"); CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support BasisCreateTensorH1");
@@ -202,7 +202,7 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt ncomp,
 
   if (!ceed->BasisCreateH1) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "Basis"); CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support BasisCreateH1");

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -55,7 +55,8 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
 
   if (!ceed->ElemRestrictionCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction");
+    CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support ElemRestrictionCreate");
@@ -105,7 +106,8 @@ int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
 
   if (!ceed->ElemRestrictionCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction");
+    CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1,
@@ -200,7 +202,8 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem, CeedInt elemsize,
 
   if (!ceed->ElemRestrictionCreateBlocked) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction");
+    CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1,

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -45,7 +45,7 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
 
   if (!ceed->OperatorCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "Operator"); CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support OperatorCreate");
@@ -86,7 +86,7 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
 
   if (!ceed->CompositeOperatorCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "Operator"); CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support \

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -50,7 +50,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
 
   if (!ceed->QFunctionCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "QFunction"); CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support QFunctionCreate");

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -40,7 +40,8 @@ int CeedTensorContractCreate(Ceed ceed, CeedBasis basis,
 
   if (!ceed->TensorContractCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "TensorContract");
+    CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1,

--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -45,7 +45,7 @@ int CeedVectorCreate(Ceed ceed, CeedInt length, CeedVector *vec) {
 
   if (!ceed->VectorCreate) {
     Ceed delegate;
-    ierr = CeedGetDelegate(ceed, &delegate); CeedChk(ierr);
+    ierr = CeedGetObjectDelegate(ceed, &delegate, "Vector"); CeedChk(ierr);
 
     if (!delegate)
       return CeedError(ceed, 1, "Backend does not support VectorCreate");

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -436,9 +436,9 @@ int CeedGetDelegate(Ceed ceed, Ceed *delegate) {
 
   @ref Advanced
 **/
-int CeedSetDelegate(Ceed ceed, Ceed *delegate) {
-  ceed->delegate = *delegate;
-  (*delegate)->parent = ceed;
+int CeedSetDelegate(Ceed ceed, Ceed delegate) {
+  ceed->delegate = delegate;
+  delegate->parent = ceed;
   return 0;
 }
 
@@ -479,7 +479,7 @@ int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *objname) {
 
   @ref Advanced
 **/
-int CeedSetObjectDelegate(Ceed ceed, Ceed *delegate, const char *objname) {
+int CeedSetObjectDelegate(Ceed ceed, Ceed delegate, const char *objname) {
   CeedInt ierr;
   CeedInt count = ceed->objdelegatecount;
 
@@ -493,13 +493,13 @@ int CeedSetObjectDelegate(Ceed ceed, Ceed *delegate, const char *objname) {
   ceed->objdelegatecount++;
 
   // Set object delegate
-  ceed->objdelegates[count].delegate = *delegate;
+  ceed->objdelegates[count].delegate = delegate;
   ierr = CeedCalloc(strlen(objname)+1, &ceed->objdelegates[count].objname);
   CeedChk(ierr);
   strncpy(ceed->objdelegates[count].objname, objname, strlen(objname)+1);
 
   // Set delegate parent
-  (*delegate)->parent = ceed;
+  delegate->parent = ceed;
 
   return 0;
 }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -443,6 +443,68 @@ int CeedSetDelegate(Ceed ceed, Ceed *delegate) {
 }
 
 /**
+  @brief Retrieve a delegate CEED for a specific object type
+
+  @param ceed           Ceed to retrieve delegate of
+  @param[out] delegate  Address to save the delegate to
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Developer
+**/
+int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *objname) {
+  CeedInt ierr;
+
+  // Check for object delegate
+  for (CeedInt i=0; i<ceed->objdelegatecount; i++) {
+    if (!strcmp(objname, ceed->objdelegates->objname)) {
+      *delegate = ceed->objdelegates->delegate;
+      return 0;
+    }
+  }
+
+  // Use default delegate if no object delegate
+  ierr = CeedGetDelegate(ceed, delegate); CeedChk(ierr);
+ 
+  return 0;
+}
+
+/**
+  @brief Set a delegate CEED for a specific object type
+
+  @param ceed           Ceed to set delegate of
+  @param[out] delegate  Address to set the delegate to
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+int CeedSetObjectDelegate(Ceed ceed, Ceed *delegate, const char *objname) {
+  CeedInt ierr;
+  CeedInt count = ceed->objdelegatecount;
+
+  // Malloc or Realloc
+  if (count) {
+    ierr = CeedRealloc(count+1, &ceed->objdelegates);
+    CeedChk(ierr);
+  } else {
+    ierr = CeedCalloc(1, &ceed->objdelegates); CeedChk(ierr);
+  }
+  ceed->objdelegatecount++;
+
+  // Set object delegate
+  ceed->objdelegates[count].delegate = *delegate;
+  ierr = CeedCalloc(strlen(objname)+1, &ceed->objdelegates[count].objname);
+  CeedChk(ierr);
+  strncpy(ceed->objdelegates[count].objname, objname, strlen(objname)+1);
+
+  // Set delegate parent
+  (*delegate)->parent = ceed;
+
+  return 0;
+}
+
+/**
   @brief Return Ceed perferred memory type
 
   @param ceed           Ceed to get preferred memory type of
@@ -554,6 +616,13 @@ int CeedDestroy(Ceed *ceed) {
   if (!*ceed || --(*ceed)->refcount > 0) return 0;
   if ((*ceed)->delegate) {
     ierr = CeedDestroy(&(*ceed)->delegate); CeedChk(ierr);
+  }
+  if ((*ceed)->objdelegatecount > 0) {
+    for (int i=0; i<(*ceed)->objdelegatecount; i++) {
+      ierr = CeedDestroy(&((*ceed)->objdelegates[i].delegate)); CeedChk(ierr);
+      ierr = CeedFree(&(*ceed)->objdelegates[i].objname); CeedChk(ierr);
+    }
+    ierr = CeedFree(&(*ceed)->objdelegates); CeedChk(ierr);
   }
   if ((*ceed)->Destroy) {
     ierr = (*ceed)->Destroy(*ceed); CeedChk(ierr);

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -429,6 +429,9 @@ int CeedGetDelegate(Ceed ceed, Ceed *delegate) {
 /**
   @brief Set a delegate CEED
 
+  This function allows a CEED to set a delegate CEED. All backend
+  implementations default to the delegate CEED, unless overridden.
+
   @param ceed           Ceed to set delegate of
   @param[out] delegate  Address to set the delegate to
 
@@ -471,6 +474,12 @@ int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *objname) {
 
 /**
   @brief Set a delegate CEED for a specific object type
+
+  This function allows a CEED to set a delegate CEED for a given type of
+  CEED object. All backend implementations default to the delegate CEED for
+  this object. For example,
+    CeedSetObjectDelegate(ceed, refceed, "Basis")
+  uses refceed implementations for all CeedBasis backend functions.
 
   @param ceed           Ceed to set delegate of
   @param[out] delegate  Address to set the delegate to

--- a/tests/tap.sh
+++ b/tests/tap.sh
@@ -6,8 +6,17 @@ ulimit -c 0 # Do not dump core
 export CEED_ERROR_HANDLER=exit
 
 output=$(mktemp $1.XXXX)
-
 backends=(${BACKENDS:?Variable must be set, e.g., \"/cpu/self/ref /cpu/self/blocked\"})
+target="$1"
+# Only the unit tests (txxx) link with libceed_test (where /cpu/self/tmpl is
+# defined), so filter those backends out for everything else.  Note that this is
+# only relevant for the prove target; the test and junit targets are managed in
+# the makefile and set BACKENDS appropriately.
+if [ "t" != "${target::1}" ]; then
+    for idx in ${!backends[@]}; do
+        test /cpu/self/tmpl = ${backends[$idx]::14} && unset backends[$idx]
+    done
+fi
 printf "1..$[3*${#backends[@]}]\n";
 
 # for examples/ceed petsc*, mfem*, or ex* grep the code to fetch arguments from a TESTARGS line


### PR DESCRIPTION
This PR adds the ability to delegate to different reference CEEDs for different objects. For example, we will be able to use `/cpu/self/ref/blocked` as the basic delegate, `/cpu/self/xsmm/blocked` as the TensorContract delegate, and `/cpu/self/juliadiff/blocked` as the QFunction delegate for our future "AD via Julia Package" backend.

This approach will help us avoid combinatorial explosion in the list of CPU backends (e.g. `/cpu/self/xsmm/blocked/juliadiff/futurecoolstuff`.

A note for testing: I am testing this by making a template backend that uses 4 different `/cpu/self/ref/blocked` CEEDs. I want to test this functionality without needing XSMM or AVX. This still provides an adequate test as these 4 CEEDs are independent. (Though if I'm careful and it's desirable I can make the test a mix of `/cpu/self/ref/blocked` and `/cpu/self/ref/serial`.)