### PR TITLE
Add Grad w/collo Interp mode to CPU backends

### DIFF
--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -141,7 +141,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,
           pre /= P;
           post *= Q;
         }
-      } else if (impl->collointerp) { // DoFs collocated at qpts
+      } else if (impl->collointerp) { // Qpts collocated with nodes
         CeedScalar *grad1d;
         ierr = CeedBasisGetGrad(basis, &grad1d); CeedChk(ierr);
 

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -59,9 +59,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,
       CeedBasis_Ref *impl;
       ierr = CeedBasisGetData(basis, (void *)&impl); CeedChk(ierr);
       if (impl->collointerp) {
-        const CeedInt vsize = nelem*ncomp*ndof;
-        for (CeedInt i = 0; i < vsize; i++)
-        v[i] = u[i];
+        memcpy(v, u, nelem*ncomp*nnodes*sizeof(u[0]));
       } else {
         CeedInt P = P1d, Q = Q1d;
         if (tmode == CEED_TRANSPOSE) {

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -16,9 +16,11 @@
 
 #include <ceed-backend.h>
 #include <string.h>
+#include <math.h>
 
 typedef struct {
-  CeedScalar *colograd1d;
+  CeedScalar *collograd1d;
+  bool collointerp;
 } CeedBasis_Ref;
 
 typedef struct {

--- a/tests/t309-basis-f.f90
+++ b/tests/t309-basis-f.f90
@@ -1,0 +1,139 @@
+!-----------------------------------------------------------------------
+      subroutine eval(dimn,x,rslt)
+      integer dimn
+      real*8 x(3)
+      real*8 rslt
+
+      rslt=tanh(x(1)+0.1)
+      if (dimn>1) then
+        rslt=rslt+atan(x(2)+0.2)
+      endif
+      if (dimn>2) then 
+        rslt=rslt+exp(-(x(3)+0.3)*(x(3)+0.3))
+      endif
+
+      end
+!-----------------------------------------------------------------------
+      program test
+
+      include 'ceedf.h'
+
+      integer ceed,err
+      integer x,xq,u,uq,ones,gtposeones
+      integer bxl,bug
+      integer dimn,d
+      integer i
+      integer p
+      integer q
+      parameter(p=8)
+      parameter(q=8)
+      integer maxdim
+      parameter(maxdim=3)
+      integer qdimnmax
+      parameter(qdimnmax=q**maxdim)
+      integer pdimnmax
+      parameter(pdimnmax=p**maxdim)
+      integer xdimmax
+      parameter(xdimmax=2**maxdim)
+      integer pdimn,qdimn,xdim
+
+      real*8 xx(xdimmax*maxdim)
+      real*8 xxx(maxdim)
+      real*8 xxq(pdimnmax*maxdim)
+      real*8 uuq(qdimnmax*maxdim)
+      real*8 uu(pdimnmax)
+      real*8 ggtposeones(pdimnmax)
+      real*8 sum1
+      real*8 sum2
+      integer dimxqdimn
+      integer*8 uoffset,xoffset,offset1,offset2,offset3
+
+      character arg*32
+
+      call getarg(1,arg)
+      call ceedinit(trim(arg)//char(0),ceed,err)
+
+      do dimn=1,maxdim
+        qdimn=q**dimn
+        pdimn=p**dimn
+        xdim=2**dimn
+        dimxqdimn=dimn*qdimn
+        sum1=0
+        sum2=0
+
+        do d=0,dimn-1
+          do i=1,xdim
+            if ((mod(i-1,2**(dimn-d))/(2**(dimn-d-1))).ne.0) then
+              xx(d*xdim+i)=1
+            else
+              xx(d*xdim+i)=-1
+            endif
+          enddo
+        enddo
+
+        call ceedvectorcreate(ceed,xdim*dimn,x,err)
+        xoffset=0
+        call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,xx,xoffset,err)
+        call ceedvectorcreate(ceed,pdimn*dimn,xq,err)
+        call ceedvectorsetvalue(xq,0.d0,err)
+        call ceedvectorcreate(ceed,pdimn,u,err)
+        call ceedvectorcreate(ceed,qdimn*dimn,uq,err)
+        call ceedvectorsetvalue(uq,0.d0,err)
+        call ceedvectorcreate(ceed,qdimn*dimn,ones,err)
+        call ceedvectorsetvalue(ones,1.d0,err)
+        call ceedvectorcreate(ceed,pdimn,gtposeones,err)
+        call ceedvectorsetvalue(gtposeones,0.d0,err)
+
+        call ceedbasiscreatetensorh1lagrange(ceed,dimn,dimn,2,p,&
+     &   ceed_gauss_lobatto,bxl,err)
+        call ceedbasisapply(bxl,1,ceed_notranspose,ceed_eval_interp,x,xq,err)
+
+        call ceedvectorgetarrayread(xq,ceed_mem_host,xxq,offset1,err)
+        do i=1,pdimn
+          do d=0,dimn-1
+            xxx(d+1)=xxq(d*pdimn+i+offset1)
+          enddo
+          call eval(dimn,xxx,uu(i))
+        enddo
+        call ceedvectorrestorearrayread(xq,xxq,offset1,err)
+        uoffset=0
+        call ceedvectorsetarray(u,ceed_mem_host,ceed_use_pointer,uu,uoffset,err)
+
+        call ceedbasiscreatetensorh1lagrange(ceed,dimn,1,p,q,&
+     &    ceed_gauss_lobatto,bug,err)
+
+        call ceedbasisapply(bug,1,ceed_notranspose,ceed_eval_grad,u,uq,err)
+        call ceedbasisapply(bug,1,ceed_transpose,ceed_eval_grad,ones,&
+     &   gtposeones,err)
+
+        call ceedvectorgetarrayread(gtposeones,ceed_mem_host,ggtposeones,&
+     &   offset1,err)
+        call ceedvectorgetarrayread(u,ceed_mem_host,uu,offset2,err)
+        call ceedvectorgetarrayread(uq,ceed_mem_host,uuq,offset3,err)
+        do i=1,pdimn
+          sum1=sum1+ggtposeones(i+offset1)*uu(i+offset2)
+        enddo
+        do i=1,dimxqdimn
+          sum2=sum2+uuq(i+offset3)
+        enddo
+        call ceedvectorrestorearrayread(gtposeones,ggtposeones,offset1,err)
+        call ceedvectorrestorearrayread(u,uu,offset2,err)
+        call ceedvectorrestorearrayread(uq,uuq,offset3,err)
+        if(abs(sum1-sum2) > 1.0D-10) then
+          write(*,'(A,I1,A,F12.6,A,F12.6)')'[',dimn,'] Error: ',sum1,  ' != ',&
+     &     sum2
+        endif
+
+        call ceedvectordestroy(x,err)
+        call ceedvectordestroy(xq,err)
+        call ceedvectordestroy(u,err)
+        call ceedvectordestroy(uq,err)
+        call ceedvectordestroy(ones,err)
+        call ceedvectordestroy(gtposeones,err)
+        call ceedbasisdestroy(bxl,err)
+        call ceedbasisdestroy(bug,err)
+      enddo
+
+      call ceeddestroy(ceed,err)
+      end
+!-----------------------------------------------------------------------

--- a/tests/t309-basis.c
+++ b/tests/t309-basis.c
@@ -1,0 +1,89 @@
+/// @file
+/// Test collocated grad in multiple dimensions
+/// \test Test collocated grad in multiple dimensions
+#include <ceed.h>
+#include <math.h>
+
+static CeedScalar Eval(CeedInt dim, const CeedScalar x[]) {
+  CeedScalar result = tanh(x[0] + 0.1);
+  if (dim > 1) result += atan(x[1] + 0.2);
+  if (dim > 2) result += exp(-(x[2] + 0.3)*(x[2] + 0.3));
+  return result;
+}
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+
+  CeedInit(argv[1], &ceed);
+  for (CeedInt dim=1; dim<=3; dim++) {
+    CeedVector X, Xq, U, Uq, Ones, Gtposeones;
+    CeedBasis bxl, bug;
+    CeedInt P = 8, Q = 8, Pdim = CeedIntPow(P, dim), Qdim = CeedIntPow(Q, dim),
+            Xdim = CeedIntPow(2, dim);
+    CeedScalar x[Xdim*dim], u[Pdim];
+    const CeedScalar *xq, *uq, *gtposeones;
+    CeedScalar sum1 = 0, sum2 = 0;
+
+    for (CeedInt d=0; d<dim; d++) {
+      for (CeedInt i=0; i<Xdim; i++) {
+        x[d*Xdim + i] = (i % CeedIntPow(2, dim-d)) / CeedIntPow(2, dim-d-1) ? 1 : -1;
+      }
+    }
+
+    CeedVectorCreate(ceed, Xdim*dim, &X);
+    CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, (CeedScalar *)&x);
+    CeedVectorCreate(ceed, Pdim*dim, &Xq);
+    CeedVectorSetValue(Xq, 0);
+    CeedVectorCreate(ceed, Pdim, &U);
+    CeedVectorCreate(ceed, Qdim*dim, &Uq);
+    CeedVectorSetValue(Uq, 0);
+    CeedVectorCreate(ceed, Qdim*dim, &Ones);
+    CeedVectorSetValue(Ones, 1);
+    CeedVectorCreate(ceed, Pdim, &Gtposeones);
+    CeedVectorSetValue(Gtposeones, 0);
+
+    // Get function values at quadrature points
+    CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, 2, P, CEED_GAUSS_LOBATTO, &bxl);
+    CeedBasisApply(bxl, 1, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, X, Xq);
+
+    CeedVectorGetArrayRead(Xq, CEED_MEM_HOST, &xq);
+    for (CeedInt i=0; i<Pdim; i++) {
+      CeedScalar xx[dim];
+      for (CeedInt d=0; d<dim; d++) xx[d] = xq[d*Pdim + i];
+      u[i] = Eval(dim, xx);
+    }
+    CeedVectorRestoreArrayRead(Xq, &xq);
+    CeedVectorSetArray(U, CEED_MEM_HOST, CEED_USE_POINTER, (CeedScalar *)&u);
+
+    // Calculate G u at quadrature points, G' * 1 at dofs
+    CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P, Q, CEED_GAUSS_LOBATTO, &bug);
+    CeedBasisApply(bug, 1, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, U, Uq);
+    CeedBasisApply(bug, 1, CEED_TRANSPOSE, CEED_EVAL_GRAD, Ones, Gtposeones);
+
+    // Check if 1' * G * u = u' * (G' * 1)
+    CeedVectorGetArrayRead(Gtposeones, CEED_MEM_HOST, &gtposeones);
+    CeedVectorGetArrayRead(Uq, CEED_MEM_HOST, &uq);
+    for (CeedInt i=0; i<Pdim; i++) {
+      sum1 += gtposeones[i]*u[i];
+    }
+    for (CeedInt i=0; i<dim*Qdim; i++) {
+      sum2 += uq[i];
+    }
+    CeedVectorRestoreArrayRead(Gtposeones, &gtposeones);
+    CeedVectorRestoreArrayRead(Uq, &uq);
+    if (fabs(sum1 - sum2) > 1e-10) {
+      printf("[%d] %f != %f\n", dim, sum1, sum2);
+    }
+
+    CeedVectorDestroy(&X);
+    CeedVectorDestroy(&Xq);
+    CeedVectorDestroy(&U);
+    CeedVectorDestroy(&Uq);
+    CeedVectorDestroy(&Ones);
+    CeedVectorDestroy(&Gtposeones);
+    CeedBasisDestroy(&bxl);
+    CeedBasisDestroy(&bug);
+  }
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
This PR improves the performance of the `/cpu/self/*` backends in the BP5/6 type situation where the DoFs are collocated with the qpts and we are taking gradients.

This PR resolves issue #287