### PR TITLE
Update Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,13 @@ script:
     fi
 
 after_success:
-  - lcov --directory . --capture --output-file coverage.info
-  - bash <(curl -s https://codecov.io/bash) -F interface
-  - bash <(curl -s https://codecov.io/bash) -F backends
-  - bash <(curl -s https://codecov.io/bash) -F tests
-  - bash <(curl -s https://codecov.io/bash) -F examples
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+        lcov --directory . --capture --output-file coverage.info
+        && bash <(curl -s https://codecov.io/bash) -F interface
+        && bash <(curl -s https://codecov.io/bash) -F backends
+        && bash <(curl -s https://codecov.io/bash) -F tests
+        && bash <(curl -s https://codecov.io/bash) -F examples;
+    fi
 
 cache:
   ccache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
     - liblapack-dev
     - libopenblas-dev
     - valgrind-dbg
+    - lcov
   homebrew:
     packages:
     - ccache
@@ -72,6 +73,7 @@ script:
     fi
 
 after_success:
+  - lcov --directory . --capture --output-file coverage.info
   - bash <(curl -s https://codecov.io/bash) -F interface
   - bash <(curl -s https://codecov.io/bash) -F backends
   - bash <(curl -s https://codecov.io/bash) -F tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,12 +73,12 @@ script:
     fi
 
 after_success:
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         lcov --directory . --capture --output-file coverage.info
-        && bash <(curl -s https://codecov.io/bash) -F interface
-        && bash <(curl -s https://codecov.io/bash) -F backends
-        && bash <(curl -s https://codecov.io/bash) -F tests
-        && bash <(curl -s https://codecov.io/bash) -F examples;
+        && bash <(curl -s https://codecov.io/bash) -f coverage.info -F interface
+        && bash <(curl -s https://codecov.io/bash) -f coverage.info -F backends
+        && bash <(curl -s https://codecov.io/bash) -f coverage.info -F tests
+        && bash <(curl -s https://codecov.io/bash) -f coverage.info -F examples;
     fi
 
 cache:

--- a/tests/t001-ceed-f.f90
+++ b/tests/t001-ceed-f.f90
@@ -17,7 +17,7 @@
       if (mtype == 1024) then
 ! LCOV_EXCL_START
           write(*,*) 'Error getting preferred memory type.'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
 
       call ceeddestroy(ceed,err)

--- a/tests/t001-ceed-f.f90
+++ b/tests/t001-ceed-f.f90
@@ -15,7 +15,9 @@
       call ceedgetpreferredmemtype(ceed,mtype,err)
 
       if (mtype == 1024) then
+! LCOV_EXCL_START
           write(*,*) 'Error getting preferred memory type.'
+! LCOV_EXCL_END
       endif
 
       call ceeddestroy(ceed,err)

--- a/tests/t001-ceed.c
+++ b/tests/t001-ceed.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
   if (type == -1)
     // LCOV_EXCL_START
     printf("Error getting preferred memory type. %d \n",type);
-    // LCOV_EXCL_END
+    // LCOV_EXCL_STOP
   CeedDestroy(&ceed);
   return 0;
 }

--- a/tests/t001-ceed.c
+++ b/tests/t001-ceed.c
@@ -9,10 +9,10 @@ int main(int argc, char **argv) {
 
   CeedInit(argv[1], &ceed);
   CeedGetPreferredMemType(ceed, (CeedMemType *)&type);
-
   if (type == -1)
+    // LCOV_EXCL_START
     printf("Error getting preferred memory type. %d \n",type);
-
+    // LCOV_EXCL_END
   CeedDestroy(&ceed);
   return 0;
 }

--- a/tests/t100-vec-f.f90
+++ b/tests/t100-vec-f.f90
@@ -32,7 +32,7 @@
         if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(i+boffset)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
 

--- a/tests/t100-vec-f.f90
+++ b/tests/t100-vec-f.f90
@@ -30,7 +30,9 @@
       do i=1,10
         diff=b(i+boffset)-10-i
         if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(i+boffset)
+! LCOV_EXCL_END
         endif
       enddo
 

--- a/tests/t100-vec.c
+++ b/tests/t100-vec.c
@@ -16,11 +16,13 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<n; i++) a[i] = 10 + i;
   CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
   CeedVectorGetArrayRead(x, CEED_MEM_HOST, &b);
-  for (CeedInt i=0; i<n; i++) {
+  for (CeedInt i=0; i<n; i++)
     if (b[i] != 10+i)
+      // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,(double)b[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(x, &b);
+
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;

--- a/tests/t100-vec.c
+++ b/tests/t100-vec.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     if (b[i] != 10+i)
       // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,(double)b[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(x, &b);
 
   CeedVectorDestroy(&x);

--- a/tests/t101-vec-f.f90
+++ b/tests/t101-vec-f.f90
@@ -32,7 +32,9 @@
       do i=1,10
         diff=b(boffset+i)-10-i
         if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(boffset+i)
+! LCOV_EXCL_END
         endif
       enddo
 
@@ -44,7 +46,9 @@
       do i=1,10
         diff=b(boffset+i)-val
         if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(boffset+i)
+! LCOV_EXCL_END
         endif
       enddo
 

--- a/tests/t101-vec-f.f90
+++ b/tests/t101-vec-f.f90
@@ -34,7 +34,7 @@
         if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(boffset+i)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
 
@@ -48,7 +48,7 @@
         if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(boffset+i)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
 

--- a/tests/t101-vec.c
+++ b/tests/t101-vec.c
@@ -10,8 +10,10 @@ static int CheckValues(Ceed ceed, CeedVector x, CeedScalar value) {
   CeedVectorGetArrayRead(x, CEED_MEM_HOST, &b);
   for (CeedInt i=0; i<n; i++) {
     if (b[i] != value)
+      // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,
              (double)b[i]);
+      // LCOV_EXCL_END
   }
   CeedVectorRestoreArrayRead(x, &b);
   return 0;
@@ -30,11 +32,12 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<n; i++) a[i] = 10 + i;
   CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
   CeedVectorGetArrayRead(x, CEED_MEM_HOST, &b);
-  for (CeedInt i=0; i<n; i++) {
+  for (CeedInt i=0; i<n; i++)
     if (b[i] != 10+i)
+      // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,
              (double)b[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(x, &b);
 
   CeedVectorSetValue(x, 3.0);

--- a/tests/t101-vec.c
+++ b/tests/t101-vec.c
@@ -13,7 +13,7 @@ static int CheckValues(Ceed ceed, CeedVector x, CeedScalar value) {
       // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,
              (double)b[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   }
   CeedVectorRestoreArrayRead(x, &b);
   return 0;
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,
              (double)b[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(x, &b);
 
   CeedVectorSetValue(x, 3.0);

--- a/tests/t103-vec-f.f90
+++ b/tests/t103-vec-f.f90
@@ -29,5 +29,5 @@
       call ceeddestroy(ceed,err)
 
       end
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
 !-----------------------------------------------------------------------

--- a/tests/t103-vec-f.f90
+++ b/tests/t103-vec-f.f90
@@ -21,6 +21,7 @@
       call ceedvectorgetarray(x,ceed_mem_host,a,aoffset,err)
       call ceedvectorgetarray(x,ceed_mem_host,b,boffset,err)
 
+! LCOV_EXCL_START
       call ceedvectorrestorearray(x,a,aoffset,err)
       call ceedvectorrestorearray(x,b,boffset,err)
 
@@ -28,4 +29,5 @@
       call ceeddestroy(ceed,err)
 
       end
+! LCOV_EXCL_END
 !-----------------------------------------------------------------------

--- a/tests/t103-vec.c
+++ b/tests/t103-vec.c
@@ -16,10 +16,12 @@ int main(int argc, char **argv) {
   CeedVectorGetArray(x, CEED_MEM_HOST, &a);
   CeedVectorGetArray(x, CEED_MEM_HOST, &b);
 
+  // LCOV_EXCL_START
   CeedVectorRestoreArray(x, &a);
   CeedVectorRestoreArray(x, &b);
 
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
+  // LCOV_EXCL_END
 }

--- a/tests/t103-vec.c
+++ b/tests/t103-vec.c
@@ -23,5 +23,5 @@ int main(int argc, char **argv) {
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
-  // LCOV_EXCL_END
+  // LCOV_EXCL_STOP
 }

--- a/tests/t104-vec-f.f90
+++ b/tests/t104-vec-f.f90
@@ -20,7 +20,9 @@
       call ceedvectorgetarray(x,ceed_mem_host,a,aoffset,err)
 
       call ceedvectordestroy(x,err)
+! LCOV_EXCL_START
       call ceeddestroy(ceed,err)
 
       end
+! LCOV_EXCL_END
 !-----------------------------------------------------------------------

--- a/tests/t104-vec-f.f90
+++ b/tests/t104-vec-f.f90
@@ -24,5 +24,5 @@
       call ceeddestroy(ceed,err)
 
       end
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
 !-----------------------------------------------------------------------

--- a/tests/t104-vec.c
+++ b/tests/t104-vec.c
@@ -16,6 +16,8 @@ int main(int argc, char **argv) {
 
   // Write access not restored should generate an error
   CeedVectorDestroy(&x);
+  // LCOV_EXCL_START
   CeedDestroy(&ceed);
   return 0;
+  // LCOV_EXCL_END
 }

--- a/tests/t104-vec.c
+++ b/tests/t104-vec.c
@@ -19,5 +19,5 @@ int main(int argc, char **argv) {
   // LCOV_EXCL_START
   CeedDestroy(&ceed);
   return 0;
-  // LCOV_EXCL_END
+  // LCOV_EXCL_STOP
 }

--- a/tests/t105-vec-f.f90
+++ b/tests/t105-vec-f.f90
@@ -28,5 +28,5 @@
       call ceeddestroy(ceed,err)
 
       end
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
 !-----------------------------------------------------------------------

--- a/tests/t105-vec-f.f90
+++ b/tests/t105-vec-f.f90
@@ -20,6 +20,7 @@
       call ceedvectorgetarrayread(x,ceed_mem_host,a,aoffset,err)
       call ceedvectorgetarray(x,ceed_mem_host,b,boffset,err)
 
+! LCOV_EXCL_START
       call ceedvectorrestorearrayread(x,a,aoffset,err)
       call ceedvectorrestorearray(x,b,boffset,err)
 
@@ -27,4 +28,5 @@
       call ceeddestroy(ceed,err)
 
       end
+! LCOV_EXCL_END
 !-----------------------------------------------------------------------

--- a/tests/t105-vec.c
+++ b/tests/t105-vec.c
@@ -18,10 +18,12 @@ int main(int argc, char **argv) {
   // Write access with read access generate an error
   CeedVectorGetArray(x, CEED_MEM_HOST, &b);
 
+  // LCOV_EXCL_START
   CeedVectorRestoreArrayRead(x, &a);
   CeedVectorRestoreArray(x, &b);
 
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
+  // LCOV_EXCL_END
 }

--- a/tests/t105-vec.c
+++ b/tests/t105-vec.c
@@ -25,5 +25,5 @@ int main(int argc, char **argv) {
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
-  // LCOV_EXCL_END
+  // LCOV_EXCL_STOP
 }

--- a/tests/t106-vec-f.f90
+++ b/tests/t106-vec-f.f90
@@ -31,7 +31,7 @@
         if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(i+boffset)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
 
@@ -47,5 +47,5 @@
       call ceeddestroy(ceed,err)
 
       end
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
 !-----------------------------------------------------------------------

--- a/tests/t106-vec-f.f90
+++ b/tests/t106-vec-f.f90
@@ -38,10 +38,12 @@
       enddo
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,aoffset,err)
 
+! LCOV_EXCL_START
       call ceedvectorrestorearrayread(x,b,boffset,err)
 
       call ceedvectordestroy(x,err)
       call ceeddestroy(ceed,err)
 
       end
+! LCOV_EXCL_END
 !-----------------------------------------------------------------------

--- a/tests/t106-vec-f.f90
+++ b/tests/t106-vec-f.f90
@@ -29,7 +29,9 @@
       do i=1,10
         diff=b(i+boffset)-10-i
         if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error reading array b(',i,')=',b(i+boffset)
+! LCOV_EXCL_END
         endif
       enddo
 

--- a/tests/t106-vec.c
+++ b/tests/t106-vec.c
@@ -17,10 +17,11 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, a);
 
   CeedVectorGetArrayRead(x, CEED_MEM_HOST, &b);
-  for (CeedInt i=0; i<n; i++) {
+  for (CeedInt i=0; i<n; i++)
     if (b[i] != 10+i)
+      // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,(double)b[i]);
-  }
+      // LCOV_EXCL_END
 
   // Try to set vector again (should fail)
   for (CeedInt i=0; i<n; i++) a[i] = 20 + i;

--- a/tests/t106-vec.c
+++ b/tests/t106-vec.c
@@ -26,9 +26,11 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<n; i++) a[i] = 20 + i;
   CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
 
+  // LCOV_EXCL_START
   CeedVectorRestoreArrayRead(x, &b);
 
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
+  // LCOV_EXCL_END
 }

--- a/tests/t106-vec.c
+++ b/tests/t106-vec.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     if (b[i] != 10+i)
       // LCOV_EXCL_START
       printf("Error reading array b[%d] = %f",i,(double)b[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
 
   // Try to set vector again (should fail)
   for (CeedInt i=0; i<n; i++) a[i] = 20 + i;
@@ -33,5 +33,5 @@ int main(int argc, char **argv) {
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
-  // LCOV_EXCL_END
+  // LCOV_EXCL_STOP
 }

--- a/tests/t107-vec-f.f90
+++ b/tests/t107-vec-f.f90
@@ -23,5 +23,5 @@
       call ceeddestroy(ceed,err)
 
       end
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
 !-----------------------------------------------------------------------

--- a/tests/t107-vec-f.f90
+++ b/tests/t107-vec-f.f90
@@ -18,9 +18,10 @@
       call ceedvectorcreate(ceed,n,x,err)
 
       call ceedvectorrestorearray(x,a,offset,err)
-
+! LCOV_EXCL_START
       call ceedvectordestroy(x,err)
       call ceeddestroy(ceed,err)
 
       end
+! LCOV_EXCL_END
 !-----------------------------------------------------------------------

--- a/tests/t107-vec.c
+++ b/tests/t107-vec.c
@@ -20,5 +20,5 @@ int main(int argc, char **argv) {
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
-  // LCOV_EXCL_END
+  // LCOV_EXCL_STOP
 }

--- a/tests/t107-vec.c
+++ b/tests/t107-vec.c
@@ -16,7 +16,9 @@ int main(int argc, char **argv) {
   // Should error because no GetArray was not called
   CeedVectorRestoreArray(x, &a);
 
+  // LCOV_EXCL_START
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);
   return 0;
+  // LCOV_EXCL_END
 }

--- a/tests/t108-vec-f.f90
+++ b/tests/t108-vec-f.f90
@@ -32,7 +32,7 @@
       if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
         write(*,*) 'Error writing array a(3)=',a(3)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
 
       call ceedvectordestroy(x,err)

--- a/tests/t108-vec-f.f90
+++ b/tests/t108-vec-f.f90
@@ -30,7 +30,9 @@
       call ceedvectorrestorearray(x,b,boffset,err)
       diff=a(3)+3.14
       if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
         write(*,*) 'Error writing array a(3)=',a(3)
+! LCOV_EXCL_END
       endif
 
       call ceedvectordestroy(x,err)

--- a/tests/t108-vec.c
+++ b/tests/t108-vec.c
@@ -18,7 +18,9 @@ int main(int argc, char **argv) {
   b[3] = -3.14;
   CeedVectorRestoreArray(x, &b);
   if (a[3] != -3.14)
+    // LCOV_EXCL_START
     printf("Error writing array a[3] = %f", (double)b[3]);
+    // LCOV_EXCL_START
 
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);

--- a/tests/t108-vec.c
+++ b/tests/t108-vec.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
   if (a[3] != -3.14)
     // LCOV_EXCL_START
     printf("Error writing array a[3] = %f", (double)b[3]);
-    // LCOV_EXCL_START
+    // LCOV_EXCL_STOP
 
   CeedVectorDestroy(&x);
   CeedDestroy(&ceed);

--- a/tests/t109-vec-f.f90
+++ b/tests/t109-vec-f.f90
@@ -34,7 +34,9 @@
       do i=1,10
         diff = c(i+coffset)-(9+i)
         if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error reading array c(',i,') = ',c(i+coffset),' != ',9+i
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(y,c,coffset,err)

--- a/tests/t109-vec-f.f90
+++ b/tests/t109-vec-f.f90
@@ -36,7 +36,7 @@
         if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error reading array c(',i,') = ',c(i+coffset),' != ',9+i
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(y,c,coffset,err)

--- a/tests/t109-vec.c
+++ b/tests/t109-vec.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     if (c[i] != 10+i)
       // LCOV_EXCL_START
       printf("Error reading array c[%d] = %f",i,(double)c[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(y, &c);
 
   CeedVectorDestroy(&x);

--- a/tests/t109-vec.c
+++ b/tests/t109-vec.c
@@ -21,11 +21,13 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(y, CEED_MEM_DEVICE, CEED_COPY_VALUES, (CeedScalar*)b);
   CeedVectorRestoreArrayRead(x, &b);
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &c);
-  for (CeedInt i=0; i<n; i++) {
+  for (CeedInt i=0; i<n; i++)
     if (c[i] != 10+i)
+      // LCOV_EXCL_START
       printf("Error reading array c[%d] = %f",i,(double)c[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(y, &c);
+
   CeedVectorDestroy(&x);
   CeedVectorDestroy(&y);
   CeedDestroy(&ceed);

--- a/tests/t110-vec-f.f90
+++ b/tests/t110-vec-f.f90
@@ -36,7 +36,9 @@
       do i=1,10
         diff=yy(i+yoffset)-10-i
         if (abs(diff)>1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error reading array y(',i,')=',yy(i+yoffset)
+! LCOV_EXCL_END
         endif
       enddo
 

--- a/tests/t110-vec-f.f90
+++ b/tests/t110-vec-f.f90
@@ -38,7 +38,7 @@
         if (abs(diff)>1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error reading array y(',i,')=',yy(i+yoffset)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
 

--- a/tests/t110-vec.c
+++ b/tests/t110-vec.c
@@ -24,11 +24,13 @@ int main(int argc, char **argv) {
   CeedVectorRestoreArray(X, &x);
 
   CeedVectorGetArrayRead(Y, CEED_MEM_HOST, &y);
-  for (CeedInt i=0; i<n; i++) {
+  for (CeedInt i=0; i<n; i++)
     if (y[i] != 10+i)
+      // LCOV_EXCL_START
       printf("Error reading array y[%d] = %f",i,(double)y[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(Y, &y);
+
   CeedVectorDestroy(&X);
   CeedVectorDestroy(&Y);
   CeedDestroy(&ceed);

--- a/tests/t110-vec.c
+++ b/tests/t110-vec.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     if (y[i] != 10+i)
       // LCOV_EXCL_START
       printf("Error reading array y[%d] = %f",i,(double)y[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(Y, &y);
 
   CeedVectorDestroy(&X);

--- a/tests/t200-elemrestriction-f.f90
+++ b/tests/t200-elemrestriction-f.f90
@@ -50,7 +50,7 @@
         if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i,')=',yy(i+yoffset)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t200-elemrestriction-f.f90
+++ b/tests/t200-elemrestriction-f.f90
@@ -48,7 +48,9 @@
       do i=1,ne*2
         diff=10+i/2-yy(i+yoffset)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i,')=',yy(i+yoffset)
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t200-elemrestriction.c
+++ b/tests/t200-elemrestriction.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f",
              i, (double)yy[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(y, &yy);
 
   CeedVectorDestroy(&x);

--- a/tests/t200-elemrestriction.c
+++ b/tests/t200-elemrestriction.c
@@ -28,12 +28,14 @@ int main(int argc, char **argv) {
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
                            CEED_REQUEST_IMMEDIATE);
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
-  for (CeedInt i=0; i<ne*2; i++) {
+  for (CeedInt i=0; i<ne*2; i++)
     if (10+(i+1)/2 != yy[i])
+      // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f",
              i, (double)yy[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(y, &yy);
+
   CeedVectorDestroy(&x);
   CeedVectorDestroy(&y);
   CeedElemRestrictionDestroy(&r);

--- a/tests/t201-elemrestriction-f.f90
+++ b/tests/t201-elemrestriction-f.f90
@@ -42,7 +42,7 @@
         if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i,')=',yy(yoffset+i)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t201-elemrestriction-f.f90
+++ b/tests/t201-elemrestriction-f.f90
@@ -40,7 +40,9 @@
       do i=1,ne*2
         diff=10+i-1-yy(yoffset+i)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i,')=',yy(yoffset+i)
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t201-elemrestriction.c
+++ b/tests/t201-elemrestriction.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f",
              i, (double)yy[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(y, &yy);
 
   CeedVectorDestroy(&x);

--- a/tests/t201-elemrestriction.c
+++ b/tests/t201-elemrestriction.c
@@ -22,12 +22,14 @@ int main(int argc, char **argv) {
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
                            CEED_REQUEST_IMMEDIATE);
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
-  for (CeedInt i=0; i<ne*2; i++) {
+  for (CeedInt i=0; i<ne*2; i++)
     if (yy[i] != 10+i)
+      // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f",
              i, (double)yy[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(y, &yy);
+
   CeedVectorDestroy(&x);
   CeedVectorDestroy(&y);
   CeedElemRestrictionDestroy(&r);

--- a/tests/t204-elemrestriction-f.f90
+++ b/tests/t204-elemrestriction-f.f90
@@ -53,14 +53,14 @@
 ! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n,')=',&
      &       yy(i*4+n+yoffset),'!=',10+(2*i+n)/2
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
           endif
           diff=20+(2*i+n)/2-yy(i*4+n+2+yoffset)
           if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n+2,')=',&
      &       yy(i*4+n+2+yoffset),'!=',20+(2*i+n)/2
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
           endif
         enddo
       enddo

--- a/tests/t204-elemrestriction-f.f90
+++ b/tests/t204-elemrestriction-f.f90
@@ -50,13 +50,17 @@
         do n=1,2
           diff=10+(2*i+n)/2-yy(i*4+n+yoffset)
           if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n,')=',&
      &       yy(i*4+n+yoffset),'!=',10+(2*i+n)/2
+! LCOV_EXCL_END
           endif
           diff=20+(2*i+n)/2-yy(i*4+n+2+yoffset)
           if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n+2,')=',&
      &       yy(i*4+n+2+yoffset),'!=',20+(2*i+n)/2
+! LCOV_EXCL_END
           endif
         enddo
       enddo

--- a/tests/t204-elemrestriction.c
+++ b/tests/t204-elemrestriction.c
@@ -43,12 +43,12 @@ int main(int argc, char **argv) {
         // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*4+n, (double)yy[i*4+n], 10.+(2*i+n+1)/2);
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
       if (yy[i*4+n+2] != 20+(2*i+n+1)/2)
         // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*4+n+2, (double)yy[i*4+n+2], 20.+(2*i+n+1)/2);
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
     }
   }
 

--- a/tests/t204-elemrestriction.c
+++ b/tests/t204-elemrestriction.c
@@ -40,11 +40,15 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ne; i++) {
     for (CeedInt n=0; n<2; n++) {
       if (yy[i*4+n] != 10+(2*i+n+1)/2)
+        // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*4+n, (double)yy[i*4+n], 10.+(2*i+n+1)/2);
+        // LCOV_EXCL_END
       if (yy[i*4+n+2] != 20+(2*i+n+1)/2)
+        // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*4+n+2, (double)yy[i*4+n+2], 20.+(2*i+n+1)/2);
+        // LCOV_EXCL_END
     }
   }
 

--- a/tests/t205-elemrestriction-f.f90
+++ b/tests/t205-elemrestriction-f.f90
@@ -53,14 +53,14 @@
 ! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n,')=',&
      &       yy(i*4+n+yoffset),'!=',10+(2*i+n)/2
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
           endif
           diff=20+(2*i+n)/2-yy(i*4+n+2+yoffset)
           if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n+2,')=',&
      &       yy(i*4+n+2+yoffset),'!=',20+(2*i+n)/2
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
           endif
         enddo
       enddo

--- a/tests/t205-elemrestriction-f.f90
+++ b/tests/t205-elemrestriction-f.f90
@@ -50,13 +50,17 @@
         do n=1,2
           diff=10+(2*i+n)/2-yy(i*4+n+yoffset)
           if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n,')=',&
      &       yy(i*4+n+yoffset),'!=',10+(2*i+n)/2
+! LCOV_EXCL_END
           endif
           diff=20+(2*i+n)/2-yy(i*4+n+2+yoffset)
           if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
             write(*,*) 'Error in restricted array y(',i*4+n+2,')=',&
      &       yy(i*4+n+2+yoffset),'!=',20+(2*i+n)/2
+! LCOV_EXCL_END
           endif
         enddo
       enddo

--- a/tests/t205-elemrestriction.c
+++ b/tests/t205-elemrestriction.c
@@ -43,12 +43,12 @@ int main(int argc, char **argv) {
         // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*2+n, (double)yy[i*4+n], 10.+(2*i+n+1)/2);
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
       if (yy[i*4+n+2] != 20+(2*i+n+1)/2)
         // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*4+n+2, (double)yy[i*4+n+2], 20.+(2*i+n+1)/2);
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
     }
   }
 

--- a/tests/t205-elemrestriction.c
+++ b/tests/t205-elemrestriction.c
@@ -40,11 +40,15 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ne; i++) {
     for (CeedInt n=0; n<2; n++) {
       if (yy[i*4+n] != 10+(2*i+n+1)/2)
+        // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*2+n, (double)yy[i*4+n], 10.+(2*i+n+1)/2);
+        // LCOV_EXCL_END
       if (yy[i*4+n+2] != 20+(2*i+n+1)/2)
+        // LCOV_EXCL_START
         printf("Error in restricted array y[%d] = %f != %f\n",
                i*4+n+2, (double)yy[i*4+n+2], 20.+(2*i+n+1)/2);
+        // LCOV_EXCL_END
     }
   }
 

--- a/tests/t206-elemrestriction-f.f90
+++ b/tests/t206-elemrestriction-f.f90
@@ -59,14 +59,14 @@
 ! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i+1,')=',&
      &     yy(i+1+yoffset),'!=',(10+i)*mult
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
         diff=(20+i)*mult-yy(i+ne+2+yoffset)
         if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i+ne+2,')=',&
      &     yy(i+ne+2+yoffset),'!=',(20+i)*mult
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t206-elemrestriction-f.f90
+++ b/tests/t206-elemrestriction-f.f90
@@ -56,13 +56,17 @@
         endif
         diff=(10+i)*mult-yy(i+1+yoffset)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i+1,')=',&
      &     yy(i+1+yoffset),'!=',(10+i)*mult
+! LCOV_EXCL_END
         endif
         diff=(20+i)*mult-yy(i+ne+2+yoffset)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',i+ne+2,')=',&
      &     yy(i+ne+2+yoffset),'!=',(20+i)*mult
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t206-elemrestriction.c
+++ b/tests/t206-elemrestriction.c
@@ -42,11 +42,15 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ne+1; i++) {
     mult = i>0&&i<ne ? 2 : 1;
     if (yy[i] != (10+i)*mult)
+      // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              i, (double)yy[i], (10.+i)*mult);
+      // LCOV_EXCL_END
     if (yy[i+ne+1] != (20+i)*mult)
+      // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              i+ne+1, (double)yy[i+ne+1], (20.+i)*mult);
+      // LCOV_EXCL_END
   }
 
   CeedVectorRestoreArrayRead(y, &yy);

--- a/tests/t206-elemrestriction.c
+++ b/tests/t206-elemrestriction.c
@@ -45,12 +45,12 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              i, (double)yy[i], (10.+i)*mult);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
     if (yy[i+ne+1] != (20+i)*mult)
       // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              i+ne+1, (double)yy[i+ne+1], (20.+i)*mult);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   }
 
   CeedVectorRestoreArrayRead(y, &yy);

--- a/tests/t207-elemrestriction-f.f90
+++ b/tests/t207-elemrestriction-f.f90
@@ -56,13 +56,17 @@
         endif
         diff=(10+i)*mult-yy(2*i+1+yoffset)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',2*i+1,')=',&
      &     yy(2*i+1+yoffset),'!=',(10+i)*mult
+! LCOV_EXCL_END
         endif
         diff=(20+i)*mult-yy(2*i+2+yoffset)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',2*i+2,')=',&
      &     yy(2*i+2+yoffset),'!=',(20+i)*mult
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t207-elemrestriction-f.f90
+++ b/tests/t207-elemrestriction-f.f90
@@ -59,14 +59,14 @@
 ! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',2*i+1,')=',&
      &     yy(2*i+1+yoffset),'!=',(10+i)*mult
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
         diff=(20+i)*mult-yy(2*i+2+yoffset)
         if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error in restricted array y(',2*i+2,')=',&
      &     yy(2*i+2+yoffset),'!=',(20+i)*mult
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(y,yy,yoffset,err)

--- a/tests/t207-elemrestriction.c
+++ b/tests/t207-elemrestriction.c
@@ -42,11 +42,15 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ne+1; i++) {
     mult = i>0&&i<ne ? 2 : 1;
     if (yy[2*i] != (10+i)*mult)
+      // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              2*i, (double)yy[2*i], (10.+i)*mult);
+      // LCOV_EXCL_END
     if (yy[2*i+1] != (20+i)*mult)
+      // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              2*i+1, (double)yy[2*i+1], (20.+i)*mult);
+      // LCOV_EXCL_END
   }
 
   CeedVectorRestoreArrayRead(y, &yy);

--- a/tests/t207-elemrestriction.c
+++ b/tests/t207-elemrestriction.c
@@ -45,12 +45,12 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              2*i, (double)yy[2*i], (10.+i)*mult);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
     if (yy[2*i+1] != (20+i)*mult)
       // LCOV_EXCL_START
       printf("Error in restricted array y[%d] = %f != %f\n",
              2*i+1, (double)yy[2*i+1], (20.+i)*mult);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   }
 
   CeedVectorRestoreArrayRead(y, &yy);

--- a/tests/t209-elemrestriction-f.f90
+++ b/tests/t209-elemrestriction-f.f90
@@ -47,7 +47,7 @@
         if (abs(diff) > 1.0D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'Error in multiplicity vector: mult(',i,')=',mm(i+moffset)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(mult,mm,moffset,err)

--- a/tests/t209-elemrestriction-f.f90
+++ b/tests/t209-elemrestriction-f.f90
@@ -45,7 +45,9 @@
         endif
         diff=1+offset-mm(i+moffset)
         if (abs(diff) > 1.0D-15) then
+! LCOV_EXCL_START
           write(*,*) 'Error in multiplicity vector: mult(',i,')=',mm(i+moffset)
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(mult,mm,moffset,err)

--- a/tests/t209-elemrestriction.c
+++ b/tests/t209-elemrestriction.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("Error in multiplicity vector: mult[%d] = %f\n",
              i, (double)mm[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(mult, &mm);
 
   CeedVectorDestroy(&mult);

--- a/tests/t209-elemrestriction.c
+++ b/tests/t209-elemrestriction.c
@@ -28,11 +28,12 @@ int main(int argc, char **argv) {
   CeedElemRestrictionGetMultiplicity(r, mult);
 
   CeedVectorGetArrayRead(mult, CEED_MEM_HOST, &mm);
-  for (CeedInt i=0; i<3*ne+1; i++) {
+  for (CeedInt i=0; i<3*ne+1; i++)
     if ((1 + (i > 0 && i < 3*ne && (i%3==0) ? 1 : 0)) != mm[i])
+      // LCOV_EXCL_START
       printf("Error in multiplicity vector: mult[%d] = %f\n",
              i, (double)mm[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(mult, &mm);
 
   CeedVectorDestroy(&mult);

--- a/tests/t301-basis-f.f90
+++ b/tests/t301-basis-f.f90
@@ -40,7 +40,7 @@
         if (abs(vv(i+voffset)-1.) > 1.D-15) then
 ! LCOV_EXCL_START
           write(*,*) 'v(',i,'=',vv(i+voffset),' not eqaul to 1.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(v,vv,voffset,err)

--- a/tests/t301-basis-f.f90
+++ b/tests/t301-basis-f.f90
@@ -38,7 +38,9 @@
       call ceedvectorgetarrayread(v,ceed_mem_host,vv,voffset,err)
       do i=1,length
         if (abs(vv(i+voffset)-1.) > 1.D-15) then
+! LCOV_EXCL_START
           write(*,*) 'v(',i,'=',vv(i+voffset),' not eqaul to 1.0'
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(v,vv,voffset,err)

--- a/tests/t301-basis.c
+++ b/tests/t301-basis.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     if (fabs(v[i] - 1.) > 1e-15)
       // LCOV_EXCL_START
       printf("v[%d] = %f != 1.\n", i, v[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(V, &v);
 
   CeedBasisDestroy(&b);

--- a/tests/t301-basis.c
+++ b/tests/t301-basis.c
@@ -28,9 +28,11 @@ int main(int argc, char **argv) {
   CeedBasisApply(b, 1, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, U, V);
 
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
-  for (i = 0; i < len; i++) {
-    if (fabs(v[i] - 1.) > 1e-15) printf("v[%d] = %f != 1.\n", i, v[i]);
-  }
+  for (i = 0; i < len; i++)
+    if (fabs(v[i] - 1.) > 1e-15)
+      // LCOV_EXCL_START
+      printf("v[%d] = %f != 1.\n", i, v[i]);
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(V, &v);
 
   CeedBasisDestroy(&b);

--- a/tests/t302-basis-f.f90
+++ b/tests/t302-basis-f.f90
@@ -80,7 +80,9 @@
       do i=1,q
         call polyeval(xxq(i+offset1),6,p,px)
         if (abs(uuq(i+offset2)-px) > 1e-14) then
+! LCOV_EXCL_START
           write(*,*) uuq(i+offset2),' not eqaul to ',px,'=p(',xxq(i+offset1),')'
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(xq,xxq,offset1,err)

--- a/tests/t302-basis-f.f90
+++ b/tests/t302-basis-f.f90
@@ -82,7 +82,7 @@
         if (abs(uuq(i+offset2)-px) > 1e-14) then
 ! LCOV_EXCL_START
           write(*,*) uuq(i+offset2),' not eqaul to ',px,'=p(',xxq(i+offset1),')'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(xq,xxq,offset1,err)

--- a/tests/t302-basis.c
+++ b/tests/t302-basis.c
@@ -56,9 +56,10 @@ int main(int argc, char **argv) {
   CeedVectorGetArrayRead(Uq, CEED_MEM_HOST, &uuq);
   for (CeedInt i=0; i<Q; i++) {
     CeedScalar px = PolyEval(xq[i], ALEN(p), p);
-    if ((fabs(uuq[i] - px) > 1e-14)) {
+    if (fabs(uuq[i] - px) > 1e-14)
+      // LCOV_EXCL_START
       printf("%f != %f=p(%f)\n", uuq[i], px, xq[i]);
-    }
+      // LCOV_EXCL_END
   }
   CeedVectorRestoreArrayRead(Xq, &xq);
   CeedVectorRestoreArrayRead(Uq, &uuq);

--- a/tests/t302-basis.c
+++ b/tests/t302-basis.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     if (fabs(uuq[i] - px) > 1e-14)
       // LCOV_EXCL_START
       printf("%f != %f=p(%f)\n", uuq[i], px, xq[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   }
   CeedVectorRestoreArrayRead(Xq, &xq);
   CeedVectorRestoreArrayRead(Uq, &uuq);

--- a/tests/t303-basis-f.f90
+++ b/tests/t303-basis-f.f90
@@ -108,7 +108,9 @@
           call eval(dimn,xxx,fx)
 
           if(dabs(uuq(i+offset2)-fx) > 1.0D-4) then
+! LCOV_EXCL_START
           write(*,*) uuq(i+offset2),' not equal to ',fx,dimn,i
+! LCOV_EXCL_END
           endif
         enddo
         call ceedvectorrestorearrayread(xq,xxq,offset1,err)

--- a/tests/t303-basis-f.f90
+++ b/tests/t303-basis-f.f90
@@ -110,7 +110,7 @@
           if(dabs(uuq(i+offset2)-fx) > 1.0D-4) then
 ! LCOV_EXCL_START
           write(*,*) uuq(i+offset2),' not equal to ',fx,dimn,i
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
           endif
         enddo
         call ceedvectorrestorearrayread(xq,xxq,offset1,err)

--- a/tests/t303-basis.c
+++ b/tests/t303-basis.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
         printf("[%d] %f != %f=f(%f", dim, u[i], fx, xx[0]);
         for (CeedInt d=1; d<dim; d++) printf(",%f", xx[d]);
         puts(")");
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
       }
     }
     CeedVectorRestoreArrayRead(Xq, &xq);

--- a/tests/t303-basis.c
+++ b/tests/t303-basis.c
@@ -68,10 +68,12 @@ int main(int argc, char **argv) {
       CeedScalar xx[dim];
       for (CeedInt d=0; d<dim; d++) xx[d] = xq[d*Qdim + i];
       CeedScalar fx = Eval(dim, xx);
-      if ((fabs(u[i] - fx) > 1e-4)) {
+      if (fabs(u[i] - fx) > 1e-4) {
+        // LCOV_EXCL_START
         printf("[%d] %f != %f=f(%f", dim, u[i], fx, xx[0]);
         for (CeedInt d=1; d<dim; d++) printf(",%f", xx[d]);
         puts(")");
+        // LCOV_EXCL_END
       }
     }
     CeedVectorRestoreArrayRead(Xq, &xq);

--- a/tests/t304-basis-f.f90
+++ b/tests/t304-basis-f.f90
@@ -119,8 +119,10 @@
         call ceedvectorrestorearrayread(u,uu,offset2,err)
         call ceedvectorrestorearrayread(uq,uuq,offset3,err)
         if(abs(sum1-sum2) > 1.0D-10) then
+! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.6,A,F12.6)')'[',dimn,'] Error: ',sum1,  ' != ',&
      &     sum2
+! LCOV_EXCL_END
         endif
 
         call ceedvectordestroy(x,err)

--- a/tests/t304-basis-f.f90
+++ b/tests/t304-basis-f.f90
@@ -122,7 +122,7 @@
 ! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.6,A,F12.6)')'[',dimn,'] Error: ',sum1,  ' != ',&
      &     sum2
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
 
         call ceedvectordestroy(x,err)

--- a/tests/t304-basis.c
+++ b/tests/t304-basis.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     if (fabs(sum1 - sum2) > 1e-10)
       // LCOV_EXCL_START
       printf("[%d] %f != %f\n", dim, sum1, sum2);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
 
     CeedVectorDestroy(&X);
     CeedVectorDestroy(&Xq);

--- a/tests/t304-basis.c
+++ b/tests/t304-basis.c
@@ -71,9 +71,10 @@ int main(int argc, char **argv) {
     }
     CeedVectorRestoreArrayRead(Gtposeones, &gtposeones);
     CeedVectorRestoreArrayRead(Uq, &uq);
-    if (fabs(sum1 - sum2) > 1e-10) {
+    if (fabs(sum1 - sum2) > 1e-10)
+      // LCOV_EXCL_START
       printf("[%d] %f != %f\n", dim, sum1, sum2);
-    }
+      // LCOV_EXCL_END
 
     CeedVectorDestroy(&X);
     CeedVectorDestroy(&Xq);

--- a/tests/t305-basis-f.f90
+++ b/tests/t305-basis-f.f90
@@ -96,7 +96,9 @@
       call polyeval(-1.0D0,plen,pint,pm1)
       error=summ-p1+pm1
       if (abs(error) > 1e-10) then
+! LCOV_EXCL_START
         write(*,*) 'Error ',error,' sum ',summ,' exact ',p1-pm1
+! LCOV_EXCL_END
       endif
 
       call ceedvectordestroy(x,err)

--- a/tests/t305-basis-f.f90
+++ b/tests/t305-basis-f.f90
@@ -98,7 +98,7 @@
       if (abs(error) > 1e-10) then
 ! LCOV_EXCL_START
         write(*,*) 'Error ',error,' sum ',summ,' exact ',p1-pm1
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
 
       call ceedvectordestroy(x,err)

--- a/tests/t305-basis.c
+++ b/tests/t305-basis.c
@@ -64,8 +64,10 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<(int)ALEN(p); i++) pint[i+1] = p[i] / (i+1);
   error = sum - PolyEval(1, ALEN(pint), pint) + PolyEval(-1, ALEN(pint), pint);
   if (error > 1.e-10)
+    // LCOV_EXCL_START
     printf("Error %e  sum %g  exact %g\n", error, sum,
            PolyEval(1, ALEN(pint), pint) - PolyEval(-1, ALEN(pint), pint));
+    // LCOV_EXCL_END
 
   CeedVectorDestroy(&X);
   CeedVectorDestroy(&Xq);

--- a/tests/t305-basis.c
+++ b/tests/t305-basis.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
     // LCOV_EXCL_START
     printf("Error %e  sum %g  exact %g\n", error, sum,
            PolyEval(1, ALEN(pint), pint) - PolyEval(-1, ALEN(pint), pint));
-    // LCOV_EXCL_END
+    // LCOV_EXCL_STOP
 
   CeedVectorDestroy(&X);
   CeedVectorDestroy(&Xq);

--- a/tests/t306-basis-f.f90
+++ b/tests/t306-basis-f.f90
@@ -18,7 +18,7 @@
         if (abs(qr(i))<1.0D-14) then
 ! LCOV_EXCL_START
           qr(i) = 0
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
         write(*,'(A,F12.8)') '',qr(i)
       enddo
@@ -26,7 +26,7 @@
         if (abs(tau(i))<1.0D-14) then
 ! LCOV_EXCL_START
           tau(i) = 0
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
         write(*,'(A,F12.8)') '',tau(i)
       enddo

--- a/tests/t306-basis-f.f90
+++ b/tests/t306-basis-f.f90
@@ -16,13 +16,17 @@
       call ceedqrfactorization(ceed,qr,tau,4,3,err);
       do i=1,12
         if (abs(qr(i))<1.0D-14) then
+! LCOV_EXCL_START
           qr(i) = 0
+! LCOV_EXCL_END
         endif
         write(*,'(A,F12.8)') '',qr(i)
       enddo
       do i=1,3
         if (abs(tau(i))<1.0D-14) then
+! LCOV_EXCL_START
           tau(i) = 0
+! LCOV_EXCL_END
         endif
         write(*,'(A,F12.8)') '',tau(i)
       enddo

--- a/tests/t307-basis-f.f90
+++ b/tests/t307-basis-f.f90
@@ -36,7 +36,9 @@
       call ceedbasisview(b,err)
       do i=1,16
         if (abs(colograd1d(i))<1.0D-14) then
+! LCOV_EXCL_START
           colograd1d(i) = 0
+! LCOV_EXCL_END
         endif
       enddo
       do i=0,3
@@ -52,7 +54,9 @@
       call ceedbasisview(b,err)
       do i=1,36
         if (abs(colograd1d2(i))<1.0D-14) then
+! LCOV_EXCL_START
           colograd1d2(i) = 0
+! LCOV_EXCL_END
         endif
       enddo
       do i=0,5

--- a/tests/t307-basis-f.f90
+++ b/tests/t307-basis-f.f90
@@ -38,7 +38,7 @@
         if (abs(colograd1d(i))<1.0D-14) then
 ! LCOV_EXCL_START
           colograd1d(i) = 0
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       do i=0,3
@@ -56,7 +56,7 @@
         if (abs(colograd1d2(i))<1.0D-14) then
 ! LCOV_EXCL_START
           colograd1d2(i) = 0
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       do i=0,5

--- a/tests/t308-basis-f.f90
+++ b/tests/t308-basis-f.f90
@@ -23,7 +23,7 @@
       call ceedvectorcreate(ceed,length+1,v,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,dimn,ncomp,p,q,ceed_gauss,b,err)
-
+! LCOV_EXCL_START
       call ceedbasisapply(b,1,ceed_notranspose,ceed_eval_interp,u,v,err)
 
       call ceedbasisdestroy(b,err)
@@ -32,4 +32,5 @@
       call ceeddestroy(ceed,err)
 
       end
+! LCOV_EXCL_END
 !-----------------------------------------------------------------------

--- a/tests/t308-basis-f.f90
+++ b/tests/t308-basis-f.f90
@@ -32,5 +32,5 @@
       call ceeddestroy(ceed,err)
 
       end
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
 !-----------------------------------------------------------------------

--- a/tests/t308-basis.c
+++ b/tests/t308-basis.c
@@ -18,11 +18,14 @@ int main(int argc, char **argv) {
 
   CeedBasisCreateTensorH1Lagrange(ceed, dim, ncomp, P, Q, CEED_GAUSS, &b);
 
+  // Basis apply will error because dimensions don't agree
   CeedBasisApply(b, 1, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, U, V);
 
+  // LCOV_EXCL_START
   CeedBasisDestroy(&b);
   CeedVectorDestroy(&U);
   CeedVectorDestroy(&V);
   CeedDestroy(&ceed);
   return 0;
+  // LCOV_EXCL_END
 }

--- a/tests/t308-basis.c
+++ b/tests/t308-basis.c
@@ -27,5 +27,5 @@ int main(int argc, char **argv) {
   CeedVectorDestroy(&V);
   CeedDestroy(&ceed);
   return 0;
-  // LCOV_EXCL_END
+  // LCOV_EXCL_STOP
 }

--- a/tests/t311-basis-f.f90
+++ b/tests/t311-basis-f.f90
@@ -77,7 +77,7 @@
 ! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.8,A,F12.8)')  '[',i,'] ',ooutput(i+ooffset),&
      &     ' != ',val
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(output,ooutput,ooffset,err)

--- a/tests/t311-basis-f.f90
+++ b/tests/t311-basis-f.f90
@@ -74,8 +74,10 @@
         call feval(x1,x2,val)
         diff=val-ooutput(i+ooffset)
         if (abs(diff)>1.0d-10) then
+! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.8,A,F12.8)')  '[',i,'] ',ooutput(i+ooffset),&
      &     ' != ',val
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(output,ooutput,ooffset,err)

--- a/tests/t311-basis.c
+++ b/tests/t311-basis.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     if (fabs(out[i] - value) > 1e-10)
       // LCOV_EXCL_START
       printf("[%d] %f != %f\n", i, out[i], value);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   }
   CeedVectorRestoreArrayRead(Out, &out);
 

--- a/tests/t311-basis.c
+++ b/tests/t311-basis.c
@@ -44,7 +44,9 @@ int main(int argc, char **argv) {
   for (int i=0; i<Q; i++) {
     value = feval(xq[0*Q+i], xq[1*Q+i]);
     if (fabs(out[i] - value) > 1e-10)
+      // LCOV_EXCL_START
       printf("[%d] %f != %f\n", i, out[i], value);
+      // LCOV_EXCL_END
   }
   CeedVectorRestoreArrayRead(Out, &out);
 

--- a/tests/t312-basis-f.f90
+++ b/tests/t312-basis-f.f90
@@ -84,7 +84,7 @@
       if (abs(diff)>1.0d-10) then
 ! LCOV_EXCL_START
         write(*,'(A,I1,A,F12.8,A,F12.8)')'[',i,'] ',val,' != ',17.d0/24.d0
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
 
       call ceedvectordestroy(input,err)

--- a/tests/t312-basis-f.f90
+++ b/tests/t312-basis-f.f90
@@ -82,7 +82,9 @@
 
       diff=val-17.d0/24.d0
       if (abs(diff)>1.0d-10) then
+! LCOV_EXCL_START
         write(*,'(A,I1,A,F12.8,A,F12.8)')'[',i,'] ',val,' != ',17.d0/24.d0
+! LCOV_EXCL_END
       endif
 
       call ceedvectordestroy(input,err)

--- a/tests/t313-basis-f.f90
+++ b/tests/t313-basis-f.f90
@@ -80,14 +80,18 @@
         call dfeval(x1,x2,val)
         diff=val-ooutput(0*q+i+ooffset)
         if (abs(diff)>1.0d-10) then
+! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.8,A,F12.8)')  '[',i,'] ',ooutput(i+ooffset),&
      &     ' != ',val
+! LCOV_EXCL_END
         endif
         call dfeval(x2,x1,val)
         diff=val-ooutput(1*q+i+ooffset)
         if (abs(diff)>1.0d-10) then
+! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.8,A,F12.8)')  '[',i,'] ',ooutput(i+ooffset),&
      &     ' != ',val
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(output,ooutput,ooffset,err)

--- a/tests/t313-basis-f.f90
+++ b/tests/t313-basis-f.f90
@@ -83,7 +83,7 @@
 ! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.8,A,F12.8)')  '[',i,'] ',ooutput(i+ooffset),&
      &     ' != ',val
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
         call dfeval(x2,x1,val)
         diff=val-ooutput(1*q+i+ooffset)
@@ -91,7 +91,7 @@
 ! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.8,A,F12.8)')  '[',i,'] ',ooutput(i+ooffset),&
      &     ' != ',val
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(output,ooutput,ooffset,err)

--- a/tests/t313-basis.c
+++ b/tests/t313-basis.c
@@ -50,12 +50,12 @@ int main(int argc, char **argv) {
     if (fabs(out[0*Q+i] - value) > 1e-10)
       // LCOV_EXCL_START
       printf("[%d] %f != %f\n", i, out[0*Q+i], value);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
     value = dfeval(xq[1*Q+i], xq[0*Q+i]);
     if (fabs(out[1*Q+i] - value) > 1e-10)
       // LCOV_EXCL_START
       printf("[%d] %f != %f\n", i, out[1*Q+i], value);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   }
   CeedVectorRestoreArrayRead(Out, &out);
 

--- a/tests/t313-basis.c
+++ b/tests/t313-basis.c
@@ -48,10 +48,14 @@ int main(int argc, char **argv) {
   for (int i=0; i<Q; i++) {
     value = dfeval(xq[0*Q+i], xq[1*Q+i]);
     if (fabs(out[0*Q+i] - value) > 1e-10)
+      // LCOV_EXCL_START
       printf("[%d] %f != %f\n", i, out[0*Q+i], value);
+      // LCOV_EXCL_END
     value = dfeval(xq[1*Q+i], xq[0*Q+i]);
     if (fabs(out[1*Q+i] - value) > 1e-10)
+      // LCOV_EXCL_START
       printf("[%d] %f != %f\n", i, out[1*Q+i], value);
+      // LCOV_EXCL_END
   }
   CeedVectorRestoreArrayRead(Out, &out);
 

--- a/tests/t314-basis-f.f90
+++ b/tests/t314-basis-f.f90
@@ -119,8 +119,10 @@
         call ceedvectorrestorearrayread(u,uu,offset2,err)
         call ceedvectorrestorearrayread(uq,uuq,offset3,err)
         if(abs(sum1-sum2) > 1.0D-10) then
+! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.6,A,F12.6)')'[',dimn,'] Error: ',sum1,  ' != ',&
      &     sum2
+! LCOV_EXCL_END
         endif
 
         call ceedvectordestroy(x,err)

--- a/tests/t314-basis-f.f90
+++ b/tests/t314-basis-f.f90
@@ -122,7 +122,7 @@
 ! LCOV_EXCL_START
           write(*,'(A,I1,A,F12.6,A,F12.6)')'[',dimn,'] Error: ',sum1,  ' != ',&
      &     sum2
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
 
         call ceedvectordestroy(x,err)

--- a/tests/t400-qfunction-f.f90
+++ b/tests/t400-qfunction-f.f90
@@ -98,7 +98,9 @@
       call ceedvectorgetarrayread(v,ceed_mem_host,vv,voffset,err)
       do i=1,q
         if (abs(vv(i+voffset)-vvv(i)) > 1.0D-14) then
+! LCOV_EXCL_START
           write(*,*) 'v(i)=',vv(i+voffset),', vv(i)=',vvv(i)
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(v,vv,voffset,err)

--- a/tests/t400-qfunction-f.f90
+++ b/tests/t400-qfunction-f.f90
@@ -100,7 +100,7 @@
         if (abs(vv(i+voffset)-vvv(i)) > 1.0D-14) then
 ! LCOV_EXCL_START
           write(*,*) 'v(i)=',vv(i+voffset),', vv(i)=',vvv(i)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(v,vv,voffset,err)

--- a/tests/t400-qfunction.c
+++ b/tests/t400-qfunction.c
@@ -73,9 +73,11 @@ int main(int argc, char **argv) {
   }
 
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &vv);
-  for (CeedInt i=0; i<Q; i++) {
-    if (v[i] != vv[i]) printf("[%d] v %f != vv %f\n",i, v[i], vv[i]);
-  }
+  for (CeedInt i=0; i<Q; i++)
+    if (v[i] != vv[i])
+      // LCOV_EXCL_START
+      printf("[%d] v %f != vv %f\n",i, v[i], vv[i]);
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(V, &vv);
 
   CeedVectorDestroy(&W);

--- a/tests/t400-qfunction.c
+++ b/tests/t400-qfunction.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     if (v[i] != vv[i])
       // LCOV_EXCL_START
       printf("[%d] v %f != vv %f\n",i, v[i], vv[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(V, &vv);
 
   CeedVectorDestroy(&W);

--- a/tests/t401-qfunction-f.f90
+++ b/tests/t401-qfunction-f.f90
@@ -105,7 +105,9 @@
       call ceedvectorgetarrayread(v,ceed_mem_host,vv,voffset,err)
       do i=1,q
         if (abs(vv(i+voffset)-ctx(5)*vvv(i)) > 1.0D-14) then
+! LCOV_EXCL_START
           write(*,*) 'v(i)=',vv(i+voffset),', 5*vv(i)=',ctx(5)*vvv(i)
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(v,vv,voffset,err)

--- a/tests/t401-qfunction-f.f90
+++ b/tests/t401-qfunction-f.f90
@@ -107,7 +107,7 @@
         if (abs(vv(i+voffset)-ctx(5)*vvv(i)) > 1.0D-14) then
 ! LCOV_EXCL_START
           write(*,*) 'v(i)=',vv(i+voffset),', 5*vv(i)=',ctx(5)*vvv(i)
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(v,vv,voffset,err)

--- a/tests/t401-qfunction.c
+++ b/tests/t401-qfunction.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     if (fabs(ctx[4] * v[i] - vv[i]) > 1.e-14)
       // LCOV_EXCL_START
       printf("[%d] v %f != vv %f\n",i, v[i], vv[i]);
-      // LCOV_EXCL_END
+      // LCOV_EXCL_STOP
   CeedVectorRestoreArrayRead(V, &vv);
 
   CeedVectorDestroy(&W);

--- a/tests/t401-qfunction.c
+++ b/tests/t401-qfunction.c
@@ -77,10 +77,11 @@ int main(int argc, char **argv) {
   }
 
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &vv);
-  for (CeedInt i=0; i<Q; i++) {
+  for (CeedInt i=0; i<Q; i++)
     if (fabs(ctx[4] * v[i] - vv[i]) > 1.e-14)
+      // LCOV_EXCL_START
       printf("[%d] v %f != vv %f\n",i, v[i], vv[i]);
-  }
+      // LCOV_EXCL_END
   CeedVectorRestoreArrayRead(V, &vv);
 
   CeedVectorDestroy(&W);

--- a/tests/t500-operator-f.f90
+++ b/tests/t500-operator-f.f90
@@ -134,7 +134,7 @@
         if (abs(hv(voffset+i))>1.0d-10) then
 ! LCOV_EXCL_START
           write(*,*) '[',i,'] v ',hv(voffset+i),' != 0.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(v,hv,voffset,err)

--- a/tests/t500-operator-f.f90
+++ b/tests/t500-operator-f.f90
@@ -132,7 +132,9 @@
       call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
       do i=1,nu
         if (abs(hv(voffset+i))>1.0d-10) then
+! LCOV_EXCL_START
           write(*,*) '[',i,'] v ',hv(voffset+i),' != 0.0'
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(v,hv,voffset,err)

--- a/tests/t501-operator-f.f90
+++ b/tests/t501-operator-f.f90
@@ -136,7 +136,9 @@
         total=total+hv(voffset+i)
       enddo
       if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_END
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t501-operator-f.f90
+++ b/tests/t501-operator-f.f90
@@ -138,7 +138,7 @@
       if (abs(total-1.)>1.0d-10) then
 ! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t502-operator-f.f90
+++ b/tests/t502-operator-f.f90
@@ -146,12 +146,12 @@
       if (abs(total1-1.)>1.0d-10) then
 ! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total1,' != True Area: 1.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
       if (abs(total2-2.)>1.0d-10) then
 ! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total2,' != True Area: 2.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t502-operator-f.f90
+++ b/tests/t502-operator-f.f90
@@ -144,10 +144,14 @@
         total2=total2+hv(voffset+2*i)
       enddo
       if (abs(total1-1.)>1.0d-10) then
+! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total1,' != True Area: 1.0'
+! LCOV_EXCL_END
       endif
       if (abs(total2-2.)>1.0d-10) then
+! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total2,' != True Area: 2.0'
+! LCOV_EXCL_END
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t510-operator-f.f90
+++ b/tests/t510-operator-f.f90
@@ -162,7 +162,9 @@
       call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
       do i=1,ndofs
         if (abs(hv(voffset+i))>1.0d-10) then
+! LCOV_EXCL_START
           write(*,*) '[',i,'] v ',hv(voffset+i),' != 0.0'
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(v,hv,voffset,err)

--- a/tests/t510-operator-f.f90
+++ b/tests/t510-operator-f.f90
@@ -164,7 +164,7 @@
         if (abs(hv(voffset+i))>1.0d-10) then
 ! LCOV_EXCL_START
           write(*,*) '[',i,'] v ',hv(voffset+i),' != 0.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(v,hv,voffset,err)

--- a/tests/t511-operator-f.f90
+++ b/tests/t511-operator-f.f90
@@ -168,7 +168,7 @@
       if (abs(total-1.)>1.0d-10) then
 ! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t511-operator-f.f90
+++ b/tests/t511-operator-f.f90
@@ -166,7 +166,9 @@
         total=total+hv(voffset+i)
       enddo
       if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_END
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -263,7 +263,7 @@
         if (abs(hv(voffset+i))>1.0d-10) then
 ! LCOV_EXCL_START
           write(*,*) '[',i,'] v ',hv(voffset+i),' != 0.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
         endif
       enddo
       call ceedvectorrestorearrayread(v,hv,voffset,err)

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -261,7 +261,9 @@
       call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
       do i=1,ndofs
         if (abs(hv(voffset+i))>1.0d-10) then
+! LCOV_EXCL_START
           write(*,*) '[',i,'] v ',hv(voffset+i),' != 0.0'
+! LCOV_EXCL_END
         endif
       enddo
       call ceedvectorrestorearrayread(v,hv,voffset,err)

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -265,7 +265,9 @@
         total=total+hv(voffset+i)
       enddo
       if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_END
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -267,7 +267,7 @@
       if (abs(total-1.)>1.0d-10) then
 ! LCOV_EXCL_START
         write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
-! LCOV_EXCL_END
+! LCOV_EXCL_STOP
       endif
       call ceedvectorrestorearrayread(v,hv,voffset,err)
 


### PR DESCRIPTION
This PR excludes lines that are skipped in the tests because of intentional failures and checks that don't print in a passing test suite. Also, I stop doing CodeCov on OSX, as it's very slow there and doesn't add anything we aren't getting on the faster linux runs.

This PR is also faster because we generate the report once and submit it 4x rather than generating and submitting 4x.

I did not add exclusion markers to the interface or backends. I can see the benefit in adding markers to error messages we intend to not test, such as when a backend does not respond to a particular resource string, but that is a bigger discussion and I wanted this PR to be small.