### PR TITLE
Improve petsc-bps benchmark output

### DIFF
--- a/benchmarks/postprocess-base.py
+++ b/benchmarks/postprocess-base.py
@@ -85,7 +85,7 @@ while True:
          data['case']='scalar'
       ## Benchmark Problem
       elif "CEED Benchmark Problem" in line:
-        data['test'] = line.split('-- ')[1]
+        data['test'] = line.split()[-2] + " " + line.split('-- ')[1]
         data['case']='scalar' if (('Problem 1' in line) or ('Problem 3' in line)
                                   or ('Problem 5' in line)) else 'vector'
       ## Backend

--- a/benchmarks/postprocess-base.py
+++ b/benchmarks/postprocess-base.py
@@ -87,7 +87,7 @@ while True:
                                   or ('Problem 5' in line)) else 'vector'
       ## Backend
       elif 'libCEED Backend' in line:
-         data['backend']=line.split(':')[1]
+         data['backend']=line.split(':')[1].strip()
       ## P
       elif 'Basis Nodes' in line:
          data['order']=int(line.split(':')[1])

--- a/benchmarks/postprocess-base.py
+++ b/benchmarks/postprocess-base.py
@@ -15,12 +15,12 @@
 # testbed platforms, in support of the nation's exascale computing imperative.
 
 from sys import stdout as out
+import pandas as pd
 import fileinput
 import pprint
 
 #####   Read all input files specified on the command line, or stdin and parse
-#####   the content, storing it as a list of dictionaries - one dictionary for
-#####   each test run.
+#####   the content, storing it as a pandas dataframe
 
 it=fileinput.input()
 state=0
@@ -66,17 +66,20 @@ while True:
          ##
          ## This is the beginning of a new run.
          ##
-         if 'cg-iteration-dps' in data:
+
+         ## Add last row
+         if 'cg_iteration_dps' in data:
             runs.append(data)
+         ## New row
          data={}
          data['file']=fileinput.filename()
          data['config']=config
          data['backend']=backend
          data['test']=test
-         data['num-procs']=num_procs
-         data['num-procs-node']=num_procs_node
+         data['num_procs']=num_procs
+         data['num_procs_node']=num_procs_node
          data['order']=mesh_p
-         data['quadrature-pts']=mesh_p
+         data['quadrature_pts']=mesh_p
          data['code']="libCEED"
          test_=test.rsplit('/',1)[-1]
          data['case']='scalar'
@@ -94,19 +97,24 @@ while True:
       ## Q
       elif 'Quadrature Points' in line:
          qpts=int(line.split(':')[1])
-         data['quadrature-pts']=qpts**3
+         data['quadrature_pts']=qpts**3
       ## Total DOFs
       elif 'Global DOFs' in line:
-         data['num-unknowns']=int(line.split(':')[1])
+         data['num_unknowns']=int(line.split(':')[1])
       ## Number of elements
       elif 'Local Elements' in line:
-         data['num-elem']=int(line.split(':')[1].split()[0])*data['num-procs']
+         data['num_elem']=int(line.split(':')[1].split()[0])*data['num_procs']
       ## CG DOFs/Sec
       elif 'DOFs/Sec in CG' in line:
-         data['cg-iteration-dps']=1e6*float(line.split(':')[1].split()[0])
+         data['cg_iteration_dps']=1e6*float(line.split(':')[1].split()[0])
       ## End of output
 
-if 'cg-iteration-dps' in data:
+## Add last row
+if 'cg_iteration_dps' in data:
    runs.append(data)
 
+## Convert to dataframe
+runs = pd.DataFrame(runs)
+
+## Summary
 print('Number of test runs read: %i'%len(runs))

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -28,6 +28,7 @@ show_figures=1        # display the figures on the screen?
 
 
 #####   Load the data
+import pandas as pd
 exec(compile(open('postprocess-base.py').read(), 'postprocess-base.py', 'exec'))
 
 
@@ -41,17 +42,14 @@ rcParams['font.sans-serif'].insert(0,'Noto Sans')
 rcParams['font.sans-serif'].insert(1,'Open Sans')
 rcParams['figure.figsize']=[10, 8] # default: 8 x 6
 
