### PR TITLE
Add Identity QFunctions

### DIFF
--- a/gallery/ceed-gallerytemplate.h
+++ b/gallery/ceed-gallerytemplate.h
@@ -16,8 +16,8 @@
 
 /**
  This file is not compiled into libCEED. This file provides a template to
-   build additional gallery QFunctions. Copy this file and the registeration/
-   initalization .c file to a new folder in this directory and modify.
+   build additional gallery QFunctions. Copy this file and the registration/
+   initialization .c file to a new folder in this directory and modify.
 **/
 
 /**

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <string.h>
+#include "ceed-backend.h"
+#include "ceed-identity.h"
+
+/**
+ This file is not compiled into libCEED. This file provides a template to
+   build additional gallery QFunctions. Copy this file and the header to a
+   new folder in this directory and modify.
+**/
+
+/**
+  @brief Set fields for new Ceed QFunction
+**/
+static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
+    CeedQFunction qf) {
+  int ierr;
+
+  // Check QFunction name
+  const char *name = "Identity";
+  if (strcmp(name, requested))
+    return CeedError(ceed, 1, "QFunction '%s' does not match requested name: %s",
+                     name, requested);
+
+  // Add QFunction fields
+  ierr = CeedQFunctionAddInput(qf, "input", 1, CEED_EVAL_INTERP); CeedChk(ierr);
+  ierr = CeedQFunctionAddOutput(qf, "output", 1, CEED_EVAL_INTERP);
+  CeedChk(ierr);
+
+  return 0;
+}
+
+/**
+  @brief Register new Ceed QFunction
+**/
+__attribute__((constructor))
+static void Register(void) {
+  CeedQFunctionRegister("Identity", Identity_loc, 1, Identity,
+                        CeedQFunctionInit_Identity);
+}

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -19,13 +19,7 @@
 #include "ceed-identity.h"
 
 /**
- This file is not compiled into libCEED. This file provides a template to
-   build additional gallery QFunctions. Copy this file and the header to a
-   new folder in this directory and modify.
-**/
-
-/**
-  @brief Set fields for new Ceed QFunction
+  @brief Set fields identity QFunction that copies inputs directly into outputs
 **/
 static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
     CeedQFunction qf) {
@@ -46,7 +40,7 @@ static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
 }
 
 /**
-  @brief Register new Ceed QFunction
+  @brief Register identity QFunction that copies inputs directly into outputs
 **/
 __attribute__((constructor))
 static void Register(void) {

--- a/gallery/identity/ceed-identity.h
+++ b/gallery/identity/ceed-identity.h
@@ -27,7 +27,7 @@ CEED_QFUNCTION(Identity)(void *ctx, const CeedInt Q,
                          const CeedScalar *const *in,
                          CeedScalar *const *out) {
   // Ctx holds field size
-  const CeedInt size = *(CeedInt *)ctx;
+  const CeedInt size = ctx ? *(CeedInt *)ctx : 1;
 
   // in[0] is input, size (Q*size)
   const CeedScalar *input = in[0];

--- a/gallery/identity/ceed-identity.h
+++ b/gallery/identity/ceed-identity.h
@@ -15,13 +15,7 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 
 /**
- This file is not compiled into libCEED. This file provides a template to
-   build additional gallery QFunctions. Copy this file and the registeration/
-   initalization .c file to a new folder in this directory and modify.
-**/
-
-/**
-  @brief New Ceed QFunction
+  @brief  Identity QFunction that copies inputs directly into outputs
 **/
 CEED_QFUNCTION(Identity)(void *ctx, const CeedInt Q,
                          const CeedScalar *const *in,

--- a/gallery/identity/ceed-identity.h
+++ b/gallery/identity/ceed-identity.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+/**
+ This file is not compiled into libCEED. This file provides a template to
+   build additional gallery QFunctions. Copy this file and the registeration/
+   initalization .c file to a new folder in this directory and modify.
+**/
+
+/**
+  @brief New Ceed QFunction
+**/
+CEED_QFUNCTION(Identity)(void *ctx, const CeedInt Q,
+                         const CeedScalar *const *in,
+                         CeedScalar *const *out) {
+  // Ctx holds field size
+  const CeedInt size = *(CeedInt *)ctx;
+
+  // in[0] is input, size (Q*size)
+  const CeedScalar *input = in[0];
+  // out[0] is output, size (Q*size)
+  CeedScalar *output = out[0];
+
+  // Quadrature point loop
+  CeedPragmaSIMD
+  for (CeedInt i=0; i<Q*size; i++) {
+    output[i] = input[i];
+  } // End of Quadrature Point Loop
+
+  return 0;
+}

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -142,6 +142,8 @@ CEED_EXTERN int CeedQFunctionGetContext(CeedQFunction qf, void* *ctx);
 CEED_EXTERN int CeedQFunctionGetInnerContext(CeedQFunction qf, void* *ctx);
 CEED_EXTERN int CeedQFunctionGetFortranStatus(CeedQFunction qf,
     bool *fortranstatus);
+CEED_EXTERN int CeedQFunctionGetIdentityStatus(CeedQFunction qf,
+    bool *identity);
 CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void* *data);
 CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void* *data);
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -163,6 +163,7 @@ struct CeedQFunction_private {
   const char *sourcepath;
   const char *qfname;
   bool fortranstatus;
+  bool identity;
   void *ctx;      /* user context for function */
   size_t ctxsize; /* size of user context; may be used to copy to a device */
   void *data;     /* backend data */

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -358,6 +358,8 @@ CEED_EXTERN int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
     CeedQFunctionUser f, const char *source, CeedQFunction *qf);
 CEED_EXTERN int CeedQFunctionCreateInteriorByName(Ceed ceed, const char *name,
     CeedQFunction *qf);
+CEED_EXTERN int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size,
+                                            CeedQFunction *qf);
 CEED_EXTERN int CeedQFunctionAddInput(CeedQFunction qf, const char *fieldname,
                                       CeedInt size, CeedEvalMode emode);
 CEED_EXTERN int CeedQFunctionAddOutput(CeedQFunction qf, const char *fieldname,

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -577,6 +577,23 @@ void fCeedQFunctionCreateInteriorByName(int *ceed, const char *name, int *qf,
   }
 }
 
