### PR TITLE
Add -include directive to Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,4 +500,30 @@ print-% :
 	$(info )
 	@true
 
+# "make configure" will autodetect any variables not passed on the
+# command line, caching the result in config.mk to be used on any
+# subsequent invocations of make.  For example,
+#
+#   make configure CC=/path/to/my/cc CUDA_DIR=/opt/cuda
+#   make
+#   make prove
+configure :
+	@echo "CC = $(CC)" | tee config.mk
+	@echo "FC = $(FC)" | tee config.mk
+	@echo "NVCC = $(NVCC)" | tee config.mk
+	@echo "CFLAGS = $(CFLAGS)" | tee -a config.mk
+	@echo "CPPFLAGS = $(CPPFLAGS)" | tee -a config.mk
+	@echo "FFLAGS = $(FFLAGS)" | tee -a config.mk
+	@echo "LDFLAGS = $(LDFLAGS)" | tee -a config.mk
+	@echo "LDLIBS = $(LDLIBS)" | tee -a config.mk
+	@echo "MAGMA_DIR = $(MAGMA_DIR)" | tee -a config.mk
+	@echo "XSMM_DIR = $(XSMM_DIR)" | tee -a config.mk
+	@echo "CUDA_DIR = $(CUDA_DIR)" | tee -a config.mk
+	@echo "MFEM_DIR = $(MFEM_DIR)" | tee -a config.mk
+	@echo "PETSC_DIR = $(PETSC_DIR)" | tee -a config.mk
+	@echo "NEK5K_DIR = $(NEK5K_DIR)" | tee -a config.mk
+	@echo "Configuration cached in config.mk"
+
+.PHONY : configure
+
 -include $(libceed.c:%.c=$(OBJDIR)/%.d) $(tests.c:tests/%.c=$(OBJDIR)/%.d)

--- a/Makefile
+++ b/Makefile
@@ -508,9 +508,10 @@ print-% :
 #   make
 #   make prove
 configure :
-	@echo "CC = $(CC)" | tee config.mk
-	@echo "FC = $(FC)" | tee config.mk
-	@echo "NVCC = $(NVCC)" | tee config.mk
+	@: > config.mk
+	@echo "CC = $(CC)" | tee -a config.mk
+	@echo "FC = $(FC)" | tee -a config.mk
+	@echo "NVCC = $(NVCC)" | tee -a config.mk
 	@echo "CFLAGS = $(CFLAGS)" | tee -a config.mk
 	@echo "CPPFLAGS = $(CPPFLAGS)" | tee -a config.mk
 	@echo "FFLAGS = $(FFLAGS)" | tee -a config.mk

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 ifeq (,$(filter-out undefined default,$(origin FC)))
   FC = gfortran
 endif
-NVCC = $(CUDA_DIR)/bin/nvcc
+NVCC ?= $(CUDA_DIR)/bin/nvcc
 
 # ASAN must be left empty if you don't want to use it
 ASAN ?=
@@ -469,10 +469,10 @@ cln clean :
 	$(RM) -r $(OBJDIR) $(LIBDIR)
 	$(MAKE) -C examples clean
 	$(RM) $(magma_tmp.c) $(magma_tmp.cu) backends/magma/*~ backends/magma/*.o
-	$(RM) -rf benchmarks/*output.txt
+	$(RM) benchmarks/*output.txt
 
 distclean : clean
-	$(RM) -r doc/html
+	$(RM) -r doc/html config.mk
 
 doc :
 	doxygen Doxyfile

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
+-include config.mk
+
 ifeq (,$(filter-out undefined default,$(origin CC)))
   CC = gcc
 endif

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,7 @@ The supplied examples solve *_A_ u = f*, where *_A_* is the Poisson operator.
 
 Bakeoff problem 4 is the Poisson problem on a vector system.
 
-The supplied examples solve *_A_ _u_ = f*, where *_A_* is the Poisson operator.
+The supplied examples solve *_A_ _u_ = f*, where *_A_* is the Laplace operator for the Poisson equation.
 
 ## Navier-Stokes Solver
 


### PR DESCRIPTION
Added -include directive to top-level Makefile to allow easy import of custom build configurations (harmless if file config.mk does not exist)