### PR TITLE
Add CeedPragmaOMP to bps

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -732,7 +732,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   string qFunction(qf_data->qFunctionSource);
 
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
-  code << "\n#define CeedPragmaOMP(args)\n";
+  code << "\n#define CeedPragmaSIMD\n";
   code << qFunction;
 
   // Setup

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -732,6 +732,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   string qFunction(qf_data->qFunctionSource);
 
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
+  code << "\n#define CeedPragmaOMP(args)\n";
   code << qFunction;
 
   // Setup

--- a/backends/cuda/ceed-cuda-qfunction-load.cpp
+++ b/backends/cuda/ceed-cuda-qfunction-load.cpp
@@ -60,7 +60,7 @@ extern "C" int CeedCudaBuildQFunction(CeedQFunction qf) {
   ostringstream code;
 
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
-  code << "\n#define CeedPragmaOMP(args)\n";
+  code << "\n#define CeedPragmaSIMD\n";
   code << "typedef struct { const CeedScalar* inputs[16]; CeedScalar* outputs[16]; } Fields_Cuda;\n";
   code << qReadWriteS;
   code << qFunction;

--- a/backends/cuda/ceed-cuda-qfunction-load.cpp
+++ b/backends/cuda/ceed-cuda-qfunction-load.cpp
@@ -60,6 +60,7 @@ extern "C" int CeedCudaBuildQFunction(CeedQFunction qf) {
   ostringstream code;
 
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
+  code << "\n#define CeedPragmaOMP(args)\n";
   code << "typedef struct { const CeedScalar* inputs[16]; CeedScalar* outputs[16]; } Fields_Cuda;\n";
   code << qReadWriteS;
   code << qFunction;

--- a/examples/ceed/ex1.h
+++ b/examples/ceed/ex1.h
@@ -27,11 +27,15 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   CeedScalar *qd = out[0];
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
+    // Quadrature Point Loop
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       qd[i] = J[i] * qw[i];
     }
     break;
   case 22:
+    // Quadrature Point Loop
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
@@ -39,6 +43,8 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     }
     break;
   case 33:
+    // Quadrature Point Loop
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // 0 3 6
       // 1 4 7
@@ -57,6 +63,9 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
                              const CeedScalar *const *in, CeedScalar *const *out) {
   const CeedScalar *u = in[0], *w = in[1];
   CeedScalar *v = out[0];
+
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     v[i] = w[i] * u[i];
   }

--- a/examples/ceed/ex1.h
+++ b/examples/ceed/ex1.h
@@ -28,14 +28,14 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       qd[i] = J[i] * qw[i];
     }
     break;
   case 22:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
@@ -44,7 +44,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     break;
   case 33:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       // 0 3 6
       // 1 4 7
@@ -65,7 +65,7 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     v[i] = w[i] * u[i];
   }

--- a/examples/mfem/bp1.h
+++ b/examples/mfem/bp1.h
@@ -29,14 +29,14 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       rho[i] = J[i] * qw[i];
     }
     break;
   case 22:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
@@ -45,7 +45,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     break;
   case 33:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       // 0 3 6
       // 1 4 7
@@ -66,7 +66,7 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     v[i] = w[i] * u[i];
   }

--- a/examples/mfem/bp1.h
+++ b/examples/mfem/bp1.h
@@ -25,13 +25,16 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   BuildContext *bc = (BuildContext *)ctx;
   const CeedScalar *J = in[0], *qw = in[1];
   CeedScalar *rho = out[0];
+
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       rho[i] = J[i] * qw[i];
     }
     break;
   case 22:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
@@ -39,6 +42,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     }
     break;
   case 33:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // 0 3 6
       // 1 4 7
@@ -57,6 +61,8 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
                              const CeedScalar *const *in, CeedScalar *const *out) {
   const CeedScalar *u = in[0], *w = in[1];
   CeedScalar *v = out[0];
+
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     v[i] = w[i] * u[i];
   }

--- a/examples/mfem/bp1.h
+++ b/examples/mfem/bp1.h
@@ -28,12 +28,14 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
 
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       rho[i] = J[i] * qw[i];
     }
     break;
   case 22:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
@@ -42,6 +44,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     }
     break;
   case 33:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // 0 3 6
@@ -62,6 +65,7 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
   const CeedScalar *u = in[0], *w = in[1];
   CeedScalar *v = out[0];
 
+  // Quadrature Point Loop
   CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     v[i] = w[i] * u[i];

--- a/examples/mfem/bp3.h
+++ b/examples/mfem/bp3.h
@@ -32,12 +32,14 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
 
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       qd[i] = qw[i] / J[i];
     }
     break;
   case 22:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // J: 0 2   qd: 0 1   adj(J):  J22 -J12
