### PR TITLE
Make examples consistent

### DIFF
--- a/examples/ceed/ex1.c
+++ b/examples/ceed/ex1.c
@@ -209,17 +209,17 @@ int main(int argc, const char *argv[]) {
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Compute the quadrature data for the mass operator.
-  CeedVector rho;
+  CeedVector qdata;
   CeedInt elem_qpts = CeedIntPow(num_qpts, dim);
   CeedInt num_elem = 1;
   for (int d = 0; d < dim; d++)
     num_elem *= nxyz[d];
-  CeedVectorCreate(ceed, num_elem*elem_qpts, &rho);
+  CeedVectorCreate(ceed, num_elem*elem_qpts, &qdata);
   if (!test) {
     printf("Computing the quadrature data for the mass operator ...");
     fflush(stdout);
   }
-  CeedOperatorApply(build_oper, mesh_coords, rho,
+  CeedOperatorApply(build_oper, mesh_coords, qdata,
                     CEED_REQUEST_IMMEDIATE);
   if (!test) {
     printf(" done.\n");
@@ -248,7 +248,7 @@ int main(int argc, const char *argv[]) {
   CeedOperatorSetField(oper, "u", sol_restr, CEED_NOTRANSPOSE,
                        sol_basis, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(oper, "qdata", sol_restr_i, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, rho);
+                       CEED_BASIS_COLLOCATED, qdata);
   CeedOperatorSetField(oper, "v", sol_restr, CEED_NOTRANSPOSE,
                        sol_basis, CEED_VECTOR_ACTIVE);
 
@@ -299,7 +299,7 @@ int main(int argc, const char *argv[]) {
   // Free dynamically allocated memory.
   CeedVectorDestroy(&u);
   CeedVectorDestroy(&v);
-  CeedVectorDestroy(&rho);
+  CeedVectorDestroy(&qdata);
   CeedVectorDestroy(&mesh_coords);
   CeedOperatorDestroy(&oper);
   CeedQFunctionDestroy(&apply_qfunc);

--- a/examples/ceed/ex1.h
+++ b/examples/ceed/ex1.h
@@ -23,7 +23,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   // in[0] is Jacobians with shape [dim, nc=dim, Q]
   // in[1] is quadrature weights, size (Q)
   struct BuildContext *bc = (struct BuildContext *)ctx;
-  const CeedScalar *J = in[0], *qw = in[1];
+  const CeedScalar *J = in[0], *w = in[1];
   CeedScalar *qdata = out[0];
 
   switch (bc->dim + 10*bc->space_dim) {
@@ -31,7 +31,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     // Quadrature Point Loop
     CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      qdata[i] = J[i] * qw[i];
+      qdata[i] = J[i] * w[i];
     } // End of Quadrature Point Loop
     break;
   case 22:
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
-      qdata[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+      qdata[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * w[i];
     } // End of Quadrature Point Loop
     break;
   case 33:
@@ -52,7 +52,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
       // 2 5 8
       qdata[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-               J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * qw[i];
+               J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * w[i];
     } // End of Quadrature Point Loop
     break;
   }
@@ -62,13 +62,13 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
 /// libCEED Q-function for applying a mass operator
 CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
                              const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *u = in[0], *w = in[1];
+  const CeedScalar *u = in[0], *qdata = in[1];
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
-    v[i] = w[i] * u[i];
+    v[i] = qdata[i] * u[i];
   } // End of Quadrature Point Loop
   return 0;
 }

--- a/examples/ceed/ex1.h
+++ b/examples/ceed/ex1.h
@@ -24,14 +24,14 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   // in[1] is quadrature weights, size (Q)
   struct BuildContext *bc = (struct BuildContext *)ctx;
   const CeedScalar *J = in[0], *qw = in[1];
-  CeedScalar *qd = out[0];
+  CeedScalar *qdata = out[0];
 
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
     // Quadrature Point Loop
     CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      qd[i] = J[i] * qw[i];
+      qdata[i] = J[i] * qw[i];
     } // End of Quadrature Point Loop
     break;
   case 22:
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
-      qd[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+      qdata[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
     } // End of Quadrature Point Loop
     break;
   case 33:
@@ -50,7 +50,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
       // 0 3 6
       // 1 4 7
       // 2 5 8
-      qd[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
+      qdata[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
                J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * qw[i];
     } // End of Quadrature Point Loop

--- a/examples/ceed/ex2.h
+++ b/examples/ceed/ex2.h
@@ -24,16 +24,16 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
   // in[0] is Jacobians with shape [dim, nc=dim, Q]
   // in[1] is quadrature weights, size (Q)
   //
-  // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
+  // At every quadrature point, compute w/det(J).adj(J).adj(J)^T and store
   // the symmetric part of the result.
-  const CeedScalar *J = in[0], *qw = in[1];
+  const CeedScalar *J = in[0], *w = in[1];
   CeedScalar *qdata = out[0];
 
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
   CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      qdata[i] = qw[i] / J[i];
+      qdata[i] = w[i] / J[i];
     } // End of Quadrature Point Loop
     break;
   case 22:
@@ -45,10 +45,10 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
       const CeedScalar J21 = J[i+Q*1];
       const CeedScalar J12 = J[i+Q*2];
       const CeedScalar J22 = J[i+Q*3];
-      const CeedScalar w = qw[i] / (J11*J22 - J21*J12);
-      qdata[i+Q*0] =   w * (J12*J12 + J22*J22);
-      qdata[i+Q*1] =   w * (J11*J11 + J21*J21);
-      qdata[i+Q*2] = - w * (J11*J12 + J21*J22);
+      const CeedScalar qw = w[i] / (J11*J22 - J21*J12);
+      qdata[i+Q*0] =   qw * (J12*J12 + J22*J22);
+      qdata[i+Q*1] =   qw * (J11*J11 + J21*J21);
+      qdata[i+Q*2] = - qw * (J11*J12 + J21*J22);
     } // End of Quadrature Point Loop
     break;
   case 33:
@@ -64,7 +64,7 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
                     J[i+Q*((j+1)%3+3*((k+2)%3))]*J[i+Q*((j+2)%3+3*((k+1)%3))];
 
       // Compute quadrature weight / det(J)
-      const CeedScalar w = qw[i] / (J[i+Q*0]*A[0][0] + J[i+Q*1]*A[1][1] +
+      const CeedScalar qw = w[i] / (J[i+Q*0]*A[0][0] + J[i+Q*1]*A[1][1] +
                                     J[i+Q*2]*A[2][2]);
 
       // Compute geometric factors
@@ -72,12 +72,12 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
       // 0 5 4
       // 5 1 3
       // 4 3 2
-      qdata[i+Q*0] = w * (A[0][0]*A[0][0] + A[0][1]*A[0][1] + A[0][2]*A[0][2]);
-      qdata[i+Q*1] = w * (A[1][0]*A[1][0] + A[1][1]*A[1][1] + A[1][2]*A[1][2]);
-      qdata[i+Q*2] = w * (A[2][0]*A[2][0] + A[2][1]*A[2][1] + A[2][2]*A[2][2]);
-      qdata[i+Q*3] = w * (A[1][0]*A[2][0] + A[1][1]*A[2][1] + A[1][2]*A[2][2]);
-      qdata[i+Q*4] = w * (A[0][0]*A[2][0] + A[0][1]*A[2][1] + A[0][2]*A[2][2]);
-      qdata[i+Q*5] = w * (A[0][0]*A[1][0] + A[0][1]*A[1][1] + A[0][2]*A[1][2]);
+      qdata[i+Q*0] = qw * (A[0][0]*A[0][0] + A[0][1]*A[0][1] + A[0][2]*A[0][2]);
+      qdata[i+Q*1] = qw * (A[1][0]*A[1][0] + A[1][1]*A[1][1] + A[1][2]*A[1][2]);
+      qdata[i+Q*2] = qw * (A[2][0]*A[2][0] + A[2][1]*A[2][1] + A[2][2]*A[2][2]);
+      qdata[i+Q*3] = qw * (A[1][0]*A[2][0] + A[1][1]*A[2][1] + A[1][2]*A[2][2]);
+      qdata[i+Q*4] = qw * (A[0][0]*A[2][0] + A[0][1]*A[2][1] + A[0][2]*A[2][2]);
+      qdata[i+Q*5] = qw * (A[0][0]*A[1][0] + A[0][1]*A[1][1] + A[0][2]*A[1][2]);
       } // End of Quadrature Point Loop
     break;
   }

--- a/examples/ceed/ex2.h
+++ b/examples/ceed/ex2.h
@@ -27,28 +27,28 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
   // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
   // the symmetric part of the result.
   const CeedScalar *J = in[0], *qw = in[1];
-  CeedScalar *qd = out[0];
+  CeedScalar *qdata = out[0];
 
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
   CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      qd[i] = qw[i] / J[i];
+      qdata[i] = qw[i] / J[i];
     } // End of Quadrature Point Loop
     break;
   case 22:
   CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      // J: 0 2   qd: 0 2   adj(J):  J22 -J12
