### PR TITLE
Adapt PETSc BPs to use CUDA

### DIFF
--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -68,7 +68,18 @@ int main(int argc, char **argv) {
   CeedQFunction qferror;
   CeedOperator operror;
   CeedVector rhsceed, target;
+  CeedMemType memtyperequested;
   bpType bpchoice;
+
+  // Check PETSc CUDA support
+  PetscBool petschavecuda, setmemtyperequest = PETSC_FALSE;
+  // *INDENT-OFF*
+  #ifdef PETSC_HAVE_CUDA
+  petschavecuda = PETSC_TRUE;
+  #else
+  petschavecuda = PETSC_FALSE;
+  #endif
+  // *INDENT-ON*
 
   ierr = PetscInitialize(&argc, &argv, NULL, help);
   if (ierr) return ierr;
@@ -114,6 +125,14 @@ int main(int argc, char **argv) {
     ierr = PetscOptionsIntArray("-cells","Number of cells per dimension", NULL,
                                 melem, &tmp, NULL); CHKERRQ(ierr);
   }
+
+  memtyperequested = petschavecuda ? CEED_MEM_DEVICE : CEED_MEM_HOST;
+  ierr = PetscOptionsEnum("-memtype",
+                          "CEED MemType requested", NULL,
+                          memTypes, (PetscEnum)memtyperequested,
+                          (PetscEnum *)&memtyperequested, &setmemtyperequest);
+  CHKERRQ(ierr);
+
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
   // Setup DM
@@ -138,11 +157,27 @@ int main(int argc, char **argv) {
     }
   }
 
+  // Set up libCEED
+  CeedInit(ceedresource, &ceed);
+  CeedMemType memtypebackend;
+  CeedGetPreferredMemType(ceed, &memtypebackend);
+
+  // Check memtype compatibility
+  if (!setmemtyperequest)
+    memtyperequested = memtypebackend;
+  else if (!petschavecuda && memtyperequested == CEED_MEM_DEVICE)
+    SETERRQ1(PETSC_COMM_WORLD, PETSC_ERR_SUP_SYS,
+             "PETSc was not built with CUDA. "
+             "Requested MemType CEED_MEM_DEVICE is not supported.", NULL);
+
   // Create DM
   ierr = SetupDMByDegree(dm, degree, ncompu, bpchoice);
   CHKERRQ(ierr);
 
   // Create vectors
+  if (memtyperequested == CEED_MEM_DEVICE) {
+    ierr = DMSetVecType(dm, VECCUDA); CHKERRQ(ierr);
+  }
   ierr = DMCreateGlobalVector(dm, &X); CHKERRQ(ierr);
   ierr = VecGetLocalSize(X, &lsize); CHKERRQ(ierr);
   ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
@@ -158,35 +193,51 @@ int main(int argc, char **argv) {
                               (void(*)(void))MatMult_Ceed); CHKERRQ(ierr);
   ierr = MatShellSetOperation(matO, MATOP_GET_DIAGONAL,
                               (void(*)(void))MatGetDiag); CHKERRQ(ierr);
-
-  // Set up libCEED
-  CeedInit(ceedresource, &ceed);
+  if (memtyperequested == CEED_MEM_DEVICE) {
+    ierr = MatShellSetVecType(matO, VECCUDA); CHKERRQ(ierr);
+  }
 
   // Print summary
   if (!test_mode) {
     PetscInt P = degree + 1, Q = P + qextra;
+
     const char *usedresource;
     CeedGetResource(ceed, &usedresource);
+
+    VecType vectype;
+    ierr = VecGetType(X, &vectype); CHKERRQ(ierr);
+
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc --\n"
+                       "  PETSc:\n"
+                       "    PETSc Vec Type                     : %s\n"
                        "  libCEED:\n"
                        "    libCEED Backend                    : %s\n"
+                       "    libCEED Backend MemType            : %s\n"
+                       "    libCEED User Requested MemType     : %s\n"
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
                        "    Global nodes                       : %D\n"
                        "    Owned nodes                        : %D\n"
                        "    DoF per node                       : %D\n",
-                       bpchoice+1, usedresource, P, Q, gsize/ncompu,
-                       lsize/ncompu, ncompu); CHKERRQ(ierr);
+                       bpchoice+1, vectype, usedresource,
+                       CeedMemTypes[memtypebackend],
+                       (setmemtyperequest) ?
+                       CeedMemTypes[memtyperequested] : "none",
+                       P, Q, gsize/ncompu, lsize/ncompu, ncompu); CHKERRQ(ierr);
   }
 
   // Create RHS vector
   ierr = VecDuplicate(Xloc, &rhsloc); CHKERRQ(ierr);
   ierr = VecZeroEntries(rhsloc); CHKERRQ(ierr);