-cm=get_cmap('Set1') # 'Accent', 'Dark2', 'Set1', 'Set2', 'Set3'
-if '_segmentdata' in cm.__dict__:
-   cm_size=len(cm.__dict__['_segmentdata']['red'])
-elif 'colors' in cm.__dict__:
-   cm_size=len(cm.__dict__['colors'])
-colors=[cm(1.*i/(cm_size-1)) for i in range(cm_size)]
+cm_size=16
+colors=['dimgrey','black','saddlebrown','firebrick','red','orange',
+        'gold','lightgreen','green','cyan','teal','blue','navy',
+        'purple','magenta','pink']
 
-##### Get runs
+##### Get test names
 sel_runs=runs
-tests=list(set([run['test'].rsplit('/',1)[-1].rsplit('.sh',1)[0]
-                for run in sel_runs]))
+tests=list(sel_runs.test.unique())
 test=tests[0]
 
 ##### Run information
@@ -60,37 +58,35 @@ print('Using test:', test)
 if 'CEED Benchmark Problem' in test:
    test_short = 'bp' + test.strip().split(' ')[-1]
 
-sel_runs=[run for run in sel_runs if
-          run['test'].rsplit('/',1)[-1].rsplit('.sh',1)[0]==test]
+##### Plot same BP
+sel_runs=sel_runs.loc[sel_runs['test'] == test]
 
-if 'case' in sel_runs[0]:
-   cases=list(set([run['case'] for run in sel_runs]))
-   case=cases[0]
-   vdim=1 if case=='scalar' else 3
-   print('Using case:', case)
-   sel_runs=[run for run in sel_runs if run['case']==case]
+##### Plot same case (scalar vs vector)
+cases=list(sel_runs.case.unique())
+case=cases[0]
+vdim=1 if case=='scalar' else 3
+print('Using case:', case)
+sel_runs=sel_runs.loc[sel_runs['case'] == case]
 
-codes = list(set([run['code'] for run in sel_runs]))
+##### Plot same 'code'
+codes = list(sel_runs.code.unique())
 code  = codes[0]
-sel_runs=[run for run in sel_runs if run['code']==code]
+sel_runs=sel_runs.loc[sel_runs['code'] == code]
 
-##### Group plots
-pl_set=[(run['backend'],run['num-procs'],run['num-procs-node'])
-        for run in sel_runs]
-pl_set=sorted(set(pl_set))
-print()
+##### Group plots by backend and number of processes
+pl_set=sel_runs[['backend', 'num_procs', 'num_procs_node']]
+pl_set=pl_set.drop_duplicates()
 
 ##### Plotting
-for plt in pl_set:
-   backend=plt[0]
-   num_procs=plt[1]
-   num_procs_node=plt[2]
+for index, row in pl_set.iterrows():
+   backend=row['backend']
+   num_procs=float(row['num_procs'])
+   num_procs_node=float(row['num_procs_node'])
    num_nodes=num_procs/num_procs_node
