### PR TITLE
Ref - remove dead code from basis collo grad

### DIFF
--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -146,14 +146,13 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,
         // Dim contractions, identity in other directions
         for (CeedInt d=0; d<dim; d++) {
           CeedInt pre = ncomp*CeedIntPow(P, dim-1), post = nelem;
-            ierr = CeedTensorContractApply(contract, pre, P, post, Q,
-                                           grad1d,
-                                           tmode, add&&(d>0),
-                                           tmode == CEED_NOTRANSPOSE
-                                             ? u : u+d*ncomp*nqpt*nelem,
-                                           tmode == CEED_TRANSPOSE
-                                             ? v : v+d*ncomp*nqpt*nelem);
-            CeedChk(ierr);
+          ierr = CeedTensorContractApply(contract, pre, P, post, Q,
+                                         grad1d, tmode, add&&(d>0),
+                                         tmode == CEED_NOTRANSPOSE
+                                           ? u : u+d*ncomp*nqpt*nelem,
+                                         tmode == CEED_TRANSPOSE
+                                           ? v : v+d*ncomp*nqpt*nelem);
+          CeedChk(ierr);
         }      
       } else { // Underintegration, P > Q
         CeedScalar *grad1d;

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -154,8 +154,6 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,
                                            tmode == CEED_TRANSPOSE
                                              ? v : v+d*ncomp*nqpt*nelem);
             CeedChk(ierr);
-            pre /= P;
-            post *= Q;
         }      
       } else { // Underintegration, P > Q
         CeedScalar *grad1d;


### PR DESCRIPTION
PR #290 introduced a `clang-tidy` issue (though Travis didn't fail; I thought it was supposed to).
This fixes this issue.