### PR TITLE
Jed/clang tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ script:
   - export COVERAGE=1
   - make -j2
   - make -j2 prove-all PROVE_OPTS=-v
+  - clang-tidy --version && make -j2 tidy || true
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -F interface

--- a/doc/libCEEDdev.md
+++ b/doc/libCEEDdev.md
@@ -29,3 +29,17 @@ and
 
 are purely implicit -- one just indexes the same array using the
 appropriate convention.
+
+## Clang-tidy
+
+Please check your code for common issues by running
+```
+make tidy
+````
+which uses the `clang-tidy` utility included in recent releases of Clang.  This
+tool is much slower than actual compilation (`make -j8` parallelism helps).  To
+run on a single file, use
+```
+make interface/ceed.c.tidy
+```
+for example.  All issues reported by `make tidy` should be fixed.

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -118,9 +118,15 @@ CEED_EXTERN int CeedErrorImpl(Ceed, const char *, int, const char *, int,
 ///
 /// @ingroup Ceed
 /// @sa CeedSetErrorHandler()
-#define CeedError(ceed, ecode, ...)                                     \
-  CeedErrorImpl((ceed), __FILE__, __LINE__, __func__, (ecode), __VA_ARGS__)
-
+#if defined(__clang__)
+  // Use nonstandard ternary to convince the compiler/clang-tidy that this
+  // function never returns zero.
+#  define CeedError(ceed, ecode, ...)                                     \
+  (CeedErrorImpl((ceed), __FILE__, __LINE__, __func__, (ecode), __VA_ARGS__) ?: (ecode))
+#else
+#  define CeedError(ceed, ecode, ...)                                     \
+  CeedErrorImpl((ceed), __FILE__, __LINE__, __func__, (ecode), __VA_ARGS__) ?: (ecode)
+#endif
 /// Specify memory type
 ///
 /// Many Ceed interfaces take or return pointers to memory.  This enum is used to

--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -141,7 +141,7 @@ int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
 int CeedVectorSyncArray(CeedVector vec, CeedMemType mtype) {
   int ierr;
 
-  if (vec && (vec->state % 2) == 1)
+  if (vec->state % 2 == 1)
     return CeedError(vec->ceed, 1,
                      "Cannot sync CeedVector, the access lock is already in use");
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -102,9 +102,16 @@ CeedRequest *const CEED_REQUEST_ORDERED = &ceed_request_ordered;
 int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func,
                   int ecode, const char *format, ...) {
   va_list args;
+  int retval;
   va_start(args, format);
-  if (ceed) return ceed->Error(ceed, filename, lineno, func, ecode, format, args);
-  return CeedErrorAbort(ceed, filename, lineno, func, ecode, format, args);
+  if (ceed) {
+    retval = ceed->Error(ceed, filename, lineno, func, ecode, format, args);
+  } else {
+    // This function doesn't actually return
+    retval = CeedErrorAbort(ceed, filename, lineno, func, ecode, format, args);
+  }
+  va_end(args);
+  return retval;
 }
 
 /**


### PR DESCRIPTION
Add clang-tidy static analysis via `make tidy` and Travis report. There are presently no issues in core, but a number of issues in the OCCA backend. Once the OCCA issues are fixed, we could make Travis report clang-tidy issues as errors. Resolves #193.