-      //    1 3       2 1           -J21  J11
+      // J: 0 2   qdata: 0 2   adj(J):  J22 -J12
+      //    1 3          2 1           -J21  J11
       const CeedScalar J11 = J[i+Q*0];
       const CeedScalar J21 = J[i+Q*1];
       const CeedScalar J12 = J[i+Q*2];
       const CeedScalar J22 = J[i+Q*3];
       const CeedScalar w = qw[i] / (J11*J22 - J21*J12);
-      qd[i+Q*0] =   w * (J12*J12 + J22*J22);
-      qd[i+Q*1] =   w * (J11*J11 + J21*J21);
-      qd[i+Q*2] = - w * (J11*J12 + J21*J22);
+      qdata[i+Q*0] =   w * (J12*J12 + J22*J22);
+      qdata[i+Q*1] =   w * (J11*J11 + J21*J21);
+      qdata[i+Q*2] = - w * (J11*J12 + J21*J22);
     } // End of Quadrature Point Loop
     break;
   case 33:
@@ -72,12 +72,12 @@ CEED_QFUNCTION(f_build_diff)(void *ctx, const CeedInt Q,
       // 0 5 4
       // 5 1 3
       // 4 3 2
-      qd[i+Q*0] = w * (A[0][0]*A[0][0] + A[0][1]*A[0][1] + A[0][2]*A[0][2]);
-      qd[i+Q*1] = w * (A[1][0]*A[1][0] + A[1][1]*A[1][1] + A[1][2]*A[1][2]);
-      qd[i+Q*2] = w * (A[2][0]*A[2][0] + A[2][1]*A[2][1] + A[2][2]*A[2][2]);
-      qd[i+Q*3] = w * (A[1][0]*A[2][0] + A[1][1]*A[2][1] + A[1][2]*A[2][2]);
-      qd[i+Q*4] = w * (A[0][0]*A[2][0] + A[0][1]*A[2][1] + A[0][2]*A[2][2]);
-      qd[i+Q*5] = w * (A[0][0]*A[1][0] + A[0][1]*A[1][1] + A[0][2]*A[1][2]);
+      qdata[i+Q*0] = w * (A[0][0]*A[0][0] + A[0][1]*A[0][1] + A[0][2]*A[0][2]);
+      qdata[i+Q*1] = w * (A[1][0]*A[1][0] + A[1][1]*A[1][1] + A[1][2]*A[1][2]);
+      qdata[i+Q*2] = w * (A[2][0]*A[2][0] + A[2][1]*A[2][1] + A[2][2]*A[2][2]);
+      qdata[i+Q*3] = w * (A[1][0]*A[2][0] + A[1][1]*A[2][1] + A[1][2]*A[2][2]);
+      qdata[i+Q*4] = w * (A[0][0]*A[2][0] + A[0][1]*A[2][1] + A[0][2]*A[2][2]);
+      qdata[i+Q*5] = w * (A[0][0]*A[1][0] + A[0][1]*A[1][1] + A[0][2]*A[1][2]);
       } // End of Quadrature Point Loop
     break;
   }
