### PR TITLE
Add PetscObjectSetName to set solution's vec name

### DIFF
--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -195,6 +195,7 @@ static PetscErrorCode TSMonitor_NS(TS ts, PetscInt stepno, PetscReal time,
   // Set up output
   PetscFunctionBeginUser;
   ierr = DMGetGlobalVector(user->dm, &U); CHKERRQ(ierr);
+  ierr = PetscObjectSetName((PetscObject)U, "StateVec");
   ierr = DMDAGetLocalInfo(user->dm, &info); CHKERRQ(ierr);
   ierr = DMDAVecGetArray(user->dm, U, &u); CHKERRQ(ierr);
   ierr = VecGetArrayRead(Q, &q); CHKERRQ(ierr);


### PR DESCRIPTION
This very small PR adds the object name to the state vector in our NS example so that it can be displayed in the output in vts/vtr formats, after the latest Petsc patch.