### PR TITLE
Fix a bug in the description of vectorial bps in petsc examples

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -780,7 +780,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     case CEED_EVAL_NONE:
       ierr = CeedElemRestrictionGetNumDoF(Erestrict, &ndof); CeedChk(ierr);
       code << "  const CeedInt ncomp_in_"<<i<<" = "<<ncomp<<";\n";
-      code << "  const CeedInt nquads_in_"<<i<<" = "<<ndof/ncomp<<";\n";
+      code << "  const CeedInt nquads_in_"<<i<<" = "<<ndof<<";\n";
       break;
     case CEED_EVAL_INTERP:
       ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
@@ -834,7 +834,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       code << "  const CeedInt ncomp_out_"<<i<<" = "<<ncomp<<";\n";
       ierr = CeedElemRestrictionGetNumDoF(Erestrict, &ndof); CeedChk(ierr);
       ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
-      code << "  const CeedInt nquads_out_"<<i<<" = "<<ndof<<"/ncomp_out_"<<i<<";\n";
+      code << "  const CeedInt nquads_out_"<<i<<" = "<<ndof<<";\n";
       break; // No action
     case CEED_EVAL_INTERP:
       code << "  const CeedInt ncomp_out_"<<i<<" = "<<ncomp<<";\n";

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -582,9 +582,9 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, vscale,
                                     &Erestrictui);
   CeedElemRestrictionCreateIdentity(ceed, nelem,
-                                    bpOptions[bpChoice].qdatasize*Q*Q*Q,
-                                    bpOptions[bpChoice].qdatasize*nelem*Q*Q*Q,
-                                    1, &Erestrictqdi);
+                                    Q*Q*Q,
+                                    nelem*Q*Q*Q,
+                                    bpOptions[bpChoice].qdatasize, &Erestrictqdi);
   CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, 1,
                                     &Erestrictxi);
   {

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -522,9 +522,9 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, vscale,
                                     &Erestrictui);
   CeedElemRestrictionCreateIdentity(ceed, nelem,
-                                    bpOptions[bpChoice].qdatasize*Q*Q*Q,
-                                    bpOptions[bpChoice].qdatasize*nelem*Q*Q*Q,
-                                    1, &Erestrictqdi);
+                                    Q*Q*Q,
+                                    nelem*Q*Q*Q,
+                                    bpOptions[bpChoice].qdatasize, &Erestrictqdi);
   CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, 1,
                                     &Erestrictxi);
 


### PR DESCRIPTION
Fix a bug in `petsc/bps.c` and `petsc/bpsdmplex.c` on the initialisation of the restriction.
Fix a bug in `cuda-gen` that was introduced to overcome the `petsc/bps` bug.