### PR TITLE
Remove PetscRoundReal because not supported anymore

### DIFF
--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -521,9 +521,9 @@ int main(int argc, char **argv) {
   resz = fabs(resz) * meter;
 
   // Find a nicely composite number of elements given the resolution
-  melem[0] = (PetscInt)(PetscRoundReal(lx / resx / p[0]));
-  melem[1] = (PetscInt)(PetscRoundReal(ly / resy / p[1]));
-  melem[2] = (PetscInt)(PetscRoundReal(lz / resz / p[2]));
+  melem[0] = (PetscInt)(PetscCeilReal(lx / resx / p[0]));
+  melem[1] = (PetscInt)(PetscCeilReal(ly / resy / p[1]));
+  melem[2] = (PetscInt)(PetscCeilReal(lz / resz / p[2]));
   for (int d=0; d<dim; d++) {
     if (melem[d] == 0)
       melem[d]++;


### PR DESCRIPTION
This is a temporary patch because PETSc has removed `PetscRoundReal`
https://gitlab.com/petsc/petsc/commit/2c44a894518ef66365b1a557f36a6a1b08519b0c

Until we merge work being done on the stabilization (now present on a few branches), where the determination of the process grid has been changed