### PR TITLE
Fix atomicAdd in cuda-gen backend

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -21,20 +21,7 @@
 #include "../cuda-reg/ceed-cuda-reg.h"
 #include "../cuda-shared/ceed-cuda-shared.h"
 
-static const char *deviceFunctions = QUOTE(
-
-typedef struct { const CeedScalar* in[16]; CeedScalar* out[16]; } CudaFields;
-typedef struct { CeedInt* in[16]; CeedInt* out[16]; } CudaFieldsInt;
-
-typedef struct {
-  CeedInt tidx;
-  CeedInt tidy;
-  CeedInt tidz;
-  CeedInt tid;
-  CeedScalar* slice;
-} BackendData;
-
-#if __CUDA_ARCH__ < 600
+static const char *atomicAdd = QUOTE(
 __device__ double atomicAdd(double *address, double val) {
   unsigned long long int *address_as_ull = (unsigned long long int *)address;
   unsigned long long int old = *address_as_ull, assumed;
@@ -49,7 +36,20 @@ __device__ double atomicAdd(double *address, double val) {
   } while (assumed != old);
   return __longlong_as_double(old);
 }
-#endif // __CUDA_ARCH__ < 600
+);
+
+static const char *deviceFunctions = QUOTE(
+
+typedef struct { const CeedScalar* in[16]; CeedScalar* out[16]; } CudaFields;
+typedef struct { CeedInt* in[16]; CeedInt* out[16]; } CudaFieldsInt;
+
+typedef struct {
+  CeedInt tidx;
+  CeedInt tidy;
+  CeedInt tidz;
+  CeedInt tid;
+  CeedScalar* slice;
+} BackendData;
 
 template <int P, int Q>
 inline __device__ void loadMatrix(BackendData& data, const CeedScalar* d_B, CeedScalar* B) {
@@ -716,6 +716,18 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
 
   ostringstream code;
   string devFunctions(deviceFunctions);
+
+  // Add atomicAdd function for old NVidia architectures
+  struct cudaDeviceProp prop;
+  Ceed delegate;
+  CeedGetDelegate(ceed, &delegate);
+  Ceed_Cuda *ceed_data;
+  ierr = CeedGetData(delegate, (void **)&ceed_data); CeedChk(ierr);
+  ierr = cudaGetDeviceProperties(&prop, ceed_data->deviceId);
+  if(prop.major<6){
+    std::cout<< "I'm an old GPU" << std::endl;
+    code << atomicAdd;
+  }
 
   code << devFunctions;
 

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -725,7 +725,6 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   ierr = CeedGetData(delegate, (void **)&ceed_data); CeedChk(ierr);
   ierr = cudaGetDeviceProperties(&prop, ceed_data->deviceId);
   if(prop.major<6){
-    std::cout<< "I'm an old GPU" << std::endl;
     code << atomicAdd;
   }
 


### PR DESCRIPTION
The preprocessor guards for `atomicAdd` were not having the intended behaviour, this was preventing `nvrtc` to use the hardware `atomicAdd` for compute capability superior to 60 (This was unfortunately not creating a compilation error). This PR proposes a fix to this issue.