### PR TITLE
CPU - Use work vectors for AssembleLinearQF

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -603,7 +603,7 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
     // LCOV_EXCL_START
     return CeedError(ceed, 1, "Cannot assemble QFunction without active inputs "
                      "and outputs");
-    // LCOV_EXCL_STOP
+  // LCOV_EXCL_STOP
 
   // Setup lvec
   ierr = CeedVectorCreate(ceed, nblks*blksize*Q*numactivein*numactiveout,

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -552,7 +552,7 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
   CeedChk(ierr);
   CeedVector vec, lvec;
   CeedInt numactivein = 0, numactiveout = 0;
-  CeedScalar **activein = NULL;
+  CeedVector *activein = NULL;
   CeedScalar *a, *tmp;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
@@ -577,7 +577,10 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
       CeedChk(ierr);
       ierr = CeedRealloc(numactivein + size, &activein); CeedChk(ierr);
       for (CeedInt field=0; field<size; field++) {
-        activein[numactivein+field] = &tmp[field*Q];
+        ierr = CeedVectorCreate(ceed, Q*blksize, &activein[numactivein+field]);
+        CeedChk(ierr);
+        ierr = CeedVectorSetArray(activein[numactivein+field], CEED_MEM_HOST,
+                                  CEED_USE_POINTER, &tmp[field*Q*blksize]);
       }
       numactivein += size;
       ierr = CeedVectorRestoreArray(impl->qvecsin[i], &tmp); CeedChk(ierr);
@@ -626,11 +629,11 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
     // Assemble QFunction
     for (CeedInt in=0; in<numactivein; in++) {
       // Set Inputs
-      for (CeedInt q=0; q<Q*blksize; q++)
-        activein[in][q] = 1;
-      if (numactivein > 1)
-        for (CeedInt q=0; q<Q*blksize; q++)
-          activein[(in+numactivein-1)%numactivein][q] = 0;
+      ierr = CeedVectorSetValue(activein[in], 1.0); CeedChk(ierr);
+      if (numactivein > 1) {
+        ierr = CeedVectorSetValue(activein[(in+numactivein-1)%numactivein],
+                                  0.0); CeedChk(ierr);
+      }
       // Set Outputs
       for (CeedInt out=0; out<numoutputfields; out++) {
         // Get output vector
@@ -681,6 +684,9 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
                                   lvec, *assembled, request); CeedChk(ierr);
 
   // Cleanup
+  for (CeedInt i=0; i<numactivein; i++) {
+    ierr = CeedVectorDestroy(&activein[i]); CeedChk(ierr);
+  }
   ierr = CeedFree(&activein); CeedChk(ierr);
   ierr = CeedVectorDestroy(&lvec); CeedChk(ierr);
   ierr = CeedElemRestrictionDestroy(&blkrstr); CeedChk(ierr);

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -618,7 +618,7 @@ static int CeedOperatorAssembleLinearQFunction_Opt(CeedOperator op,
     // LCOV_EXCL_START
     return CeedError(ceed, 1, "Cannot assemble QFunction without active inputs "
                      "and outputs");
-    // LCOV_EXCL_STOP
+  // LCOV_EXCL_STOP
 
   // Setup lvec
   ierr = CeedVectorCreate(ceed, nblks*blksize*Q*numactivein*numactiveout,

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -601,9 +601,11 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   }
 
   // Check sizes
-  if (!numactivein || !numactiveout) 
-    return CeedError(ceed, 1,
-                       "Cannot assemble QFunction without active inputs and outputs");
+  if (!numactivein || !numactiveout)
+    // LCOV_EXCL_START
+    return CeedError(ceed, 1, "Cannot assemble QFunction without active inputs "
+                     "and outputs");
+  // LCOV_EXCL_STOP
 
   // Create output restriction
   ierr = CeedElemRestrictionCreateIdentity(ceed, numelements, Q,

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -555,7 +555,7 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   CeedChk(ierr);
   CeedVector vec;
   CeedInt numactivein = 0, numactiveout = 0;
-  CeedScalar **activein = NULL;
+  CeedVector *activein = NULL;
   CeedScalar *a, *tmp;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
@@ -579,7 +579,10 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
       CeedChk(ierr);
       ierr = CeedRealloc(numactivein + size, &activein); CeedChk(ierr);
       for (CeedInt field=0; field<size; field++) {
-        activein[numactivein+field] = &tmp[field*Q];
+        ierr = CeedVectorCreate(ceed, Q, &activein[numactivein+field]);
+        CeedChk(ierr);
+        ierr = CeedVectorSetArray(activein[numactivein+field], CEED_MEM_HOST,
+                                  CEED_USE_POINTER, &tmp[field*Q]);
       }
       numactivein += size;
       ierr = CeedVectorRestoreArray(impl->qvecsin[i], &tmp); CeedChk(ierr);
@@ -623,11 +626,11 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
     // Assemble QFunction
     for (CeedInt in=0; in<numactivein; in++) {
       // Set Inputs
-      for (CeedInt q=0; q<Q; q++)
-        activein[in][q] = 1;
-      if (numactivein > 1)
-        for (CeedInt q=0; q<Q; q++)
-          activein[(in+numactivein-1)%numactivein][q] = 0;
+      ierr = CeedVectorSetValue(activein[in], 1.0); CeedChk(ierr);
+      if (numactivein > 1) {
+        ierr = CeedVectorSetValue(activein[(in+numactivein-1)%numactivein],
+                                  0.0); CeedChk(ierr);
+      }
       // Set Outputs
       for (CeedInt out=0; out<numoutputfields; out++) {
         // Get output vector
@@ -669,6 +672,9 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   ierr = CeedVectorRestoreArray(*assembled, &a); CeedChk(ierr);
 
   // Cleanup
+  for (CeedInt i=0; i<numactivein; i++) {
+    ierr = CeedVectorDestroy(&activein[i]); CeedChk(ierr);
+  }
   ierr = CeedFree(&activein); CeedChk(ierr);
 
   return 0;

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -282,16 +282,26 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
   CeedQFunction qf = op->qf;
 
   if (op->composite) {
+    // LCOV_EXCL_START
     return CeedError(ceed, 1, "Cannot assemble QFunction for composite operator");
+    // LCOV_EXCL_STOP
   } else {
     if (op->nfields == 0)
+      // LCOV_EXCL_START
       return CeedError(ceed, 1, "No operator fields set");
+      // LCOV_EXCL_STOP
     if (op->nfields < qf->numinputfields + qf->numoutputfields)
+      // LCOV_EXCL_START
       return CeedError( ceed, 1, "Not all operator fields set");
+    // LCOV_EXCL_STOP
     if (op->numelements == 0)
+      // LCOV_EXCL_START
       return CeedError(ceed, 1, "At least one restriction required");
+    // LCOV_EXCL_STOP
     if (op->numqpoints == 0)
+      // LCOV_EXCL_START
       return CeedError(ceed, 1, "At least one non-collocated basis required");
+    // LCOV_EXCL_STOP
   }
   ierr = op->AssembleLinearQFunction(op, assembled, rstr, request);
   CeedChk(ierr);

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -158,7 +158,9 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
     }
   }
   if (!matchlen)
+    // LCOV_EXCL_START
     return CeedError(NULL, 1, "No suitable gallery QFunction");
+  // LCOV_EXCL_STOP
 
   // Create QFunction
   ierr = CeedQFunctionCreateInterior(ceed, qfunctions[matchidx].vlength,


### PR DESCRIPTION
@jedbrown, I think that I just got what you meant by using work vectors for AssembleLinearQFunction. I think this is cleaner than dragging around the pointers.