### PR TITLE
PETSc - add MPI_Reduce and PetscBarrier for benchmarking

### DIFF
--- a/examples/navier-stokes/Makefile
+++ b/examples/navier-stokes/Makefile
@@ -14,7 +14,7 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
-OPT ?= -O3 -g -march=native -ffp-contract=fast -fopenmp-simd
+OPT ?= -O -g -march=native -ffp-contract=fast -fopenmp-simd
 
 PETSc.pc := $(PETSC_DIR)/$(PETSC_ARCH)/lib/pkgconfig/PETSc.pc
 CEED_DIR ?= ../..

--- a/examples/navier-stokes/Makefile
+++ b/examples/navier-stokes/Makefile
@@ -14,7 +14,7 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
-OPT ?= -O -g -march=native -ffp-contract=fast -fopenmp-simd
+OPT ?= -O3 -g -march=native -ffp-contract=fast -fopenmp-simd
 
 PETSc.pc := $(PETSC_DIR)/$(PETSC_ARCH)/lib/pkgconfig/PETSc.pc
 CEED_DIR ?= ../..

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -799,8 +799,8 @@ int main(int argc, char **argv) {
     if (benchmark_mode && (!test_mode)) {
       CeedInt gsize;
       ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
-      MPI_Reduce(&my_rt, &rt_min, 1, MPI_DOUBLE, MPI_MIN, 0, comm);
-      MPI_Reduce(&my_rt, &rt_max, 1, MPI_DOUBLE, MPI_MAX, 0, comm);
+      MPI_Allreduce(&my_rt, &rt_min, 1, MPI_DOUBLE, MPI_MIN, comm);
+      MPI_Allreduce(&my_rt, &rt_max, 1, MPI_DOUBLE, MPI_MAX, comm);
       ierr = PetscPrintf(comm,
                          "  Performance:\n"
                          "    CG Solve Time                      : %g (%g) sec\n"

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -762,7 +762,7 @@ int main(int argc, char **argv) {
     my_rt_start = MPI_Wtime();
     ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
     my_rt = MPI_Wtime() - my_rt_start;
-    MPI_Allreduce(&my_rt, &my_rt, 1, MPI_DOUBLE, MPI_MIN, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &my_rt, 1, MPI_DOUBLE, MPI_MIN, comm);
     // Set maxits based on first iteration timing
     if (my_rt > 0.02) {
       ierr = KSPSetTolerances(ksp, 1e-10, PETSC_DEFAULT, PETSC_DEFAULT, 5);

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -762,6 +762,7 @@ int main(int argc, char **argv) {
     my_rt_start = MPI_Wtime();
     ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
     my_rt = MPI_Wtime() - my_rt_start;
+    MPI_Reduce(&my_rt, &my_rt, 1, MPI_DOUBLE, MPI_MIN, 0, comm);
     // Set maxits based on first iteration timing
     if (my_rt > 0.02) {
       ierr = KSPSetTolerances(ksp, 1e-10, PETSC_DEFAULT, PETSC_DEFAULT, 5);
@@ -772,6 +773,7 @@ int main(int argc, char **argv) {
     }
   }
   // Timed solve
+  ierr = PetscBarrier(NULL); CHKERRQ(ierr);
   my_rt_start = MPI_Wtime();
   ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
   my_rt = MPI_Wtime() - my_rt_start;

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -674,7 +674,7 @@ int main(int argc, char **argv) {
     my_rt_start = MPI_Wtime();
     ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
     my_rt = MPI_Wtime() - my_rt_start;
-    MPI_Allreduce(&my_rt, &my_rt, 1, MPI_DOUBLE, MPI_MIN, comm);
+    MPI_Allreduce(MPI_IN_PLACE, &my_rt, 1, MPI_DOUBLE, MPI_MIN, comm);
     // Set maxits based on first iteration timing
     if (my_rt > 0.02) {
       ierr = KSPSetTolerances(ksp, 1e-10, PETSC_DEFAULT, PETSC_DEFAULT, 5);

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -674,6 +674,7 @@ int main(int argc, char **argv) {
     my_rt_start = MPI_Wtime();
     ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
     my_rt = MPI_Wtime() - my_rt_start;
+    MPI_Reduce(&my_rt, &my_rt, 1, MPI_DOUBLE, MPI_MIN, 0, comm);
     // Set maxits based on first iteration timing
     if (my_rt > 0.02) {
       ierr = KSPSetTolerances(ksp, 1e-10, PETSC_DEFAULT, PETSC_DEFAULT, 5);
@@ -685,6 +686,7 @@ int main(int argc, char **argv) {
   }
 
   // Timed solve
+  ierr = PetscBarrier(NULL); CHKERRQ(ierr);
   my_rt_start = MPI_Wtime();
   ierr = KSPSolve(ksp, rhs, X); CHKERRQ(ierr);
   my_rt = MPI_Wtime() - my_rt_start;

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -712,8 +712,8 @@ int main(int argc, char **argv) {
     if (benchmark_mode && (!test_mode)) {
       CeedInt gsize;
       ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
-      MPI_Reduce(&my_rt, &rt_min, 1, MPI_DOUBLE, MPI_MIN, 0, comm);
-      MPI_Reduce(&my_rt, &rt_max, 1, MPI_DOUBLE, MPI_MAX, 0, comm);
+      MPI_Allreduce(&my_rt, &rt_min, 1, MPI_DOUBLE, MPI_MIN, comm);
+      MPI_Allreduce(&my_rt, &rt_max, 1, MPI_DOUBLE, MPI_MAX, comm);
       ierr = PetscPrintf(comm,
                          "  Performance:\n"
                          "    CG Solve Time                      : %g (%g) sec\n"


### PR DESCRIPTION
This fixes a small bug in the PETSc BPs when running in parallel.