@@ -53,6 +55,7 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
     }
     break;
   case 33:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // J: 0 3 6   qd: 0 1 2
@@ -99,12 +102,14 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
 
   switch (bc->dim) {
   case 1:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       vg[i] = ug[i] * qd[i];
     }
     break;
   case 2:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       const CeedScalar ug0 = ug[i+Q*0];
@@ -114,6 +119,7 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
     }
     break;
   case 3:
+    // Quadrature Point Loop
     CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       const CeedScalar ug0 = ug[i+Q*0];

--- a/examples/mfem/bp3.h
+++ b/examples/mfem/bp3.h
@@ -29,13 +29,16 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
   // the symmetric part of the result.
   const CeedScalar *J = in[0], *qw = in[1];
   CeedScalar *qd = out[0];
+
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       qd[i] = qw[i] / J[i];
     }
     break;
   case 22:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // J: 0 2   qd: 0 1   adj(J):  J22 -J12
       //    1 3       1 2           -J21  J11
@@ -50,6 +53,7 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
     }
     break;
   case 33:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       // J: 0 3 6   qd: 0 1 2
       //    1 4 7       1 3 4
@@ -92,13 +96,16 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
   // in[0], out[0] have shape [dim, nc=1, Q]
   const CeedScalar *ug = in[0], *qd = in[1];
   CeedScalar *vg = out[0];
+
   switch (bc->dim) {
   case 1:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       vg[i] = ug[i] * qd[i];
     }
     break;
   case 2:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       const CeedScalar ug0 = ug[i+Q*0];
       const CeedScalar ug1 = ug[i+Q*1];
@@ -107,6 +114,7 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
     }
     break;
   case 3:
+    CeedPragmaOMP(simd)
     for (CeedInt i=0; i<Q; i++) {
       const CeedScalar ug0 = ug[i+Q*0];
       const CeedScalar ug1 = ug[i+Q*1];

--- a/examples/mfem/bp3.h
+++ b/examples/mfem/bp3.h
@@ -33,14 +33,14 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       qd[i] = qw[i] / J[i];
     }
     break;
   case 22:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       // J: 0 2   qd: 0 1   adj(J):  J22 -J12
       //    1 3       1 2           -J21  J11
@@ -56,7 +56,7 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
     break;
   case 33:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       // J: 0 3 6   qd: 0 1 2
       //    1 4 7       1 3 4
@@ -103,14 +103,14 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
   switch (bc->dim) {
   case 1:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       vg[i] = ug[i] * qd[i];
     }
     break;
   case 2:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       const CeedScalar ug0 = ug[i+Q*0];
       const CeedScalar ug1 = ug[i+Q*1];
@@ -120,7 +120,7 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
     break;
   case 3:
     // Quadrature Point Loop
-    CeedPragmaOMP(simd)
+    CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
       const CeedScalar ug0 = ug[i+Q*0];
       const CeedScalar ug1 = ug[i+Q*1];

