### PR TITLE
Change default NS problemtype to density_current

### DIFF
--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
   Units units;
   char ceedresource[4096] = "/cpu/self";
   PetscFunctionList icsflist = NULL, qflist = NULL;
-  char problemtype[PETSC_MAX_PATH_LEN] = "advection";
+  char problemtype[PETSC_MAX_PATH_LEN] = "density_current";
   PetscInt localNelem, lsize, steps,
            melem[3], mdof[3], p[3], irank[3], ldof[3];
   PetscMPIInt size, rank;


### PR DESCRIPTION
It makes more sense to have the default problemtype to be the density_current example rather than the advection test case, that was intended to be an internal tool for validation of code, and technically does not fall under the umbrella of the NS equations, but it's a transport equation.