### PR TITLE
NS: clean geometric factors

### DIFF
--- a/examples/navier-stokes/advection.h
+++ b/examples/navier-stokes/advection.h
@@ -168,16 +168,16 @@ static int Advection(void *ctx, CeedInt Q,
     // -- Interp-to-Interp qdata
     const CeedScalar wJ        =    qdata[0][i];
     // -- Interp-to-Grad qdata
-    //      Symmetric 3x3 matrix
-    const CeedScalar wBJ[3][3] = {{qdata[1][i],
-                                   qdata[2][i],
-                                   qdata[3][i]},
-                                  {qdata[4][i],
-                                   qdata[5][i],
-                                   qdata[6][i]},
-                                  {qdata[7][i],
-                                   qdata[8][i],
-                                   qdata[9][i]}
+    //    3x3 matrix
+    const CeedScalar wBJ[3][3] = {{qdata[1][i] * wJ,
+                                   qdata[2][i] * wJ,
+                                   qdata[3][i] * wJ},
+                                  {qdata[4][i] * wJ,
+                                   qdata[5][i] * wJ,
+                                   qdata[6][i] * wJ},
+                                  {qdata[7][i] * wJ,
+                                   qdata[8][i] * wJ,
+                                   qdata[9][i] * wJ}
                                  };
 
     // The Physics

--- a/examples/navier-stokes/advection.h
+++ b/examples/navier-stokes/advection.h
@@ -140,12 +140,12 @@ static int Advection(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho        =  q[0][i];
-    const CeedScalar u[3]       = {q[1][i] / rho,
-                                   q[2][i] / rho,
-                                   q[3][i] / rho
+    const CeedScalar rho        =    q[0][i];
+    const CeedScalar u[3]       = {  q[1][i] / rho,
+                                     q[2][i] / rho,
+                                     q[3][i] / rho
                                   };
-    const CeedScalar E          =  q[4][i];
+    const CeedScalar E          =    q[4][i];
     // -- Grad in
     const CeedScalar drho[3]    = {  dq[0][0][i],
                                      dq[1][0][i],
@@ -166,9 +166,9 @@ static int Advection(void *ctx, CeedInt Q,
                                      dq[2][4][i]
                                   };
     // -- Interp-to-Interp qdata
-    const CeedScalar wJ         =  qdata[0][i];
+    const CeedScalar wJ         =   qdata[0][i];
     // -- Interp-to-Grad qdata
-    //    3x3 matrix
+    // ---- Inverse of change of coordinate matrix: X_i,j
     const CeedScalar dXdx[3][3] = {{qdata[1][i],
                                     qdata[2][i],
                                     qdata[3][i]},

--- a/examples/navier-stokes/advection.h
+++ b/examples/navier-stokes/advection.h
@@ -140,33 +140,33 @@ static int Advection(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho      =   q[0][i];
-    const CeedScalar u[3]     = { q[1][i] / rho,
-                                  q[2][i] / rho,
-                                  q[3][i] / rho
-                                };
-    const CeedScalar E        =   q[4][i];
+    const CeedScalar rho        =  q[0][i];
+    const CeedScalar u[3]       = {q[1][i] / rho,
+                                   q[2][i] / rho,
+                                   q[3][i] / rho
+                                  };
+    const CeedScalar E          =  q[4][i];
     // -- Grad in
-    const CeedScalar drho[3]  = {  dq[0][0][i],
-                                   dq[1][0][i],
-                                   dq[2][0][i]
-                                };
-    const CeedScalar du[3][3]  = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
-                                   (dq[1][1][i] - drho[1]*u[0]) / rho,
-                                   (dq[2][1][i] - drho[2]*u[0]) / rho},
-                                  {(dq[0][2][i] - drho[0]*u[1]) / rho,
-                                   (dq[1][2][i] - drho[1]*u[1]) / rho,
-                                   (dq[2][2][i] - drho[2]*u[1]) / rho},
-                                  {(dq[0][3][i] - drho[0]*u[2]) / rho,
-                                   (dq[1][3][i] - drho[1]*u[2]) / rho,
-                                   (dq[2][3][i] - drho[2]*u[2]) / rho}
-                                 };
-    const CeedScalar dE[3]    = {  dq[0][4][i],
-                                   dq[1][4][i],
-                                   dq[2][4][i]
-                                };
+    const CeedScalar drho[3]    = {  dq[0][0][i],
+                                     dq[1][0][i],
+                                     dq[2][0][i]
+                                  };
+    const CeedScalar du[3][3]   = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
+                                    (dq[1][1][i] - drho[1]*u[0]) / rho,
+                                    (dq[2][1][i] - drho[2]*u[0]) / rho},
+                                   {(dq[0][2][i] - drho[0]*u[1]) / rho,
+                                    (dq[1][2][i] - drho[1]*u[1]) / rho,
+                                    (dq[2][2][i] - drho[2]*u[1]) / rho},
+                                   {(dq[0][3][i] - drho[0]*u[2]) / rho,
+                                    (dq[1][3][i] - drho[1]*u[2]) / rho,
+                                    (dq[2][3][i] - drho[2]*u[2]) / rho}
+                                  };
+    const CeedScalar dE[3]      = {  dq[0][4][i],
+                                     dq[1][4][i],
+                                     dq[2][4][i]
+                                  };
     // -- Interp-to-Interp qdata
-    const CeedScalar wJ        =    qdata[0][i];
+    const CeedScalar wJ         =  qdata[0][i];
     // -- Interp-to-Grad qdata
     //    3x3 matrix
     const CeedScalar dXdx[3][3] = {{qdata[1][i],
@@ -178,7 +178,7 @@ static int Advection(void *ctx, CeedInt Q,
                                    {qdata[7][i],
                                     qdata[8][i],
                                     qdata[9][i]}
-                                 };
+                                  };
 
     // The Physics
 

--- a/examples/navier-stokes/advection.h
+++ b/examples/navier-stokes/advection.h
@@ -55,15 +55,16 @@
 static int ICsAdvection(void *ctx, CeedInt Q,
                         const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
-  const CeedScalar *X = in[0];
+  const CeedScalar (*X)[Q] = (CeedScalar(*)[Q])in[0];
   // Outputs
-  CeedScalar *q0 = out[0], *coords = out[1];
+  CeedScalar (*q0)[Q] = (CeedScalar(*)[Q])out[0],
+             (*coords)[Q] = (CeedScalar(*)[Q])out[1];
   // Context
   const CeedScalar *context = (const CeedScalar*)ctx;
-  const CeedScalar rc         = context[8];
-  const CeedScalar lx         = context[9];
-  const CeedScalar ly         = context[10];
-  const CeedScalar lz         = context[11];
+  const CeedScalar rc = context[8];
+  const CeedScalar lx = context[9];
+  const CeedScalar ly = context[10];
+  const CeedScalar lz = context[11];
   // Setup
   const CeedScalar tol = 1.e-14;
   const CeedScalar x0[3] = {0.25*lx, 0.5*ly, 0.5*lz};
@@ -74,34 +75,34 @@ static int ICsAdvection(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Coordinates
-    const CeedScalar x = X[i+0*Q];
-    const CeedScalar y = X[i+1*Q];
-    const CeedScalar z = X[i+2*Q];
+    const CeedScalar x = X[0][i];
+    const CeedScalar y = X[1][i];
+    const CeedScalar z = X[2][i];
     // -- Energy
     const CeedScalar r = sqrt(pow((x - x0[0]), 2) +
                               pow((y - x0[1]), 2) +
                               pow((z - x0[2]), 2));
 
     // Initial Conditions
-    q0[i+0*Q] = 1.;
-    q0[i+1*Q] = -0.5*(y - center[1]);
-    q0[i+2*Q] =  0.5*(x - center[0]);
-    q0[i+3*Q] = 0.0;
-    q0[i+4*Q] = r <= rc ? (1.-r/rc) : 0.;
+    q0[0][i] = 1.;
+    q0[1][i] = -0.5*(y - center[1]);
+    q0[2][i] =  0.5*(x - center[0]);
+    q0[3][i] = 0.0;
+    q0[4][i] = r <= rc ? (1.-r/rc) : 0.;
 
     // Homogeneous Dirichlet Boundary Conditions for Momentum
     if ( fabs(x - 0.0) < tol || fabs(x - lx) < tol
          || fabs(y - 0.0) < tol || fabs(y - ly) < tol
          || fabs(z - 0.0) < tol || fabs(z - lz) < tol ) {
-      q0[i+1*Q] = 0.0;
-      q0[i+2*Q] = 0.0;
-      q0[i+3*Q] = 0.0;
+      q0[1][i] = 0.0;
+      q0[2][i] = 0.0;
+      q0[3][i] = 0.0;
     }
 
     // Coordinates
-    coords[i+0*Q] = x;
-    coords[i+1*Q] = y;
-    coords[i+2*Q] = z;
+    coords[0][i] = x;
+    coords[1][i] = y;
+    coords[2][i] = z;
 
   } // End of Quadrature Point Loop
 
@@ -126,93 +127,102 @@ static int ICsAdvection(void *ctx, CeedInt Q,
 static int Advection(void *ctx, CeedInt Q,
                      const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
-  const CeedScalar *q = in[0], *dq = in[1], *qdata = in[2], *x = in[3];
+  const CeedScalar (*q)[Q] = (CeedScalar(*)[Q])in[0],
+                   (*dq)[5][Q] = (CeedScalar(*)[5][Q])in[1],
+                   (*qdata)[Q] = (CeedScalar(*)[Q])in[2],
+                   (*x)[Q] = (CeedScalar(*)[Q])in[3];
   // Outputs
-  CeedScalar *v = out[0], *dv = out[1];
+  CeedScalar (*v)[Q] = (CeedScalar(*)[Q])out[0],
+             (*dv)[5][Q] = (CeedScalar(*)[5][Q])out[1];
 
   CeedPragmaOMP(simd)
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho     =   q[i+0*Q];
-    const CeedScalar u[3]    = { q[i+1*Q] / rho,
-                                 q[i+2*Q] / rho,
-                                 q[i+3*Q] / rho
-                               };
-    const CeedScalar E       =   q[i+4*Q];
+    const CeedScalar rho      =   q[0][i];
+    const CeedScalar u[3]     = { q[1][i] / rho,
+                                  q[2][i] / rho,
+                                  q[3][i] / rho
+                                };
+    const CeedScalar E        =   q[4][i];
     // -- Grad in
-    const CeedScalar drho[3] = {  dq[i+(0+5*0)*Q],
-                                  dq[i+(0+5*1)*Q],
-                                  dq[i+(0+5*2)*Q]
-                               };
-    const CeedScalar du[9]   = { (dq[i+(1+5*0)*Q] - drho[0]*u[0]) / rho,
-                                 (dq[i+(1+5*1)*Q] - drho[1]*u[0]) / rho,
-                                 (dq[i+(1+5*2)*Q] - drho[2]*u[0]) / rho,
-                                 (dq[i+(2+5*0)*Q] - drho[0]*u[1]) / rho,
-                                 (dq[i+(2+5*1)*Q] - drho[1]*u[1]) / rho,
-                                 (dq[i+(2+5*2)*Q] - drho[2]*u[1]) / rho,
-                                 (dq[i+(3+5*0)*Q] - drho[0]*u[2]) / rho,
-                                 (dq[i+(3+5*1)*Q] - drho[1]*u[2]) / rho,
-                                 (dq[i+(3+5*2)*Q] - drho[2]*u[2]) / rho
-                               };
-    const CeedScalar dE[3]   = {  dq[i+(4+5*0)*Q],
-                                  dq[i+(4+5*1)*Q],
-                                  dq[i+(4+5*2)*Q]
-                               };
+    const CeedScalar drho[3]  = {  dq[0][0][i],
+                                   dq[1][0][i],
+                                   dq[2][0][i]
+                                };
+    const CeedScalar du[3][3]  = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
+                                   (dq[1][1][i] - drho[1]*u[0]) / rho,
+                                   (dq[2][1][i] - drho[2]*u[0]) / rho},
+                                  {(dq[0][2][i] - drho[0]*u[1]) / rho,
+                                   (dq[1][2][i] - drho[1]*u[1]) / rho,
+                                   (dq[2][2][i] - drho[2]*u[1]) / rho},
+                                  {(dq[0][3][i] - drho[0]*u[2]) / rho,
+                                   (dq[1][3][i] - drho[1]*u[2]) / rho,
+                                   (dq[2][3][i] - drho[2]*u[2]) / rho}
+                                 };
+    const CeedScalar dE[3]    = {  dq[0][4][i],
+                                   dq[1][4][i],
+                                   dq[2][4][i]
+                                };
+    // -- Interp-to-Interp qdata
+    const CeedScalar wJ        =    qdata[0][i];
     // -- Interp-to-Grad qdata
     //      Symmetric 3x3 matrix
-    const CeedScalar wBJ[9]   = { qdata[i+ 1*Q],
-                                  qdata[i+ 2*Q],
-                                  qdata[i+ 3*Q],
-                                  qdata[i+ 4*Q],
-                                  qdata[i+ 5*Q],
-                                  qdata[i+ 6*Q],
-                                  qdata[i+ 7*Q],
-                                  qdata[i+ 8*Q],
-                                  qdata[i+ 9*Q]
-                                };
+    const CeedScalar wBJ[3][3] = {{qdata[1][i],
+                                   qdata[2][i],
+                                   qdata[3][i]},
+                                  {qdata[4][i],
+                                   qdata[5][i],
+                                   qdata[6][i]},
+                                  {qdata[7][i],
+                                   qdata[8][i],
+                                   qdata[9][i]}
+                                 };
 
     // The Physics
 
     // -- Density
     // ---- No Change
-    dv[i+(0+0*5)*Q] = 0;
-    dv[i+(0+1*5)*Q] = 0;
-    dv[i+(0+2*5)*Q] = 0;
-    v[i+0*Q] = 0;
+    dv[0][0][i] = 0;
+    dv[1][0][i] = 0;
+    dv[2][0][i] = 0;
+    v[0][1] = 0;
 
     // -- Momentum
     // ---- No Change
-    dv[i+(1+0*5)*Q] = 0;
-    dv[i+(1+1*5)*Q] = 0;
-    dv[i+(1+2*5)*Q] = 0;
-    dv[i+(2+0*5)*Q] = 0;
-    dv[i+(2+1*5)*Q] = 0;
-    dv[i+(2+2*5)*Q] = 0;
-    dv[i+(3+0*5)*Q] = 0;
-    dv[i+(3+1*5)*Q] = 0;
-    dv[i+(3+2*5)*Q] = 0;
-    v[i+1*Q] = 0;
-    v[i+2*Q] = 0;
-    v[i+3*Q] = 0;
+    dv[0][1][i] = 0;
+    dv[1][1][i] = 0;
+    dv[2][1][i] = 0;
+    dv[0][2][i] = 0;
+    dv[1][2][i] = 0;
+    dv[2][2][i] = 0;
+    dv[0][3][i] = 0;
+    dv[1][3][i] = 0;
+    dv[2][3][i] = 0;
+    v[1][i] = 0;
+    v[2][i] = 0;
+    v[3][i] = 0;
 
     // -- Total Energy
-    // ---- Version 1: dv E u
-    if (1) {
-      dv[i+(4+5*0)*Q]  = E*(u[0]*wBJ[0] + u[1]*wBJ[1] + u[2]*wBJ[2]);
-      dv[i+(4+5*1)*Q]  = E*(u[0]*wBJ[3] + u[1]*wBJ[4] + u[2]*wBJ[5]);
-      dv[i+(4+5*2)*Q]  = E*(u[0]*wBJ[6] + u[1]*wBJ[7] + u[2]*wBJ[8]);
-      v[i+4*Q] = 0;
-    }
-    // ---- Version 2: v E du
+    // ---- Version 1: dv \cdot (E u)
     if (0) {
-      dv[i+(4+0*5)*Q] = 0;
-      dv[i+(4+1*5)*Q] = 0;
-      dv[i+(4+2*5)*Q] = 0;
-      v[i+4*Q]   = E*(du[0]*wBJ[0] + du[3]*wBJ[1] + du[6]*wBJ[2]);
-      v[i+4*Q]  -= E*(du[1]*wBJ[3] + du[4]*wBJ[4] + du[7]*wBJ[5]);
-      v[i+4*Q]  -= E*(du[2]*wBJ[6] + du[5]*wBJ[7] + du[8]*wBJ[8]);
+      dv[0][4][i] = E*(u[0]*wBJ[0][0] + u[1]*wBJ[0][1] + u[2]*wBJ[0][2]);
+      dv[1][4][i] = E*(u[0]*wBJ[1][0] + u[1]*wBJ[1][1] + u[2]*wBJ[1][2]);
+      dv[2][4][i] = E*(u[0]*wBJ[2][0] + u[1]*wBJ[2][1] + u[2]*wBJ[2][2]);
+      v[4][i] = 0;
+    }
+    // ---- Version 2: - v (E div(u) + u \cdot grad(E))
+    if (1) {
+      dv[0][4][i] = 0;
+      dv[1][4][i] = 0;
+      dv[2][4][i] = 0;
+      v[4][i] = -E*(du[0][0]*wBJ[0][0] + du[1][0]*wBJ[1][0] + du[2][0]*wBJ[2][0] +
+                    du[0][1]*wBJ[0][1] + du[1][1]*wBJ[1][1] + du[2][1]*wBJ[2][1] +
+                    du[0][2]*wBJ[0][2] + du[1][2]*wBJ[1][2] + du[2][2]*wBJ[2][2]) -
+                u[0]*(dE[0]*wBJ[0][0] + dE[1]*wBJ[1][0] + dE[2]*wBJ[2][0]) -
+                u[1]*(dE[0]*wBJ[0][1] + dE[1]*wBJ[1][1] + dE[2]*wBJ[2][1]) -
+                u[2]*(dE[0]*wBJ[0][2] + dE[1]*wBJ[1][2] + dE[2]*wBJ[2][2]);
     }
 
   } // End Quadrature Point Loop

--- a/examples/navier-stokes/common.h
+++ b/examples/navier-stokes/common.h
@@ -116,7 +116,7 @@ static int Setup(void *ctx, CeedInt Q,
     // -- Interp-to-Interp qdata
     qdata[0][i] = w[i] * detJ;
     // -- Interp-to-Grad qdata
-    // Inverse of change of coordinate matrix X_i,j
+    // Inverse of change of coordinate matrix: X_i,j
     qdata[1][i] = A11 / detJ;
     qdata[2][i] = A12 / detJ;
     qdata[3][i] = A13 / detJ;

--- a/examples/navier-stokes/common.h
+++ b/examples/navier-stokes/common.h
@@ -53,7 +53,7 @@
 //     Jij = Jacobian entry ij
 //     Aij = Adjoint ij
 //
-// Stored: detJ
+// Stored: w detJ
 //   qd: 0
 //
 // We require the transpose of the inverse of the Jacobian to properly compute

--- a/examples/navier-stokes/common.h
+++ b/examples/navier-stokes/common.h
@@ -111,34 +111,21 @@ static int Setup(void *ctx, CeedInt Q,
     const CeedScalar A32 = J12*J31 - J11*J32;
     const CeedScalar A33 = J11*J22 - J12*J21;
     const CeedScalar detJ = J11*A11 + J21*A12 + J31*A13;
-    // Inverse of change of coordinate matrix (symmetric)
-    const CeedScalar dXdx00 = (A11*A11 + A12*A12 + A13*A13) / detJ;
-    const CeedScalar dXdx01 = (A11*A21 + A12*A22 + A13*A23) / detJ;
-    const CeedScalar dXdx02 = (A11*A31 + A12*A32 + A13*A33) / detJ;
-    const CeedScalar dXdx11 = (A21*A21 + A22*A22 + A23*A23) / detJ;
-    const CeedScalar dXdx12 = (A21*A31 + A22*A32 + A23*A33) / detJ;
-    const CeedScalar dXdx22 = (A31*A31 + A32*A32 + A33*A33) / detJ;
 
     // Qdata
     // -- Interp-to-Interp qdata
     qdata[0][i] = w[i] * detJ;
     // -- Interp-to-Grad qdata
-    qdata[1][i] = w[i] * A11;
-    qdata[2][i] = w[i] * A12;
-    qdata[3][i] = w[i] * A13;
-    qdata[4][i] = w[i] * A21;
-    qdata[5][i] = w[i] * A22;
-    qdata[6][i] = w[i] * A23;
-    qdata[7][i] = w[i] * A31;
-    qdata[8][i] = w[i] * A32;
-    qdata[9][i] = w[i] * A33;
-    // -- Grad-to-Grad qdata
-    qdata[10][i] = w[i] * dXdx00;
-    qdata[11][i] = w[i] * dXdx01;
-    qdata[12][i] = w[i] * dXdx02;
-    qdata[13][i] = w[i] * dXdx11;
-    qdata[14][i] = w[i] * dXdx12;
-    qdata[15][i] = w[i] * dXdx22;
+    // Inverse of change of coordinate matrix X_i,j
+    qdata[1][i] = A11 / detJ;
+    qdata[2][i] = A12 / detJ;
+    qdata[3][i] = A13 / detJ;
+    qdata[4][i] = A21 / detJ;
+    qdata[5][i] = A22 / detJ;
+    qdata[6][i] = A23 / detJ;
+    qdata[7][i] = A31 / detJ;
+    qdata[8][i] = A32 / detJ;
+    qdata[9][i] = A33 / detJ;
 
   } // End of Quadrature Point Loop
 

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -222,66 +222,53 @@ static int DC(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho       =    q[0][i];
-    const CeedScalar u[3]      =  { q[1][i] / rho,
+    const CeedScalar rho        =   q[0][i];
+    const CeedScalar u[3]       = { q[1][i] / rho,
                                     q[2][i] / rho,
                                     q[3][i] / rho
                                   };
-    const CeedScalar E         =    q[4][i];
+    const CeedScalar E          =   q[4][i];
     // -- Grad in
-    const CeedScalar drho[3]   =  { dq[0][0][i],
+    const CeedScalar drho[3]    = { dq[0][0][i],
                                     dq[1][0][i],
                                     dq[2][0][i]
                                   };
-    const CeedScalar du[3][3]  = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
-                                   (dq[1][1][i] - drho[1]*u[0]) / rho,
-                                   (dq[2][1][i] - drho[2]*u[0]) / rho},
-                                  {(dq[0][2][i] - drho[0]*u[1]) / rho,
-                                   (dq[1][2][i] - drho[1]*u[1]) / rho,
-                                   (dq[2][2][i] - drho[2]*u[1]) / rho},
-                                  {(dq[0][3][i] - drho[0]*u[2]) / rho,
-                                   (dq[1][3][i] - drho[1]*u[2]) / rho,
-                                   (dq[2][3][i] - drho[2]*u[2]) / rho}
-                                 };
-    const CeedScalar dE[3]     =  { dq[0][4][i],
+    const CeedScalar du[3][3]   = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
+                                    (dq[1][1][i] - drho[1]*u[0]) / rho,
+                                    (dq[2][1][i] - drho[2]*u[0]) / rho},
+                                   {(dq[0][2][i] - drho[0]*u[1]) / rho,
+                                    (dq[1][2][i] - drho[1]*u[1]) / rho,
+                                    (dq[2][2][i] - drho[2]*u[1]) / rho},
+                                   {(dq[0][3][i] - drho[0]*u[2]) / rho,
+                                    (dq[1][3][i] - drho[1]*u[2]) / rho,
+                                    (dq[2][3][i] - drho[2]*u[2]) / rho}
+                                  };
+    const CeedScalar dE[3]      = { dq[0][4][i],
                                     dq[1][4][i],
                                     dq[2][4][i]
                                   };
     // -- Interp-to-Interp qdata
-    const CeedScalar wJ        =    qdata[0][i];
+    const CeedScalar wJ         =   qdata[0][i];
     // -- Interp-to-Grad qdata
-    //    3x3 matrix
-    const CeedScalar wBJ[3][3] = {{qdata[1][i] * wJ,
-                                   qdata[2][i] * wJ,
-                                   qdata[3][i] * wJ},
-                                  {qdata[4][i] * wJ,
-                                   qdata[5][i] * wJ,
-                                   qdata[6][i] * wJ},
-                                  {qdata[7][i] * wJ,
-                                   qdata[8][i] * wJ,
-                                   qdata[9][i] * wJ}
-                                 };
-    // X_i,j * X_j,i / detJ^2
-    const CeedScalar dXdx00 = wBJ[0][0]*wBJ[0][0] + wBJ[0][1]*wBJ[0][1] + wBJ[0][2]*wBJ[0][2];
-    const CeedScalar dXdx01 = wBJ[0][0]*wBJ[1][0] + wBJ[0][1]*wBJ[1][1] + wBJ[0][2]*wBJ[1][2];
-    const CeedScalar dXdx02 = wBJ[0][0]*wBJ[2][0] + wBJ[0][1]*wBJ[2][1] + wBJ[0][2]*wBJ[2][2];
-    const CeedScalar dXdx10 = wBJ[1][0]*wBJ[0][0] + wBJ[1][1]*wBJ[0][1] + wBJ[1][2]*wBJ[1][2];
-    const CeedScalar dXdx12 = wBJ[1][0]*wBJ[1][0] + wBJ[1][1]*wBJ[1][1] + wBJ[1][2]*wBJ[1][2];
-    const CeedScalar dXdx13 = wBJ[1][0]*wBJ[2][0] + wBJ[1][1]*wBJ[2][1] + wBJ[1][2]*wBJ[2][2];
-    const CeedScalar dXdx20 = wBJ[2][0]*wBJ[0][0] + wBJ[2][1]*wBJ[0][1] + wBJ[2][2]*wBJ[0][2];
-    const CeedScalar dXdx21 = wBJ[2][0]*wBJ[1][0] + wBJ[2][1]*wBJ[1][1] + wBJ[2][2]*wBJ[1][2];
-    const CeedScalar dXdx22 = wBJ[2][0]*wBJ[2][0] + wBJ[2][1]*wBJ[2][1] + wBJ[2][2]*wBJ[2][2];
-    // -- Grad-to-Grad qdata
-    const CeedScalar wBBJ[3][3] = {{dXdx00 * wJ,
-                                    dXdx01 * wJ,
-                                    dXdx02 * wJ},
-                                   {dXdx10 * wJ,
-                                    dXdx12 * wJ,
-                                    dXdx13 * wJ},
-                                   {dXdx20 * wJ,
-                                    dXdx21 * wJ,
-                                    dXdx22 * wJ}
+    // ---- Inverse of change of coordinate matrix: X_i,j
+    const CeedScalar dXdx[3][3] = {{qdata[1][i],
+                                    qdata[2][i],
+                                    qdata[3][i]},
+                                   {qdata[4][i],
+                                    qdata[5][i],
+                                    qdata[6][i]},
+                                   {qdata[7][i],
+                                    qdata[8][i],
+                                    qdata[9][i]}
                                   };
+    // -- Grad-to-Grad qdata
+    // ---- dXdx_j,k * dXdx_k,j
+    CeedScalar dXdxdXdxT[3][3];
+    for (int j=0; j<3; j++) {
+      for (int k=0; k<3; k++) {
+        dXdxdXdxT[j][k] = dXdx[j][k] * dXdx[k][j];
+      }
+    }
     // -- gradT
     const CeedScalar gradT[3]  = {(dE[0]/rho - E*drho[0]/(rho*rho) -
                                   (u[0]*du[0][0] + u[1]*du[1][0] + u[2]*du[2][0]))/cv,
@@ -291,7 +278,7 @@ static int DC(void *ctx, CeedInt Q,
                                   (u[0]*du[0][2] + u[1]*du[1][2] + u[2]*du[2][2]) - g)/cv
                                  };
     // -- Fuvisc
-    //      Symmetric 3x3 matrix
+    // ---- Symmetric 3x3 matrix
     const CeedScalar Fu[6]     =  { mu * (du[0][0] * (2 + lambda) +
                                     lambda * (du[1][1] + du[2][2])),
                                     mu * (du[0][1] + du[1][0]),
@@ -318,56 +305,41 @@ static int DC(void *ctx, CeedInt Q,
 
     // -- Density
     // ---- u rho
-    dv[0][0][i]  = rho*u[0]*wBJ[0][0] + rho*u[1]*wBJ[0][1] + rho*u[2]*wBJ[0][2];
-    dv[1][0][i]  = rho*u[0]*wBJ[1][0] + rho*u[1]*wBJ[1][1] + rho*u[2]*wBJ[1][2];
-    dv[2][0][i]  = rho*u[0]*wBJ[2][0] + rho*u[1]*wBJ[2][1] + rho*u[2]*wBJ[2][2];
+    for (int j=0; j<3; j++)
+      dv[j][0][i]  = wJ * (rho*u[0]*dXdx[j][0] + rho*u[1]*dXdx[j][1] + rho*u[2]*dXdx[j][2]);
     // ---- No Change
     v[0][i] = 0;
 
     // -- Momentum
     // ---- rho (u x u) + P I3
-    dv[0][1][i]  = (rho*u[0]*u[0]+P)*wBJ[0][0] + rho*u[0]*u[1]*wBJ[0][1] +
-                    rho*u[0]*u[2]*wBJ[0][2];
-    dv[1][1][i]  = (rho*u[0]*u[0]+P)*wBJ[1][0] + rho*u[0]*u[1]*wBJ[1][1] +
-                    rho*u[0]*u[2]*wBJ[1][2];
-    dv[2][1][i]  = (rho*u[0]*u[0]+P)*wBJ[2][0] + rho*u[0]*u[1]*wBJ[2][1] +
-                    rho*u[0]*u[2]*wBJ[2][2];
-    dv[0][2][i]  =  rho*u[1]*u[0]*wBJ[0][0] +   (rho*u[1]*u[1]+P)*wBJ[0][1] +
-                    rho*u[1]*u[2]*wBJ[0][2];
-    dv[1][2][i]  =  rho*u[1]*u[0]*wBJ[1][0] +   (rho*u[1]*u[1]+P)*wBJ[1][1] +
-                    rho*u[1]*u[2]*wBJ[1][2];
-    dv[2][2][i]  =  rho*u[1]*u[0]*wBJ[2][0] +   (rho*u[1]*u[1]+P)*wBJ[2][1] +
-                    rho*u[1]*u[2]*wBJ[2][2];
-    dv[0][3][i]  =  rho*u[2]*u[0]*wBJ[0][0] +    rho*u[2]*u[1]*wBJ[0][1] +
-                   (rho*u[2]*u[2]+P)*wBJ[0][2];
-    dv[1][3][i]  =  rho*u[2]*u[0]*wBJ[1][0] +    rho*u[2]*u[1]*wBJ[1][1] +
-                   (rho*u[2]*u[2]+P)*wBJ[1][2];
-    dv[2][3][i]  =  rho*u[2]*u[0]*wBJ[2][0] +    rho*u[2]*u[1]*wBJ[2][1] +
-                   (rho*u[2]*u[2]+P)*wBJ[2][2];
+    for (int j=0; j<3; j++) {
+      for (int k=0; k<3; k++) {
+        dv[k][j+1][i]  = wJ * ((rho*u[j]*u[0] + (j==0?P:0))*dXdx[k][0] +
+                               (rho*u[j]*u[1] + (j==1?P:0))*dXdx[k][1] +
+                               (rho*u[j]*u[2] + (j==2?P:0))*dXdx[k][2]);
+      }
+    }
     // ---- Fuvisc
-    dv[0][1][i] -= Fu[0]*wBBJ[0][0] + Fu[1]*wBBJ[0][1] + Fu[2]*wBBJ[0][2];
-    dv[1][1][i] -= Fu[0]*wBBJ[1][0] + Fu[1]*wBBJ[1][1] + Fu[2]*wBBJ[1][2];
-    dv[2][1][i] -= Fu[0]*wBBJ[2][0] + Fu[1]*wBBJ[2][1] + Fu[2]*wBBJ[2][2];
-    dv[0][2][i] -= Fu[1]*wBBJ[0][0] + Fu[3]*wBBJ[0][1] + Fu[4]*wBBJ[0][2];
-    dv[1][2][i] -= Fu[1]*wBBJ[1][0] + Fu[3]*wBBJ[1][1] + Fu[4]*wBBJ[1][2];
-    dv[2][2][i] -= Fu[1]*wBBJ[2][0] + Fu[3]*wBBJ[2][1] + Fu[4]*wBBJ[2][2];
-    dv[0][3][i] -= Fu[2]*wBBJ[0][0] + Fu[4]*wBBJ[0][1] + Fu[5]*wBBJ[0][2];
-    dv[1][3][i] -= Fu[2]*wBBJ[1][0] + Fu[4]*wBBJ[1][1] + Fu[5]*wBBJ[2][1];
-    dv[2][3][i] -= Fu[2]*wBBJ[2][0] + Fu[4]*wBBJ[2][1] + Fu[5]*wBBJ[2][2];
+    const CeedInt Fuviscidx[3][3] = {{0, 1, 2}, {1, 3, 4}, {2, 4, 5}}; // symmetric matrix indices
+    for (int j=0; j<3; j++) {
+      for (int k=0; k<3; k++) {
+        dv[k][j+1][i] -= wJ * (Fu[Fuviscidx[j][0]]*dXdxdXdxT[k][0] +
+                               Fu[Fuviscidx[j][1]]*dXdxdXdxT[k][1] +
+                               Fu[Fuviscidx[j][2]]*dXdxdXdxT[k][2]);
+      }
+    }
     // ---- -rho g khat
     v[1][i] = 0;
     v[2][i] = 0;
     v[3][i] = -rho*g*wJ;
 
-    // -- Total Energy
+    // -- Total Energy Density
     // ---- (E + P) u
-    dv[0][4][i]  = (E + P)*(u[0]*wBJ[0][0] + u[1]*wBJ[0][1] + u[2]*wBJ[0][2]);
-    dv[1][4][i]  = (E + P)*(u[0]*wBJ[1][0] + u[1]*wBJ[1][1] + u[2]*wBJ[1][2]);
-    dv[2][4][i]  = (E + P)*(u[0]*wBJ[2][0] + u[1]*wBJ[2][1] + u[2]*wBJ[2][2]);
+    for (int j=0; j<3; j++)
+      dv[j][4][i]  = wJ * (E + P) * (u[0]*dXdx[j][0] + u[1]*dXdx[j][1] + u[2]*dXdx[j][2]);
     // ---- Fevisc
-    dv[0][0][i] -= Fe[0]*wBBJ[0][0] + Fe[1]*wBBJ[0][1] + Fe[2]*wBBJ[0][2];
-    dv[1][4][i] -= Fe[0]*wBBJ[1][0] + Fe[1]*wBBJ[1][1] + Fe[2]*wBBJ[1][2];
-    dv[2][4][i] -= Fe[0]*wBBJ[2][0] + Fe[1]*wBBJ[2][1] + Fe[2]*wBBJ[2][2];
+    for (int j=0; j<3; j++)
+      dv[j][4][i] -= wJ * (Fe[0]*dXdxdXdxT[j][0] + Fe[1]*dXdxdXdxT[j][1] + Fe[2]*dXdxdXdxT[j][2]);
     // ---- No Change
     v[4][i] = 0;
 

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -250,27 +250,37 @@ static int DC(void *ctx, CeedInt Q,
     // -- Interp-to-Interp qdata
     const CeedScalar wJ        =    qdata[0][i];
     // -- Interp-to-Grad qdata
-    //      Symmetric 3x3 matrix
-    const CeedScalar wBJ[3][3] = {{qdata[1][i],
-                                   qdata[2][i],
-                                   qdata[3][i]},
-                                  {qdata[4][i],
-                                   qdata[5][i],
-                                   qdata[6][i]},
-                                  {qdata[7][i],
-                                   qdata[8][i],
-                                   qdata[9][i]}
+    //    3x3 matrix
+    const CeedScalar wBJ[3][3] = {{qdata[1][i] * wJ,
+                                   qdata[2][i] * wJ,
+                                   qdata[3][i] * wJ},
+                                  {qdata[4][i] * wJ,
+                                   qdata[5][i] * wJ,
+                                   qdata[6][i] * wJ},
+                                  {qdata[7][i] * wJ,
+                                   qdata[8][i] * wJ,
+                                   qdata[9][i] * wJ}
                                  };
+    // X_i,j * X_j,i / detJ^2
+    const CeedScalar dXdx00 = wBJ[0][0]*wBJ[0][0] + wBJ[0][1]*wBJ[0][1] + wBJ[0][2]*wBJ[0][2];
+    const CeedScalar dXdx01 = wBJ[0][0]*wBJ[1][0] + wBJ[0][1]*wBJ[1][1] + wBJ[0][2]*wBJ[1][2];
+    const CeedScalar dXdx02 = wBJ[0][0]*wBJ[2][0] + wBJ[0][1]*wBJ[2][1] + wBJ[0][2]*wBJ[2][2];
+    const CeedScalar dXdx10 = wBJ[1][0]*wBJ[0][0] + wBJ[1][1]*wBJ[0][1] + wBJ[1][2]*wBJ[1][2];
+    const CeedScalar dXdx12 = wBJ[1][0]*wBJ[1][0] + wBJ[1][1]*wBJ[1][1] + wBJ[1][2]*wBJ[1][2];
+    const CeedScalar dXdx13 = wBJ[1][0]*wBJ[2][0] + wBJ[1][1]*wBJ[2][1] + wBJ[1][2]*wBJ[2][2];
+    const CeedScalar dXdx20 = wBJ[2][0]*wBJ[0][0] + wBJ[2][1]*wBJ[0][1] + wBJ[2][2]*wBJ[0][2];
+    const CeedScalar dXdx21 = wBJ[2][0]*wBJ[1][0] + wBJ[2][1]*wBJ[1][1] + wBJ[2][2]*wBJ[1][2];
+    const CeedScalar dXdx22 = wBJ[2][0]*wBJ[2][0] + wBJ[2][1]*wBJ[2][1] + wBJ[2][2]*wBJ[2][2];
     // -- Grad-to-Grad qdata
-    const CeedScalar wBBJ[3][3] = {{qdata[10][i],
-                                    qdata[11][i],
-                                    qdata[12][i]},
-                                   {qdata[11][i],
-                                    qdata[13][i],
-                                    qdata[14][i]},
-                                   {qdata[12][i],
-                                    qdata[14][i],
-                                    qdata[15][i]}
+    const CeedScalar wBBJ[3][3] = {{dXdx00 * wJ,
+                                    dXdx01 * wJ,
+                                    dXdx02 * wJ},
+                                   {dXdx10 * wJ,
+                                    dXdx12 * wJ,
+                                    dXdx13 * wJ},
+                                   {dXdx20 * wJ,
+                                    dXdx21 * wJ,
+                                    dXdx22 * wJ}
                                   };
     // -- gradT
     const CeedScalar gradT[3]  = {(dE[0]/rho - E*drho[0]/(rho*rho) -

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -222,12 +222,12 @@ static int DC(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho        =  q[0][i];
-    const CeedScalar u[3]       = {q[1][i] / rho,
-                                   q[2][i] / rho,
-                                   q[3][i] / rho
+    const CeedScalar rho        =    q[0][i];
+    const CeedScalar u[3]       = {  q[1][i] / rho,
+                                     q[2][i] / rho,
+                                     q[3][i] / rho
                                   };
-    const CeedScalar E          =  q[4][i];
+    const CeedScalar E          =    q[4][i];
     // -- Grad in
     const CeedScalar drho[3]    = {  dq[0][0][i],
                                      dq[1][0][i],

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -222,16 +222,16 @@ static int DC(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho        =   q[0][i];
-    const CeedScalar u[3]       = { q[1][i] / rho,
-                                    q[2][i] / rho,
-                                    q[3][i] / rho
+    const CeedScalar rho        =  q[0][i];
+    const CeedScalar u[3]       = {q[1][i] / rho,
+                                   q[2][i] / rho,
+                                   q[3][i] / rho
                                   };
-    const CeedScalar E          =   q[4][i];
+    const CeedScalar E          =  q[4][i];
     // -- Grad in
-    const CeedScalar drho[3]    = { dq[0][0][i],
-                                    dq[1][0][i],
-                                    dq[2][0][i]
+    const CeedScalar drho[3]    = {  dq[0][0][i],
+                                     dq[1][0][i],
+                                     dq[2][0][i]
                                   };
     const CeedScalar du[3][3]   = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
                                     (dq[1][1][i] - drho[1]*u[0]) / rho,
@@ -243,9 +243,9 @@ static int DC(void *ctx, CeedInt Q,
                                     (dq[1][3][i] - drho[1]*u[2]) / rho,
                                     (dq[2][3][i] - drho[2]*u[2]) / rho}
                                   };
-    const CeedScalar dE[3]      = { dq[0][4][i],
-                                    dq[1][4][i],
-                                    dq[2][4][i]
+    const CeedScalar dE[3]      = {  dq[0][4][i],
+                                     dq[1][4][i],
+                                     dq[2][4][i]
                                   };
     // -- Interp-to-Interp qdata
     const CeedScalar wJ         =   qdata[0][i];
@@ -264,11 +264,10 @@ static int DC(void *ctx, CeedInt Q,
     // -- Grad-to-Grad qdata
     // ---- dXdx_j,k * dXdx_k,j
     CeedScalar dXdxdXdxT[3][3];
-    for (int j=0; j<3; j++) {
-      for (int k=0; k<3; k++) {
+    for (int j=0; j<3; j++)
+      for (int k=0; k<3; k++)
         dXdxdXdxT[j][k] = dXdx[j][k] * dXdx[k][j];
-      }
-    }
+
     // -- gradT
     const CeedScalar gradT[3]  = {(dE[0]/rho - E*drho[0]/(rho*rho) -
                                   (u[0]*du[0][0] + u[1]*du[1][0] + u[2]*du[2][0]))/cv,
@@ -306,28 +305,24 @@ static int DC(void *ctx, CeedInt Q,
     // -- Density
     // ---- u rho
     for (int j=0; j<3; j++)
-      dv[j][0][i]  = wJ * (rho*u[0]*dXdx[j][0] + rho*u[1]*dXdx[j][1] + rho*u[2]*dXdx[j][2]);
+      dv[j][0][i]  = wJ*(rho*u[0]*dXdx[j][0] + rho*u[1]*dXdx[j][1] + rho*u[2]*dXdx[j][2]);
     // ---- No Change
     v[0][i] = 0;
 
     // -- Momentum
     // ---- rho (u x u) + P I3
-    for (int j=0; j<3; j++) {
-      for (int k=0; k<3; k++) {
-        dv[k][j+1][i]  = wJ * ((rho*u[j]*u[0] + (j==0?P:0))*dXdx[k][0] +
-                               (rho*u[j]*u[1] + (j==1?P:0))*dXdx[k][1] +
-                               (rho*u[j]*u[2] + (j==2?P:0))*dXdx[k][2]);
-      }
-    }
+    for (int j=0; j<3; j++)
+      for (int k=0; k<3; k++)
+        dv[k][j+1][i]  = wJ*((rho*u[j]*u[0] + (j==0?P:0))*dXdx[k][0] +
+                             (rho*u[j]*u[1] + (j==1?P:0))*dXdx[k][1] +
+                             (rho*u[j]*u[2] + (j==2?P:0))*dXdx[k][2]);
     // ---- Fuvisc
     const CeedInt Fuviscidx[3][3] = {{0, 1, 2}, {1, 3, 4}, {2, 4, 5}}; // symmetric matrix indices
-    for (int j=0; j<3; j++) {
-      for (int k=0; k<3; k++) {
-        dv[k][j+1][i] -= wJ * (Fu[Fuviscidx[j][0]]*dXdxdXdxT[k][0] +
-                               Fu[Fuviscidx[j][1]]*dXdxdXdxT[k][1] +
-                               Fu[Fuviscidx[j][2]]*dXdxdXdxT[k][2]);
-      }
-    }
+    for (int j=0; j<3; j++)
+      for (int k=0; k<3; k++)
+        dv[k][j+1][i] -= wJ*(Fu[Fuviscidx[j][0]]*dXdxdXdxT[k][0] +
+                             Fu[Fuviscidx[j][1]]*dXdxdXdxT[k][1] +
+                             Fu[Fuviscidx[j][2]]*dXdxdXdxT[k][2]);
     // ---- -rho g khat
     v[1][i] = 0;
     v[2][i] = 0;

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -92,23 +92,24 @@ static int ICsDC(void *ctx, CeedInt Q,
 #endif
 
   // Inputs
-  const CeedScalar *X = in[0];
+  const CeedScalar (*X)[Q] = (CeedScalar(*)[Q])in[0];
   // Outputs
-  CeedScalar *q0 = out[0], *coords = out[1];
+  CeedScalar (*q0)[Q] = (CeedScalar(*)[Q])out[0],
+             (*coords)[Q] = (CeedScalar(*)[Q])out[1];
   // Context
   const CeedScalar *context = (const CeedScalar*)ctx;
-  const CeedScalar theta0     = context[0];
-  const CeedScalar thetaC     = context[1];
-  const CeedScalar P0         = context[2];
-  const CeedScalar N          = context[3];
-  const CeedScalar cv         = context[4];
-  const CeedScalar cp         = context[5];
-  const CeedScalar Rd         = context[6];
-  const CeedScalar g          = context[7];
-  const CeedScalar rc         = context[8];
-  const CeedScalar lx         = context[9];
-  const CeedScalar ly         = context[10];
-  const CeedScalar lz         = context[11];
+  const CeedScalar theta0 = context[0];
+  const CeedScalar thetaC = context[1];
+  const CeedScalar P0     = context[2];
+  const CeedScalar N      = context[3];
+  const CeedScalar cv     = context[4];
+  const CeedScalar cp     = context[5];
+  const CeedScalar Rd     = context[6];
+  const CeedScalar g      = context[7];
+  const CeedScalar rc     = context[8];
+  const CeedScalar lx     = context[9];
+  const CeedScalar ly     = context[10];
+  const CeedScalar lz     = context[11];
   // Setup
   const CeedScalar tol = 1.e-14;
   const CeedScalar center[3] = {0.5*lx, 0.5*ly, 0.5*lz};
@@ -118,9 +119,9 @@ static int ICsDC(void *ctx, CeedInt Q,
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Coordinates
-    const CeedScalar x = X[i+0*Q];
-    const CeedScalar y = X[i+1*Q];
-    const CeedScalar z = X[i+2*Q];
+    const CeedScalar x = X[0][i];
+    const CeedScalar y = X[1][i];
+    const CeedScalar z = X[2][i];
     // -- Potential temperature, density current
     const CeedScalar r = sqrt(pow((x - center[0]), 2) +
                               pow((y - center[1]), 2) +
@@ -133,25 +134,25 @@ static int ICsDC(void *ctx, CeedInt Q,
     const CeedScalar rho = P0 * pow(Pi, cv/Rd) / (Rd*theta);
 
     // Initial Conditions
-    q0[i+0*Q] = rho;
-    q0[i+1*Q] = 0.0;
-    q0[i+2*Q] = 0.0;
-    q0[i+3*Q] = 0.0;
-    q0[i+4*Q] = rho * (cv*theta*Pi + g*z);
+    q0[0][i] = rho;
+    q0[1][i] = 0.0;
+    q0[2][i] = 0.0;
+    q0[3][i] = 0.0;
+    q0[4][i] = rho * (cv*theta*Pi + g*z);
 
     // Homogeneous Dirichlet Boundary Conditions for Momentum
     if ( fabs(x - 0.0) < tol || fabs(x - lx) < tol ||
          fabs(y - 0.0) < tol || fabs(y - ly) < tol ||
          fabs(z - 0.0) < tol || fabs(z - lz) < tol ) {
-      q0[i+1*Q] = 0.0;
-      q0[i+2*Q] = 0.0;
-      q0[i+3*Q] = 0.0;
+      q0[1][i] = 0.0;
+      q0[2][i] = 0.0;
+      q0[3][i] = 0.0;
     }
 
     // Coordinates
-    coords[i+0*Q] = x;
-    coords[i+1*Q] = y;
-    coords[i+2*Q] = z;
+    coords[0][i] = x;
+    coords[1][i] = y;
+    coords[2][i] = z;
 
   } // End of Quadrature Point Loop
 
@@ -199,159 +200,166 @@ static int ICsDC(void *ctx, CeedInt Q,
 static int DC(void *ctx, CeedInt Q,
               const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
-  const CeedScalar *q = in[0], *dq = in[1], *qdata = in[2], *x = in[3];
+  const CeedScalar (*q)[Q] = (CeedScalar(*)[Q])in[0],
+                   (*dq)[5][Q] = (CeedScalar(*)[5][Q])in[1],
+                   (*qdata)[Q] = (CeedScalar(*)[Q])in[2],
+                   (*x)[Q] = (CeedScalar(*)[Q])in[3];
   // Outputs
-  CeedScalar *v = out[0], *dv = out[1];
+  CeedScalar (*v)[Q] = (CeedScalar(*)[Q])out[0],
+             (*dv)[5][Q] = (CeedScalar(*)[5][Q])out[1];
   // Context
   const CeedScalar *context = (const CeedScalar*)ctx;
-  const CeedScalar lambda     = context[0];
-  const CeedScalar mu         = context[1];
-  const CeedScalar k          = context[2];
-  const CeedScalar cv         = context[3];
-  const CeedScalar cp         = context[4];
-  const CeedScalar g          = context[5];
-  const CeedScalar gamma      = cp / cv;
+  const CeedScalar lambda = context[0];
+  const CeedScalar mu     = context[1];
+  const CeedScalar k      = context[2];
+  const CeedScalar cv     = context[3];
+  const CeedScalar cp     = context[4];
+  const CeedScalar g      = context[5];
+  const CeedScalar gamma  = cp / cv;
 
   CeedPragmaOMP(simd)
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup
     // -- Interp in
-    const CeedScalar rho      =    q[i+0*Q];
-    const CeedScalar u[3]     =  { q[i+1*Q] / rho,
-                                   q[i+2*Q] / rho,
-                                   q[i+3*Q] / rho
-                                 };
-    const CeedScalar E        =    q[i+4*Q];
+    const CeedScalar rho       =    q[0][i];
+    const CeedScalar u[3]      =  { q[1][i] / rho,
+                                    q[2][i] / rho,
+                                    q[3][i] / rho
+                                  };
+    const CeedScalar E         =    q[4][i];
     // -- Grad in
-    const CeedScalar drho[3]  =  { dq[i+(0+5*0)*Q],
-                                   dq[i+(0+5*1)*Q],
-                                   dq[i+(0+5*2)*Q]
+    const CeedScalar drho[3]   =  { dq[0][0][i],
+                                    dq[1][0][i],
+                                    dq[2][0][i]
+                                  };
+    const CeedScalar du[3][3]  = {{(dq[0][1][i] - drho[0]*u[0]) / rho,
+                                   (dq[1][1][i] - drho[1]*u[0]) / rho,
+                                   (dq[2][1][i] - drho[2]*u[0]) / rho},
+                                  {(dq[0][2][i] - drho[0]*u[1]) / rho,
+                                   (dq[1][2][i] - drho[1]*u[1]) / rho,
+                                   (dq[2][2][i] - drho[2]*u[1]) / rho},
+                                  {(dq[0][3][i] - drho[0]*u[2]) / rho,
+                                   (dq[1][3][i] - drho[1]*u[2]) / rho,
+                                   (dq[2][3][i] - drho[2]*u[2]) / rho}
                                  };
-    const CeedScalar du[3][3] = {{(dq[i+(1+5*0)*Q] - drho[0]*u[0]) / rho,
-                                  (dq[i+(1+5*1)*Q] - drho[1]*u[0]) / rho,
-                                  (dq[i+(1+5*2)*Q] - drho[2]*u[0]) / rho},
-                                 {(dq[i+(2+5*0)*Q] - drho[0]*u[1]) / rho,
-                                  (dq[i+(2+5*1)*Q] - drho[1]*u[1]) / rho,
-                                  (dq[i+(2+5*2)*Q] - drho[2]*u[1]) / rho},
-                                 {(dq[i+(3+5*0)*Q] - drho[0]*u[2]) / rho,
-                                  (dq[i+(3+5*1)*Q] - drho[1]*u[2]) / rho,
-                                  (dq[i+(3+5*2)*Q] - drho[2]*u[2]) / rho}
-                                };
-    const CeedScalar dE[3]    =  { dq[i+(4+5*0)*Q],
-                                   dq[i+(4+5*1)*Q],
-                                   dq[i+(4+5*2)*Q]
-                                 };
+    const CeedScalar dE[3]     =  { dq[0][4][i],
+                                    dq[1][4][i],
+                                    dq[2][4][i]
+                                  };
     // -- Interp-to-Interp qdata
-    const CeedScalar wJ       =    qdata[i+ 0*Q];
+    const CeedScalar wJ        =    qdata[0][i];
     // -- Interp-to-Grad qdata
     //      Symmetric 3x3 matrix
-    const CeedScalar wBJ[9]   =  { qdata[i+ 1*Q],
-                                   qdata[i+ 2*Q],
-                                   qdata[i+ 3*Q],
-                                   qdata[i+ 4*Q],
-                                   qdata[i+ 5*Q],
-                                   qdata[i+ 6*Q],
-                                   qdata[i+ 7*Q],
-                                   qdata[i+ 8*Q],
-                                   qdata[i+ 9*Q]
+    const CeedScalar wBJ[3][3] = {{qdata[1][i],
+                                   qdata[2][i],
+                                   qdata[3][i]},
+                                  {qdata[4][i],
+                                   qdata[5][i],
+                                   qdata[6][i]},
+                                  {qdata[7][i],
+                                   qdata[8][i],
+                                   qdata[9][i]}
                                  };
     // -- Grad-to-Grad qdata
-    const CeedScalar wBBJ[6]  =  { qdata[i+10*Q],
-                                   qdata[i+11*Q],
-                                   qdata[i+12*Q],
-                                   qdata[i+13*Q],
-                                   qdata[i+14*Q],
-                                   qdata[i+15*Q]
-                                 };
+    const CeedScalar wBBJ[3][3] = {{qdata[10][i],
+                                    qdata[11][i],
+                                    qdata[12][i]},
+                                   {qdata[11][i],
+                                    qdata[13][i],
+                                    qdata[14][i]},
+                                   {qdata[12][i],
+                                    qdata[14][i],
+                                    qdata[15][i]}
+                                  };
     // -- gradT
-    const CeedScalar gradT[3] = {( dE[0]/rho - E*drho[0]/(rho*rho) -
-                                 ( u[0]*du[0][0] + u[1]*du[1][0] + u[2]*du[2][0])) / cv,
-                                 ( dE[1]/rho - E*drho[1]/(rho*rho) -
-                                 ( u[0]*du[0][1] + u[1]*du[1][1] + u[2]*du[2][1])) / cv,
-                                 ( dE[2]/rho - E*drho[2]/(rho*rho) -
-                                 ( u[0]*du[0][2] + u[1]*du[1][2] + u[2]*du[2][2]) - g) / cv
-                                };
+    const CeedScalar gradT[3]  = {(dE[0]/rho - E*drho[0]/(rho*rho) -
+                                  (u[0]*du[0][0] + u[1]*du[1][0] + u[2]*du[2][0]))/cv,
+                                  (dE[1]/rho - E*drho[1]/(rho*rho) -
+                                  (u[0]*du[0][1] + u[1]*du[1][1] + u[2]*du[2][1]))/cv,
+                                  (dE[2]/rho - E*drho[2]/(rho*rho) -
+                                  (u[0]*du[0][2] + u[1]*du[1][2] + u[2]*du[2][2]) - g)/cv
+                                 };
     // -- Fuvisc
     //      Symmetric 3x3 matrix
-    const CeedScalar Fu[6]    =  { mu * (du[0][0] * (2 + lambda) +
-                                   lambda * (du[1][1] + du[2][2])),
-                                   mu * (du[0][1] + du[1][0]),
-                                   mu * (du[0][2] + du[2][0]),
-                                   mu * (du[1][1] * (2 + lambda) +
-                                   lambda * (du[0][0] + du[2][2])),
-                                   mu * (du[1][2] + du[2][1]),
-                                   mu * (du[2][2] * (2 + lambda) +
-                                   lambda * (du[0][0] + du[1][1]))
-                                 };
+    const CeedScalar Fu[6]     =  { mu * (du[0][0] * (2 + lambda) +
+                                    lambda * (du[1][1] + du[2][2])),
+                                    mu * (du[0][1] + du[1][0]),
+                                    mu * (du[0][2] + du[2][0]),
+                                    mu * (du[1][1] * (2 + lambda) +
+                                    lambda * (du[0][0] + du[2][2])),
+                                    mu * (du[1][2] + du[2][1]),
+                                    mu * (du[2][2] * (2 + lambda) +
+                                    lambda * (du[0][0] + du[1][1]))
+                                  };
     // -- Fevisc
-    const CeedScalar Fe[3]    =  { u[0]*Fu[0] + u[1]*Fu[1] + u[2]*Fu[2] +
-                                   k * gradT[0],
-                                   u[0]*Fu[1] + u[1]*Fu[3] + u[2]*Fu[4] +
-                                   k * gradT[1],
-                                   u[0]*Fu[2] + u[1]*Fu[4] + u[2]*Fu[5] +
-                                   k * gradT[2]
-                                 };
+    const CeedScalar Fe[3]     =  { u[0]*Fu[0] + u[1]*Fu[1] + u[2]*Fu[2] +
+                                    k * gradT[0],
+                                    u[0]*Fu[1] + u[1]*Fu[3] + u[2]*Fu[4] +
+                                    k * gradT[1],
+                                    u[0]*Fu[2] + u[1]*Fu[4] + u[2]*Fu[5] +
+                                    k * gradT[2]
+                                  };
     // -- P
-    const CeedScalar P        =  ( E - (u[0]*u[0] + u[1]*u[1] + u[2]*u[2])*rho / 2 -
-                                   rho*g*x[i+Q*2] ) * (gamma - 1);
+    const CeedScalar P         =  (E - (u[0]*u[0] + u[1]*u[1] + u[2]*u[2])*rho/2 -
+                                   rho*g*x[2][i] ) * (gamma - 1);
 
     // The Physics
 
     // -- Density
     // ---- u rho
-    dv[i+(0+5*0)*Q]  = rho*u[0]*wBJ[0] + rho*u[1]*wBJ[1] + rho*u[2]*wBJ[2];
-    dv[i+(0+5*1)*Q]  = rho*u[0]*wBJ[3] + rho*u[1]*wBJ[4] + rho*u[2]*wBJ[5];
-    dv[i+(0+5*2)*Q]  = rho*u[0]*wBJ[6] + rho*u[1]*wBJ[7] + rho*u[2]*wBJ[8];
+    dv[0][0][i]  = rho*u[0]*wBJ[0][0] + rho*u[1]*wBJ[0][1] + rho*u[2]*wBJ[0][2];
+    dv[1][0][i]  = rho*u[0]*wBJ[1][0] + rho*u[1]*wBJ[1][1] + rho*u[2]*wBJ[1][2];
+    dv[2][0][i]  = rho*u[0]*wBJ[2][0] + rho*u[1]*wBJ[2][1] + rho*u[2]*wBJ[2][2];
     // ---- No Change
-    v[i+0*Q] = 0;
+    v[0][i] = 0;
 
     // -- Momentum
     // ---- rho (u x u) + P I3
-    dv[i+(1+5*0)*Q]  = (rho*u[0]*u[0]+P)*wBJ[0] + rho*u[0]*u[1]*wBJ[1] +
-                       rho*u[0]*u[2]*wBJ[2];
-    dv[i+(1+5*1)*Q]  = (rho*u[0]*u[0]+P)*wBJ[3] + rho*u[0]*u[1]*wBJ[4] +
-                       rho*u[0]*u[2]*wBJ[5];
-    dv[i+(1+5*2)*Q]  = (rho*u[0]*u[0]+P)*wBJ[6] + rho*u[0]*u[1]*wBJ[7] +
-                       rho*u[0]*u[2]*wBJ[8];
-    dv[i+(2+5*0)*Q]  =  rho*u[1]*u[0]*wBJ[0] +   (rho*u[1]*u[1]+P)*wBJ[1] +
-                        rho*u[1]*u[2]*wBJ[2];
-    dv[i+(2+5*1)*Q]  =  rho*u[1]*u[0]*wBJ[3] +   (rho*u[1]*u[1]+P)*wBJ[4] +
-                        rho*u[1]*u[2]*wBJ[5];
-    dv[i+(2+5*2)*Q]  =  rho*u[1]*u[0]*wBJ[6] +   (rho*u[1]*u[1]+P)*wBJ[7] +
-                        rho*u[1]*u[2]*wBJ[8];
-    dv[i+(3+5*0)*Q]  =  rho*u[2]*u[0]*wBJ[0] +    rho*u[2]*u[1]*wBJ[1] +
-                        (rho*u[2]*u[2]+P)*wBJ[2];
-    dv[i+(3+5*1)*Q]  =  rho*u[2]*u[0]*wBJ[3] +    rho*u[2]*u[1]*wBJ[4] +
-                        (rho*u[2]*u[2]+P)*wBJ[5];
-    dv[i+(3+5*2)*Q]  =  rho*u[2]*u[0]*wBJ[6] +    rho*u[2]*u[1]*wBJ[7] +
-                        (rho*u[2]*u[2]+P)*wBJ[8];
+    dv[0][1][i]  = (rho*u[0]*u[0]+P)*wBJ[0][0] + rho*u[0]*u[1]*wBJ[0][1] +
+                    rho*u[0]*u[2]*wBJ[0][2];
+    dv[1][1][i]  = (rho*u[0]*u[0]+P)*wBJ[1][0] + rho*u[0]*u[1]*wBJ[1][1] +
+                    rho*u[0]*u[2]*wBJ[1][2];
+    dv[2][1][i]  = (rho*u[0]*u[0]+P)*wBJ[2][0] + rho*u[0]*u[1]*wBJ[2][1] +
+                    rho*u[0]*u[2]*wBJ[2][2];
+    dv[0][2][i]  =  rho*u[1]*u[0]*wBJ[0][0] +   (rho*u[1]*u[1]+P)*wBJ[0][1] +
+                    rho*u[1]*u[2]*wBJ[0][2];
+    dv[1][2][i]  =  rho*u[1]*u[0]*wBJ[1][0] +   (rho*u[1]*u[1]+P)*wBJ[1][1] +
+                    rho*u[1]*u[2]*wBJ[1][2];
+    dv[2][2][i]  =  rho*u[1]*u[0]*wBJ[2][0] +   (rho*u[1]*u[1]+P)*wBJ[2][1] +
+                    rho*u[1]*u[2]*wBJ[2][2];
+    dv[0][3][i]  =  rho*u[2]*u[0]*wBJ[0][0] +    rho*u[2]*u[1]*wBJ[0][1] +
+                   (rho*u[2]*u[2]+P)*wBJ[0][2];
+    dv[1][3][i]  =  rho*u[2]*u[0]*wBJ[1][0] +    rho*u[2]*u[1]*wBJ[1][1] +
+                   (rho*u[2]*u[2]+P)*wBJ[1][2];
+    dv[2][3][i]  =  rho*u[2]*u[0]*wBJ[2][0] +    rho*u[2]*u[1]*wBJ[2][1] +
+                   (rho*u[2]*u[2]+P)*wBJ[2][2];
     // ---- Fuvisc
-    dv[i+(1+5*0)*Q] -= Fu[0]*wBBJ[0] + Fu[1]*wBBJ[1] + Fu[2]*wBBJ[2];
-    dv[i+(1+5*1)*Q] -= Fu[0]*wBBJ[1] + Fu[1]*wBBJ[3] + Fu[2]*wBBJ[4];
-    dv[i+(1+5*2)*Q] -= Fu[0]*wBBJ[2] + Fu[1]*wBBJ[4] + Fu[2]*wBBJ[5];
-    dv[i+(2+5*0)*Q] -= Fu[1]*wBBJ[0] + Fu[3]*wBBJ[1] + Fu[4]*wBBJ[2];
-    dv[i+(2+5*1)*Q] -= Fu[1]*wBBJ[1] + Fu[3]*wBBJ[3] + Fu[4]*wBBJ[4];
-    dv[i+(2+5*2)*Q] -= Fu[1]*wBBJ[2] + Fu[3]*wBBJ[4] + Fu[4]*wBBJ[5];
-    dv[i+(3+5*0)*Q] -= Fu[2]*wBBJ[0] + Fu[4]*wBBJ[1] + Fu[5]*wBBJ[2];
-    dv[i+(3+5*1)*Q] -= Fu[2]*wBBJ[1] + Fu[4]*wBBJ[3] + Fu[5]*wBBJ[4];
-    dv[i+(3+5*2)*Q] -= Fu[2]*wBBJ[2] + Fu[4]*wBBJ[4] + Fu[5]*wBBJ[5];
+    dv[0][1][i] -= Fu[0]*wBBJ[0][0] + Fu[1]*wBBJ[0][1] + Fu[2]*wBBJ[0][2];
+    dv[1][1][i] -= Fu[0]*wBBJ[1][0] + Fu[1]*wBBJ[1][1] + Fu[2]*wBBJ[1][2];
+    dv[2][1][i] -= Fu[0]*wBBJ[2][0] + Fu[1]*wBBJ[2][1] + Fu[2]*wBBJ[2][2];
+    dv[0][2][i] -= Fu[1]*wBBJ[0][0] + Fu[3]*wBBJ[0][1] + Fu[4]*wBBJ[0][2];
+    dv[1][2][i] -= Fu[1]*wBBJ[1][0] + Fu[3]*wBBJ[1][1] + Fu[4]*wBBJ[1][2];
+    dv[2][2][i] -= Fu[1]*wBBJ[2][0] + Fu[3]*wBBJ[2][1] + Fu[4]*wBBJ[2][2];
+    dv[0][3][i] -= Fu[2]*wBBJ[0][0] + Fu[4]*wBBJ[0][1] + Fu[5]*wBBJ[0][2];
+    dv[1][3][i] -= Fu[2]*wBBJ[1][0] + Fu[4]*wBBJ[1][1] + Fu[5]*wBBJ[2][1];
+    dv[2][3][i] -= Fu[2]*wBBJ[2][0] + Fu[4]*wBBJ[2][1] + Fu[5]*wBBJ[2][2];
     // ---- -rho g khat
-    v[i+1*Q] = 0;
-    v[i+2*Q] = 0;
-    v[i+3*Q] = - rho*g*wJ;
+    v[1][i] = 0;
+    v[2][i] = 0;
+    v[3][i] = -rho*g*wJ;
 
     // -- Total Energy
     // ---- (E + P) u
-    dv[i+(4+5*0)*Q]  = (E + P)*(u[0]*wBJ[0] + u[1]*wBJ[1] + u[2]*wBJ[2]);
-    dv[i+(4+5*1)*Q]  = (E + P)*(u[0]*wBJ[3] + u[1]*wBJ[4] + u[2]*wBJ[5]);
-    dv[i+(4+5*2)*Q]  = (E + P)*(u[0]*wBJ[6] + u[1]*wBJ[7] + u[2]*wBJ[8]);
+    dv[0][4][i]  = (E + P)*(u[0]*wBJ[0][0] + u[1]*wBJ[0][1] + u[2]*wBJ[0][2]);
+    dv[1][4][i]  = (E + P)*(u[0]*wBJ[1][0] + u[1]*wBJ[1][1] + u[2]*wBJ[1][2]);
+    dv[2][4][i]  = (E + P)*(u[0]*wBJ[2][0] + u[1]*wBJ[2][1] + u[2]*wBJ[2][2]);
     // ---- Fevisc
-    dv[i+(4+5*0)*Q] -= Fe[0]*wBBJ[0] + Fe[1]*wBBJ[1] + Fe[2]*wBBJ[2];
-    dv[i+(4+5*1)*Q] -= Fe[0]*wBBJ[1] + Fe[1]*wBBJ[3] + Fe[2]*wBBJ[4];
-    dv[i+(4+5*2)*Q] -= Fe[0]*wBBJ[2] + Fe[1]*wBBJ[4] + Fe[2]*wBBJ[5];
+    dv[0][0][i] -= Fe[0]*wBBJ[0][0] + Fe[1]*wBBJ[0][1] + Fe[2]*wBBJ[0][2];
+    dv[1][4][i] -= Fe[0]*wBBJ[1][0] + Fe[1]*wBBJ[1][1] + Fe[2]*wBBJ[1][2];
+    dv[2][4][i] -= Fe[0]*wBBJ[2][0] + Fe[1]*wBBJ[2][1] + Fe[2]*wBBJ[2][2];
     // ---- No Change
-    v[i+4*Q] = 0;
+    v[4][i] = 0;
 
   } // End Quadrature Point Loop
 

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -644,8 +644,8 @@ int main(int argc, char **argv) {
   CreateRestriction(ceed, melem, 2, 3, &restrictx);
   CreateRestriction(ceed, melem, numP, 3, &restrictxc);
   CreateRestriction(ceed, melem, numP, 1, &restrictmult);
-  CeedElemRestrictionCreateIdentity(ceed, localNelem, 16*numQ*numQ*numQ,
-                                    16*localNelem*numQ*numQ*numQ, 1,
+  CeedElemRestrictionCreateIdentity(ceed, localNelem, 10*numQ*numQ*numQ,
+                                    10*localNelem*numQ*numQ*numQ, 1,
                                     &restrictqdi);
   CeedElemRestrictionCreateIdentity(ceed, localNelem, numQ*numQ*numQ,
                                     localNelem*numQ*numQ*numQ, 1,
@@ -677,7 +677,7 @@ int main(int argc, char **argv) {
   CeedInt Nqpts, Nnodes;
   CeedBasisGetNumQuadraturePoints(basisq, &Nqpts);
   CeedBasisGetNumNodes(basisq, &Nnodes);
-  CeedVectorCreate(ceed, 16*localNelem*Nqpts, &qdata);
+  CeedVectorCreate(ceed, 10*localNelem*Nqpts, &qdata);
   CeedVectorCreate(ceed, 5*lsize, &q0ceed);
   CeedVectorCreate(ceed, 5*lsize, &mceed);
   CeedVectorCreate(ceed, 5*lsize, &onesvec);
@@ -696,13 +696,13 @@ int main(int argc, char **argv) {
                               Setup, __FILE__ ":Setup", &qf_setup);
   CeedQFunctionAddInput(qf_setup, "dx", 3, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
-  CeedQFunctionAddOutput(qf_setup, "qdata", 16, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_setup, "qdata", 10, CEED_EVAL_NONE);
 
   // Create the Q-function that defines the action of the mass operator
   CeedQFunctionCreateInterior(ceed, 1,
                               Mass, __FILE__ ":Mass", &qf_mass);
   CeedQFunctionAddInput(qf_mass, "q", 5, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(qf_mass, "qdata", 16, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "qdata", 10, CEED_EVAL_NONE);
   CeedQFunctionAddOutput(qf_mass, "v", 5, CEED_EVAL_INTERP);
 
   // Create the Q-function that sets the ICs of the operator
@@ -731,7 +731,7 @@ int main(int argc, char **argv) {
                               str, &qf);
   CeedQFunctionAddInput(qf, "q", 5, CEED_EVAL_INTERP);
   CeedQFunctionAddInput(qf, "dq", 5, CEED_EVAL_GRAD);
-  CeedQFunctionAddInput(qf, "qdata", 16, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf, "qdata", 10, CEED_EVAL_NONE);
   CeedQFunctionAddInput(qf, "x", 3, CEED_EVAL_INTERP);
   CeedQFunctionAddOutput(qf, "v", 5, CEED_EVAL_INTERP);
   CeedQFunctionAddOutput(qf, "dv", 5, CEED_EVAL_GRAD);


### PR DESCRIPTION
As per our conversation, it is cleaner to adopt a notation `x_i,j` (Jacobian `dx_i / dX_j` in indicial notation) for the change of coordinate matrix, and consequently, `X_i,j` for its inverse.