-   pl_runs=[run for run in sel_runs
-            if run['backend']==backend and
-               run['num-procs']==num_procs and
-               run['num-procs-node']==num_procs_node]
-   if len(pl_runs)==0:
+   pl_runs=sel_runs[(sel_runs.backend==backend) |
+                    (sel_runs.num_procs==num_procs) |
+                    (sel_runs.num_procs_node==num_procs_node)]
+   if len(pl_runs.index)==0:
       continue
 
    print('backend: %s, compute nodes: %i, number of MPI tasks = %i'%(
@@ -98,19 +94,20 @@ for plt in pl_set:
 
    figure()
    i=0
-   sol_p_set=sorted(set([run['order'] for run in pl_runs]))
+   sol_p_set=sel_runs['order'].drop_duplicates()
+   sol_p_set=sol_p_set.sort_values()
+   ##### Iterate over P
    for sol_p in sol_p_set:
-      qpts=sorted(list(set([run['quadrature-pts'] for run in pl_runs
-                            if run['order']==sol_p])))
-      qpts.reverse()
-      print('Order: %i, quadrature points:'%sol_p, qpts)
-      qpts_1d=[int(q**(1./3)+0.5) for q in qpts]
-
-      d=[[run['order'],run['num-elem'],1.*run['num-unknowns']/num_nodes/vdim,
-          run['cg-iteration-dps']/num_nodes]
-         for run in pl_runs
-         if run['order']==sol_p and
-            run['quadrature-pts']==qpts[0]]
+      qpts=sel_runs['quadrature_pts'].loc[pl_runs['order']==sol_p]
+      qpts=qpts.drop_duplicates().sort_values(ascending=False)
+      qpts=qpts.reset_index(drop=True)
+      print('Order: %i, quadrature points:'%sol_p, qpts[0])
+      # Generate plot data
+      d=[[run['order'],run['num_elem'],1.*run['num_unknowns']/num_nodes/vdim,
+          run['cg_iteration_dps']/num_nodes]
+         for index, run in
+         pl_runs.loc[(pl_runs['order']==sol_p) |
+                     (pl_runs['quadrature_pts']==qpts[0])].iterrows()]
       d=[[e[2],e[3]] for e in d if e[0]==sol_p]
       # (DOFs/[sec/iter]/node)/(DOFs/node) = iter/sec
       d=[[nun,
@@ -118,19 +115,22 @@ for plt in pl_set:
           max([e[1] for e in d if e[0]==nun])]
          for nun in set([e[0] for e in d])]
       d=asarray(sorted(d))
+      # Plot
       plot(d[:,0],d[:,2],'o-',color=colors[i%cm_size],
            label='p=%i'%(sol_p-1))
       if list(d[:,1]) != list(d[:,2]):
          plot(d[:,0],d[:,1],'o-',color=colors[i])
          fill_between(d[:,0],d[:,1],d[:,2],facecolor=colors[i],alpha=0.2)
-      ##
+      # Continue if only 1 set of qpts
       if len(qpts)==1:
          i=i+1
          continue
-      d=[[run['order'],run['num-elem'],1.*run['num-unknowns']/num_nodes/vdim,
-          run['cg-iteration-dps']/num_nodes]
-         for run in pl_runs
-         if run['order']==sol_p and (run['quadrature-pts']==qpts[1])]
+      # Second set of qpts
+      d=[[run['order'],run['num_elem'],1.*run['num_unknowns']/num_nodes/vdim,
+          run['cg_iteration_dps']/num_nodes]
+         for index, run in
+         pl_runs.loc[(pl_runs['order']==sol_p) |
+                     (pl_runs['quadrature_pts']==qpts[1])].iterrows()]
       d=[[e[2],e[3]] for e in d if e[0]==sol_p]
       if len(d)==0:
          i=i+1
@@ -155,6 +155,7 @@ for plt in pl_set:
       plot(y/slope1,y,'k--',label='%g iter/s'%(slope1/vdim))
       plot(y/slope2,y,'k-',label='%g iter/s'%(slope2/vdim))
 
+   # Plot information
    title('(%i node%s, %i tasks/node), %s, %s'%(
          num_nodes,'' if num_nodes==1 else 's',
          num_procs_node,backend,test_short))
@@ -172,6 +173,7 @@ for plt in pl_set:
    ylabel('[DOFs x CG iterations] / [compute nodes x seconds]')
    legend(ncol=legend_ncol, loc='best')
 
+   # Write
    if write_figures: # write .pdf file?
       shortbackend=backend.replace('/','')
       pdf_file='plot_%s_%s_%s_N%03i_pn%i.pdf'%(
@@ -180,5 +182,5 @@ for plt in pl_set:
       savefig(pdf_file, format='pdf', bbox_inches='tight')
 
 if show_figures: # show the figures?
-   print('\nshowing figures ...')
+   print('\nShowing figures ...')
    show()

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -119,7 +119,7 @@ for plt in pl_set:
          for nun in set([e[0] for e in d])]
       d=asarray(sorted(d))
       plot(d[:,0],d[:,2],'o-',color=colors[i%cm_size],
-           label='p=%i'%(sol_p))
+           label='p=%i'%(sol_p-1))
       if list(d[:,1]) != list(d[:,2]):
          plot(d[:,0],d[:,1],'o-',color=colors[i])
          fill_between(d[:,0],d[:,1],d[:,2],facecolor=colors[i],alpha=0.2)
@@ -141,7 +141,7 @@ for plt in pl_set:
          for nun in set([e[0] for e in d])]
       d=asarray(sorted(d))
       plot(d[:,0],d[:,2],'s--',color=colors[i],
-           label='p=%i, q=p+%i'%(sol_p,qpts_1d[1]-sol_p))
+           label='p=%i'%(sol_p-1))
       if list(d[:,1]) != list(d[:,2]):
          plot(d[:,0],d[:,1],'s--',color=colors[i])
       ##

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -156,7 +156,7 @@ for index, row in pl_set.iterrows():
       plot(y/slope2,y,'k-',label='%g iter/s'%(slope2/vdim))
 
    # Plot information
