### PR TITLE
OCCA Backend clang-tidy fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ script:
   - export COVERAGE=1
   - make -j2
   - make -j2 prove-all PROVE_OPTS=-v
-  - clang-tidy --version && make -j2 tidy || true
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        clang-tidy --version && make -j2 tidy;
+    fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -F interface

--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -107,24 +107,26 @@ static int CeedBasisBuildKernel(CeedBasis basis) {
 // * CeedScalars are used here, not CeedVectors: we don't touch it yet
 // *****************************************************************************
 static int CeedTensorContract_Occa(CeedInt A, CeedInt B, CeedInt C, CeedInt J,
-                                   const CeedScalar *t, CeedTransposeMode tmode,
-                                   const CeedInt Add,
-                                   const CeedScalar *u, CeedScalar *v) {
-  const CeedInt transpose = tmode == CEED_TRANSPOSE;
-  const CeedInt tstride0 = transpose?1:B;
-  const CeedInt tstride1 = transpose?J:1;
-  for (CeedInt a=0; a<A; a++) {
-    for (CeedInt j=0; j<J; j++) {
-      if (!Add)
-        for (CeedInt c=0; c<C; c++)
-          v[(a*J+j)*C+c] = 0.0;
-      for (CeedInt b=0; b<B; b++) {
-        for (CeedInt c=0; c<C; c++) {
-          v[(a*J+j)*C+c] += t[j*tstride0 + b*tstride1] * u[(a*B+b)*C+c];
-        }
-      }
-    }
+                                   const CeedScalar *restrict t,
+                                   CeedTransposeMode tmode, const CeedInt Add,
+                                   const CeedScalar *restrict u,
+                                   CeedScalar *restrict v) {
+  CeedInt tstride0 = B, tstride1 = 1;
+  if (tmode == CEED_TRANSPOSE) {
+    tstride0 = 1; tstride1 = J;
   }
+
+  if (!Add)
+    for (CeedInt q=0; q<A*J*C; q++)
+      v[q] = (CeedScalar) 0.0;
+
+  for (CeedInt a=0; a<A; a++)
+    for (CeedInt b=0; b<B; b++)
+      for (CeedInt j=0; j<J; j++) {
+        CeedScalar tq = t[j*tstride0 + b*tstride1];
+        for (CeedInt c=0; c<C; c++)
+          v[(a*J+j)*C+c] += tq * u[(a*B+b)*C+c];
+      }
   return 0;
 }
 

--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -125,6 +125,7 @@ static int CeedTensorContract_Occa(CeedInt A, CeedInt B, CeedInt C, CeedInt J,
       for (CeedInt j=0; j<J; j++) {
         CeedScalar tq = t[j*tstride0 + b*tstride1];
         for (CeedInt c=0; c<C; c++)
+          // NOLINTNEXTLINE: False positive for unitalized values
           v[(a*J+j)*C+c] += tq * u[(a*B+b)*C+c];
       }
   return 0;

--- a/backends/occa/ceed-occa-okl.c
+++ b/backends/occa/ceed-occa-okl.c
@@ -32,7 +32,7 @@ int CeedOklPath_Occa(const Ceed ceed, const char *c_src_file,
   if (!last_dot)
     return CeedError(ceed, 1, "Cannot find file's extension!");
   const size_t okl_path_len = last_dot - okl;
-  strcpy(&okl[okl_path_len],".okl");
+  strncpy(&okl[okl_path_len],".okl",5);
   dbg("[CeedOklPath] Current OKL is %s",okl);
   // Test if we can get file's status,
   if (stat(okl, &buf)!=0) { // if not revert to occa cache

--- a/backends/occa/ceed-occa-okl.c
+++ b/backends/occa/ceed-occa-okl.c
@@ -32,6 +32,7 @@ int CeedOklPath_Occa(const Ceed ceed, const char *c_src_file,
   if (!last_dot)
     return CeedError(ceed, 1, "Cannot find file's extension!");
   const size_t okl_path_len = last_dot - okl;
+  // TODO: Update strncpy to avoid memory corruption
   strncpy(&okl[okl_path_len],".okl",5);
   dbg("[CeedOklPath] Current OKL is %s",okl);
   // Test if we can get file's status,

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -148,6 +148,7 @@ static int CeedOperatorSetupFields_Occa(CeedQFunction qf, CeedOperator op,
           i + starte);
       ierr = CeedOperatorFieldGetBasis(opfields[i], &basis); CeedChk(ierr);
       ierr = CeedQFunctionFieldGetNumComponents(qffields[i], &ncomp);
+      CeedChk(ierr);
       ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
       ierr = CeedQFunctionFieldGetNumComponents(qffields[i], &ncomp);
       CeedChk(ierr);
@@ -192,6 +193,7 @@ static int CeedOperatorSetup_Occa(CeedOperator op) {
   CeedInt Q, numinputfields, numoutputfields;
   ierr = CeedOperatorGetNumQuadraturePoints(op, &Q); CeedChk(ierr);
   ierr = CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
+  CeedChk(ierr);
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -461,6 +463,7 @@ static int CeedOperatorApply_Occa(CeedOperator op,
         ierr = CeedVectorSetArray(data->evecsout[i], CEED_MEM_HOST,
                                   CEED_USE_POINTER,
                                   &data->Edata[i + numinputfields][e*elemsize*ncomp]);
+        CeedChk(ierr);
         ierr = CeedBasisApply(basis, 1, CEED_TRANSPOSE,
                               CEED_EVAL_INTERP, data->qvecsout[i],
                               data->evecsout[i]); CeedChk(ierr);
@@ -471,6 +474,7 @@ static int CeedOperatorApply_Occa(CeedOperator op,
         ierr = CeedVectorSetArray(data->evecsout[i], CEED_MEM_HOST,
                                   CEED_USE_POINTER,
                                   &data->Edata[i + numinputfields][e*elemsize*ncomp]);
+        CeedChk(ierr);
         ierr = CeedBasisApply(basis, 1, CEED_TRANSPOSE,
                               CEED_EVAL_GRAD, data->qvecsout[i],
                               data->evecsout[i]); CeedChk(ierr);
@@ -537,7 +541,7 @@ int CeedOperatorCreate_Occa(CeedOperator op) {
 
   dbg("[CeedOperator][Create]");
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
-  ierr = CeedOperatorSetData(op, (void *)&impl);
+  ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Occa); CeedChk(ierr);

--- a/backends/occa/ceed-occa-qfunction-noop.c
+++ b/backends/occa/ceed-occa-qfunction-noop.c
@@ -32,7 +32,7 @@ int CeedQFunctionAllocNoOpIn_Occa(CeedQFunction qf, CeedInt Q,
   ierr = CeedGetData(ceed, (void *)&ceed_data); CeedChk(ierr);
   const occaDevice device = ceed_data->device;
   int nIn;
-  ierr = CeedQFunctionGetNumArgs(qf, &nIn, NULL);
+  ierr = CeedQFunctionGetNumArgs(qf, &nIn, NULL); CeedChk(ierr);
   assert(nIn<N_MAX_IDX);
   size_t cbytes;
   ierr = CeedQFunctionGetContextSize(qf, &cbytes); CeedChk(ierr);

--- a/backends/occa/ceed-occa.c
+++ b/backends/occa/ceed-occa.c
@@ -49,7 +49,7 @@ static int CeedDestroy_Occa(Ceed ceed) {
   dbg("[CeedDestroy]");
   ierr = CeedFree(&data->occa_cache_dir); CeedChk(ierr);
   occaFree(data->device);
-  ierr = CeedFree(&data->libceed_dir);
+  ierr = CeedFree(&data->libceed_dir); CeedChk(ierr);
   ierr = CeedFree(&data); CeedChk(ierr);
   return 0;
 }


### PR DESCRIPTION
This PR is a series of small changes to the OCCA backend for `clang-tidy` issues.