### PR TITLE
Fix typo in t209-f

### DIFF
--- a/tests/t209-elemrestriction-f.f90
+++ b/tests/t209-elemrestriction-f.f90
@@ -50,7 +50,7 @@
       enddo
       call ceedvectorrestorearrayread(mult,mm,moffset,err)
 
-      call ceedvectordestroy(m,err)
+      call ceedvectordestroy(mult,err)
       call ceedelemrestrictiondestroy(r,err)
       call ceeddestroy(ceed,err)
 


### PR DESCRIPTION
This fixes a bug that was by freeing a vector that was never created (typo in name).