+#define fCeedQFunctionCreateIdentity \
+    FORTRAN_NAME(ceedqfunctioncreateidentity, CEEDQFUNCTIONCREATEIDENTITY)
+void fCeedQFunctionCreateIdentity(int *ceed, int *size, int *qf, int *err) {
+  if (CeedQFunction_count == CeedQFunction_count_max) {
+    CeedQFunction_count_max += CeedQFunction_count_max/2 + 1;
+    CeedRealloc(CeedQFunction_count_max, &CeedQFunction_dict);
+  }
+
+  CeedQFunction *qf_ = &CeedQFunction_dict[CeedQFunction_count];
+  *err = CeedQFunctionCreateIdentity(Ceed_dict[*ceed], *size, qf_);
+
+  if (*err == 0) {
+    *qf = CeedQFunction_count++;
+    CeedQFunction_n++;
+  }
+}
+
 #define fCeedQFunctionAddInput \
     FORTRAN_NAME(ceedqfunctionaddinput,CEEDQFUNCTIONADDINPUT)
 void fCeedQFunctionAddInput(int *qf, const char *fieldname,

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -25,7 +25,9 @@
 ///   @{
 
 /**
-  @brief Create an operator from element restriction, basis, and QFunction
+  @brief Create a CeedOperator and associate a CeedQFunction. A CeedBasis and
+           CeedElemRestriction can be associated with CeedQFunction fields with
+           \ref CeedOperatorSetField.
 
   @param ceed    A Ceed object where the CeedOperator will be created
   @param qf      QFunction defining the action of the operator at quadrature points

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -166,7 +166,12 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
 
 /**
   @brief Create an identity CeedQFunction. Inputs are written into outputs in
-           the order given.
+           the order given. This is useful for CeedOperators of the form
+           A = G^T B^T I B G. These operators can be represented with only the
+           action of a CeedRestriction and CeedBasis, such as restriction and
+           prolongation operators for p-multigrid. Backends may optimize
+           CeedOperators with this CeedQFunction to avoid the copy of input data
+           to output fields by using the same memory location for both.
 
   @param ceed       A Ceed object where the CeedQFunction will be created
   @param size       Size of the qfunction fields
@@ -622,7 +627,7 @@ int CeedQFunctionDestroy(CeedQFunction *qf) {
   ierr = CeedFree(&(*qf)->inputfields); CeedChk(ierr);
   ierr = CeedFree(&(*qf)->outputfields); CeedChk(ierr);
   // Free ctx if identity
-  if ((*qf)->identity && (*qf)->ctx) {
+  if ((*qf)->identity) {
     ierr = CeedFree(&(*qf)->ctx); CeedChk(ierr);
   }
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -183,10 +183,12 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedQFunction *qf) {
   ierr = CeedQFunctionCreateInteriorByName(ceed, "Identity", qf); CeedChk(ierr);
 
   (*qf)->identity = 1;
-  CeedInt *ctx;
-  ierr = CeedCalloc(1, &ctx); CeedChk(ierr);
-  ctx[0] = size;
-  ierr = CeedQFunctionSetContext(*qf, ctx, sizeof(ctx)); CeedChk(ierr);
+  if (size > 1) {
+    CeedInt *ctx;
+    ierr = CeedCalloc(1, &ctx); CeedChk(ierr);
+    ctx[0] = size;
+    ierr = CeedQFunctionSetContext(*qf, ctx, sizeof(ctx)); CeedChk(ierr);
+  }
 
   return 0;
 }
@@ -619,6 +621,10 @@ int CeedQFunctionDestroy(CeedQFunction *qf) {
   }
   ierr = CeedFree(&(*qf)->inputfields); CeedChk(ierr);
   ierr = CeedFree(&(*qf)->outputfields); CeedChk(ierr);
+  // Free ctx if identity
+  if ((*qf)->identity && (*qf)->ctx) {
+    ierr = CeedFree(&(*qf)->ctx); CeedChk(ierr);
+  }
 
   ierr = CeedFree(&(*qf)->sourcepath); CeedChk(ierr);
   ierr = CeedDestroy(&(*qf)->ceed); CeedChk(ierr);

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -78,6 +78,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
   ceed->refcount++;
   (*qf)->refcount = 1;
   (*qf)->vlength = vlength;
+  (*qf)->identity = 0;
   (*qf)->function = f;
   ierr = CeedCalloc(strlen(source)+1, &source_copy); CeedChk(ierr);
   strncpy(source_copy, source, strlen(source));
@@ -159,6 +160,33 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
 
   // QFunction specific setup
   ierr = qfunctions[matchidx].init(ceed, name, *qf); CeedChk(ierr);
+
+  return 0;
+}
+
+/**
+  @brief Create an identity CeedQFunction. Inputs are written into outputs in
+           the order given.
+
+  @param ceed       A Ceed object where the CeedQFunction will be created
+  @param size       Size of the qfunction fields
+  @param[out] qf    Address of the variable where the newly created
+                      CeedQFunction will be stored
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Basic
+**/
+int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedQFunction *qf) {
+  int ierr;
+
+  ierr = CeedQFunctionCreateInteriorByName(ceed, "Identity", qf); CeedChk(ierr);
+
+  (*qf)->identity = 1;
+  CeedInt *ctx;
+  ierr = CeedCalloc(1, &ctx); CeedChk(ierr);
+  ctx[0] = size;
+  ierr = CeedQFunctionSetContext(*qf, ctx, sizeof(ctx)); CeedChk(ierr);
 
   return 0;
 }