-   title('(%i node%s, %i tasks), %s, %s'%(
+   title('(%i node%s, %i ranks), %s, %s'%(
          num_nodes,'' if num_nodes==1 else 's',
          num_procs,backend,test_short))
    xscale('log') # subsx=[2,4,6,8]

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -156,9 +156,9 @@ for index, row in pl_set.iterrows():
       plot(y/slope2,y,'k-',label='%g iter/s'%(slope2/vdim))
 
    # Plot information
-   title('(%i node%s, %i ranks), %s, %s'%(
+   title(r'%i node%s $\times$ %i ranks, %s, %s'%(
          num_nodes,'' if num_nodes==1 else 's',
-         num_procs,backend,test_short))
+         num_procs,backend,test_short),fontsize=16)
    xscale('log') # subsx=[2,4,6,8]
    if log_y:
       yscale('log')
@@ -168,10 +168,13 @@ for index, row in pl_set.iterrows():
       ylim(y_range)
    grid('on', color='gray', ls='dotted')
    grid('on', axis='both', which='minor', color='gray', ls='dotted')
+   plt.tick_params(labelsize=14)
+   exptext = gca().yaxis.get_offset_text()
+   exptext.set_size(14)
    gca().set_axisbelow(True)
-   xlabel('Points per compute node')
-   ylabel('[DOFs x CG iterations] / [compute nodes x seconds]')
-   legend(ncol=legend_ncol, loc='best')
+   xlabel('Points per compute node',fontsize=14)
+   ylabel('[DOFs x CG iterations] / [compute nodes x seconds]',fontsize=14)
+   legend(ncol=legend_ncol, loc='best',fontsize=13)
 
    # Write
    if write_figures: # write .pdf file?

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -56,7 +56,7 @@ test=tests[0]
 print('Using test:', test)
 
 if 'CEED Benchmark Problem' in test:
-   test_short = 'bp' + test.strip().split(' ')[-1]
+   test_short = test.strip().split()[0] + ' BP' + test.strip().split()[-1]
 
 ##### Plot same BP
 sel_runs=sel_runs.loc[sel_runs['test'] == test]
@@ -156,9 +156,9 @@ for index, row in pl_set.iterrows():
       plot(y/slope2,y,'k-',label='%g iter/s'%(slope2/vdim))
 
    # Plot information
-   title('(%i node%s, %i tasks/node), %s, %s'%(
+   title('(%i node%s, %i tasks), %s, %s'%(
          num_nodes,'' if num_nodes==1 else 's',
-         num_procs_node,backend,test_short))
+         num_procs,backend,test_short))
    xscale('log') # subsx=[2,4,6,8]
    if log_y:
       yscale('log')
@@ -175,9 +175,10 @@ for index, row in pl_set.iterrows():
 
    # Write
    if write_figures: # write .pdf file?
-      shortbackend=backend.replace('/','')
+      short_backend=backend.replace('/','')
+      test_short_save=test_short.replace(' ','')
       pdf_file='plot_%s_%s_%s_N%03i_pn%i.pdf'%(
-               code,test_short,shortbackend,num_nodes,num_procs_node)
+               code,test_short_save,short_backend,num_nodes,num_procs_node)
       print('\nsaving figure --> %s'%pdf_file)
       savefig(pdf_file, format='pdf', bbox_inches='tight')
 

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -56,7 +56,10 @@ test=tests[0]
 
 ##### Run information
 print('Using test:', test)
-test_short=test
+
+if 'CEED Benchmark Problem' in test:
+   test_short = 'bp' + test.strip().split(' ')[-1]
+
 sel_runs=[run for run in sel_runs if
           run['test'].rsplit('/',1)[-1].rsplit('.sh',1)[0]==test]
 
@@ -152,8 +155,8 @@ for plt in pl_set:
       plot(y/slope1,y,'k--',label='%g iter/s'%(slope1/vdim))
       plot(y/slope2,y,'k-',label='%g iter/s'%(slope2/vdim))
 
-   title('Config: %s (%i node%s, %i tasks/node), %s, %s'%(
-         code,num_nodes,'' if num_nodes==1 else 's',
+   title('(%i node%s, %i tasks/node), %s, %s'%(
+         num_nodes,'' if num_nodes==1 else 's',
          num_procs_node,backend,test_short))
    xscale('log') # subsx=[2,4,6,8]
    if log_y:

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -158,7 +158,7 @@ for index, row in pl_set.iterrows():
    # Plot information
    title(r'%i node%s $\times$ %i ranks, %s, %s'%(
          num_nodes,'' if num_nodes==1 else 's',
-         num_procs,backend,test_short),fontsize=16)
+         num_procs_node,backend,test_short),fontsize=16)
    xscale('log') # subsx=[2,4,6,8]
    if log_y:
       yscale('log')

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -32,7 +32,6 @@ exec(compile(open('postprocess-base.py').read(), 'postprocess-base.py', 'exec'))
 
 
 #####   Sample plot output
-
 from matplotlib import use
 if not show_figures:
    use('pdf')
@@ -49,15 +48,13 @@ elif 'colors' in cm.__dict__:
    cm_size=len(cm.__dict__['colors'])
 colors=[cm(1.*i/(cm_size-1)) for i in range(cm_size)]
 
-# colors=['blue','green','crimson','turquoise','m','gold','cornflowerblue',
-#         'darkorange']
-
+##### Get runs
 sel_runs=runs
-
 tests=list(set([run['test'].rsplit('/',1)[-1].rsplit('.sh',1)[0]
                 for run in sel_runs]))
-# print 'Present tests:', tests
 test=tests[0]
+
+##### Run information
 print('Using test:', test)
 test_short=test
 sel_runs=[run for run in sel_runs if
@@ -74,12 +71,13 @@ codes = list(set([run['code'] for run in sel_runs]))
 code  = codes[0]
 sel_runs=[run for run in sel_runs if run['code']==code]
 
+##### Group plots
 pl_set=[(run['backend'],run['num-procs'],run['num-procs-node'])
         for run in sel_runs]
 pl_set=sorted(set(pl_set))
 print()
-pprint.pprint(pl_set)
 
+##### Plotting
 for plt in pl_set:
    backend=plt[0]
    num_procs=plt[1]
@@ -92,7 +90,6 @@ for plt in pl_set:
    if len(pl_runs)==0:
       continue
 
-   print()
    print('backend: %s, compute nodes: %i, number of MPI tasks = %i'%(
       backend,num_nodes,num_procs))
 
@@ -111,9 +108,6 @@ for plt in pl_set:
          for run in pl_runs
          if run['order']==sol_p and
             run['quadrature-pts']==qpts[0]]
-      # print
-      # print 'order = %i'%sol_p
-      # pprint.pprint(sorted(d))
       d=[[e[2],e[3]] for e in d if e[0]==sol_p]
       # (DOFs/[sec/iter]/node)/(DOFs/node) = iter/sec
       d=[[nun,
@@ -168,10 +162,6 @@ for plt in pl_set:
       xlim(x_range)
    if 'y_range' in vars() and len(y_range)==2:
       ylim(y_range)
-   # rng=arange(1e7,1.02e8,1e7)
-   # yticks(rng,['%i'%int(v/1e6) for v in rng])
-   # ylim(min(rng),max(rng))
-   # xlim(0.5,max([run['order'] for run in pl_runs])+0.5)
    grid('on', color='gray', ls='dotted')
    grid('on', axis='both', which='minor', color='gray', ls='dotted')
    gca().set_axisbelow(True)
@@ -183,7 +173,7 @@ for plt in pl_set:
       shortbackend=backend.replace('/','')
       pdf_file='plot_%s_%s_%s_N%03i_pn%i.pdf'%(
                code,test_short,shortbackend,num_nodes,num_procs_node)
-      print('saving figure --> %s'%pdf_file)
+      print('\nsaving figure --> %s'%pdf_file)
       savefig(pdf_file, format='pdf', bbox_inches='tight')
 
 if show_figures: # show the figures?

--- a/benchmarks/postprocess-table.py
+++ b/benchmarks/postprocess-table.py
@@ -15,23 +15,12 @@
 # testbed platforms, in support of the nation's exascale computing imperative.
 
 
-#####   Load the data
+##### Load the data
+import pandas as pd
 exec(compile(open('postprocess-base.py').read(), 'postprocess-base.py', 'exec'))
 
 
-#####   Sample data output
-
-set1=sorted(
-   [(run['backend'],run['order'],run['quadrature-pts'],run['num-procs'],
-     run['num-unknowns'],run['cg-iteration-dps']/1e6,
-     1.*run['num-elem']*run['quadrature-pts']/run['num-unknowns'])
-    for run in runs])
-
-out.write('''\
-                    |    | quad |     | number of | cg-iter dps | qpts per
-       backend      |  p |  pts |  np |  unknowns |   millions  |  unknown
---------------------+----+------+-----+-----------+-------------+---------
-''')
-line_fmt=' %-18s | %2i | %4i | %3i | %9i | %11.6f | %7.4f\n'
-for run in set1:
-   out.write(line_fmt%run)
+##### Data output
+print('Writing data to \'benchmark_data.csv\'...')
+runs.to_csv('benchmark_data.csv', sep='\t', index=False)
+print('Writing complete')

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -380,6 +380,8 @@ int main(int argc, char **argv) {
                          "Target number of locally owned degrees of freedom per process",
                          NULL, localdof, &localdof, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  P = degree + 1;
+  Q = P + qextra;
 
   // Determine size of process grid
   ierr = MPI_Comm_size(comm, &size); CHKERRQ(ierr);
@@ -410,13 +412,21 @@ int main(int argc, char **argv) {
   if (!test_mode) {
     CeedInt gsize;
     ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
-    ierr = PetscPrintf(comm, "Global dofs: %D\n", gsize/vscale); CHKERRQ(ierr);
-    ierr = PetscPrintf(comm, "Process decomposition: %D %D %D\n",
-                       p[0], p[1], p[2]); CHKERRQ(ierr);
-    ierr = PetscPrintf(comm, "Local elements: %D = %D %D %D\n", localelem,
-                       melem[0], melem[1], melem[2]); CHKERRQ(ierr);
-    ierr = PetscPrintf(comm, "Owned dofs: %D = %D %D %D\n",
-                       mdof[0]*mdof[1]*mdof[2], mdof[0], mdof[1], mdof[2]); CHKERRQ(ierr);
+    ierr = PetscPrintf(comm,
+                       "\n-- CEED Benchmark Problem %d -- libCEED + PETSc --\n"
+                       "  libCEED:\n"
+                       "    libCEED backend                    : %s\n"
+                       "  Mesh:\n"
+                       "    Number of 1D Basis Nodes (p)       : %d\n"
+                       "    Number of 1D Quadrature Points (q) : %d\n"
+                       "    Global DOFs                        : %D\n"
+                       "    Process Decomposition              : %D %D %D\n"
+                       "    Local Elements                     : %D = %D %D %D\n"
+                       "    Owned DOFs                         : %D = %D %D %D\n",
+                       bpChoice+1, ceedresource, P, Q,  gsize/vscale, p[0],
+                       p[1], p[2], localelem, melem[0], melem[1], melem[2],
+                       mdof[0]*mdof[1]*mdof[2], mdof[0], mdof[1], mdof[2]);
+    CHKERRQ(ierr);
   }
 
   {
@@ -507,8 +517,6 @@ int main(int argc, char **argv) {
 
   // Set up libCEED
   CeedInit(ceedresource, &ceed);
-  P = degree + 1;
-  Q = P + qextra;
   CeedBasisCreateTensorH1Lagrange(ceed, 3, vscale, P, Q, CEED_GAUSS, &basisu);
   CeedBasisCreateTensorH1Lagrange(ceed, 3, 3, 2, Q, CEED_GAUSS, &basisx);
 
@@ -708,8 +716,14 @@ int main(int argc, char **argv) {
     ierr = KSPGetIterationNumber(ksp, &its); CHKERRQ(ierr);
     ierr = KSPGetResidualNorm(ksp, &rnorm); CHKERRQ(ierr);
     if (!test_mode || reason < 0 || rnorm > 1e-8) {
-      ierr = PetscPrintf(comm, "KSP %s %s iterations %D rnorm %e\n", ksptype,
-                         KSPConvergedReasons[reason], its, (double)rnorm); CHKERRQ(ierr);
+      ierr = PetscPrintf(comm,
+                         "  KSP:\n"
+                         "    KSP Type                           : %s\n"
+                         "    KSP Convergence                    : %s\n"
+                         "    Total KSP Iterations               : %D\n"
+                         "    Final rnorm                        : %e\n",
+                         ksptype, KSPConvergedReasons[reason], its,
+                         (double)rnorm); CHKERRQ(ierr);
     }
     if (benchmark_mode && (!test_mode)) {
       CeedInt gsize;
@@ -717,11 +731,11 @@ int main(int argc, char **argv) {
       MPI_Reduce(&my_rt, &rt_min, 1, MPI_DOUBLE, MPI_MIN, 0, comm);
       MPI_Reduce(&my_rt, &rt_max, 1, MPI_DOUBLE, MPI_MAX, 0, comm);
       ierr = PetscPrintf(comm,
-                         "CG solve time  : %g (%g) sec.\n"
-                         "DOFs/sec in CG : %g (%g) million.\n",
-                         rt_max, rt_min,
-                         1e-6*gsize*its/rt_max, 1e-6*gsize*its/rt_min);
-      CHKERRQ(ierr);
+                         "  Performance:\n"
+                         "    CG Solve Time                      : %g (%g) sec\n"
+                         "    DOFs/Sec in CG                     : %g (%g) million\n",
+                         rt_max, rt_min, 1e-6*gsize*its/rt_max,
+                         1e-6*gsize*its/rt_min); CHKERRQ(ierr);
     }
   }
 
@@ -730,8 +744,9 @@ int main(int argc, char **argv) {
     ierr = ComputeErrorMax(user, op_error, X, target, &maxerror); CHKERRQ(ierr);
     PetscReal tol = (bpChoice == CEED_BP1 || bpChoice == CEED_BP2) ? 5e-3 : 5e-2;
     if (!test_mode || maxerror > tol) {
-      ierr = PetscPrintf(comm, "Pointwise error (max) %e\n", (double)maxerror);
-      CHKERRQ(ierr);
+      ierr = PetscPrintf(comm,
+                         "    Pointwise Error (max)              : %e\n",
+                         (double)maxerror); CHKERRQ(ierr);
     }
   }
 

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -415,7 +415,7 @@ int main(int argc, char **argv) {
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc --\n"
                        "  libCEED:\n"
-                       "    libCEED backend                    : %s\n"
+                       "    libCEED Backend                    : %s\n"
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"


### PR DESCRIPTION
This PR starts to improve the `petsc-bps` output. See #263. Please feel free to add more commits to this branch.

Sample output:
```
[jeremy@pheonix libCEED]$ ./build/petsc-bps -problem BP6 -ceed /cpu/self/avx/blocked -benchmark -degree 7 -qextra 3

CEED Benchmark Problem 6:
  backend        : /cpu/self/avx/blocked
  p              : 8
  q              : 11
  Global dofs    : 960
  Process decomp : 1 1 1
  Local elements : 2 = 1 1 2
  Owned dofs     : 960 = 8 8 15
  KSP cg DIVERGED_ITS iterations 20 rnorm 6.241902e-04
  CG solve time  : 0.0377591 (0.0377591) sec.
  DOFs/sec in CG : 1.52546 (1.52546) million.
  Pointwise error (max) 4.921658e-04
```