### PR TITLE
Makefile - drop BLAS link for XSMM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,14 +290,7 @@ endif
 # libXSMM Backends
 ifneq ($(wildcard $(XSMM_DIR)/lib/libxsmm.*),)
   $(libceeds) : LDFLAGS += -L$(XSMM_DIR)/lib -Wl,-rpath,$(abspath $(XSMM_DIR)/lib)
-  $(libceeds) : LDLIBS += -lxsmm -ldl
-  MKL ?= 0
-  ifneq (0,$(MKL))
-    BLAS_LIB = -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
-  else
-    BLAS_LIB = -lblas
-  endif
-  $(libceeds) : LDLIBS += $(BLAS_LIB)
+  $(libceeds) : LDLIBS += -lxsmmnoblas -ldl
   libceed.c += $(xsmm.c)
   $(xsmm.c:%.c=$(OBJDIR)/%.o) $(xsmm.c:%=%.tidy) : CPPFLAGS += -I$(XSMM_DIR)/include
   BACKENDS += /cpu/self/xsmm/serial /cpu/self/xsmm/blocked

--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ The `/cpu/self/opt/*` backends are written in pure C and use partial e-vectors t
 The `/cpu/self/avx/*` backends rely upon AVX instructions to provide vectorized CPU performance.
 
 The `/cpu/self/xsmm/*` backends rely upon the [LIBXSMM](http://github.com/hfp/libxsmm) package
-to provide vectorized CPU performance. The LIBXSMM backend does not use BLAS or MKL; however,
-if LIBXSMM was linked to MKL, this can be specified with the compilation flag `MKL=1`.
+to provide vectorized CPU performance.
 
 The `/cpu/self/ref/memcheck` backend relies upon the [Valgrind](http://valgrind.org/) Memcheck tool
 to help verify that user QFunctions have no undefined values. To use, run your code with


### PR DESCRIPTION
This fixes Issue #199 by dropping the unneeded BLAS link from the Makefile.