@@ -89,14 +89,14 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
                              const CeedScalar *const *in, CeedScalar *const *out) {
   struct BuildContext *bc = (struct BuildContext *)ctx;
   // in[0], out[0] have shape [dim, nc=1, Q]
-  const CeedScalar *ug = in[0], *qd = in[1];
+  const CeedScalar *ug = in[0], *qdata = in[1];
   CeedScalar *vg = out[0];
 
   switch (bc->dim) {
   case 1:
     CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      vg[i] = ug[i] * qd[i];
+      vg[i] = ug[i] * qdata[i];
     } // End of Quadrature Point Loop
     break;
   case 2:
@@ -111,10 +111,10 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
       // Stored in Voigt convention
       // 0 2
       // 2 1
-      const CeedScalar dXdxdXdxT[2][2] = {{qd[i+0*Q],
-                                           qd[i+2*Q]},
-                                          {qd[i+2*Q],
-                                           qd[i+1*Q]}
+      const CeedScalar dXdxdXdxT[2][2] = {{qdata[i+0*Q],
+                                           qdata[i+2*Q]},
+                                          {qdata[i+2*Q],
+                                           qdata[i+1*Q]}
                                          };
       // j = direction of vg
       for (int j=0; j<2; j++)
@@ -136,15 +136,15 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q,
       // 0 5 4
       // 5 1 3
       // 4 3 2
-      const CeedScalar dXdxdXdxT[3][3] = {{qd[i+0*Q],
-                                           qd[i+5*Q],
-                                           qd[i+4*Q]},
-                                          {qd[i+5*Q],
-                                           qd[i+1*Q],
-                                           qd[i+3*Q]},
-                                          {qd[i+4*Q],
-                                           qd[i+3*Q],
-                                           qd[i+2*Q]}
+      const CeedScalar dXdxdXdxT[3][3] = {{qdata[i+0*Q],
+                                           qdata[i+5*Q],
+                                           qdata[i+4*Q]},
+                                          {qdata[i+5*Q],
+                                           qdata[i+1*Q],
+                                           qdata[i+3*Q]},
+                                          {qdata[i+4*Q],
+                                           qdata[i+3*Q],
+                                           qdata[i+2*Q]}
                                          };
       // j = direction of vg
       for (int j=0; j<3; j++)

--- a/examples/mfem/bp1.h
+++ b/examples/mfem/bp1.h
@@ -23,7 +23,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   // in[0] is Jacobians with shape [dim, nc=dim, Q]
   // in[1] is quadrature weights, size (Q)
   BuildContext *bc = (BuildContext *)ctx;
-  const CeedScalar *J = in[0], *qw = in[1];
+  const CeedScalar *J = in[0], *w = in[1];
   CeedScalar *qdata = out[0];
 
   switch (bc->dim + 10*bc->space_dim) {
@@ -31,7 +31,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     // Quadrature Point Loop
     CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      qdata[i] = J[i] * qw[i];
+      qdata[i] = J[i] * w[i];
     }
     break;
   case 22:
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
-      qdata[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+      qdata[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * w[i];
     }
     break;
   case 33:
@@ -52,7 +52,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
       // 2 5 8
       qdata[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                 J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * qw[i];
+                J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * w[i];
     }
     break;
   }
@@ -62,13 +62,13 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
 /// libCEED Q-function for applying a mass operator
 CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q,
                              const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *u = in[0], *w = in[1];
+  const CeedScalar *u = in[0], *qdata = in[1];
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
-    v[i] = w[i] * u[i];
+    v[i] = qdata[i] * u[i];
   }
   return 0;
 }

--- a/examples/mfem/bp1.h
+++ b/examples/mfem/bp1.h
@@ -24,14 +24,14 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
   // in[1] is quadrature weights, size (Q)
   BuildContext *bc = (BuildContext *)ctx;
   const CeedScalar *J = in[0], *qw = in[1];
-  CeedScalar *rho = out[0];
+  CeedScalar *qdata = out[0];
 
   switch (bc->dim + 10*bc->space_dim) {
   case 11:
     // Quadrature Point Loop
     CeedPragmaSIMD
     for (CeedInt i=0; i<Q; i++) {
-      rho[i] = J[i] * qw[i];
+      qdata[i] = J[i] * qw[i];
     }
     break;
   case 22:
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
     for (CeedInt i=0; i<Q; i++) {
       // 0 2
       // 1 3
-      rho[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+      qdata[i] = (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
     }
     break;
   case 33:
@@ -50,7 +50,7 @@ CEED_QFUNCTION(f_build_mass)(void *ctx, const CeedInt Q,
       // 0 3 6
       // 1 4 7
       // 2 5 8
-      rho[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
+      qdata[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                 J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
                 J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * qw[i];
     }

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -29,7 +29,7 @@ class CeedMassOperator : public mfem::Operator {
   CeedBasis basis, mesh_basis;
   CeedElemRestriction restr, mesh_restr, restr_i, mesh_restr_i;
   CeedQFunction apply_qfunc, build_qfunc;
-  CeedVector node_coords, rho;
+  CeedVector node_coords, qdata;
   CeedVector u, v;
 
   BuildContext build_ctx;
@@ -134,7 +134,7 @@ class CeedMassOperator : public mfem::Operator {
     CeedVectorSetArray(node_coords, CEED_MEM_HOST, CEED_USE_POINTER,
                        mesh->GetNodes()->GetData());
 
-    CeedVectorCreate(ceed, nelem*nqpts, &rho);
+    CeedVectorCreate(ceed, nelem*nqpts, &qdata);
 
     // Context data to be passed to the 'f_build_mass' Q-function.
     build_ctx.dim = mesh->Dimension();
@@ -147,7 +147,7 @@ class CeedMassOperator : public mfem::Operator {
     CeedQFunctionAddInput(build_qfunc, "dx", ncompx*dim,
                           CEED_EVAL_GRAD);
     CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
-    CeedQFunctionAddOutput(build_qfunc, "rho", 1, CEED_EVAL_NONE);
+    CeedQFunctionAddOutput(build_qfunc, "qdata", 1, CEED_EVAL_NONE);
     CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));
 
     // Create the operator that builds the quadrature data for the mass operator.
@@ -156,26 +156,26 @@ class CeedMassOperator : public mfem::Operator {
                          mesh_basis, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
                          mesh_basis, CEED_VECTOR_NONE);
-    CeedOperatorSetField(build_oper, "rho", restr_i, CEED_NOTRANSPOSE,
+    CeedOperatorSetField(build_oper, "qdata", restr_i, CEED_NOTRANSPOSE,
                          CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
     // Compute the quadrature data for the mass operator.
-    CeedOperatorApply(build_oper, node_coords, rho,
+    CeedOperatorApply(build_oper, node_coords, qdata,
                       CEED_REQUEST_IMMEDIATE);
 
     // Create the Q-function that defines the action of the mass operator.
     CeedQFunctionCreateInterior(ceed, 1, f_apply_mass,
                                 f_apply_mass_loc, &apply_qfunc);
     CeedQFunctionAddInput(apply_qfunc, "u", 1, CEED_EVAL_INTERP);
-    CeedQFunctionAddInput(apply_qfunc, "rho", 1, CEED_EVAL_NONE);
+    CeedQFunctionAddInput(apply_qfunc, "qdata", 1, CEED_EVAL_NONE);
     CeedQFunctionAddOutput(apply_qfunc, "v", 1, CEED_EVAL_INTERP);
 
     // Create the mass operator.
     CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
     CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
                          basis, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(oper, "rho", restr_i, CEED_NOTRANSPOSE,
-                         CEED_BASIS_COLLOCATED, rho);
+    CeedOperatorSetField(oper, "qdata", restr_i, CEED_NOTRANSPOSE,
+                         CEED_BASIS_COLLOCATED, qdata);
     CeedOperatorSetField(oper, "v", restr, CEED_NOTRANSPOSE,
                          basis, CEED_VECTOR_ACTIVE);
 
@@ -187,7 +187,7 @@ class CeedMassOperator : public mfem::Operator {
   ~CeedMassOperator() {
     CeedVectorDestroy(&u);
     CeedVectorDestroy(&v);
-    CeedVectorDestroy(&rho);
+    CeedVectorDestroy(&qdata);
     CeedVectorDestroy(&node_coords);
     CeedOperatorDestroy(&build_oper);
     CeedQFunctionDestroy(&build_qfunc);

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -29,7 +29,7 @@ class CeedDiffusionOperator : public mfem::Operator {
   CeedBasis basis, mesh_basis;
   CeedElemRestriction restr, mesh_restr, restr_i, mesh_restr_i;
   CeedQFunction apply_qfunc, build_qfunc;
-  CeedVector node_coords, rho;
+  CeedVector node_coords, qdata;
 
   BuildContext build_ctx;
 
@@ -135,7 +135,7 @@ class CeedDiffusionOperator : public mfem::Operator {
     CeedVectorSetArray(node_coords, CEED_MEM_HOST, CEED_USE_POINTER,
                        mesh->GetNodes()->GetData());
 
-    CeedVectorCreate(ceed, nelem*nqpts*dim*(dim+1)/2, &rho);
+    CeedVectorCreate(ceed, nelem*nqpts*dim*(dim+1)/2, &qdata);
 
     // Context data to be passed to the 'f_build_diff' Q-function.
     build_ctx.dim = mesh->Dimension();
@@ -147,7 +147,7 @@ class CeedDiffusionOperator : public mfem::Operator {
                                 f_build_diff_loc, &build_qfunc);
     CeedQFunctionAddInput(build_qfunc, "dx", ncompx*dim, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
-    CeedQFunctionAddOutput(build_qfunc, "rho", dim*(dim+1)/2, CEED_EVAL_NONE);
+    CeedQFunctionAddOutput(build_qfunc, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
     CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));
 
     // Create the operator that builds the quadrature data for the diff operator.
@@ -156,18 +156,18 @@ class CeedDiffusionOperator : public mfem::Operator {
                          mesh_basis, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
                          mesh_basis, CEED_VECTOR_NONE);
-    CeedOperatorSetField(build_oper, "rho", restr_i, CEED_NOTRANSPOSE,
+    CeedOperatorSetField(build_oper, "qdata", restr_i, CEED_NOTRANSPOSE,
                          CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
     // Compute the quadrature data for the diff operator.
-    CeedOperatorApply(build_oper, node_coords, rho,
+    CeedOperatorApply(build_oper, node_coords, qdata,
                       CEED_REQUEST_IMMEDIATE);
 
     // Create the Q-function that defines the action of the diff operator.
     CeedQFunctionCreateInterior(ceed, 1, f_apply_diff,
                                 f_apply_diff_loc, &apply_qfunc);
     CeedQFunctionAddInput(apply_qfunc, "u", dim, CEED_EVAL_GRAD);
-    CeedQFunctionAddInput(apply_qfunc, "rho", dim*(dim+1)/2, CEED_EVAL_NONE);
+    CeedQFunctionAddInput(apply_qfunc, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
     CeedQFunctionAddOutput(apply_qfunc, "v", dim, CEED_EVAL_GRAD);
     CeedQFunctionSetContext(apply_qfunc, &build_ctx, sizeof(build_ctx));
 
@@ -175,8 +175,8 @@ class CeedDiffusionOperator : public mfem::Operator {
     CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
     CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
                          basis, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(oper, "rho", restr_i, CEED_NOTRANSPOSE,
-                         CEED_BASIS_COLLOCATED, rho);
+    CeedOperatorSetField(oper, "qdata", restr_i, CEED_NOTRANSPOSE,
+                         CEED_BASIS_COLLOCATED, qdata);
     CeedOperatorSetField(oper, "v", restr, CEED_NOTRANSPOSE,
                          basis, CEED_VECTOR_ACTIVE);
 
@@ -188,7 +188,7 @@ class CeedDiffusionOperator : public mfem::Operator {
   ~CeedDiffusionOperator() {
     CeedVectorDestroy(&u);
     CeedVectorDestroy(&v);
-    CeedVectorDestroy(&rho);
+    CeedVectorDestroy(&qdata);
     CeedVectorDestroy(&node_coords);
     CeedElemRestrictionDestroy(&restr);
     CeedElemRestrictionDestroy(&mesh_restr);

--- a/examples/navier-stokes/common.h
+++ b/examples/navier-stokes/common.h
@@ -114,8 +114,8 @@ CEED_QFUNCTION(Setup)(void *ctx, CeedInt Q,
 // This QFunction applies the mass matrix to five interlaced fields.
 //
 // Inputs:
-//   u - Input vector at quadrature points
-//   w - Quadrature weights
+//   u     - Input vector at quadrature points
+//   qdata - Quadrature weights
 //
 // Output:
 //   v - Output vector at quadrature points
@@ -125,16 +125,16 @@ CEED_QFUNCTION(Mass)(void *ctx, CeedInt Q,
                      const CeedScalar *const *in, CeedScalar *const *out) {
   (void)ctx;
   const CeedScalar (*u)[Q] = (CeedScalar(*)[Q])in[0],
-                   (*w) = in[1];
+                   (*qdata) = in[1];
   CeedScalar (*v)[Q] = (CeedScalar(*)[Q])out[0];
 
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
-    v[0][i] = w[i] * u[0][i];
-    v[1][i] = w[i] * u[1][i];
-    v[2][i] = w[i] * u[2][i];
-    v[3][i] = w[i] * u[3][i];
-    v[4][i] = w[i] * u[4][i];
+    v[0][i] = qdata[i] * u[0][i];
+    v[1][i] = qdata[i] * u[1][i];
+    v[2][i] = qdata[i] * u[2][i];
+    v[3][i] = qdata[i] * u[3][i];
+    v[4][i] = qdata[i] * u[4][i];
   }
   return 0;
 }

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -818,7 +818,7 @@ C     Create ceed qfunctions for masssetupf and massf
      $  ceed_eval_grad,err)
       call ceedqfunctionaddinput(qf_setup,'weight',ncompu,
      $  ceed_eval_weight,err)
-      call ceedqfunctionaddoutput(qf_setup,'rho',ncompu,
+      call ceedqfunctionaddoutput(qf_setup,'qdata',ncompu,
      $  ceed_eval_none,err)
       call ceedqfunctionaddoutput(qf_setup,'rhs',ncompu,
      $  ceed_eval_interp,err)
@@ -828,7 +828,7 @@ C     Create ceed qfunctions for masssetupf and massf
      $  //':massf',qf_mass,err)
       call ceedqfunctionaddinput(qf_mass,'u',ncompu,
      $  ceed_eval_interp,err)
-      call ceedqfunctionaddinput(qf_mass,'rho',ncompu,
+      call ceedqfunctionaddinput(qf_mass,'qdata',ncompu,
      $  ceed_eval_none,err)
       call ceedqfunctionaddoutput(qf_mass,'v',ncompu,
      $  ceed_eval_interp,err)
@@ -842,7 +842,7 @@ C     Create ceed operators
      $  ceed_notranspose,basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'weight',erstrctx,
      $  ceed_notranspose,basisx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'rho',erstrctw,
+      call ceedoperatorsetfield(op_setup,'qdata',erstrctw,
      $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rhs',erstrctu,
@@ -852,7 +852,7 @@ C     Create ceed operators
      $  ceed_null,ceed_null,op_mass,err)
       call ceedoperatorsetfield(op_mass,'u',erstrctu,
      $  ceed_notranspose,basisu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'rho',erstrctw,
+      call ceedoperatorsetfield(op_mass,'qdata',erstrctw,
      $  ceed_notranspose,ceed_basis_collocated,
      $  vec_qdata,err)
       call ceedoperatorsetfield(op_mass,'v',erstrctu,
@@ -1135,7 +1135,7 @@ C     Create ceed qfunctions for diffsetupf and diffusionf
      $  ceed_eval_grad,err)
       call ceedqfunctionaddinput(qf_setup,'weight',ncompu,
      $  ceed_eval_weight,err)
-      call ceedqfunctionaddoutput(qf_setup,'rho',ngeo,
+      call ceedqfunctionaddoutput(qf_setup,'qdata',ngeo,
      $  ceed_eval_none,err)
       call ceedqfunctionaddoutput(qf_setup,'rhs',ncompu,
      $  ceed_eval_interp,err)
@@ -1145,7 +1145,7 @@ C     Create ceed qfunctions for diffsetupf and diffusionf
      $  //':diffusionf'//char(0),qf_diffusion,err)
       call ceedqfunctionaddinput(qf_diffusion,'u',ncompu*ldim,
      $  ceed_eval_grad,err)
-      call ceedqfunctionaddinput(qf_diffusion,'rho',ngeo,
+      call ceedqfunctionaddinput(qf_diffusion,'qdata',ngeo,
      $  ceed_eval_none,err)
       call ceedqfunctionaddoutput(qf_diffusion,'v',ncompu*ldim,
      $  ceed_eval_grad,err)  
@@ -1159,7 +1159,7 @@ C     Create ceed operators
      $  ceed_notranspose,basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'weight',erstrctx,
      $  ceed_notranspose,basisx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'rho',erstrctw,
+      call ceedoperatorsetfield(op_setup,'qdata',erstrctw,
      $  ceed_notranspose,ceed_basis_collocated,
      $  ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rhs',erstrctu,
@@ -1169,7 +1169,7 @@ C     Create ceed operators
      $  ceed_null,ceed_null,op_diffusion,err)
       call ceedoperatorsetfield(op_diffusion,'u',erstrctu,
      $  ceed_notranspose,basisu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_diffusion,'rho',erstrctw,
+      call ceedoperatorsetfield(op_diffusion,'qdata',erstrctw,
      $  ceed_notranspose,ceed_basis_collocated,
      $  vec_qdata,err)
       call ceedoperatorsetfield(op_diffusion,'v',erstrctu,

--- a/examples/petsc/bp1.h
+++ b/examples/petsc/bp1.h
@@ -25,7 +25,7 @@
 CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q,
                           const CeedScalar *const *in, CeedScalar *const *out) {
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
-  CeedScalar *rho = out[0], *true_soln = out[1], *rhs = out[2];
+  CeedScalar *qdata = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
@@ -33,24 +33,24 @@ CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q,
     const CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                             J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
                             J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6]));
-    rho[i] = det * w[i];
+    qdata[i] = det * w[i];
 
     true_soln[i] = sqrt(x[i]*x[i] + x[i+Q]*x[i+Q] + x[i+2*Q]*x[i+2*Q]);
 
-    rhs[i] = rho[i] * true_soln[i];
+    rhs[i] = qdata[i] * true_soln[i];
   } // End of Quadrature Point Loop
   return 0;
 }
 
 CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q,
                      const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *u = in[0], *rho = in[1];
+  const CeedScalar *u = in[0], *qw = in[1];
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++)
-    v[i] = rho[i] * u[i];
+    v[i] = qw[i] * u[i];
 
   return 0;
 }

--- a/examples/petsc/bp1.h
+++ b/examples/petsc/bp1.h
@@ -44,13 +44,13 @@ CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q,
 
 CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q,
                      const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *u = in[0], *qw = in[1];
+  const CeedScalar *u = in[0], *qdata = in[1];
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++)
-    v[i] = qw[i] * u[i];
+    v[i] = qdata[i] * u[i];
 
   return 0;
 }

--- a/examples/petsc/bp2.h
+++ b/examples/petsc/bp2.h
@@ -25,7 +25,7 @@
 CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
                            const CeedScalar *const *in, CeedScalar *const *out) {
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
-  CeedScalar *rho = out[0], *true_soln = out[1], *rhs = out[2];
+  CeedScalar *qdata = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
@@ -33,7 +33,7 @@ CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
     const CeedScalar det = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
                             J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
                             J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6]));
-    rho[i] = det * w[i];
+    qdata[i] = det * w[i];
 
     // Component 1
     true_soln[i+0*Q] =  sqrt(x[i]*x[i] + x[i+Q]*x[i+Q] + x[i+2*Q]*x[i+2*Q]);;
@@ -43,24 +43,24 @@ CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
     true_soln[i+2*Q] = true_soln[i+0*Q];
 
     // Component 1
-    rhs[i+0*Q] = rho[i] * true_soln[i+0*Q];
+    rhs[i+0*Q] = qdata[i] * true_soln[i+0*Q];
     // Component 2
-    rhs[i+1*Q] = rho[i] * true_soln[i+0*Q];
+    rhs[i+1*Q] = qdata[i] * true_soln[i+0*Q];
     // Component 3
-    rhs[i+2*Q] = rho[i] * true_soln[i+0*Q];
+    rhs[i+2*Q] = qdata[i] * true_soln[i+0*Q];
   } // End of Quadrature Point Loop
   return 0;
 }
 
 CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q,
                       const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *u = in[0], *rho = in[1];
+  const CeedScalar *u = in[0], *qw = in[1];
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
-    const CeedScalar r = rho[i];
+    const CeedScalar r = qw[i];
     // Component 1
     v[i+0*Q] = r * u[i+0*Q];
     // Component 2

--- a/examples/petsc/bp2.h
+++ b/examples/petsc/bp2.h
@@ -54,13 +54,13 @@ CEED_QFUNCTION(SetupMass3)(void *ctx, const CeedInt Q,
 
 CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q,
                       const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *u = in[0], *qw = in[1];
+  const CeedScalar *u = in[0], *qdata = in[1];
   CeedScalar *v = out[0];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
   for (CeedInt i=0; i<Q; i++) {
-    const CeedScalar r = qw[i];
+    const CeedScalar r = qdata[i];
     // Component 1
     v[i+0*Q] = r * u[i+0*Q];
     // Component 2

--- a/examples/petsc/bp3.h
+++ b/examples/petsc/bp3.h
@@ -28,7 +28,7 @@ CEED_QFUNCTION(SetupDiff)(void *ctx, const CeedInt Q,
 #  define M_PI    3.14159265358979323846
 #endif
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
-  CeedScalar *qd = out[0], *true_soln = out[1], *rhs = out[2];
+  CeedScalar *qdata = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
@@ -56,12 +56,12 @@ CEED_QFUNCTION(SetupDiff)(void *ctx, const CeedInt Q,
     const CeedScalar A32 = J12*J31 - J11*J32;
     const CeedScalar A33 = J11*J22 - J12*J21;
     const CeedScalar qw = w[i] / (J11*A11 + J21*A12 + J31*A13);
-    qd[i+Q*0] = qw * (A11*A11 + A12*A12 + A13*A13);
-    qd[i+Q*1] = qw * (A21*A21 + A22*A22 + A23*A23);
-    qd[i+Q*2] = qw * (A31*A31 + A32*A32 + A33*A33);
-    qd[i+Q*3] = qw * (A21*A31 + A22*A32 + A23*A33);
-    qd[i+Q*4] = qw * (A11*A31 + A12*A32 + A13*A33);
-    qd[i+Q*5] = qw * (A11*A21 + A12*A22 + A13*A23);
+    qdata[i+Q*0] = qw * (A11*A11 + A12*A12 + A13*A13);
+    qdata[i+Q*1] = qw * (A21*A21 + A22*A22 + A23*A23);
+    qdata[i+Q*2] = qw * (A31*A31 + A32*A32 + A33*A33);
+    qdata[i+Q*3] = qw * (A21*A31 + A22*A32 + A23*A33);
+    qdata[i+Q*4] = qw * (A11*A31 + A12*A32 + A13*A33);
+    qdata[i+Q*5] = qw * (A11*A21 + A12*A22 + A13*A23);
 
     const CeedScalar c[3] = { 0, 1., 2. };
     const CeedScalar k[3] = { 1., 2., 3. };
@@ -79,7 +79,7 @@ CEED_QFUNCTION(SetupDiff)(void *ctx, const CeedInt Q,
 
 CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
                      const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *ug = in[0], *qd = in[1];
+  const CeedScalar *ug = in[0], *qdata = in[1];
   CeedScalar *vg = out[0];
 
   // Quadrature Point Loop
@@ -91,15 +91,15 @@ CEED_QFUNCTION(Diff)(void *ctx, const CeedInt Q,
                                       ug[i+Q*2]
                                      };
     // Read qdata (dXdxdXdxT symmetric matrix)
-    const CeedScalar dXdxdXdxT[3][3] = {{qd[i+0*Q],
-                                         qd[i+5*Q],
-                                         qd[i+4*Q]},
-                                        {qd[i+5*Q],
-                                         qd[i+1*Q],
-                                         qd[i+3*Q]},
-                                        {qd[i+4*Q],
-                                         qd[i+3*Q],
-                                         qd[i+2*Q]}
+    const CeedScalar dXdxdXdxT[3][3] = {{qdata[i+0*Q],
+                                         qdata[i+5*Q],
+                                         qdata[i+4*Q]},
+                                        {qdata[i+5*Q],
+                                         qdata[i+1*Q],
+                                         qdata[i+3*Q]},
+                                        {qdata[i+4*Q],
+                                         qdata[i+3*Q],
+                                         qdata[i+2*Q]}
                                        };
 
     for (int j=0; j<3; j++) // j = direction of vg

--- a/examples/petsc/bp4.h
+++ b/examples/petsc/bp4.h
@@ -28,7 +28,7 @@ CEED_QFUNCTION(SetupDiff3)(void *ctx, const CeedInt Q,
 #  define M_PI    3.14159265358979323846
 #endif
   const CeedScalar *x = in[0], *J = in[1], *w = in[2];
-  CeedScalar *qd = out[0], *true_soln = out[1], *rhs = out[2];
+  CeedScalar *qdata = out[0], *true_soln = out[1], *rhs = out[2];
 
   // Quadrature Point Loop
   CeedPragmaSIMD
@@ -56,12 +56,12 @@ CEED_QFUNCTION(SetupDiff3)(void *ctx, const CeedInt Q,
     const CeedScalar A32 = J12*J31 - J11*J32;
     const CeedScalar A33 = J11*J22 - J12*J21;
     const CeedScalar qw = w[i] / (J11*A11 + J21*A12 + J31*A13);
-    qd[i+Q*0] = qw * (A11*A11 + A12*A12 + A13*A13);
-    qd[i+Q*1] = qw * (A21*A21 + A22*A22 + A23*A23);
-    qd[i+Q*2] = qw * (A31*A31 + A32*A32 + A33*A33);
-    qd[i+Q*3] = qw * (A21*A31 + A22*A32 + A23*A33);
-    qd[i+Q*4] = qw * (A11*A31 + A12*A32 + A13*A33);
-    qd[i+Q*5] = qw * (A11*A21 + A12*A22 + A13*A23);
+    qdata[i+Q*0] = qw * (A11*A11 + A12*A12 + A13*A13);
+    qdata[i+Q*1] = qw * (A21*A21 + A22*A22 + A23*A23);
+    qdata[i+Q*2] = qw * (A31*A31 + A32*A32 + A33*A33);
+    qdata[i+Q*3] = qw * (A21*A31 + A22*A32 + A23*A33);
+    qdata[i+Q*4] = qw * (A11*A31 + A12*A32 + A13*A33);
+    qdata[i+Q*5] = qw * (A11*A21 + A12*A22 + A13*A23);
 
     const CeedScalar c[3] = { 0, 1., 2. };
     const CeedScalar k[3] = { 1., 2., 3. };
@@ -89,7 +89,7 @@ CEED_QFUNCTION(SetupDiff3)(void *ctx, const CeedInt Q,
 
 CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q,
                       const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar *ug = in[0], *qd = in[1];
+  const CeedScalar *ug = in[0], *qdata = in[1];
   CeedScalar *vg = out[0];
 
   // Quadrature Point Loop
@@ -107,15 +107,15 @@ CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q,
                                          ug[i+(2+2*3)*Q]}
                                        };
     // Read qdata (dXdxdXdxT symmetric matrix)
-    const CeedScalar dXdxdXdxT[3][3] = {{qd[i+0*Q],
-                                         qd[i+5*Q],
-                                         qd[i+4*Q]},
-                                        {qd[i+5*Q],
-                                         qd[i+1*Q],
-                                         qd[i+3*Q]},
-                                        {qd[i+4*Q],
-                                         qd[i+3*Q],
-                                         qd[i+2*Q]}
+    const CeedScalar dXdxdXdxT[3][3] = {{qdata[i+0*Q],
+                                         qdata[i+5*Q],
+                                         qdata[i+4*Q]},
+                                        {qdata[i+5*Q],
+                                         qdata[i+1*Q],
+                                         qdata[i+3*Q]},
+                                        {qdata[i+4*Q],
+                                         qdata[i+3*Q],
+                                         qdata[i+2*Q]}
                                        };
 
     for (int k=0; k<3; k++) // k = component

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -152,7 +152,7 @@ struct User_ {
   Vec Xloc, Yloc;
   CeedVector xceed, yceed;
   CeedOperator op;
-  CeedVector rho;
+  CeedVector qdata;
   Ceed ceed;
   DM   dm;
 };
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
                       Erestrictqdi;
   CeedQFunction qf_setup, qf_apply, qf_error;
   CeedOperator op_setup, op_apply, op_error;
-  CeedVector xcoord, rho, rhsceed, target;
+  CeedVector xcoord, qdata, rhsceed, target;
   CeedInt P, Q;
   bpType bpChoice;
 
@@ -550,7 +550,7 @@ int main(int argc, char **argv) {
   CeedQFunctionAddInput(qf_setup, "x", ncompx, CEED_EVAL_INTERP);
   CeedQFunctionAddInput(qf_setup, "dx", ncompx*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
-  CeedQFunctionAddOutput(qf_setup, "rho", bpOptions[bpChoice].qdatasize,
+  CeedQFunctionAddOutput(qf_setup, "qdata", bpOptions[bpChoice].qdatasize,
                          CEED_EVAL_NONE);
   CeedQFunctionAddOutput(qf_setup, "true_soln", ncompu, CEED_EVAL_NONE);
   CeedQFunctionAddOutput(qf_setup, "rhs", ncompu, CEED_EVAL_INTERP);
@@ -563,7 +563,7 @@ int main(int argc, char **argv) {
   // Add inputs and outputs
   CeedQFunctionAddInput(qf_apply, "u", ncompu*gradInScale,
                         bpOptions[bpChoice].inmode);
-  CeedQFunctionAddInput(qf_apply, "rho", bpOptions[bpChoice].qdatasize,
+  CeedQFunctionAddInput(qf_apply, "qdata", bpOptions[bpChoice].qdatasize,
                         CEED_EVAL_NONE);
   CeedQFunctionAddOutput(qf_apply, "v", ncompu*gradOutScale,
                          bpOptions[bpChoice].outmode);
@@ -578,7 +578,7 @@ int main(int argc, char **argv) {
   // Create the persistent vectors that will be needed in setup
   CeedInt nqpts;
   CeedBasisGetNumQuadraturePoints(basisu, &nqpts);
-  CeedVectorCreate(ceed, bpOptions[bpChoice].qdatasize*nelem*nqpts, &rho);
+  CeedVectorCreate(ceed, bpOptions[bpChoice].qdatasize*nelem*nqpts, &qdata);
   CeedVectorCreate(ceed, nelem*nqpts*ncompu, &target);
   CeedVectorCreate(ceed, Xlocsize, &rhsceed);
 
@@ -590,7 +590,7 @@ int main(int argc, char **argv) {
                        basisx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup, "weight", Erestrictxi, CEED_NOTRANSPOSE,
                        basisx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictqdi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setup, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup, "true_soln", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, target);
@@ -601,8 +601,8 @@ int main(int argc, char **argv) {
   CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
   CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_TRANSPOSE,
                        basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "rho", Erestrictqdi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, rho);
+  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdata);
   CeedOperatorSetField(op_apply, "v", Erestrictu, CEED_TRANSPOSE,
                        basisu, CEED_VECTOR_ACTIVE);
 
@@ -624,7 +624,7 @@ int main(int argc, char **argv) {
   CeedVectorCreate(ceed, Xlocsize, &user->xceed);
   CeedVectorCreate(ceed, Xlocsize, &user->yceed);
   user->op = op_apply;
-  user->rho = rho;
+  user->qdata = qdata;
   user->ceed = ceed;
 
   ierr = MatCreateShell(comm, lsize, lsize, gsize, gsize, user, &mat);
@@ -639,8 +639,8 @@ int main(int argc, char **argv) {
   ierr = VecGetArray(rhsloc, &r); CHKERRQ(ierr);
   CeedVectorSetArray(rhsceed, CEED_MEM_HOST, CEED_USE_POINTER, r);
 
-  // Setup rho, rhs, and target
-  CeedOperatorApply(op_setup, xcoord, rho, CEED_REQUEST_IMMEDIATE);
+  // Setup qdata, rhs, and target
+  CeedOperatorApply(op_setup, xcoord, qdata, CEED_REQUEST_IMMEDIATE);
   ierr = CeedVectorSyncArray(rhsceed, CEED_MEM_HOST); CHKERRQ(ierr);
   CeedVectorDestroy(&xcoord);
 
@@ -757,7 +757,7 @@ int main(int argc, char **argv) {
 
   CeedVectorDestroy(&user->xceed);
   CeedVectorDestroy(&user->yceed);
-  CeedVectorDestroy(&user->rho);
+  CeedVectorDestroy(&user->qdata);
   CeedVectorDestroy(&target);
   CeedOperatorDestroy(&op_setup);
   CeedOperatorDestroy(&op_apply);

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -490,8 +490,6 @@ int main(int argc, char **argv) {
 
   // Print summary
   if (!test_mode) {
-    CeedInt gsize;
-    ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc --\n"
                        "  libCEED:\n"
@@ -555,7 +553,7 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup, "true_soln", ncompu, CEED_EVAL_NONE);
   CeedQFunctionAddOutput(qf_setup, "rhs", ncompu, CEED_EVAL_INTERP);
 
-  // Set up PDE operator  CeedInt gradInScale = 1;
+  // Set up PDE operator
   CeedInt gradInScale = bpOptions[bpChoice].inmode==CEED_EVAL_GRAD ? 3 : 1;
   CeedInt gradOutScale = bpOptions[bpChoice].outmode==CEED_EVAL_GRAD ? 3 : 1;
   CeedQFunctionCreateInterior(ceed, 1, bpOptions[bpChoice].apply,


### PR DESCRIPTION
We had several inconsistencies in our examples suite. Some used `qd` for qdata (but we have used the prefix/suffix `d` for derivatives in other examples), some used `rho`. Some used `w` for quadrature weights, some used `qw`.
I tried to clean up a bit.