### PR TITLE
Homogenize examples by using ncomp and dim

### DIFF
--- a/examples/ceed/ex1.c
+++ b/examples/ceed/ex1.c
@@ -53,6 +53,7 @@ CeedScalar TransformMeshCoords(int dim, int mesh_size, CeedVector mesh_coords);
 int main(int argc, const char *argv[]) {
   const char *ceed_spec = "/cpu/self";
   int dim        = 3;           // dimension of the mesh
+  int ncomp      = 3;           // number of field components
   int mesh_order = 4;           // polynomial degree for the mesh
   int sol_order  = 4;           // polynomial degree for the solution
   int num_qpts   = sol_order+2; // number of 1D quadrature points
@@ -109,7 +110,7 @@ int main(int argc, const char *argv[]) {
 
   // Construct the mesh and solution bases.
   CeedBasis mesh_basis, sol_basis;
-  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, mesh_order+1, num_qpts,
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncomp, mesh_order+1, num_qpts,
                                   CEED_GAUSS, &mesh_basis);
   CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, sol_order+1, num_qpts,
                                   CEED_GAUSS, &sol_basis);
@@ -129,7 +130,7 @@ int main(int argc, const char *argv[]) {
   // representations.
   CeedInt mesh_size, sol_size;
   CeedElemRestriction mesh_restr, sol_restr, mesh_restr_i, sol_restr_i;
-  BuildCartesianRestriction(ceed, dim, nxyz, mesh_order, dim, &mesh_size,
+  BuildCartesianRestriction(ceed, dim, nxyz, mesh_order, ncomp, &mesh_size,
                             num_qpts, &mesh_restr, &mesh_restr_i);
   BuildCartesianRestriction(ceed, dim, nxyz, sol_order, 1, &sol_size,
                             num_qpts, &sol_restr, &sol_restr_i);
@@ -155,7 +156,7 @@ int main(int argc, const char *argv[]) {
   CeedQFunction build_qfunc;
   CeedQFunctionCreateInterior(ceed, 1, f_build_mass,
                               f_build_mass_loc, &build_qfunc);
-  CeedQFunctionAddInput(build_qfunc, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(build_qfunc, "dx", ncomp*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
   CeedQFunctionAddOutput(build_qfunc, "rho", 1, CEED_EVAL_NONE);
   CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));
@@ -205,7 +206,7 @@ int main(int argc, const char *argv[]) {
   CeedOperatorSetField(oper, "v", sol_restr, CEED_NOTRANSPOSE,
                        sol_basis, CEED_VECTOR_ACTIVE);
 
-  // Compute the mesh volume using the mass operator: vol = 1^T.M.1.
+  // Compute the mesh volume using the mass operator: vol = 1^T \cdot M \cdot 1
   if (!test) {
     printf("Computing the mesh volume using the formula: vol = 1^T.M.1 ...");
     fflush(stdout);

--- a/examples/ceed/ex1.c
+++ b/examples/ceed/ex1.c
@@ -53,7 +53,7 @@ CeedScalar TransformMeshCoords(int dim, int mesh_size, CeedVector mesh_coords);
 int main(int argc, const char *argv[]) {
   const char *ceed_spec = "/cpu/self";
   int dim        = 3;           // dimension of the mesh
-  int ncomp      = 3;           // number of field components
+  int ncompx      = 3;           // number of x components
   int mesh_order = 4;           // polynomial degree for the mesh
   int sol_order  = 4;           // polynomial degree for the solution
   int num_qpts   = sol_order+2; // number of 1D quadrature points
@@ -110,7 +110,7 @@ int main(int argc, const char *argv[]) {
 
   // Construct the mesh and solution bases.
   CeedBasis mesh_basis, sol_basis;
-  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncomp, mesh_order+1, num_qpts,
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompx, mesh_order+1, num_qpts,
                                   CEED_GAUSS, &mesh_basis);
   CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, sol_order+1, num_qpts,
                                   CEED_GAUSS, &sol_basis);
@@ -130,7 +130,7 @@ int main(int argc, const char *argv[]) {
   // representations.
   CeedInt mesh_size, sol_size;
   CeedElemRestriction mesh_restr, sol_restr, mesh_restr_i, sol_restr_i;
-  BuildCartesianRestriction(ceed, dim, nxyz, mesh_order, ncomp, &mesh_size,
+  BuildCartesianRestriction(ceed, dim, nxyz, mesh_order, ncompx, &mesh_size,
                             num_qpts, &mesh_restr, &mesh_restr_i);
   BuildCartesianRestriction(ceed, dim, nxyz, sol_order, 1, &sol_size,
                             num_qpts, &sol_restr, &sol_restr_i);
@@ -156,7 +156,7 @@ int main(int argc, const char *argv[]) {
   CeedQFunction build_qfunc;
   CeedQFunctionCreateInterior(ceed, 1, f_build_mass,
                               f_build_mass_loc, &build_qfunc);
-  CeedQFunctionAddInput(build_qfunc, "dx", ncomp*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(build_qfunc, "dx", ncompx*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
   CeedQFunctionAddOutput(build_qfunc, "rho", 1, CEED_EVAL_NONE);
   CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -116,7 +116,7 @@ class CeedMassOperator : public mfem::Operator {
     const mfem::IntegrationRule &ir =
       mfem::IntRules.Get(mfem::Geometry::SEGMENT, ir_order);
     CeedInt nqpts, nelem = mesh->GetNE(), dim = mesh->SpaceDimension(),
-            ncomp = dim;
+            ncompx = dim;
 
     FESpace2Ceed(fes, ir, ceed, &basis, &restr);
 
@@ -144,7 +144,7 @@ class CeedMassOperator : public mfem::Operator {
     // quadrature data) and set its context data.
     CeedQFunctionCreateInterior(ceed, 1, f_build_mass,
                                 f_build_mass_loc, &build_qfunc);
-    CeedQFunctionAddInput(build_qfunc, "dx", ncomp*dim,
+    CeedQFunctionAddInput(build_qfunc, "dx", ncompx*dim,
                           CEED_EVAL_GRAD);
     CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
     CeedQFunctionAddOutput(build_qfunc, "rho", 1, CEED_EVAL_NONE);

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -115,7 +115,8 @@ class CeedMassOperator : public mfem::Operator {
     const int ir_order = 2*(order + 2) - 1; // <-----
     const mfem::IntegrationRule &ir =
       mfem::IntRules.Get(mfem::Geometry::SEGMENT, ir_order);
-    CeedInt nqpts, nelem = mesh->GetNE(), dim = mesh->SpaceDimension();
+    CeedInt nqpts, nelem = mesh->GetNE(), dim = mesh->SpaceDimension(),
+            ncomp = dim;
 
     FESpace2Ceed(fes, ir, ceed, &basis, &restr);
 
@@ -143,7 +144,7 @@ class CeedMassOperator : public mfem::Operator {
     // quadrature data) and set its context data.
     CeedQFunctionCreateInterior(ceed, 1, f_build_mass,
                                 f_build_mass_loc, &build_qfunc);
-    CeedQFunctionAddInput(build_qfunc, "dx", dim*dim,
+    CeedQFunctionAddInput(build_qfunc, "dx", ncomp*dim,
                           CEED_EVAL_GRAD);
     CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
     CeedQFunctionAddOutput(build_qfunc, "rho", 1, CEED_EVAL_NONE);

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -116,7 +116,8 @@ class CeedDiffusionOperator : public mfem::Operator {
     const int ir_order = 2*(order + 2) - 1; // <-----
     const mfem::IntegrationRule &ir =
       mfem::IntRules.Get(mfem::Geometry::SEGMENT, ir_order);
-    CeedInt nqpts, nelem = mesh->GetNE(), dim = mesh->SpaceDimension();
+    CeedInt nqpts, nelem = mesh->GetNE(), dim = mesh->SpaceDimension(),
+            ncomp = dim;
 
     FESpace2Ceed(fes, ir, ceed, &basis, &restr);
 
@@ -144,7 +145,7 @@ class CeedDiffusionOperator : public mfem::Operator {
     // quadrature data) and set its context data.
     CeedQFunctionCreateInterior(ceed, 1, f_build_diff,
                                 f_build_diff_loc, &build_qfunc);
-    CeedQFunctionAddInput(build_qfunc, "dx", dim*dim, CEED_EVAL_GRAD);
+    CeedQFunctionAddInput(build_qfunc, "dx", ncomp*dim, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
     CeedQFunctionAddOutput(build_qfunc, "rho", dim*(dim+1)/2, CEED_EVAL_NONE);
     CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -117,7 +117,7 @@ class CeedDiffusionOperator : public mfem::Operator {
     const mfem::IntegrationRule &ir =
       mfem::IntRules.Get(mfem::Geometry::SEGMENT, ir_order);
     CeedInt nqpts, nelem = mesh->GetNE(), dim = mesh->SpaceDimension(),
-            ncomp = dim;
+            ncompx = dim;
 
     FESpace2Ceed(fes, ir, ceed, &basis, &restr);
 
@@ -145,7 +145,7 @@ class CeedDiffusionOperator : public mfem::Operator {
     // quadrature data) and set its context data.
     CeedQFunctionCreateInterior(ceed, 1, f_build_diff,
                                 f_build_diff_loc, &build_qfunc);
-    CeedQFunctionAddInput(build_qfunc, "dx", ncomp*dim, CEED_EVAL_GRAD);
+    CeedQFunctionAddInput(build_qfunc, "dx", ncompx*dim, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
     CeedQFunctionAddOutput(build_qfunc, "rho", dim*(dim+1)/2, CEED_EVAL_NONE);
     CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -841,7 +841,8 @@ int main(int argc, char **argv) {
                        basisq, CEED_VECTOR_ACTIVE);
 
   // Set up the libCEED context
-  CeedScalar ctxSetup[15] = {theta0, thetaC, P0, N, cv, cp, Rd, g, rc, lx, ly, lz, periodic[0], periodic[1], periodic[2]};
+  CeedScalar ctxSetup[15] = {theta0, thetaC, P0, N, cv, cp, Rd, g, rc,
+                             lx, ly, lz, periodic[0], periodic[1], periodic[2]};
   CeedQFunctionSetContext(qf_ics, &ctxSetup, sizeof ctxSetup);
   CeedScalar ctxNS[6] = {lambda, mu, k, cv, cp, g};
   CeedQFunctionSetContext(qf, &ctxNS, sizeof ctxNS);

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -734,7 +734,7 @@ int main(int argc, char **argv) {
     CeedScalar *xloc;
     CeedInt shape[3] = {melem[0]+1, melem[1]+1, melem[2]+1}, len =
                          shape[0]*shape[1]*shape[2];
-    xloc = malloc(len*dim*sizeof xloc[0]);
+    xloc = malloc(len*ncompx*sizeof xloc[0]);
     for (CeedInt i=0; i<shape[0]; i++) {
       for (CeedInt j=0; j<shape[1]; j++) {
         for (CeedInt k=0; k<shape[2]; k++) {
@@ -747,7 +747,7 @@ int main(int argc, char **argv) {
         }
       }
     }
-    CeedVectorCreate(ceed, len*dim, &xcorners);
+    CeedVectorCreate(ceed, len*ncompx, &xcorners);
     CeedVectorSetArray(xcorners, CEED_MEM_HOST, CEED_OWN_POINTER, xloc);
   }
 

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -349,6 +349,7 @@ int main(int argc, char **argv) {
 
   Ceed ceed;
   CeedInt numP, numQ;
+  const CeedInt dim = 3, ncompx = 3, ncompq = 5;
   CeedVector xcorners, xceed, qdata, q0ceed, mceed,
              onesvec, multevec, multlvec;
   CeedBasis basisx, basisxc, basisq;
@@ -516,7 +517,7 @@ int main(int argc, char **argv) {
   melem[0] = (PetscInt)(PetscRoundReal(lx / resx / p[0]));
   melem[1] = (PetscInt)(PetscRoundReal(ly / resy / p[1]));
   melem[2] = (PetscInt)(PetscRoundReal(lz / resz / p[2]));
-  for (int d=0; d<3; d++) {
+  for (int d=0; d<dim; d++) {
     if (melem[d] == 0)
       melem[d]++;
   }
@@ -527,7 +528,7 @@ int main(int argc, char **argv) {
 
   // Find my location in the process grid
   ierr = MPI_Comm_rank(comm, &rank); CHKERRQ(ierr);
-  for (int d=0,rankleft=rank; d<3; d++) {
+  for (int d=0,rankleft=rank; d<dim; d++) {
     const int pstride[3] = {p[1]*p[2], p[2], 1};
     irank[d] = rankleft / pstride[d];
     rankleft -= irank[d] * pstride[d];
@@ -537,25 +538,25 @@ int main(int argc, char **argv) {
 
   // Set up global state vector
   ierr = VecCreate(comm, &Q); CHKERRQ(ierr);
-  ierr = VecSetSizes(Q, 5*mnode[0]*mnode[1]*mnode[2], PETSC_DECIDE);
+  ierr = VecSetSizes(Q, ncompq*mnode[0]*mnode[1]*mnode[2], PETSC_DECIDE);
   CHKERRQ(ierr);
   ierr = VecSetUp(Q); CHKERRQ(ierr);
 
   // Set up local state vector
   lsize = 1;
-  for (int d=0; d<3; d++) {
+  for (int d=0; d<dim; d++) {
     lnode[d] = melem[d]*degree + 1;
     lsize *= lnode[d];
   }
   ierr = VecCreate(PETSC_COMM_SELF, &Qloc); CHKERRQ(ierr);
-  ierr = VecSetSizes(Qloc, 5*lsize, PETSC_DECIDE); CHKERRQ(ierr);
-  ierr = VecSetBlockSize(Qloc, 5); CHKERRQ(ierr);
+  ierr = VecSetSizes(Qloc, ncompq*lsize, PETSC_DECIDE); CHKERRQ(ierr);
+  ierr = VecSetBlockSize(Qloc, ncompq); CHKERRQ(ierr);
   ierr = VecSetUp(Qloc); CHKERRQ(ierr);
 
   // Print grid information
   CeedInt gsize;
   ierr = VecGetSize(Q, &gsize); CHKERRQ(ierr);
-  gsize /= 5;
+  gsize /= ncompq;
   ierr = PetscPrintf(comm, "Global nodes: %D\n", gsize); CHKERRQ(ierr);
   ierr = PetscPrintf(comm, "Process decomposition: %D %D %D\n",
                      p[0], p[1], p[2]); CHKERRQ(ierr);
@@ -578,8 +579,8 @@ int main(int argc, char **argv) {
 
   // Set up local coordinates vector
   ierr = VecCreate(PETSC_COMM_SELF, &Xloc); CHKERRQ(ierr);
-  ierr = VecSetSizes(Xloc, 3*lsize, PETSC_DECIDE); CHKERRQ(ierr);
-  ierr = VecSetBlockSize(Xloc, 3); CHKERRQ(ierr);
+  ierr = VecSetSizes(Xloc, ncompx*lsize, PETSC_DECIDE); CHKERRQ(ierr);
+  ierr = VecSetBlockSize(Xloc, ncompx); CHKERRQ(ierr);
   ierr = VecSetUp(Xloc); CHKERRQ(ierr);
 
   // Set up global boundary values vector
@@ -589,13 +590,13 @@ int main(int argc, char **argv) {
     // Create local-to-global scatters
     PetscInt *ltogind, *ltogind0, *locind, l0count;
     IS ltogis, ltogis0, locis;
-    PetscInt gstart[2][2][2], gmnode[2][2][2][3];
+    PetscInt gstart[2][2][2], gmnode[2][2][2][dim];
 
     for (int i=0; i<2; i++) {
       for (int j=0; j<2; j++) {
         for (int k=0; k<2; k++) {
           PetscInt ijkrank[3] = {irank[0]+i, irank[1]+j, irank[2]+k};
-          for (int d=0; d<3; d++) {
+          for (int d=0; d<dim; d++) {
             if (periodic[d]) ijkrank[d] %= p[d];
           }
           gstart[i][j][k] = GlobalStart(p, ijkrank, periodic, degree, melem);
@@ -629,13 +630,13 @@ int main(int argc, char **argv) {
     }
 
     // Create local-to-global scatters
-    ierr = ISCreateBlock(comm, 5, lsize, ltogind, PETSC_OWN_POINTER, &ltogis);
+    ierr = ISCreateBlock(comm, ncompq, lsize, ltogind, PETSC_OWN_POINTER, &ltogis);
     CHKERRQ(ierr);
     ierr = VecScatterCreate(Qloc, NULL, Q, ltogis, &ltog);
     CHKERRQ(ierr);
-    ierr = ISCreateBlock(comm, 5, l0count, ltogind0, PETSC_OWN_POINTER, &ltogis0);
+    ierr = ISCreateBlock(comm, ncompq, l0count, ltogind0, PETSC_OWN_POINTER, &ltogis0);
     CHKERRQ(ierr);
-    ierr = ISCreateBlock(comm, 5, l0count, locind, PETSC_OWN_POINTER, &locis);
+    ierr = ISCreateBlock(comm, ncompq, l0count, locind, PETSC_OWN_POINTER, &locis);
     CHKERRQ(ierr);
     ierr = VecScatterCreate(Qloc, locis, Q, ltogis0, &ltog0);
     CHKERRQ(ierr);
@@ -656,7 +657,7 @@ int main(int argc, char **argv) {
       ierr = PetscMalloc1(qend-qstart, &indD); CHKERRQ(ierr);
       ierr = VecGetArrayRead(Q, &q); CHKERRQ(ierr);
       for (PetscInt i=0; i<qend-qstart; i++) {
-        if (q[i] == 1. && (i % 5 == 1 || i % 5 == 2 || i % 5 == 3))
+        if (q[i] == 1. && (i % ncompq == 1 || i % ncompq == 2 || i % ncompq == 3))
           indD[countD++] = qstart + i;
       }
       ierr = VecRestoreArrayRead(Q, &q); CHKERRQ(ierr);
@@ -672,10 +673,10 @@ int main(int argc, char **argv) {
 
     {
       // Set up DMDA
-      PetscInt *lnodes[3];
+      PetscInt *lnodes[dim];
       ierr = PetscMalloc3(p[0], &lnodes[0], p[1], &lnodes[1], p[2], &lnodes[2]);
       CHKERRQ(ierr);
-      for (PetscInt d=0; d<3; d++) {
+      for (PetscInt d=0; d<dim; d++) {
         for (PetscInt r=0; r<p[d]; r++) {
           // DMDA coordinate handling for periodic with stencil_width=0 is
           // ambiguous, so we create a non-periodic DM and map into it from a
@@ -694,7 +695,7 @@ int main(int argc, char **argv) {
                           degree*melem[2]*p[2]+1,
                           degree*melem[1]*p[1]+1,
                           degree*melem[0]*p[0]+1,
-                          p[2], p[1], p[0], 5, 0,
+                          p[2], p[1], p[0], ncompq, 0,
                           lnodes[2], lnodes[1], lnodes[0], &dm); CHKERRQ(ierr);
       ierr = PetscFree3(lnodes[0], lnodes[1], lnodes[2]); CHKERRQ(ierr);
       ierr = DMSetUp(dm); CHKERRQ(ierr);
@@ -711,15 +712,15 @@ int main(int argc, char **argv) {
   CeedInit(ceedresource, &ceed);
   numP = degree + 1;
   numQ = numP + qextra;
-  CeedBasisCreateTensorH1Lagrange(ceed, 3, 5, numP, numQ, CEED_GAUSS, &basisq);
-  CeedBasisCreateTensorH1Lagrange(ceed, 3, 3, 2, numQ, CEED_GAUSS, &basisx);
-  CeedBasisCreateTensorH1Lagrange(ceed, 3, 3, 2, numP, CEED_GAUSS_LOBATTO,
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompq, numP, numQ, CEED_GAUSS, &basisq);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompx, 2, numQ, CEED_GAUSS, &basisx);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompx, 2, numP, CEED_GAUSS_LOBATTO,
                                   &basisxc);
 
   // CEED Restrictions
-  CreateRestriction(ceed, melem, numP, 5, &restrictq);
-  CreateRestriction(ceed, melem, 2, 3, &restrictx);
-  CreateRestriction(ceed, melem, numP, 3, &restrictxc);
+  CreateRestriction(ceed, melem, numP, ncompq, &restrictq);
+  CreateRestriction(ceed, melem, 2, dim, &restrictx);
+  CreateRestriction(ceed, melem, numP, dim, &restrictxc);
   CreateRestriction(ceed, melem, numP, 1, &restrictmult);
   CeedElemRestrictionCreateIdentity(ceed, localNelem, 10*numQ*numQ*numQ,
                                     10*localNelem*numQ*numQ*numQ, 1,
@@ -733,7 +734,7 @@ int main(int argc, char **argv) {
     CeedScalar *xloc;
     CeedInt shape[3] = {melem[0]+1, melem[1]+1, melem[2]+1}, len =
                          shape[0]*shape[1]*shape[2];
-    xloc = malloc(len*3*sizeof xloc[0]);
+    xloc = malloc(len*dim*sizeof xloc[0]);
     for (CeedInt i=0; i<shape[0]; i++) {
       for (CeedInt j=0; j<shape[1]; j++) {
         for (CeedInt k=0; k<shape[2]; k++) {
@@ -746,7 +747,7 @@ int main(int argc, char **argv) {
         }
       }
     }
-    CeedVectorCreate(ceed, len*3, &xcorners);
+    CeedVectorCreate(ceed, len*dim, &xcorners);
     CeedVectorSetArray(xcorners, CEED_MEM_HOST, CEED_OWN_POINTER, xloc);
   }
 
@@ -755,10 +756,10 @@ int main(int argc, char **argv) {
   CeedBasisGetNumQuadraturePoints(basisq, &Nqpts);
   CeedBasisGetNumNodes(basisq, &Nnodes);
   CeedVectorCreate(ceed, 10*localNelem*Nqpts, &qdata);
-  CeedVectorCreate(ceed, 5*lsize, &q0ceed);
-  CeedVectorCreate(ceed, 5*lsize, &mceed);
-  CeedVectorCreate(ceed, 5*lsize, &onesvec);
-  CeedVectorCreate(ceed, 3*lsize, &xceed);
+  CeedVectorCreate(ceed, ncompq*lsize, &q0ceed);
+  CeedVectorCreate(ceed, ncompq*lsize, &mceed);
+  CeedVectorCreate(ceed, ncompq*lsize, &onesvec);
+  CeedVectorCreate(ceed, ncompx*lsize, &xceed);
   CeedVectorCreate(ceed, lsize, &multlvec);
   CeedVectorCreate(ceed, localNelem*Nnodes, &multevec);
 
@@ -770,32 +771,32 @@ int main(int argc, char **argv) {
 
   // Create the Q-function that builds the quadrature data for the NS operator
   CeedQFunctionCreateInterior(ceed, 1, Setup, Setup_loc, &qf_setup);
-  CeedQFunctionAddInput(qf_setup, "dx", 3*3, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup, "dx", ncompx*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
   CeedQFunctionAddOutput(qf_setup, "qdata", 10, CEED_EVAL_NONE);
 
   // Create the Q-function that defines the action of the mass operator
   CeedQFunctionCreateInterior(ceed, 1, Mass, Mass_loc, &qf_mass);
-  CeedQFunctionAddInput(qf_mass, "q", 5, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_mass, "q", ncompq, CEED_EVAL_INTERP);
   CeedQFunctionAddInput(qf_mass, "qdata", 10, CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_mass, "v", 5, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", ncompq, CEED_EVAL_INTERP);
 
   // Create the Q-function that sets the ICs of the operator
   CeedQFunctionCreateInterior(ceed, 1, problemOptions[problemChoice].ics,
                               problemOptions[problemChoice].icsfname, &qf_ics);
-  CeedQFunctionAddInput(qf_ics, "x", 3, CEED_EVAL_INTERP);
-  CeedQFunctionAddOutput(qf_ics, "q0", 5, CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_ics, "coords", 3, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_ics, "x", ncompx, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_ics, "q0", ncompq, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_ics, "coords", ncompx, CEED_EVAL_NONE);
 
   // Create the Q-function that defines the action of the operator
   CeedQFunctionCreateInterior(ceed, 1, problemOptions[problemChoice].apply,
                               problemOptions[problemChoice].applyfname, &qf);
-  CeedQFunctionAddInput(qf, "q", 5, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(qf, "dq", 5*3, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf, "q", ncompq, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf, "dq", ncompq*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(qf, "qdata", 10, CEED_EVAL_NONE);
-  CeedQFunctionAddInput(qf, "x", 3, CEED_EVAL_INTERP);
-  CeedQFunctionAddOutput(qf, "v", 5, CEED_EVAL_INTERP);
-  CeedQFunctionAddOutput(qf, "dv", 5*3, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf, "x", ncompx, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf, "v", ncompq, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf, "dv", ncompq*dim, CEED_EVAL_GRAD);
 
   // Create the operator that builds the quadrature data for the NS operator
   CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
@@ -862,14 +863,14 @@ int main(int argc, char **argv) {
   // Set up user structure
   user->comm = comm;
   user->degree = degree;
-  for (int d=0; d<3; d++) user->melem[d] = melem[d];
+  for (int d=0; d<dim; d++) user->melem[d] = melem[d];
   user->outputfreq = outputfreq;
   user->contsteps = contsteps;  
   user->units = units;
   user->dm = dm;
   user->ceed = ceed;
-  CeedVectorCreate(ceed, 5*lsize, &user->qceed);
-  CeedVectorCreate(ceed, 5*lsize, &user->gceed);
+  CeedVectorCreate(ceed, ncompq*lsize, &user->qceed);
+  CeedVectorCreate(ceed, ncompq*lsize, &user->gceed);
   user->op = op;
   user->ltog = ltog;
   user->ltog0 = ltog0;
@@ -906,10 +907,10 @@ int main(int argc, char **argv) {
   CeedVectorGetArray(xceed, CEED_MEM_HOST, &x);
   CeedVectorGetArray(multlvec, CEED_MEM_HOST, &mult);
   for (PetscInt i=0; i<lsize; i++) {
-    for (PetscInt f=0; f<5; f++)
-      q0[i*5+f] /= mult[i];
-    for (PetscInt d=0; d<3; d++)
-      x[i*3+d] /= mult[i];
+    for (PetscInt f=0; f<ncompq; f++)
+      q0[i*ncompq+f] /= mult[i];
+    for (PetscInt d=0; d<dim; d++)
+      x[i*dim+d] /= mult[i];
   }
 
   CeedVectorRestoreArray(q0ceed, &q0);

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -717,7 +717,7 @@ C     Solution to BP1 using libCEED
       integer ceed,err,test
       character*64 spec
 
-      integer p,q,ncomp,enode,lnode
+      integer p,q,ncompx,ncompu,enode,lnode
       integer vec_p1,vec_ap1,vec_qdata,vec_coords,vec_rhs
       integer erstrctu,erstrctx,erstrctw
       integer basisu,basisx
@@ -772,19 +772,20 @@ C     Set up solver parameters
 C     Create ceed basis for mesh and computation
       p=nx1
       q=p+1
-      ncomp=1
+      ncompu=1
+      ncompx=ldim
       call ceedbasiscreatetensorh1lagrange(ceed,ndim,ndim,p,q,
      $  ceed_gauss,basisx,err)
-      call ceedbasiscreatetensorh1lagrange(ceed,ndim,ncomp,p,q,
+      call ceedbasiscreatetensorh1lagrange(ceed,ndim,ncompu,p,q,
      $  ceed_gauss,basisu,err)
 
 C     Create ceed element restrictions for mesh and computation
       enode=p**ldim
-      lnode=enode*nelt*ncomp
+      lnode=enode*nelt*ncompu
       call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
      $  ldim,erstrctx,err)
       call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
-     $  ncomp,erstrctu,err)
+     $  ncompu,erstrctu,err)
       call ceedelemrestrictioncreateidentity(ceed,nelt,q**ldim,
      $  nelt*q**ldim,1,erstrctw,err)
 
@@ -803,25 +804,25 @@ C     Create ceed qfunctions for masssetupf and massf
       call ceedqfunctioncreateinterior(ceed,1,masssetupf,
      $  __FILE__
      $  //':masssetupf',qf_setup,err)
-      call ceedqfunctionaddinput(qf_setup,'x',ldim,
+      call ceedqfunctionaddinput(qf_setup,'x',ncompx,
      $  ceed_eval_interp,err)
-      call ceedqfunctionaddinput(qf_setup,'dx',ldim*ldim,
+      call ceedqfunctionaddinput(qf_setup,'dx',ncompx*ldim,
      $  ceed_eval_grad,err)
-      call ceedqfunctionaddinput(qf_setup,'weight',1,
+      call ceedqfunctionaddinput(qf_setup,'weight',ncompu,
      $  ceed_eval_weight,err)
-      call ceedqfunctionaddoutput(qf_setup,'rho',1,
+      call ceedqfunctionaddoutput(qf_setup,'rho',ncompu,
      $  ceed_eval_none,err)
-      call ceedqfunctionaddoutput(qf_setup,'rhs',1,
+      call ceedqfunctionaddoutput(qf_setup,'rhs',ncompu,
      $  ceed_eval_interp,err)
 
       call ceedqfunctioncreateinterior(ceed,1,massf,
      $  __FILE__
      $  //':massf',qf_mass,err)
-      call ceedqfunctionaddinput(qf_mass,'u',1,
+      call ceedqfunctionaddinput(qf_mass,'u',ncompu,
      $  ceed_eval_interp,err)
-      call ceedqfunctionaddinput(qf_mass,'rho',1,
+      call ceedqfunctionaddinput(qf_mass,'rho',ncompu,
      $  ceed_eval_none,err)
-      call ceedqfunctionaddoutput(qf_mass,'v',1,
+      call ceedqfunctionaddoutput(qf_mass,'v',ncompu,
      $  ceed_eval_interp,err)
 
 C     Create ceed operators
@@ -1024,7 +1025,7 @@ C     Solution to BP3 using libCEED
       integer ceed,err,test
       character*64 spec
 
-      integer p,q,ncomp,enode,lnode
+      integer p,q,ncompx,ncompu,enode,lnode
       integer vec_p1,vec_ap1,vec_qdata,vec_coords,vec_rhs
       integer erstrctu,erstrctx,erstrctw
       integer basisu,basisx
@@ -1087,20 +1088,21 @@ C     Set up solver parameters
 C     Create ceed basis for mesh and computation
       p=nx1
       q=p+1
-      ncomp=1
-      call ceedbasiscreatetensorh1lagrange(ceed,ldim,3*ncomp,p,q,
+      ncompu=1
+      ncompx=ldim
+      call ceedbasiscreatetensorh1lagrange(ceed,ldim,ncompx,p,q,
      $  ceed_gauss,basisx,err)
-      call ceedbasiscreatetensorh1lagrange(ceed,ldim,ncomp,p,q,
+      call ceedbasiscreatetensorh1lagrange(ceed,ldim,ncompu,p,q,
      $  ceed_gauss,basisu,err)
 
 C     Create ceed element restrictions for mesh and computation
       enode=p**ldim
-      lnode=enode*nelt*ncomp
+      lnode=enode*nelt*ncompu
       ngeo=(ldim*(ldim+1))/2
       call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
      $  ldim,erstrctx,err)
       call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
-     $  ncomp,erstrctu,err)
+     $  ncompu,erstrctu,err)
       call ceedelemrestrictioncreateidentity(ceed,nelt,q**ldim,
      $  nelt*q**ldim,ngeo,erstrctw,err)
 
@@ -1119,25 +1121,25 @@ C     Create ceed qfunctions for diffsetupf and diffusionf
       call ceedqfunctioncreateinterior(ceed,1,diffsetupf,
      $  __FILE__
      $  //':diffsetupf'//char(0),qf_setup,err)
-      call ceedqfunctionaddinput(qf_setup,'x',ldim,
+      call ceedqfunctionaddinput(qf_setup,'x',ncompx,
      $  ceed_eval_interp,err)
-      call ceedqfunctionaddinput(qf_setup,'dx',ldim*ldim,
+      call ceedqfunctionaddinput(qf_setup,'dx',ncompx*ldim,
      $  ceed_eval_grad,err)
-      call ceedqfunctionaddinput(qf_setup,'weight',1,
+      call ceedqfunctionaddinput(qf_setup,'weight',ncompu,
      $  ceed_eval_weight,err)
       call ceedqfunctionaddoutput(qf_setup,'rho',ngeo,
      $  ceed_eval_none,err)
-      call ceedqfunctionaddoutput(qf_setup,'rhs',1,
+      call ceedqfunctionaddoutput(qf_setup,'rhs',ncompu,
      $  ceed_eval_interp,err)
 
       call ceedqfunctioncreateinterior(ceed,1,diffusionf,
      $  __FILE__
      $  //':diffusionf'//char(0),qf_diffusion,err)
-      call ceedqfunctionaddinput(qf_diffusion,'u',1*ldim,
+      call ceedqfunctionaddinput(qf_diffusion,'u',ncompu*ldim,
      $  ceed_eval_grad,err)
       call ceedqfunctionaddinput(qf_diffusion,'rho',ngeo,
      $  ceed_eval_none,err)
-      call ceedqfunctionaddoutput(qf_diffusion,'v',1*ldim,
+      call ceedqfunctionaddoutput(qf_diffusion,'v',ncompu*ldim,
      $  ceed_eval_grad,err)  
 
 C     Create ceed operators

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -598,7 +598,7 @@ int main(int argc, char **argv) {
     CeedScalar *xloc;
     CeedInt shape[3] = {melem[0]+1, melem[1]+1, melem[2]+1}, len =
                          shape[0]*shape[1]*shape[2];
-    xloc = malloc(len*dim*sizeof xloc[0]);
+    xloc = malloc(len*ncompx*sizeof xloc[0]);
     for (CeedInt i=0; i<shape[0]; i++) {
       for (CeedInt j=0; j<shape[1]; j++) {
         for (CeedInt k=0; k<shape[2]; k++) {
@@ -611,7 +611,7 @@ int main(int argc, char **argv) {
         }
       }
     }
-    CeedVectorCreate(ceed, len*dim, &xcoord);
+    CeedVectorCreate(ceed, len*ncompx, &xcoord);
     CeedVectorSetArray(xcoord, CEED_MEM_HOST, CEED_OWN_POINTER, xloc);
   }
 

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -152,7 +152,7 @@ static const char *const bpTypes[] = {"bp1","bp2","bp3","bp4","bp5","bp6",
 
 // BP specific data
 typedef struct {
-  CeedInt vscale, qdatasize, qextra;
+  CeedInt ncompu, qdatasize, qextra;
   CeedQFunctionUser setup, apply, error;
   const char *setupfname, *applyfname, *errorfname;
   CeedEvalMode inmode, outmode;
@@ -161,7 +161,7 @@ typedef struct {
 
 bpData bpOptions[6] = {
   [CEED_BP1] = {
-    .vscale = 1,
+    .ncompu = 1,
     .qdatasize = 1,
     .qextra = 1,
     .setup = SetupMass,
@@ -175,7 +175,7 @@ bpData bpOptions[6] = {
     .qmode = CEED_GAUSS
   },
   [CEED_BP2] = {
-    .vscale = 3,
+    .ncompu = 3,
     .qdatasize = 1,
     .qextra = 1,
     .setup = SetupMass3,
@@ -189,7 +189,7 @@ bpData bpOptions[6] = {
     .qmode = CEED_GAUSS
   },
   [CEED_BP3] = {
-    .vscale = 1,
+    .ncompu = 1,
     .qdatasize = 6,
     .qextra = 1,
     .setup = SetupDiff,
@@ -203,7 +203,7 @@ bpData bpOptions[6] = {
     .qmode = CEED_GAUSS
   },
   [CEED_BP4] = {
-    .vscale = 3,
+    .ncompu = 3,
     .qdatasize = 6,
     .qextra = 1,
     .setup = SetupDiff3,
@@ -217,7 +217,7 @@ bpData bpOptions[6] = {
     .qmode = CEED_GAUSS
   },
   [CEED_BP5] = {
-    .vscale = 1,
+    .ncompu = 1,
     .qdatasize = 6,
     .qextra = 0,
     .setup = SetupDiff,
@@ -231,7 +231,7 @@ bpData bpOptions[6] = {
     .qmode = CEED_GAUSS_LOBATTO
   },
   [CEED_BP6] = {
-    .vscale = 3,
+    .ncompu = 3,
     .qdatasize = 6,
     .qextra = 0,
     .setup = SetupDiff3,
@@ -381,7 +381,7 @@ int main(int argc, char **argv) {
   char ceedresource[PETSC_MAX_PATH_LEN] = "/cpu/self";
   double my_rt_start, my_rt, rt_min, rt_max;
   PetscInt degree, qextra, localnodes, localelem, melem[3], mnodes[3], p[3],
-           irank[3], lnodes[3], lsize, vscale = 1;
+           irank[3], lnodes[3], lsize, ncompu = 1;
   PetscScalar *r;
   PetscBool test_mode, benchmark_mode, write_solution;
   PetscMPIInt size, rank;
@@ -398,6 +398,7 @@ int main(int argc, char **argv) {
   CeedOperator op_setup, op_apply, op_error;
   CeedVector xcoord, rho, rhsceed, target;
   CeedInt P, Q;
+  const CeedInt dim = 3, ncompx = 3;
   bpType bpChoice;
 
   ierr = PetscInitialize(&argc, &argv, NULL, help);
@@ -409,7 +410,7 @@ int main(int argc, char **argv) {
                           "CEED benchmark problem to solve", NULL,
                           bpTypes, (PetscEnum)bpChoice, (PetscEnum *)&bpChoice,
                           NULL); CHKERRQ(ierr);
-  vscale = bpOptions[bpChoice].vscale;
+  ncompu = bpOptions[bpChoice].ncompu;
   test_mode = PETSC_FALSE;
   ierr = PetscOptionsBool("-test",
                           "Testing mode (do not print unless error is large)",
@@ -454,7 +455,7 @@ int main(int argc, char **argv) {
 
   // Find my location in the process grid
   ierr = MPI_Comm_rank(comm, &rank); CHKERRQ(ierr);
-  for (int d=0,rankleft=rank; d<3; d++) {
+  for (int d=0,rankleft=rank; d<dim; d++) {
     const int pstride[3] = {p[1] *p[2], p[2], 1};
     irank[d] = rankleft / pstride[d];
     rankleft -= irank[d] * pstride[d];
@@ -464,7 +465,7 @@ int main(int argc, char **argv) {
 
   // Setup global vector
   ierr = VecCreate(comm, &X); CHKERRQ(ierr);
-  ierr = VecSetSizes(X, mnodes[0]*mnodes[1]*mnodes[2]*vscale, PETSC_DECIDE);
+  ierr = VecSetSizes(X, mnodes[0]*mnodes[1]*mnodes[2]*ncompu, PETSC_DECIDE);
   CHKERRQ(ierr);
   ierr = VecSetUp(X); CHKERRQ(ierr);
 
@@ -483,7 +484,7 @@ int main(int argc, char **argv) {
                        "    Process Decomposition              : %D %D %D\n"
                        "    Local Elements                     : %D = %D %D %D\n"
                        "    Owned nodes                        : %D = %D %D %D\n",
-                       bpChoice+1, ceedresource, P, Q,  gsize/vscale, p[0],
+                       bpChoice+1, ceedresource, P, Q,  gsize/ncompu, p[0],
                        p[1], p[2], localelem, melem[0], melem[1], melem[2],
                        mnodes[0]*mnodes[1]*mnodes[2], mnodes[0], mnodes[1], mnodes[2]);
     CHKERRQ(ierr);
@@ -491,18 +492,18 @@ int main(int argc, char **argv) {
 
   {
     lsize = 1;
-    for (int d=0; d<3; d++) {
+    for (int d=0; d<dim; d++) {
       lnodes[d] = melem[d]*degree + 1;
       lsize *= lnodes[d];
     }
     ierr = VecCreate(PETSC_COMM_SELF, &Xloc); CHKERRQ(ierr);
-    ierr = VecSetSizes(Xloc, lsize*vscale, PETSC_DECIDE); CHKERRQ(ierr);
+    ierr = VecSetSizes(Xloc, lsize*ncompu, PETSC_DECIDE); CHKERRQ(ierr);
     ierr = VecSetUp(Xloc); CHKERRQ(ierr);
 
     // Create local-to-global scatter
     PetscInt *ltogind, *ltogind0, *locind, l0count;
     IS ltogis, ltogis0, locis;
-    PetscInt gstart[2][2][2], gmnodes[2][2][2][3];
+    PetscInt gstart[2][2][2], gmnodes[2][2][2][dim];
 
     for (int i=0; i<2; i++) {
       for (int j=0; j<2; j++) {
@@ -536,13 +537,13 @@ int main(int argc, char **argv) {
         }
       }
     }
-    ierr = ISCreateBlock(comm, vscale, lsize, ltogind, PETSC_OWN_POINTER,
+    ierr = ISCreateBlock(comm, ncompu, lsize, ltogind, PETSC_OWN_POINTER,
                          &ltogis); CHKERRQ(ierr);
     ierr = VecScatterCreate(Xloc, NULL, X, ltogis, &ltog); CHKERRQ(ierr);
     CHKERRQ(ierr);
-    ierr = ISCreateBlock(comm, vscale, l0count, ltogind0, PETSC_OWN_POINTER,
+    ierr = ISCreateBlock(comm, ncompu, l0count, ltogind0, PETSC_OWN_POINTER,
                          &ltogis0); CHKERRQ(ierr);
-    ierr = ISCreateBlock(comm, vscale, l0count, locind, PETSC_OWN_POINTER,
+    ierr = ISCreateBlock(comm, ncompu, l0count, locind, PETSC_OWN_POINTER,
                          &locis); CHKERRQ(ierr);
     ierr = VecScatterCreate(Xloc, locis, X, ltogis0, &ltog0); CHKERRQ(ierr);
     {
@@ -577,15 +578,15 @@ int main(int argc, char **argv) {
 
   // Set up libCEED
   CeedInit(ceedresource, &ceed);
-  CeedBasisCreateTensorH1Lagrange(ceed, 3, vscale, P, Q,
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompu, P, Q,
                                   bpOptions[bpChoice].qmode, &basisu);
-  CeedBasisCreateTensorH1Lagrange(ceed, 3, 3, 2, Q,
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompx, 2, Q,
                                   bpOptions[bpChoice].qmode, &basisx);
 
-  CreateRestriction(ceed, melem, P, vscale, &Erestrictu);
-  CreateRestriction(ceed, melem, 2, 3, &Erestrictx);
+  CreateRestriction(ceed, melem, P, ncompu, &Erestrictu);
+  CreateRestriction(ceed, melem, 2, dim, &Erestrictx);
   CeedInt nelem = melem[0]*melem[1]*melem[2];
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, vscale,
+  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, ncompu,
                                     &Erestrictui);
   CeedElemRestrictionCreateIdentity(ceed, nelem,
                                     Q*Q*Q,
@@ -597,7 +598,7 @@ int main(int argc, char **argv) {
     CeedScalar *xloc;
     CeedInt shape[3] = {melem[0]+1, melem[1]+1, melem[2]+1}, len =
                          shape[0]*shape[1]*shape[2];
-    xloc = malloc(len*3*sizeof xloc[0]);
+    xloc = malloc(len*dim*sizeof xloc[0]);
     for (CeedInt i=0; i<shape[0]; i++) {
       for (CeedInt j=0; j<shape[1]; j++) {
         for (CeedInt k=0; k<shape[2]; k++) {
@@ -610,7 +611,7 @@ int main(int argc, char **argv) {
         }
       }
     }
-    CeedVectorCreate(ceed, len*3, &xcoord);
+    CeedVectorCreate(ceed, len*dim, &xcoord);
     CeedVectorSetArray(xcoord, CEED_MEM_HOST, CEED_OWN_POINTER, xloc);
   }
 
@@ -618,13 +619,13 @@ int main(int argc, char **argv) {
   // quadrature data) and set its context data
   CeedQFunctionCreateInterior(ceed, 1, bpOptions[bpChoice].setup,
                               bpOptions[bpChoice].setupfname, &qf_setup);
-  CeedQFunctionAddInput(qf_setup, "x", 3, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(qf_setup, "dx", 9, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup, "x", ncompx, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_setup, "dx", ncompx*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
   CeedQFunctionAddOutput(qf_setup, "rho", bpOptions[bpChoice].qdatasize,
                          CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_setup, "true_soln", vscale, CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_setup, "rhs", vscale, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_setup, "true_soln", ncompu, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_setup, "rhs", ncompu, CEED_EVAL_INTERP);
 
   // Set up PDE operator
   CeedQFunctionCreateInterior(ceed, 1, bpOptions[bpChoice].apply,
@@ -632,26 +633,26 @@ int main(int argc, char **argv) {
   // Add inputs and outputs
   CeedInt gradInScale = bpOptions[bpChoice].inmode==CEED_EVAL_GRAD ? 3 : 1;
   CeedInt gradOutScale = bpOptions[bpChoice].outmode==CEED_EVAL_GRAD ? 3 : 1;
-  CeedQFunctionAddInput(qf_apply, "u", vscale*gradInScale,
+  CeedQFunctionAddInput(qf_apply, "u", ncompu*gradInScale,
                          bpOptions[bpChoice].inmode);
   CeedQFunctionAddInput(qf_apply, "rho", bpOptions[bpChoice].qdatasize,
                         CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_apply, "v", vscale*gradOutScale,
+  CeedQFunctionAddOutput(qf_apply, "v", ncompu*gradOutScale,
                          bpOptions[bpChoice].outmode);
 
   // Create the error qfunction
   CeedQFunctionCreateInterior(ceed, 1, bpOptions[bpChoice].error,
                               bpOptions[bpChoice].errorfname, &qf_error);
-  CeedQFunctionAddInput(qf_error, "u", vscale, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(qf_error, "true_soln", vscale, CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_error, "error", vscale, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_error, "u", ncompu, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_error, "true_soln", ncompu, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_error, "error", ncompu, CEED_EVAL_NONE);
 
   // Create the persistent vectors that will be needed in setup
   CeedInt nqpts;
   CeedBasisGetNumQuadraturePoints(basisu, &nqpts);
   CeedVectorCreate(ceed, bpOptions[bpChoice].qdatasize*nelem*nqpts, &rho);
-  CeedVectorCreate(ceed, nelem*nqpts*vscale, &target);
-  CeedVectorCreate(ceed, lsize*vscale, &rhsceed);
+  CeedVectorCreate(ceed, nelem*nqpts*ncompu, &target);
+  CeedVectorCreate(ceed, lsize*ncompu, &rhsceed);
 
   // Create the operator that builds the quadrature data for the ceed operator
   CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
@@ -697,14 +698,14 @@ int main(int argc, char **argv) {
   }
   user->Xloc = Xloc;
   ierr = VecDuplicate(Xloc, &user->Yloc); CHKERRQ(ierr);
-  CeedVectorCreate(ceed, lsize*vscale, &user->xceed);
-  CeedVectorCreate(ceed, lsize*vscale, &user->yceed);
+  CeedVectorCreate(ceed, lsize*ncompu, &user->xceed);
+  CeedVectorCreate(ceed, lsize*ncompu, &user->yceed);
   user->op = op_apply;
   user->rho = rho;
   user->ceed = ceed;
 
-  ierr = MatCreateShell(comm, mnodes[0]*mnodes[1]*mnodes[2]*vscale,
-                        mnodes[0]*mnodes[1]*mnodes[2]*vscale,
+  ierr = MatCreateShell(comm, mnodes[0]*mnodes[1]*mnodes[2]*ncompu,
+                        mnodes[0]*mnodes[1]*mnodes[2]*ncompu,
                         PETSC_DECIDE, PETSC_DECIDE, user, &mat); CHKERRQ(ierr);
   if (bpChoice == CEED_BP1 || bpChoice == CEED_BP2) {
     ierr = MatShellSetOperation(mat, MATOP_MULT, (void(*)(void))MatMult_Mass);

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -578,11 +578,14 @@ int main(int argc, char **argv) {
 
   // Set up libCEED
   CeedInit(ceedresource, &ceed);
+
+  // CEED bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompu, P, Q,
                                   bpOptions[bpChoice].qmode, &basisu);
   CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompx, 2, Q,
                                   bpOptions[bpChoice].qmode, &basisx);
 
+  // CEED restrictions
   CreateRestriction(ceed, melem, P, ncompu, &Erestrictu);
   CreateRestriction(ceed, melem, 2, dim, &Erestrictx);
   CeedInt nelem = melem[0]*melem[1]*melem[2];


### PR DESCRIPTION
This very simple PR tries to homogenize the example suite by using variables `ncomp` and `dim` where appropriate. We had some discrepancies, among example files in `examples/ceed`, `examples/petsc` and `examples/mfem`.