### PR TITLE
Fix ref backend priorities

### DIFF
--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -36,5 +36,5 @@ static int CeedInit_Blocked(const char *resource, Ceed ceed) {
 
 __attribute__((constructor))
 static void Register(void) {
-  CeedRegister("/cpu/self/ref/blocked", CeedInit_Blocked, 50);
+  CeedRegister("/cpu/self/ref/blocked", CeedInit_Blocked, 55);
 }

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -47,6 +47,6 @@ static int CeedInit_Ref(const char *resource, Ceed ceed) {
 __attribute__((constructor))
 static void Register(void) {
 //! [Register]
-  CeedRegister("/cpu/self/ref/serial", CeedInit_Ref, 55);
+  CeedRegister("/cpu/self/ref/serial", CeedInit_Ref, 50);
 //! [Register]
 }


### PR DESCRIPTION
I had set `/cpu/self/ref/serial` to be the default for `/cpu/self/ref` but I did not update the priorities to match. 