### PR TITLE
Facilitate Empty Operators

### DIFF
--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -219,6 +219,7 @@ struct CeedOperator_private {
   CeedQFunction dqfT;
   bool setupdone;
   bool composite;
+  bool restrictionadded;
   CeedOperator *suboperators;
   CeedInt numsub;
   void *data;

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -107,6 +107,7 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
   (*op)->ceed = ceed;
   ceed->refcount++;
   (*op)->composite = true;
+  (*op)->numelements = -2;
   ierr = CeedCalloc(16, &(*op)->suboperators); CeedChk(ierr);
   ierr = ceed->CompositeOperatorCreate(*op); CeedChk(ierr);
   return 0;
@@ -552,7 +553,9 @@ int CeedOperatorApply(CeedOperator op, CeedVector in,
       return CeedError(ceed, 1,"At least one non-collocated basis required");
     // LCOV_EXCL_STOP
   }
-  ierr = op->Apply(op, in, out, request); CeedChk(ierr);
+  if (op->numelements) {
+    ierr = op->Apply(op, in, out, request); CeedChk(ierr);
+  }
   return 0;
 }
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -68,6 +68,7 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
   if (dqf) dqf->refcount++;
   (*op)->dqfT = dqfT;
   if (dqfT) dqfT->refcount++;
+  (*op)->numelements = -1;
   ierr = CeedCalloc(16, &(*op)->inputfields); CeedChk(ierr);
   ierr = CeedCalloc(16, &(*op)->outputfields); CeedChk(ierr);
   ierr = ceed->OperatorCreate(*op); CeedChk(ierr);
@@ -168,7 +169,7 @@ int CeedOperatorSetField(CeedOperator op, const char *fieldname,
 
   CeedInt numelements;
   ierr = CeedElemRestrictionGetNumElements(r, &numelements); CeedChk(ierr);
-  if (op->numelements && op->numelements != numelements)
+  if (op->numelements != -1 && op->numelements != numelements)
     // LCOV_EXCL_START
     return CeedError(op->ceed, 1,
                      "ElemRestriction with %d elements incompatible with prior "
@@ -295,7 +296,7 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
       // LCOV_EXCL_START
       return CeedError( ceed, 1, "Not all operator fields set");
     // LCOV_EXCL_STOP
-    if (op->numelements == 0)
+    if (op->numelements == -1)
       // LCOV_EXCL_START
       return CeedError(ceed, 1, "At least one restriction required");
     // LCOV_EXCL_STOP
@@ -342,7 +343,7 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
       // LCOV_EXCL_START
       return CeedError( ceed, 1, "Not all operator fields set");
     // LCOV_EXCL_STOP
-    if (op->numelements == 0)
+    if (op->numelements == -1)
       // LCOV_EXCL_START
       return CeedError(ceed, 1, "At least one restriction required");
     // LCOV_EXCL_STOP


### PR DESCRIPTION
Process decomposition may provide a restriction that is empty (0 elements), which currently causes an error in a libCEED operator as if the user did not define a restriction. This PR allows a user to intentionally set a restriction with 0 elements. If there are 0 elements, then the backend code is not called. (proper backend code should run fine with 0 elements, but it seems silly to make the function calls for an empty operator)

Thanks @valeriabarra for catching this.