-  ierr = VecGetArray(rhsloc, &r); CHKERRQ(ierr);
+  if (memtyperequested == CEED_MEM_HOST) {
+    ierr = VecGetArray(rhsloc, &r); CHKERRQ(ierr);
+  } else {
+    ierr = VecCUDAGetArray(rhsloc, &r); CHKERRQ(ierr);
+  }
   CeedVectorCreate(ceed, xlsize, &rhsceed);
-  CeedVectorSetArray(rhsceed, CEED_MEM_HOST, CEED_USE_POINTER, r);
+  CeedVectorSetArray(rhsceed, memtyperequested, CEED_USE_POINTER, r);
 
   ierr = PetscMalloc1(1, &ceeddata); CHKERRQ(ierr);
   ierr = SetupLibceedByDegree(dm, ceed, degree, dim, qextra,
@@ -194,7 +245,12 @@ int main(int argc, char **argv) {
                               true, rhsceed, &target); CHKERRQ(ierr);
 
   // Gather RHS
-  ierr = VecRestoreArray(rhsloc, &r); CHKERRQ(ierr);
+  CeedVectorSyncArray(rhsceed, memtyperequested);
+  if (memtyperequested == CEED_MEM_HOST) {
+    ierr = VecRestoreArray(rhsloc, &r); CHKERRQ(ierr);
+  } else {
+    ierr = VecCUDARestoreArray(rhsloc, &r); CHKERRQ(ierr);
+  }
   ierr = VecZeroEntries(rhs); CHKERRQ(ierr);
   ierr = DMLocalToGlobalBegin(dm, rhsloc, ADD_VALUES, rhs); CHKERRQ(ierr);
   ierr = DMLocalToGlobalEnd(dm, rhsloc, ADD_VALUES, rhs); CHKERRQ(ierr);
@@ -226,6 +282,18 @@ int main(int argc, char **argv) {
   userO->yceed = ceeddata->yceed;
   userO->op = ceeddata->opapply;
   userO->ceed = ceed;
+  userO->memtype = memtyperequested;
+  if (memtyperequested == CEED_MEM_HOST) {
+    userO->VecGetArray = VecGetArray;
+    userO->VecGetArrayRead = VecGetArrayRead;
+    userO->VecRestoreArray = VecRestoreArray;
+    userO->VecRestoreArrayRead = VecRestoreArrayRead;
+  } else {
+    userO->VecGetArray = VecCUDAGetArray;
+    userO->VecGetArrayRead = VecCUDAGetArrayRead;
+    userO->VecRestoreArray = VecCUDARestoreArray;
+    userO->VecRestoreArrayRead = VecCUDARestoreArrayRead;
+  }
 
   ierr = KSPCreate(comm, &ksp); CHKERRQ(ierr);
   {

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -58,6 +58,7 @@ int main(int argc, char **argv) {
            ncompu = 1, xlsize;
   PetscScalar *r;
   PetscBool test_mode, benchmark_mode, read_mesh, write_solution;
+  PetscLogStage solvestage;
   Vec X, Xloc, rhs, rhsloc;
   Mat matO;
   KSP ksp;
@@ -335,9 +336,18 @@ int main(int argc, char **argv) {
   // Timed solve
   ierr = VecZeroEntries(X); CHKERRQ(ierr);
   ierr = PetscBarrier((PetscObject)ksp); CHKERRQ(ierr);
+
+  // -- Performance logging
+  ierr = PetscLogStageRegister("Solve Stage", &solvestage); CHKERRQ(ierr);
+  ierr = PetscLogStagePush(solvestage); CHKERRQ(ierr);
+
+  // -- Solve
   my_rt_start = MPI_Wtime();
   ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
   my_rt = MPI_Wtime() - my_rt_start;
+
+  // -- Performance logging
+  ierr = PetscLogStagePop();
 
   // Output results
   {

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -538,10 +538,10 @@ int main(int argc, char **argv) {
   GlobalNodes(p, irank, degree, melem, mnodes);
 
   // Setup global vector
+  ierr = VecCreate(comm, &X); CHKERRQ(ierr);
   if (memtyperequested == CEED_MEM_DEVICE) {
     ierr = VecSetType(X, VECCUDA); CHKERRQ(ierr);
   }
-  ierr = VecCreate(comm, &X); CHKERRQ(ierr);
   ierr = VecSetSizes(X, mnodes[0]*mnodes[1]*mnodes[2]*ncompu, PETSC_DECIDE);
   CHKERRQ(ierr);
   ierr = VecSetUp(X); CHKERRQ(ierr);
@@ -591,10 +591,10 @@ int main(int argc, char **argv) {
       lnodes[d] = melem[d]*degree + 1;
       lsize *= lnodes[d];
     }
+    ierr = VecCreate(PETSC_COMM_SELF, &Xloc); CHKERRQ(ierr);
     if (memtyperequested == CEED_MEM_DEVICE) {
       ierr = VecSetType(Xloc, VECCUDA); CHKERRQ(ierr);
     }
-    ierr = VecCreate(PETSC_COMM_SELF, &Xloc); CHKERRQ(ierr);
     ierr = VecSetSizes(Xloc, lsize*ncompu, PETSC_DECIDE); CHKERRQ(ierr);
     ierr = VecSetUp(Xloc); CHKERRQ(ierr);
 

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -59,8 +59,8 @@ int main(int argc, char **argv) {
   PetscInt degree = 3, qextra, lsize, gsize, topodim = 2, ncompx = 3,
            ncompu = 1, xlsize;
   PetscScalar *r;
-  PetscBool test_mode, benchmark_mode, read_mesh,
-            write_solution, simplex;
+  PetscBool test_mode, benchmark_mode, read_mesh, write_solution, simplex;
+  PetscLogStage solvestage;
   Vec X, Xloc, rhs, rhsloc;
   Mat matO;
   KSP ksp;
@@ -284,9 +284,18 @@ int main(int argc, char **argv) {
   // Timed solve
   ierr = VecZeroEntries(X); CHKERRQ(ierr);
   ierr = PetscBarrier((PetscObject)ksp); CHKERRQ(ierr);
+
+  // -- Performance logging
+  ierr = PetscLogStageRegister("Solve Stage", &solvestage); CHKERRQ(ierr);
+  ierr = PetscLogStagePush(solvestage); CHKERRQ(ierr);
+
+  // -- Solve
   my_rt_start = MPI_Wtime();
   ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
   my_rt = MPI_Wtime() - my_rt_start;
+
+  // -- Performance logging
+  ierr = PetscLogStagePop();
 
   // Output results
   {

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -51,6 +51,7 @@ int main(int argc, char **argv) {
            melem[3] = {3, 3, 3}, ncompu = 1, numlevels = degree, *leveldegrees;
   PetscScalar *r;
   PetscBool test_mode, benchmark_mode, read_mesh, write_solution;
+  PetscLogStage solvestage;
   DM  *dm, dmorig;
   SNES snesdummy;
   KSP ksp;
@@ -545,9 +546,19 @@ int main(int argc, char **argv) {
   // Timed solve
   ierr = VecZeroEntries(X[fineLevel]); CHKERRQ(ierr);
   ierr = PetscBarrier((PetscObject)ksp); CHKERRQ(ierr);
+
+  // -- Performance logging
+  ierr = PetscLogStageRegister("Solve Stage", &solvestage); CHKERRQ(ierr);
+  ierr = PetscLogStagePush(solvestage); CHKERRQ(ierr);
+
+  // -- Solve
   my_rt_start = MPI_Wtime();
   ierr = KSPSolve(ksp, rhs, X[fineLevel]); CHKERRQ(ierr);
   my_rt = MPI_Wtime() - my_rt_start;
+
+
+  // -- Performance logging
+  ierr = PetscLogStagePop();
 
   // Output results
   {

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -61,6 +61,7 @@ int main(int argc, char **argv) {
   UserProlongRestr *userPR;
   Ceed ceed;
   CeedData *ceeddata;
+  CeedMemType memtyperequested;
   CeedVector rhsceed, target;
   CeedQFunction qferror, qfrestrict, qfprolong;
   CeedOperator operror;
@@ -70,6 +71,16 @@ int main(int argc, char **argv) {
   ierr = PetscInitialize(&argc, &argv, NULL, help);
   if (ierr) return ierr;
   comm = PETSC_COMM_WORLD;
+
+  // Check PETSc CUDA avaliability
+  PetscBool petschavecuda, setmemtyperequest = PETSC_FALSE;
+  // *INDENT-OFF*
+  #ifdef PETSC_HAVE_CUDA
+  petschavecuda = PETSC_TRUE;
+  #else
+  petschavecuda = PETSC_FALSE;
+  #endif
+  // *INDENT-ON*
 
   // Parse command line options
   ierr = PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL); CHKERRQ(ierr);
@@ -118,7 +129,26 @@ int main(int argc, char **argv) {
     ierr = PetscOptionsIntArray("-cells","Number of cells per dimension", NULL,
                                 melem, &tmp, NULL); CHKERRQ(ierr);
   }
+  memtyperequested = petschavecuda ? CEED_MEM_DEVICE : CEED_MEM_HOST;
+  ierr = PetscOptionsEnum("-memtype",
+                          "CEED MemType requested", NULL,
+                          memTypes, (PetscEnum)memtyperequested,
+                          (PetscEnum *)&memtyperequested, &setmemtyperequest);
+  CHKERRQ(ierr);
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+
+  // Set up libCEED
+  CeedInit(ceedresource, &ceed);
+  CeedMemType memtypebackend;
+  CeedGetPreferredMemType(ceed, &memtypebackend);
+
+  // Check memtype compatibility
+  if (!setmemtyperequest)
+    memtyperequested = memtypebackend;
+  else if (!petschavecuda && memtyperequested == CEED_MEM_DEVICE)
+    SETERRQ1(PETSC_COMM_WORLD, PETSC_ERR_SUP_SYS,
+             "PETSc was not built with CUDA. "
+             "Requested MemType CEED_MEM_DEVICE is not supported.", NULL);
 
   // Setup DM
   if (read_mesh) {
@@ -183,6 +213,9 @@ int main(int argc, char **argv) {
     CHKERRQ(ierr);
 
     // Create vectors
+    if (memtyperequested == CEED_MEM_DEVICE) {
+      ierr = DMSetVecType(dm[i], VECCUDA); CHKERRQ(ierr);
+    }
     ierr = DMCreateGlobalVector(dm[i], &X[i]); CHKERRQ(ierr);
     ierr = VecGetLocalSize(X[i], &lsize[i]); CHKERRQ(ierr);
     ierr = VecGetSize(X[i], &gsize[i]); CHKERRQ(ierr);
@@ -197,6 +230,9 @@ int main(int argc, char **argv) {
                                 (void(*)(void))MatMult_Ceed); CHKERRQ(ierr);
     ierr = MatShellSetOperation(matO[i], MATOP_GET_DIAGONAL,
                                 (void(*)(void))MatGetDiag); CHKERRQ(ierr);
+    if (memtyperequested == CEED_MEM_DEVICE) {
+      ierr = MatShellSetVecType(matO[i], VECCUDA); CHKERRQ(ierr);
+    }
 
     // Level transfers
     if (i > 0) {
@@ -210,6 +246,9 @@ int main(int argc, char **argv) {
       ierr = MatShellSetOperation(matPR[i], MATOP_MULT_TRANSPOSE,
                                   (void(*)(void))MatMult_Restrict);
       CHKERRQ(ierr);
+      if (memtyperequested == CEED_MEM_DEVICE) {
+        ierr = MatShellSetVecType(matPR[i], VECCUDA); CHKERRQ(ierr);
+      }
     }
   }
   ierr = VecDuplicate(X[fineLevel], &rhs); CHKERRQ(ierr);
@@ -220,12 +259,21 @@ int main(int argc, char **argv) {
   // Print global grid information
   if (!test_mode) {
     PetscInt P = degree + 1, Q = P + qextra;
+
     const char *usedresource;
     CeedGetResource(ceed, &usedresource);
+
+    VecType vectype;
+    ierr = VecGetType(X[0], &vectype); CHKERRQ(ierr);
+
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc + PCMG --\n"
+                       "  PETSc:\n"
+                       "    PETSc Vec Type                     : %s\n"
                        "  libCEED:\n"
                        "    libCEED Backend                    : %s\n"
+                       "    libCEED Backend MemType            : %s\n"
+                       "    libCEED User Requested MemType     : %s\n"
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
@@ -234,15 +282,22 @@ int main(int argc, char **argv) {
                        "    DoF per node                       : %D\n"
                        "  Multigrid:\n"
                        "    Number of Levels                   : %d\n",
-                       bpchoice+1, usedresource, P, Q,
-                       gsize[fineLevel]/ncompu, lsize[fineLevel]/ncompu,
+                       bpchoice+1, vectype, usedresource,
+                       CeedMemTypes[memtypebackend],
+                       (setmemtyperequest) ?
+                       CeedMemTypes[memtyperequested] : "none",
+                       P, Q, gsize[fineLevel]/ncompu, lsize[fineLevel]/ncompu,
                        ncompu, numlevels); CHKERRQ(ierr);
   }
 
   // Create RHS vector
   ierr = VecDuplicate(Xloc[fineLevel], &rhsloc); CHKERRQ(ierr);
   ierr = VecZeroEntries(rhsloc); CHKERRQ(ierr);
-  ierr = VecGetArray(rhsloc, &r); CHKERRQ(ierr);
+  if (memtyperequested == CEED_MEM_HOST) {
+    ierr = VecGetArray(rhsloc, &r); CHKERRQ(ierr);
+  } else {
+    ierr = VecCUDAGetArray(rhsloc, &r); CHKERRQ(ierr);
+  }
   CeedVectorCreate(ceed, xlsize[fineLevel], &rhsceed);
   CeedVectorSetArray(rhsceed, CEED_MEM_HOST, CEED_USE_POINTER, r);
 
@@ -266,10 +321,14 @@ int main(int argc, char **argv) {
   }
 
   // Gather RHS
-  ierr = VecRestoreArray(rhsloc, &r); CHKERRQ(ierr);
+  CeedVectorSyncArray(rhsceed, memtyperequested);
+  if (memtyperequested == CEED_MEM_HOST) {
+    ierr = VecRestoreArray(rhsloc, &r); CHKERRQ(ierr);
+  } else {
+    ierr = VecCUDARestoreArray(rhsloc, &r); CHKERRQ(ierr);
+  }
   ierr = VecZeroEntries(rhs); CHKERRQ(ierr);
-  ierr = DMLocalToGlobal(dm[fineLevel], rhsloc, ADD_VALUES, rhs);
-  CHKERRQ(ierr);
+  ierr = DMLocalToGlobal(dm[fineLevel], rhsloc, ADD_VALUES, rhs); CHKERRQ(ierr);
   CeedVectorDestroy(&rhsceed);
 
   // Create the restriction/interpolation Q-function
@@ -344,6 +403,18 @@ int main(int argc, char **argv) {
     userO[i]->yceed = ceeddata[i]->yceed;
     userO[i]->op = ceeddata[i]->opapply;
     userO[i]->ceed = ceed;
+    userO[i]->memtype = memtyperequested;
+    if (memtyperequested == CEED_MEM_HOST) {
+      userO[i]->VecGetArray = VecGetArray;
+      userO[i]->VecGetArrayRead = VecGetArrayRead;
+      userO[i]->VecRestoreArray = VecRestoreArray;
+      userO[i]->VecRestoreArrayRead = VecRestoreArrayRead;
+    } else {
+      userO[i]->VecGetArray = VecCUDAGetArray;
+      userO[i]->VecGetArrayRead = VecCUDAGetArrayRead;
+      userO[i]->VecRestoreArray = VecCUDARestoreArray;
+      userO[i]->VecRestoreArrayRead = VecCUDARestoreArrayRead;
+    }
 
     if (i > 0) {
       // Prolongation/Restriction Operator
@@ -358,6 +429,11 @@ int main(int argc, char **argv) {
       userPR[i]->opprolong = ceeddata[i]->opprolong;
       userPR[i]->oprestrict = ceeddata[i]->oprestrict;
       userPR[i]->ceed = ceed;
+      userPR[i]->memtype = userO[i]->memtype;
+      userPR[i]->VecGetArray = userO[i]->VecGetArray;
+      userPR[i]->VecGetArrayRead = userO[i]->VecGetArrayRead;
+      userPR[i]->VecRestoreArray = userO[i]->VecRestoreArray;
+      userPR[i]->VecRestoreArrayRead = userO[i]->VecRestoreArrayRead;
     }
   }
 

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -29,6 +29,15 @@
 #include "qfunctions/bps/bp3.h"
 #include "qfunctions/bps/bp4.h"
 
+#include <petscsys.h>
+#if PETSC_VERSION_LT(3,12,0)
+#ifdef PETSC_HAVE_CUDA
+#include <petsccuda.h>
+// Note: With PETSc prior to version 3.12.0, providing the source path to
+//       include 'cublas_v2.h' will be needed to use 'petsccuda.h'.
+#endif
+#endif
+
 // -----------------------------------------------------------------------------
 // PETSc Operator Structs
 // -----------------------------------------------------------------------------
@@ -42,6 +51,11 @@ struct UserO_ {
   CeedVector xceed, yceed;
   CeedOperator op;
   Ceed ceed;
+  CeedMemType memtype;
+  int (*VecGetArray)(Vec, PetscScalar **);
+  int (*VecGetArrayRead)(Vec, const PetscScalar **);
+  int (*VecRestoreArray)(Vec, PetscScalar **);
+  int (*VecRestoreArrayRead)(Vec, const PetscScalar **);
 };
 
 // Data for PETSc Prolong/Restrict Matshells
@@ -53,6 +67,11 @@ struct UserProlongRestr_ {
   CeedVector ceedvecc, ceedvecf;
   CeedOperator opprolong, oprestrict;
   Ceed ceed;
+  CeedMemType memtype;
+  int (*VecGetArray)(Vec, PetscScalar **);
+  int (*VecGetArrayRead)(Vec, const PetscScalar **);
+  int (*VecRestoreArray)(Vec, PetscScalar **);
+  int (*VecRestoreArrayRead)(Vec, const PetscScalar **);
 };
 
 // -----------------------------------------------------------------------------
@@ -73,6 +92,11 @@ struct CeedData_ {
 // -----------------------------------------------------------------------------
 // Command Line Options
 // -----------------------------------------------------------------------------
+
+// MemType Options
+static const char *const memTypes[] = {"host","device","memType",
+                                       "CEED_MEM_",0
+                                      };
 
 // Coarsening options
 typedef enum {
@@ -716,20 +740,21 @@ static PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, UserO user) {
   ierr = DMGlobalToLocal(user->dm, X, INSERT_VALUES, user->Xloc); CHKERRQ(ierr);
   ierr = VecZeroEntries(user->Yloc); CHKERRQ(ierr);
 
-  // Setup CEED vectors
-  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
-  ierr = VecGetArray(user->Yloc, &y); CHKERRQ(ierr);
-  CeedVectorSetArray(user->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
-  CeedVectorSetArray(user->yceed, CEED_MEM_HOST, CEED_USE_POINTER, y);
+  // Setup libCEED vectors
+  ierr = user->VecGetArrayRead(user->Xloc, (const PetscScalar **)&x);
+  CHKERRQ(ierr);
+  ierr = user->VecGetArray(user->Yloc, &y); CHKERRQ(ierr);
+  CeedVectorSetArray(user->xceed, user->memtype, CEED_USE_POINTER, x);
+  CeedVectorSetArray(user->yceed, user->memtype, CEED_USE_POINTER, y);
 
-  // Apply CEED operator
+  // Apply libCEED operator
   CeedOperatorApply(user->op, user->xceed, user->yceed, CEED_REQUEST_IMMEDIATE);
-  CeedVectorSyncArray(user->yceed, CEED_MEM_HOST);
+  CeedVectorSyncArray(user->yceed, user->memtype);
 
   // Restore PETSc vectors
-  ierr = VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x);
+  ierr = user->VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x);
   CHKERRQ(ierr);
-  ierr = VecRestoreArray(user->Yloc, &y); CHKERRQ(ierr);
+  ierr = user->VecRestoreArray(user->Yloc, &y); CHKERRQ(ierr);
 
   // Local-to-global
   ierr = VecZeroEntries(Y); CHKERRQ(ierr);
@@ -785,22 +810,22 @@ static PetscErrorCode MatMult_Prolong(Mat A, Vec X, Vec Y) {
   CHKERRQ(ierr);
   ierr = VecZeroEntries(user->locvecf); CHKERRQ(ierr);
 
-  // Setup CEED vectors
-  ierr = VecGetArrayRead(user->locvecc, (const PetscScalar **)&c);
+  // Setup libCEED vectors
+  ierr = user->VecGetArrayRead(user->locvecc, (const PetscScalar **)&c);
   CHKERRQ(ierr);
-  ierr = VecGetArray(user->locvecf, &f); CHKERRQ(ierr);
-  CeedVectorSetArray(user->ceedvecc, CEED_MEM_HOST, CEED_USE_POINTER, c);
-  CeedVectorSetArray(user->ceedvecf, CEED_MEM_HOST, CEED_USE_POINTER, f);
+  ierr = user->VecGetArray(user->locvecf, &f); CHKERRQ(ierr);
+  CeedVectorSetArray(user->ceedvecc, user->memtype, CEED_USE_POINTER, c);
+  CeedVectorSetArray(user->ceedvecf, user->memtype, CEED_USE_POINTER, f);
 
-  // Apply CEED operator
+  // Apply libCEED operator
   CeedOperatorApply(user->opprolong, user->ceedvecc, user->ceedvecf,
                     CEED_REQUEST_IMMEDIATE);
-  CeedVectorSyncArray(user->ceedvecf, CEED_MEM_HOST);
+  CeedVectorSyncArray(user->ceedvecf, user->memtype);
 
   // Restore PETSc vectors
-  ierr = VecRestoreArrayRead(user->locvecc, (const PetscScalar **)c);
+  ierr = user->VecRestoreArrayRead(user->locvecc, (const PetscScalar **)c);
   CHKERRQ(ierr);
-  ierr = VecRestoreArray(user->locvecf, &f); CHKERRQ(ierr);
+  ierr = user->VecRestoreArray(user->locvecf, &f); CHKERRQ(ierr);
 
   // Multiplicity
   ierr = VecPointwiseMult(user->locvecf, user->locvecf, user->multvec);
@@ -835,21 +860,22 @@ static PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y) {
   ierr = VecPointwiseMult(user->locvecf, user->locvecf, user->multvec);
   CHKERRQ(ierr);
 
-  // Setup CEED vectors
-  ierr = VecGetArrayRead(user->locvecf, (const PetscScalar **)&f); CHKERRQ(ierr);
-  ierr = VecGetArray(user->locvecc, &c); CHKERRQ(ierr);
-  CeedVectorSetArray(user->ceedvecf, CEED_MEM_HOST, CEED_USE_POINTER, f);
-  CeedVectorSetArray(user->ceedvecc, CEED_MEM_HOST, CEED_USE_POINTER, c);
+  // Setup libCEED vectors
+  ierr = user->VecGetArrayRead(user->locvecf, (const PetscScalar **)&f);
+  CHKERRQ(ierr);
+  ierr = user->VecGetArray(user->locvecc, &c); CHKERRQ(ierr);
+  CeedVectorSetArray(user->ceedvecf, user->memtype, CEED_USE_POINTER, f);
+  CeedVectorSetArray(user->ceedvecc, user->memtype, CEED_USE_POINTER, c);
 
   // Apply CEED operator
   CeedOperatorApply(user->oprestrict, user->ceedvecf, user->ceedvecc,
                     CEED_REQUEST_IMMEDIATE);
-  CeedVectorSyncArray(user->ceedvecc, CEED_MEM_HOST);
+  CeedVectorSyncArray(user->ceedvecc, user->memtype);
 
   // Restore PETSc vectors
-  ierr = VecRestoreArrayRead(user->locvecf, (const PetscScalar **)&f);
+  ierr = user->VecRestoreArrayRead(user->locvecf, (const PetscScalar **)&f);
   CHKERRQ(ierr);
-  ierr = VecRestoreArray(user->locvecc, &c); CHKERRQ(ierr);
+  ierr = user->VecRestoreArray(user->locvecc, &c); CHKERRQ(ierr);
 
   // Local-to-global
   ierr = VecZeroEntries(Y); CHKERRQ(ierr);
@@ -876,16 +902,18 @@ static PetscErrorCode ComputeErrorMax(UserO user, CeedOperator op_error,
   // Global-to-local
   ierr = DMGlobalToLocal(user->dm, X, INSERT_VALUES, user->Xloc); CHKERRQ(ierr);
 
-  // Setup CEED vector
-  ierr = VecGetArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
-  CeedVectorSetArray(user->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
+  // Setup libCEED vector
+  ierr = user->VecGetArrayRead(user->Xloc, (const PetscScalar **)&x);
+  CHKERRQ(ierr);
+  CeedVectorSetArray(user->xceed, user->memtype, CEED_USE_POINTER, x);
 
-  // Apply CEED operator
+  // Apply libCEED operator
   CeedOperatorApply(op_error, user->xceed, collocated_error,
                     CEED_REQUEST_IMMEDIATE);
 
   // Restore PETSc vector
-  VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x); CHKERRQ(ierr);
+  ierr = user->VecRestoreArrayRead(user->Xloc, (const PetscScalar **)&x);
+  CHKERRQ(ierr);
 
   // Reduce max error
   *maxerror = 0;
@@ -895,8 +923,8 @@ static PetscErrorCode ComputeErrorMax(UserO user, CeedOperator op_error,
     *maxerror = PetscMax(*maxerror, PetscAbsScalar(e[i]));
   }
   CeedVectorRestoreArrayRead(collocated_error, &e);
-  ierr = MPI_Allreduce(MPI_IN_PLACE, maxerror,
-                       1, MPIU_REAL, MPIU_MAX, user->comm); CHKERRQ(ierr);
+  ierr = MPI_Allreduce(MPI_IN_PLACE, maxerror, 1, MPIU_REAL, MPIU_MAX,
+                       user->comm); CHKERRQ(ierr);
 
   // Cleanup
   CeedVectorDestroy(&collocated_error);


### PR DESCRIPTION
This WIP PR modifies the PETSc BPs that we use to benchmark to use CUDA vectors, if the libCEED backend and PETSc both support it. I need to test it, but I believe it works.