--- a/examples/navier-stokes/advection.h
+++ b/examples/navier-stokes/advection.h
@@ -62,7 +62,7 @@ CEED_QFUNCTION(ICsAdvection)(void *ctx, CeedInt Q,
   const CeedScalar x0[3] = {0.25*lx, 0.5*ly, 0.5*lz};
   const CeedScalar center[3] = {0.5*lx, 0.5*ly, 0.5*lz};
 
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup
@@ -127,7 +127,7 @@ CEED_QFUNCTION(Advection)(void *ctx, CeedInt Q,
   CeedScalar (*v)[Q] = (CeedScalar(*)[Q])out[0],
              (*dv)[5][Q] = (CeedScalar(*)[5][Q])out[1];
 
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup

--- a/examples/navier-stokes/advection.h
+++ b/examples/navier-stokes/advection.h
@@ -20,15 +20,6 @@
 #ifndef advection_h
 #define advection_h
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #include <math.h>
 
 // *****************************************************************************

--- a/examples/navier-stokes/common.h
+++ b/examples/navier-stokes/common.h
@@ -65,7 +65,7 @@ CEED_QFUNCTION(Setup)(void *ctx, CeedInt Q,
   // Outputs
   CeedScalar (*qdata)[Q] = (CeedScalar(*)[Q])out[0];
 
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup
@@ -128,7 +128,7 @@ CEED_QFUNCTION(Mass)(void *ctx, CeedInt Q,
                    (*w) = in[1];
   CeedScalar (*v)[Q] = (CeedScalar(*)[Q])out[0];
 
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     v[0][i] = w[i] * u[0][i];
     v[1][i] = w[i] * u[1][i];

--- a/examples/navier-stokes/common.h
+++ b/examples/navier-stokes/common.h
@@ -20,15 +20,6 @@
 #ifndef common_h
 #define common_h
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #include <math.h>
 
 // *****************************************************************************

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -106,7 +106,7 @@ CEED_QFUNCTION(ICsDC)(void *ctx, CeedInt Q,
   const CeedScalar tol = 1.e-14;
   const CeedScalar center[3] = {0.5*lx, 0.5*ly, 0.5*lz};
 
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup
@@ -219,7 +219,7 @@ CEED_QFUNCTION(DC)(void *ctx, CeedInt Q,
   const CeedScalar g      = context[5];
   const CeedScalar gamma  = cp / cv;
 
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     // Setup

--- a/examples/navier-stokes/densitycurrent.h
+++ b/examples/navier-stokes/densitycurrent.h
@@ -24,15 +24,6 @@
 #ifndef densitycurrent_h
 #define densitycurrent_h
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #include <math.h>
 
 // *****************************************************************************

--- a/examples/nek/bps/bps.h
+++ b/examples/nek/bps/bps.h
@@ -26,6 +26,8 @@ CEED_QFUNCTION(masssetupf)(void *ctx, CeedInt Q, const CeedScalar *const *in, Ce
   const CeedScalar *x = in[0];
   const CeedScalar *J = in[1];
   const CeedScalar *w = in[2];
+
+  // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                       J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
@@ -33,7 +35,7 @@ CEED_QFUNCTION(masssetupf)(void *ctx, CeedInt Q, const CeedScalar *const *in, Ce
     rho[i] = det * w[i];
     rhs[i] = rho[i] * w[i] * 
                sqrt(x[i]*x[i] + x[i+Q]*x[i+Q] + x[i+2*Q]*x[i+2*Q]);
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }
 
@@ -41,9 +43,11 @@ CEED_QFUNCTION int massf(void *ctx, CeedInt Q, const CeedScalar *const *in, Ceed
   const CeedScalar *u = in[0];
   const CeedScalar *rho = in[1];
   CeedScalar *v = out[0];
-  for (CeedInt i=0; i<Q; i++) {
+
+  // Quadrature Point Loop
+  for (CeedInt i=0; i<Q; i++)
     v[i] = rho[i] * u[i];
-  }
+
   return 0;
 }
 // *****************************************************************************
@@ -57,6 +61,8 @@ CEED_QFUNCTION(diffsetupf)(void *ctx, CeedInt Q, const CeedScalar *const *in, Ce
   const CeedScalar *J = in[1];
   const CeedScalar *w = in[2];
   CeedScalar *qd = out[0], *rhs = out[1];
+
+  // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar J11 = J[i+Q*0];
     const CeedScalar J21 = J[i+Q*1];
@@ -90,7 +96,7 @@ CEED_QFUNCTION(diffsetupf)(void *ctx, CeedInt Q, const CeedScalar *const *in, Ce
                sin(M_PI*(c[0] + k[0]*x[i+Q*0])) *
                sin(M_PI*(c[1] + k[1]*x[i+Q*1])) *
                sin(M_PI*(c[2] + k[2]*x[i+Q*2]));
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }
 
@@ -98,6 +104,8 @@ CEED_QFUNCTION int diffusionf(void *ctx, CeedInt Q, const CeedScalar *const *in,
   const CeedScalar *ug = in[0];
   const CeedScalar *qd = in[1];
   CeedScalar *vg = out[0];
+
+  // Quadrature Point Loop
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar ug0 = ug[i+Q*0];
     const CeedScalar ug1 = ug[i+Q*1];
@@ -105,6 +113,6 @@ CEED_QFUNCTION int diffusionf(void *ctx, CeedInt Q, const CeedScalar *const *in,
     vg[i+Q*0] = qd[i+Q*0]*ug0 + qd[i+Q*1]*ug1 + qd[i+Q*2]*ug2;
     vg[i+Q*1] = qd[i+Q*1]*ug0 + qd[i+Q*3]*ug1 + qd[i+Q*4]*ug2;
     vg[i+Q*2] = qd[i+Q*2]*ug0 + qd[i+Q*4]*ug1 + qd[i+Q*5]*ug2;
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -18,15 +18,6 @@ C> @file
 C> Mass and diffusion operators examples using Nek5000
 C TESTARGS -c {ceed_resource} -e bp1 -n 1 -b 4 -test
 
-C PragmaOMP preprocessor directive
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP(a) !$omp a
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 C-----------------------------------------------------------------------
       subroutine masssetupf(ctx,q,u1,u2,u3,u4,u5,u6,u7,
      $  u8,u9,u10,u11,u12,u13,u14,u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,
@@ -45,7 +36,6 @@ C     Input: u1,u2,u3,q             Output: v1,v2,ierr
       real*8 jacmq
 
 C     Quadrature Point Loop
-CeedPragmaOMP(simd)
       do i=1,q
         a11=u2(i+q*0)
         a12=u2(i+q*3)
@@ -98,7 +88,6 @@ C     Input: u1,u2,q                Output: v1,ierr
       real*8 v1(q)
 
 C     Quadrature Point Loop
-CeedPragmaOMP(simd)
       do i=1,q
         v1(i)=u2(i)*u1(i)
       enddo
@@ -124,7 +113,6 @@ C     Input: u1,u2,u3,q             Output: v1,v2,ierr
       real*8 c(3),k(3)
 
 C     Quadrature Point Loop
-CeedPragmaOMP(simd)
       do i=1,q
         pi = 3.14159265358979323846
 
@@ -195,7 +183,6 @@ C     Input: u1,u2,q                Output: v1,ierr
       real*8 v1(3*q)
 
 C     Quadrature Point Loop
-CeedPragmaOMP(simd)
       do i=1,q
         v1(i+0*q)=
      $     u2(i+0*q)*u1(i)+u2(i+1*q)*u1(i+q)+u2(i+2*q)*u1(i+2*q)

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -18,6 +18,16 @@ C> @file
 C> Mass and diffusion operators examples using Nek5000
 C TESTARGS -c {ceed_resource} -e bp1 -n 1 -b 4 -test
 
+C PragmaOMP preprocessor directive
+#ifndef CeedPragmaOMP
+#  ifdef _OPENMP
+#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#  else
+#    define CeedPragmaOMP(a)
+#  endif
+#endif
+
 C-----------------------------------------------------------------------
       subroutine masssetupf(ctx,q,u1,u2,u3,u4,u5,u6,u7,
      $  u8,u9,u10,u11,u12,u13,u14,u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,
@@ -35,6 +45,8 @@ C     Input: u1,u2,u3,q             Output: v1,v2,ierr
       real*8 g11,g12,g13,g21,g22,g23,g31,g32,g33
       real*8 jacmq
 
+C     Quadrature Point Loop
+      CeedPragmaOMP(simd)
       do i=1,q
         a11=u2(i+q*0)
         a12=u2(i+q*3)
@@ -86,6 +98,8 @@ C     Input: u1,u2,q                Output: v1,ierr
       real*8 u2(q)
       real*8 v1(q)
 
+C     Quadrature Point Loop
+      CeedPragmaOMP(simd)
       do i=1,q
         v1(i)=u2(i)*u1(i)
       enddo
@@ -110,6 +124,8 @@ C     Input: u1,u2,u3,q             Output: v1,v2,ierr
       real*8 jacmq,scl
       real*8 c(3),k(3)
 
+C     Quadrature Point Loop
+      CeedPragmaOMP(simd)
       do i=1,q
         pi = 3.14159265358979323846
 
@@ -179,6 +195,8 @@ C     Input: u1,u2,q                Output: v1,ierr
       real*8 u2(6*q)
       real*8 v1(3*q)
 
+C     Quadrature Point Loop
+      CeedPragmaOMP(simd)
       do i=1,q
         v1(i+0*q)=
      $     u2(i+0*q)*u1(i)+u2(i+1*q)*u1(i+q)+u2(i+2*q)*u1(i+2*q)

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -21,7 +21,7 @@ C TESTARGS -c {ceed_resource} -e bp1 -n 1 -b 4 -test
 C PragmaOMP preprocessor directive
 #ifndef CeedPragmaOMP
 #  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP_(a) C$#a
 #    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
 #  else
 #    define CeedPragmaOMP(a)
@@ -46,7 +46,7 @@ C     Input: u1,u2,u3,q             Output: v1,v2,ierr
       real*8 jacmq
 
 C     Quadrature Point Loop
-      CeedPragmaOMP(simd)
+CeedPragmaOMP(simd)
       do i=1,q
         a11=u2(i+q*0)
         a12=u2(i+q*3)
@@ -99,7 +99,7 @@ C     Input: u1,u2,q                Output: v1,ierr
       real*8 v1(q)
 
 C     Quadrature Point Loop
-      CeedPragmaOMP(simd)
+CeedPragmaOMP(simd)
       do i=1,q
         v1(i)=u2(i)*u1(i)
       enddo
@@ -125,7 +125,7 @@ C     Input: u1,u2,u3,q             Output: v1,v2,ierr
       real*8 c(3),k(3)
 
 C     Quadrature Point Loop
-      CeedPragmaOMP(simd)
+CeedPragmaOMP(simd)
       do i=1,q
         pi = 3.14159265358979323846
 
@@ -196,7 +196,7 @@ C     Input: u1,u2,q                Output: v1,ierr
       real*8 v1(3*q)
 
 C     Quadrature Point Loop
-      CeedPragmaOMP(simd)
+CeedPragmaOMP(simd)
       do i=1,q
         v1(i+0*q)=
      $     u2(i+0*q)*u1(i)+u2(i+1*q)*u1(i+q)+u2(i+2*q)*u1(i+2*q)

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -21,8 +21,7 @@ C TESTARGS -c {ceed_resource} -e bp1 -n 1 -b 4 -test
 C PragmaOMP preprocessor directive
 #ifndef CeedPragmaOMP
 #  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) C$#a
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#    define CeedPragmaOMP(a) !$omp a
 #  else
 #    define CeedPragmaOMP(a)
 #  endif

--- a/examples/petsc/bp1.h
+++ b/examples/petsc/bp1.h
@@ -38,7 +38,7 @@ CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q,
     true_soln[i] = sqrt(x[i]*x[i] + x[i+Q]*x[i+Q] + x[i+2*Q]*x[i+2*Q]);
 
     rhs[i] = rho[i] * true_soln[i];
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }
 
@@ -49,8 +49,8 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q,
 
   // Quadrature Point Loop
   CeedPragmaOMP(simd)
-  for (CeedInt i=0; i<Q; i++) {
+  for (CeedInt i=0; i<Q; i++)
     v[i] = rho[i] * u[i];
-  }
+
   return 0;
 }

--- a/examples/petsc/bp1.h
+++ b/examples/petsc/bp1.h
@@ -28,7 +28,7 @@ CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q,
   CeedScalar *rho = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                             J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
@@ -48,7 +48,7 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q,
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++)
     v[i] = rho[i] * u[i];
 

--- a/examples/petsc/bp1.h
+++ b/examples/petsc/bp1.h
@@ -17,15 +17,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example using PETSc
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #ifndef __CUDACC__
 #  include <math.h>
 #endif

--- a/examples/petsc/bp1.h
+++ b/examples/petsc/bp1.h
@@ -17,6 +17,15 @@
 /// @file
 /// libCEED QFunctions for mass operator example using PETSc
 
+#ifndef CeedPragmaOMP
+#  ifdef _OPENMP
+#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#  else
+#    define CeedPragmaOMP(a)
+#  endif
+#endif
+
 #ifndef __CUDACC__
 #  include <math.h>
 #endif
@@ -27,6 +36,8 @@ CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q,
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
   CeedScalar *rho = out[0], *true_soln = out[1], *rhs = out[2];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                             J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
@@ -45,6 +56,8 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q,
   const CeedScalar *u = in[0], *rho = in[1];
   CeedScalar *v = out[0];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     v[i] = rho[i] * u[i];
   }

--- a/examples/petsc/bp2.h
+++ b/examples/petsc/bp2.h
@@ -28,7 +28,7 @@ CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
   CeedScalar *rho = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                             J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
@@ -58,7 +58,7 @@ CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q,
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar r = rho[i];
     // Component 1

--- a/examples/petsc/bp2.h
+++ b/examples/petsc/bp2.h
@@ -17,15 +17,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example using PETSc
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #ifndef __CUDACC__
 #  include <math.h>
 #endif

--- a/examples/petsc/bp2.h
+++ b/examples/petsc/bp2.h
@@ -17,6 +17,15 @@
 /// @file
 /// libCEED QFunctions for mass operator example using PETSc
 
+#ifndef CeedPragmaOMP
+#  ifdef _OPENMP
+#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#  else
+#    define CeedPragmaOMP(a)
+#  endif
+#endif
+
 #ifndef __CUDACC__
 #  include <math.h>
 #endif
@@ -27,6 +36,8 @@ CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
   CeedScalar *rho = out[0], *true_soln = out[1], *rhs = out[2];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                             J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
@@ -55,6 +66,8 @@ CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q,
   const CeedScalar *u = in[0], *rho = in[1];
   CeedScalar *v = out[0];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar r = rho[i];
     // Component 1

--- a/examples/petsc/bp2.h
+++ b/examples/petsc/bp2.h
@@ -48,7 +48,7 @@ CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
     rhs[i+1*Q] = rho[i] * true_soln[i+0*Q];
     // Component 3
     rhs[i+2*Q] = rho[i] * true_soln[i+0*Q];
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }
 
@@ -67,6 +67,6 @@ CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q,
     v[i+1*Q] = r * u[i+1*Q];
     // Component 3
     v[i+2*Q] = r * u[i+2*Q];
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -69,7 +69,7 @@ CEED_QFUNCTION(SetupDiff)(void *ctx, const CeedInt Q,
     const CeedScalar rho = w[i] * (J11*A11 + J21*A12 + J31*A13);
 
     rhs[i] = rho * M_PI*M_PI * (k[0]*k[0] + k[1]*k[1] + k[2]*k[2]) * true_soln[i];
-  }
+  } // End of Quadrature Point Loop
   return 0;
 }
 
@@ -81,12 +81,27 @@ CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
   // Quadrature Point Loop
   CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
-    const CeedScalar ug0 = ug[i+Q*0];
-    const CeedScalar ug1 = ug[i+Q*1];
-    const CeedScalar ug2 = ug[i+Q*2];
-    vg[i+Q*0] = qd[i+Q*0]*ug0 + qd[i+Q*1]*ug1 + qd[i+Q*2]*ug2;
-    vg[i+Q*1] = qd[i+Q*1]*ug0 + qd[i+Q*3]*ug1 + qd[i+Q*4]*ug2;
-    vg[i+Q*2] = qd[i+Q*2]*ug0 + qd[i+Q*4]*ug1 + qd[i+Q*5]*ug2;
-  }
+    // Read spatial derivatives of u
+    const CeedScalar uJ[3]        =  {ug[i+Q*0],
+                                      ug[i+Q*1],
+                                      ug[i+Q*2]
+                                     };
+    // Read qdata
+    const CeedScalar dXdxdXdxT[6] =  {qd[i+0*Q],
+                                      qd[i+1*Q],
+                                      qd[i+2*Q],
+                                      qd[i+3*Q],
+                                      qd[i+4*Q],
+                                      qd[i+5*Q]
+                                     };
+
+    const CeedInt idx[3][3] = {{0, 1, 2}, {1, 3, 4}, {2, 4, 5}}; // symmetric matrix indices
+
+    for (int j=0; j<3; j++) {
+      vg[i+Q*j]  = 0;
+      for (int k=0; k<3; k++)
+        vg[i+Q*j] += uJ[k] * dXdxdXdxT[idx[j][k]];
+    }
+  } // End of Quadrature Point Loop
   return 0;
 }

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -17,15 +17,6 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example using PETSc
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #ifndef __CUDACC__
 #  include <math.h>
 #endif

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -17,6 +17,15 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example using PETSc
 
+#ifndef CeedPragmaOMP
+#  ifdef _OPENMP
+#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#  else
+#    define CeedPragmaOMP(a)
+#  endif
+#endif
+
 #ifndef __CUDACC__
 #  include <math.h>
 #endif
@@ -24,12 +33,14 @@
 // *****************************************************************************
 CEED_QFUNCTION(SetupDiff)(void *ctx, const CeedInt Q,
                           const CeedScalar *const *in, CeedScalar *const *out) {
-  #ifndef M_PI
-#define M_PI    3.14159265358979323846
-  #endif
+#ifndef M_PI
+#  define M_PI    3.14159265358979323846
+#endif
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
   CeedScalar *qd = out[0], *true_soln = out[1], *rhs = out[2];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar J11 = J[i+Q*0];
     const CeedScalar J21 = J[i+Q*1];
@@ -76,6 +87,8 @@ CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
   const CeedScalar *ug = in[0], *qd = in[1];
   CeedScalar *vg = out[0];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar ug0 = ug[i+Q*0];
     const CeedScalar ug1 = ug[i+Q*1];

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -75,8 +75,8 @@ CEED_QFUNCTION(SetupDiff)(void *ctx, const CeedInt Q,
 
 CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
                      const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *restrict ug = in[0], *restrict qd = in[1];
-  CeedScalar *restrict vg = out[0];
+  const CeedScalar *ug = in[0], *qd = in[1];
+  CeedScalar *vg = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
@@ -86,7 +86,7 @@ CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
                                       ug[i+Q*1],
                                       ug[i+Q*2]
                                      };
-    // Read qdata (6 distinct entries of dXdxdXdxT symmetric matrix)
+    // Read qdata (dXdxdXdxT symmetric matrix)
     const CeedScalar dXdxdXdxT[3][3] = {{qd[i+0*Q],
                                          qd[i+1*Q],
                                          qd[i+2*Q]},

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -82,11 +82,11 @@ CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
   CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     // Read spatial derivatives of u
-    const CeedScalar uJ[3]        =  {ug[i+Q*0],
+    const CeedScalar du[3]        =  {ug[i+Q*0],
                                       ug[i+Q*1],
                                       ug[i+Q*2]
                                      };
-    // Read qdata
+    // Read qdata (6 distinct entries of dXdxdXdxT symmetric matrix)
     const CeedScalar dXdxdXdxT[6] =  {qd[i+0*Q],
                                       qd[i+1*Q],
                                       qd[i+2*Q],
@@ -100,7 +100,7 @@ CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
     for (int j=0; j<3; j++) {
       vg[i+Q*j]  = 0;
       for (int k=0; k<3; k++)
-        vg[i+Q*j] += uJ[k] * dXdxdXdxT[idx[j][k]];
+        vg[i+Q*j] += du[k] * dXdxdXdxT[idx[j][k]];
     }
   } // End of Quadrature Point Loop
   return 0;

--- a/examples/petsc/bp4.h
+++ b/examples/petsc/bp4.h
@@ -17,15 +17,6 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example using PETSc
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
-#  else
-#    define CeedPragmaOMP(a)
-#  endif
-#endif
-
 #ifndef __CUDACC__
 #  include <math.h>
 #endif

--- a/examples/petsc/bp4.h
+++ b/examples/petsc/bp4.h
@@ -102,7 +102,7 @@ CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q,
                                          ug[i+(2+1*3)*Q],
                                          ug[i+(2+2*3)*Q]}
                                        };
-    // Read qdata (6 distinct entries of dXdxdXdxT symmetric matrix)
+    // Read qdata (dXdxdXdxT symmetric matrix)
     const CeedScalar dXdxdXdxT[3][3] = {{qd[i+0*Q],
                                          qd[i+1*Q],
                                          qd[i+2*Q]},

--- a/examples/petsc/bp4.h
+++ b/examples/petsc/bp4.h
@@ -31,7 +31,7 @@ CEED_QFUNCTION(SetupDiff3)(void *ctx, const CeedInt Q,
   CeedScalar *qd = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar J11 = J[i+Q*0];
     const CeedScalar J21 = J[i+Q*1];
@@ -89,7 +89,7 @@ CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q,
   CeedScalar *vg = out[0];
 
   // Quadrature Point Loop
-  CeedPragmaOMP(simd)
+  CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
     // Read spatial derivatives of u components
     const CeedScalar uJ[3][3]        = {{ug[i+(0+0*3)*Q],

--- a/examples/petsc/bp4.h
+++ b/examples/petsc/bp4.h
@@ -17,6 +17,15 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example using PETSc
 
+#ifndef CeedPragmaOMP
+#  ifdef _OPENMP
+#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#  else
+#    define CeedPragmaOMP(a)
+#  endif
+#endif
+
 #ifndef __CUDACC__
 #  include <math.h>
 #endif
@@ -24,12 +33,14 @@
 // *****************************************************************************
 CEED_QFUNCTION(SetupDiff3)(void *ctx, const CeedInt Q,
                            const CeedScalar *const *in, CeedScalar *const *out) {
-  #ifndef M_PI
-#define M_PI    3.14159265358979323846
-  #endif
+#ifndef M_PI
+#  define M_PI    3.14159265358979323846
+#endif
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
   CeedScalar *qd = out[0], *true_soln = out[1], *rhs = out[2];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     const CeedScalar J11 = J[i+Q*0];
     const CeedScalar J21 = J[i+Q*1];
@@ -86,6 +97,8 @@ CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q,
   const CeedScalar *ug = in[0], *qd = in[1];
   CeedScalar *vg = out[0];
 
+  // Quadrature Point Loop
+  CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     // Component 1
     const CeedScalar ug00 = ug[i+(0+0*3)*Q];

--- a/examples/petsc/bp4.h
+++ b/examples/petsc/bp4.h
@@ -92,47 +92,33 @@ CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q,
   CeedPragmaOMP(simd)
   for (CeedInt i=0; i<Q; i++) {
     // Read spatial derivatives of u components
-    const CeedScalar uJ[3][3]     = {{ug[i+(0+0*3)*Q],
-                                      ug[i+(0+1*3)*Q],
-                                      ug[i+(0+2*3)*Q]},
-                                     {ug[i+(1+0*3)*Q],
-                                      ug[i+(1+1*3)*Q],
-                                      ug[i+(1+2*3)*Q]},
-                                     {ug[i+(2+0*3)*Q],
-                                      ug[i+(2+1*3)*Q],
-                                      ug[i+(2+2*3)*Q]}
-                                    };
-    // Read qdata
-    const CeedScalar dXdxdXdxT[6] =  {qd[i+0*Q],
-                                      qd[i+1*Q],
-                                      qd[i+2*Q],
-                                      qd[i+3*Q],
-                                      qd[i+4*Q],
-                                      qd[i+5*Q]
-                                     };
+    const CeedScalar uJ[3][3]        = {{ug[i+(0+0*3)*Q],
+                                         ug[i+(0+1*3)*Q],
+                                         ug[i+(0+2*3)*Q]},
+                                        {ug[i+(1+0*3)*Q],
+                                         ug[i+(1+1*3)*Q],
+                                         ug[i+(1+2*3)*Q]},
+                                        {ug[i+(2+0*3)*Q],
+                                         ug[i+(2+1*3)*Q],
+                                         ug[i+(2+2*3)*Q]}
+                                       };
+    // Read qdata (6 distinct entries of dXdxdXdxT symmetric matrix)
+    const CeedScalar dXdxdXdxT[3][3] = {{qd[i+0*Q],
+                                         qd[i+1*Q],
+                                         qd[i+2*Q]},
+                                        {qd[i+1*Q],
+                                         qd[i+3*Q],
+                                         qd[i+4*Q]},
+                                        {qd[i+2*Q],
+                                         qd[i+4*Q],
+                                         qd[i+5*Q]}
+                                       };
 
-     const CeedInt idx[3][3] = {{0, 1, 2}, {1, 3, 4}, {2, 4, 5}}; // symmetric matrix indices
-
-     // Component 1
-     for (int j=0; j<3; j++) {
-       vg[i+(0+j*3)*Q]  = 0;
-       for (int k=0; k<3; k++)
-         vg[i+(0+j*3)*Q] += uJ[0][k] * dXdxdXdxT[idx[j][k]];
-     }
-
-     // Component 2
-     for (int j=0; j<3; j++) {
-       vg[i+(1+j*3)*Q]  = 0;
-       for (int k=0; k<3; k++)
-         vg[i+(1+j*3)*Q] += uJ[1][k] * dXdxdXdxT[idx[j][k]];
-     }
-
-     // Component 3
-     for (int j=0; j<3; j++) {
-       vg[i+(2+j*3)*Q]  = 0;
-       for (int k=0; k<3; k++)
-         vg[i+(2+j*3)*Q] += uJ[2][k] * dXdxdXdxT[idx[j][k]];
-     }
+    for (int k=0; k<3; k++) // k = component
+      for (int j=0; j<3; j++) // j = direction of vg
+        vg[i+(k+j*3)*Q] = (uJ[k][0] * dXdxdXdxT[0][j] +
+                           uJ[k][1] * dXdxdXdxT[1][j] +
+                           uJ[k][2] * dXdxdXdxT[2][j]);
   } // End of Quadrature Point Loop
   return 0;
 }

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -59,6 +59,14 @@
   static const char name ## _loc[] = __FILE__ ":" #name;        \
   static int name
 #endif
+#ifndef CeedPragmaOMP
+#  ifdef _OPENMP
+#    define CeedPragmaOMP_(a) _Pragma(#a)
+#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#  else
+#    define CeedPragmaOMP(a)
+#  endif
+#endif
 
 #include <assert.h>
 #include <stdint.h>

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -54,11 +54,13 @@
 #else
 #  define CEED_EXTERN extern
 #endif
+
 #ifndef CEED_QFUNCTION
 #define CEED_QFUNCTION(name) \
   static const char name ## _loc[] = __FILE__ ":" #name;        \
   static int name
 #endif
+
 #ifndef CeedPragmaOMP
 #  ifdef _OPENMP
 #    define CeedPragmaOMP_(a) _Pragma(#a)

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -61,12 +61,13 @@
   static int name
 #endif
 
-#ifndef CeedPragmaOMP
-#  ifdef _OPENMP
-#    define CeedPragmaOMP_(a) _Pragma(#a)
-#    define CeedPragmaOMP(a) CeedPragmaOMP_(omp a)
+#ifndef CeedPragmaSIMD
+#  if defined(__GNUC__) && __GNUC__ >= 5
+#    define CeedPragmaSIMD _Pragma("GCC ivdep")
+#  elif defined(_OPENMP) && _OPENMP >= 201307 // OpenMP-4.0 (July, 2013)
+#    define CeedPragmaSIMD _Pragma("omp simd")
 #  else
-#    define CeedPragmaOMP(a)
+#    define CeedPragmaSIMD
 #  endif
 #endif
 


### PR DESCRIPTION
This PR adds the CeedPragmaOMP preprocessor directive, that was included only in the NS-example before, to all BPs (excluded the MFEM ones for now).