@@ -377,6 +405,22 @@ int CeedQFunctionGetContext(CeedQFunction qf, void* *ctx) {
 
 int CeedQFunctionGetFortranStatus(CeedQFunction qf, bool *fortranstatus) {
   *fortranstatus = qf->fortranstatus;
+  return 0;
+}
+
+/**
+  @brief Determine if QFunction is identity
+
+  @param qf               CeedQFunction
+  @param[out] identity    Variable to store identity status
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+
+int CeedQFunctionGetIdentityStatus(CeedQFunction qf, bool *identity) {
+  *identity = qf->identity;
   return 0;
 }
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -166,12 +166,12 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
 
 /**
   @brief Create an identity CeedQFunction. Inputs are written into outputs in
-           the order given. This is useful for CeedOperators of the form
-           A = G^T B^T I B G. These operators can be represented with only the
-           action of a CeedRestriction and CeedBasis, such as restriction and
-           prolongation operators for p-multigrid. Backends may optimize
-           CeedOperators with this CeedQFunction to avoid the copy of input data
-           to output fields by using the same memory location for both.
+           the order given. This is useful for CeedOperators that can be
+           represented with only the action of a CeedRestriction and CeedBasis,
+           such as restriction and prolongation operators for p-multigrid.
+           Backends may optimize CeedOperators with this CeedQFunction to avoid
+           the copy of input data to output fields by using the same memory
+           location for both.
 
   @param ceed       A Ceed object where the CeedQFunction will be created
   @param size       Size of the qfunction fields

--- a/tests/t411-qfunction-f.f90
+++ b/tests/t411-qfunction-f.f90
@@ -1,0 +1,53 @@
+!-----------------------------------------------------------------------
+      program test
+
+      include 'ceedf.h'
+
+      integer ceed,err
+      integer u,v
+      integer qf
+      integer q,i
+      parameter(q=8)
+      real*8 uu(q)
+      real*8 vv(q)
+      character arg*32
+      integer*8 uoffset,voffset
+
+      call getarg(1,arg)
+      call ceedinit(trim(arg)//char(0),ceed,err)
+
+      call ceedqfunctioncreateidentity(ceed,1,qf,err)
+
+      do i=0,q-1
+        uu(i+1)=i*i
+      enddo
+
+      call ceedvectorcreate(ceed,q,u,err)
+      uoffset=0
+      call ceedvectorsetarray(u,ceed_mem_host,ceed_use_pointer,uu,uoffset,err)
+      call ceedvectorcreate(ceed,q,v,err)
+      call ceedvectorsetvalue(v,0.d0,err)
+
+      call ceedqfunctionapply(qf,q,u,ceed_null,ceed_null,ceed_null,&
+             &ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,&
+             &ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,&
+             &v,ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,&
+             &ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,ceed_null,&
+             &ceed_null,ceed_null,ceed_null,ceed_null,err)
+
+      call ceedvectorgetarrayread(v,ceed_mem_host,vv,voffset,err)
+      do i=1,q
+        if (abs(vv(i+voffset)-(i-1)*(i-1)) > 1.0D-14) then
+! LCOV_EXCL_START
+          write(*,*) 'v(i)=',vv(i+voffset),', u(i)=',(i-1)*(i-1)
+! LCOV_EXCL_STOP
+        endif
+      enddo
+      call ceedvectorrestorearrayread(v,vv,voffset,err)
+
+      call ceedvectordestroy(u,err)
+      call ceedvectordestroy(v,err)
+      call ceedqfunctiondestroy(qf,err)
+      call ceeddestroy(ceed,err)
+      end
+!-----------------------------------------------------------------------

--- a/tests/t411-qfunction.c
+++ b/tests/t411-qfunction.c
@@ -1,0 +1,47 @@
+/// @file
+/// Test creation, evaluation, and destruction for qfunction by name
+/// \test Test creation, evaluation, and destruction for qfunction by name
+#include <ceed.h>
+#include <math.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector in[16], out[16];
+  CeedVector U, V;
+  CeedQFunction qf;
+  CeedInt Q = 8;
+  const CeedScalar *v;
+  CeedScalar u[Q];
+
+  CeedInit(argv[1], &ceed);
+
+  CeedQFunctionCreateIdentity(ceed, 1, &qf);
+
+  for (CeedInt i=0; i<Q; i++)
+    u[i] = i*i;
+
+  CeedVectorCreate(ceed, Q, &U);
+  CeedVectorSetArray(U, CEED_MEM_HOST, CEED_USE_POINTER, u);
+  CeedVectorCreate(ceed, Q, &V);
+  CeedVectorSetValue(V, 0);
+
+  {
+    in[0] = U;
+    out[0] = V;
+    CeedQFunctionApply(qf, Q, in, out);
+  }
+
+  CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+  for (CeedInt i=0; i<Q; i++)
+    if (fabs(v[i] - u[i])>1E-14)
+      // LCOV_EXCL_START
+      printf("[%d] v %f != u %f\n",i, v[i], u[i]);
+  // LCOV_EXCL_STOP
+  CeedVectorRestoreArrayRead(V, &v);
+
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedQFunctionDestroy(&qf);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/tap.sh
+++ b/tests/tap.sh
@@ -101,9 +101,10 @@ for ((i=0;i<${#backends[@]};++i)); do
         continue
     fi
 
-    # grep to skip tests t410 and ex1 for OCCA' \
+    # grep to skip tests t41*, ex1, and ex2 for OCCA
+    #  This exception will be removed with the OCCA backend overhaul
     if grep -F -q -e 'OklPath' ${output}.err \
-            && [[ "$1" = "t410"* || "$1" = "t411"* || "$1" = "ex"* ]] ; then
+            && [[ "$1" = "t41"* || "$1" = "ex"* ]] ; then
         printf "ok $i0 # SKIP - gallery not supported $1 $backend\n"
         printf "ok $i1 # SKIP - gallery not supported $1 $backend stdout\n"
         printf "ok $i2 # SKIP - gallery not supported $1 $backend stderr\n"

--- a/tests/tap.sh
+++ b/tests/tap.sh
@@ -103,7 +103,7 @@ for ((i=0;i<${#backends[@]};++i)); do
 
     # grep to skip tests t410 and ex1 for OCCA' \
     if grep -F -q -e 'OklPath' ${output}.err \
-            && [[ "$1" = "t410"* || "$1" = "ex"* ]] ; then
+            && [[ "$1" = "t410"* || "$1" = "t411"* || "$1" = "ex"* ]] ; then
         printf "ok $i0 # SKIP - gallery not supported $1 $backend\n"
         printf "ok $i1 # SKIP - gallery not supported $1 $backend stdout\n"
         printf "ok $i2 # SKIP - gallery not supported $1 $backend stderr\n"


### PR DESCRIPTION
This WIP PR adds `CEED_QFUNCTION_IDENTITY` to make restriction/interpolation operators more efficient. For this QFunction, each qfunction infield writes directly into each qfunction outfield.

i.e.
```
static int IdentQF(void *ctx, CeedInt Q,
                   const CeedScalar *const *in, CeedScalar *const *out) {
  const CeedScalar *u = in[0];
  CeedScalar *v = out[0];
  for (CeedInt i=0; i<Q; i++) {
    v[i] = u[i];
  }
  return 0;
}
```
we replicate this without the extra copy for any number of input/output pairs.

TODO:
- ~~Update interface~~
- ~~Add test for CEED_QFUNCTION_IDENTITY~~
- Update OCCA backend
- Update CUDA backends (@YohannDudouit, I will run my ideas by you for this)

This resolves issue #252.