### PR TITLE
Get Full Ceed Resource Name

### DIFF
--- a/backends/memcheck/ceed-memcheck-qfunction.c
+++ b/backends/memcheck/ceed-memcheck-qfunction.c
@@ -25,8 +25,8 @@ static int CeedQFunctionApply_Memcheck(CeedQFunction qf, CeedInt Q,
   void *ctx;
   ierr = CeedQFunctionGetContext(qf, &ctx); CeedChk(ierr);
 
-  int (*f)() = NULL;
-  ierr = CeedQFunctionGetUserFunction(qf, (int (* *)())&f); CeedChk(ierr);
+  CeedQFunctionUser f = NULL;
+  ierr = CeedQFunctionGetUserFunction(qf, (int (**)())&f); CeedChk(ierr);
 
   CeedInt nIn, nOut;
   ierr = CeedQFunctionGetNumArgs(qf, &nIn, &nOut); CeedChk(ierr);

--- a/backends/ref/ceed-ref-qfunction.c
+++ b/backends/ref/ceed-ref-qfunction.c
@@ -25,8 +25,8 @@ static int CeedQFunctionApply_Ref(CeedQFunction qf, CeedInt Q,
   void *ctx;
   ierr = CeedQFunctionGetContext(qf, &ctx); CeedChk(ierr);
 
-  int (*f)() = NULL;
-  ierr = CeedQFunctionGetUserFunction(qf, (int (* *)())&f); CeedChk(ierr);
+  CeedQFunctionUser f = NULL;
+  ierr = CeedQFunctionGetUserFunction(qf, (int (**)())&f); CeedChk(ierr);
 
   CeedInt nIn, nOut;
   ierr = CeedQFunctionGetNumArgs(qf, &nIn, &nOut); CeedChk(ierr);

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -477,10 +477,15 @@ int main(int argc, char **argv) {
   CHKERRQ(ierr);
   ierr = VecSetUp(X); CHKERRQ(ierr);
 
+  // Set up libCEED
+  CeedInit(ceedresource, &ceed);
+
   // Print summary
   if (!test_mode) {
     CeedInt gsize;
     ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
+    const char *usedresource;
+    CeedGetResource(ceed, &usedresource);
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc --\n"
                        "  libCEED:\n"
@@ -492,10 +497,10 @@ int main(int argc, char **argv) {
                        "    Process Decomposition              : %D %D %D\n"
                        "    Local Elements                     : %D = %D %D %D\n"
                        "    Owned nodes                        : %D = %D %D %D\n",
-                       bpChoice+1, ceedresource, P, Q,  gsize/ncompu, p[0],
+                       bpChoice+1, usedresource, P, Q,  gsize/ncompu, p[0],
                        p[1], p[2], localelem, melem[0], melem[1], melem[2],
-                       mnodes[0]*mnodes[1]*mnodes[2], mnodes[0], mnodes[1], mnodes[2]);
-    CHKERRQ(ierr);
+                       mnodes[0]*mnodes[1]*mnodes[2], mnodes[0], mnodes[1],
+                       mnodes[2]); CHKERRQ(ierr);
   }
 
   {
@@ -581,9 +586,6 @@ int main(int argc, char **argv) {
     ierr = ISDestroy(&ltogis0); CHKERRQ(ierr);
     ierr = ISDestroy(&locis); CHKERRQ(ierr);
   }
-
-  // Set up libCEED
-  CeedInit(ceedresource, &ceed);
 
   // CEED bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, ncompu, P, Q,

--- a/examples/petsc/bpsdmplex.c
+++ b/examples/petsc/bpsdmplex.c
@@ -157,9 +157,14 @@ int main(int argc, char **argv) {
                               (void(*)(void))MatMult_Ceed);
   CHKERRQ(ierr);
 
+  // Set up libCEED
+  CeedInit(ceedresource, &ceed);
+
   // Print summary
   if (!test_mode) {
     PetscInt P = degree + 1, Q = P + qextra;
+    const char *usedresource;
+    CeedGetResource(ceed, &usedresource);
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc --\n"
                        "  libCEED:\n"
@@ -169,12 +174,9 @@ int main(int argc, char **argv) {
                        "    Number of 1D Quadrature Points (q) : %d\n"
                        "    Global nodes                       : %D\n"
                        "    Owned nodes                        : %D\n",
-                       bpChoice+1, ceedresource, P, Q, gsize/ncompu,
+                       bpChoice+1, usedresource, P, Q, gsize/ncompu,
                        lsize/ncompu); CHKERRQ(ierr);
   }
-
-  // Set up libCEED
-  CeedInit(ceedresource, &ceed);
 
   // Create RHS vector
   ierr = VecDuplicate(Xloc, &rhsloc); CHKERRQ(ierr);

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -218,9 +218,14 @@ int main(int argc, char **argv) {
   }
   ierr = VecDuplicate(X[numlevels-1], &rhs); CHKERRQ(ierr);
 
+  // Set up libCEED
+  CeedInit(ceedresource, &ceed);
+
   // Print global grid information
   if (!test_mode) {
     PetscInt P = degree + 1, Q = P + qextra;
+    const char *usedresource;
+    CeedGetResource(ceed, &usedresource);
     ierr = PetscPrintf(comm,
                        "\n-- CEED Benchmark Problem %d -- libCEED + PETSc + PCMG --\n"
                        "  libCEED:\n"
@@ -232,13 +237,10 @@ int main(int argc, char **argv) {
                        "    Owned Nodes                        : %D\n"
                        "  Multigrid:\n"
                        "    Number of Levels                   : %d\n",
-                       bpChoice+1, ceedresource, P, Q,
+                       bpChoice+1, usedresource, P, Q,
                        gsize[numlevels-1]/ncompu, lsize[numlevels-1]/ncompu,
                        numlevels); CHKERRQ(ierr);
   }
-
-  // Set up libCEED
-  CeedInit(ceedresource, &ceed);
 
   // Create RHS vector
   ierr = VecDuplicate(Xloc[numlevels-1], &rhsloc); CHKERRQ(ierr);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -68,13 +68,13 @@ CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed delegate,
 CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
                                        const char *type, void *object,
                                        const char *fname, int (*f)());
-CEED_EXTERN int CeedGetData(Ceed ceed, void* *data);
-CEED_EXTERN int CeedSetData(Ceed ceed, void* *data);
+CEED_EXTERN int CeedGetData(Ceed ceed, void **data);
+CEED_EXTERN int CeedSetData(Ceed ceed, void **data);
 
 CEED_EXTERN int CeedVectorGetCeed(CeedVector vec, Ceed *ceed);
 CEED_EXTERN int CeedVectorGetState(CeedVector vec, uint64_t *state);
-CEED_EXTERN int CeedVectorGetData(CeedVector vec, void* *data);
-CEED_EXTERN int CeedVectorSetData(CeedVector vec, void* *data);
+CEED_EXTERN int CeedVectorGetData(CeedVector vec, void **data);
+CEED_EXTERN int CeedVectorSetData(CeedVector vec, void **data);
 
 CEED_EXTERN int CeedElemRestrictionGetCeed(CeedElemRestriction rstr,
     Ceed *ceed);
@@ -91,9 +91,9 @@ CEED_EXTERN int CeedElemRestrictionGetNumBlocks(CeedElemRestriction rstr,
 CEED_EXTERN int CeedElemRestrictionGetBlockSize(CeedElemRestriction rstr,
     CeedInt *blksize);
 CEED_EXTERN int CeedElemRestrictionGetData(CeedElemRestriction rstr,
-    void* *data);
+    void **data);
 CEED_EXTERN int CeedElemRestrictionSetData(CeedElemRestriction rstr,
-    void* *data);
+    void **data);
 
 CEED_EXTERN int CeedBasisGetCollocatedGrad(CeedBasis basis,
     CeedScalar *colograd1d);
@@ -104,15 +104,15 @@ CEED_EXTERN int CeedBasisGetNumComponents(CeedBasis basis, CeedInt *numcomp);
 CEED_EXTERN int CeedBasisGetNumNodes1D(CeedBasis basis, CeedInt *P1d);
 CEED_EXTERN int CeedBasisGetNumQuadraturePoints1D(CeedBasis basis,
     CeedInt *Q1d);
-CEED_EXTERN int CeedBasisGetQRef(CeedBasis basis, CeedScalar* *qref);
-CEED_EXTERN int CeedBasisGetQWeights(CeedBasis basis, CeedScalar* *qweight);
-CEED_EXTERN int CeedBasisGetInterp(CeedBasis basis, CeedScalar* *interp);
-CEED_EXTERN int CeedBasisGetGrad(CeedBasis basis, CeedScalar* *grad);
+CEED_EXTERN int CeedBasisGetQRef(CeedBasis basis, CeedScalar **qref);
+CEED_EXTERN int CeedBasisGetQWeights(CeedBasis basis, CeedScalar **qweight);
+CEED_EXTERN int CeedBasisGetInterp(CeedBasis basis, CeedScalar **interp);
+CEED_EXTERN int CeedBasisGetGrad(CeedBasis basis, CeedScalar **grad);
 CEED_EXTERN int CeedBasisGetValue(CeedBasis basis, CeedEvalMode emode,
                                   CeedInt node, CeedInt qpt, CeedInt dim,
                                   CeedScalar *value);
-CEED_EXTERN int CeedBasisGetData(CeedBasis basis, void* *data);
-CEED_EXTERN int CeedBasisSetData(CeedBasis basis, void* *data);
+CEED_EXTERN int CeedBasisGetData(CeedBasis basis, void **data);
+CEED_EXTERN int CeedBasisSetData(CeedBasis basis, void **data);
 
 CEED_EXTERN int CeedBasisGetTopologyDimension(CeedElemTopology topo,
     CeedInt *dim);
@@ -132,9 +132,9 @@ CEED_EXTERN int CeedTensorContractApply(CeedTensorContract contract, CeedInt A,
 CEED_EXTERN int CeedTensorContractGetCeed(CeedTensorContract contract,
     Ceed *ceed);
 CEED_EXTERN int CeedTensorContractGetData(CeedTensorContract contract,
-    void* *data);
+    void **data);
 CEED_EXTERN int CeedTensorContractSetData(CeedTensorContract contract,
-    void* *data);
+    void **data);
 CEED_EXTERN int CeedTensorContractDestroy(CeedTensorContract *contract);
 
 CEED_EXTERN int CeedQFunctionRegister(const char *, const char *, CeedInt,
@@ -145,24 +145,24 @@ CEED_EXTERN int CeedQFunctionGetVectorLength(CeedQFunction qf,
 CEED_EXTERN int CeedQFunctionGetNumArgs(CeedQFunction qf,
                                         CeedInt *numinputfields,
                                         CeedInt *numoutputfields);
-CEED_EXTERN int CeedQFunctionGetSourcePath(CeedQFunction qf, char* *source);
+CEED_EXTERN int CeedQFunctionGetSourcePath(CeedQFunction qf, char **source);
 CEED_EXTERN int CeedQFunctionGetUserFunction(CeedQFunction qf,
     int (**f)());
 CEED_EXTERN int CeedQFunctionGetContextSize(CeedQFunction qf, size_t *ctxsize);
-CEED_EXTERN int CeedQFunctionGetContext(CeedQFunction qf, void* *ctx);
-CEED_EXTERN int CeedQFunctionGetInnerContext(CeedQFunction qf, void* *ctx);
+CEED_EXTERN int CeedQFunctionGetContext(CeedQFunction qf, void **ctx);
+CEED_EXTERN int CeedQFunctionGetInnerContext(CeedQFunction qf, void **ctx);
 CEED_EXTERN int CeedQFunctionGetFortranStatus(CeedQFunction qf,
     bool *fortranstatus);
 CEED_EXTERN int CeedQFunctionGetIdentityStatus(CeedQFunction qf,
     bool *identity);
-CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void* *data);
-CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void* *data);
+CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void **data);
+CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void **data);
 
 CEED_EXTERN int CeedQFunctionGetFields(CeedQFunction qf,
-                                       CeedQFunctionField* *inputfields,
-                                       CeedQFunctionField* *outputfields);
+                                       CeedQFunctionField **inputfields,
+                                       CeedQFunctionField **outputfields);
 CEED_EXTERN int CeedQFunctionFieldGetName(CeedQFunctionField qffield,
-    char* *fieldname);
+    char **fieldname);
 CEED_EXTERN int CeedQFunctionFieldGetSize(CeedQFunctionField qffield,
     CeedInt *size);
 CEED_EXTERN int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qffield,
@@ -177,14 +177,14 @@ CEED_EXTERN int CeedOperatorGetSetupStatus(CeedOperator op, bool *setupdone);
 CEED_EXTERN int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf);
 CEED_EXTERN int CeedOperatorGetNumSub(CeedOperator op, CeedInt *numsub);
 CEED_EXTERN int CeedOperatorGetSubList(CeedOperator op,
-                                       CeedOperator* *suboperators);
-CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void* *data);
-CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void* *data);
+                                       CeedOperator **suboperators);
+CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void **data);
+CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
 CEED_EXTERN int CeedOperatorGetFields(CeedOperator op,
-                                      CeedOperatorField* *inputfields,
-                                      CeedOperatorField* *outputfields);
+                                      CeedOperatorField **inputfields,
+                                      CeedOperatorField **outputfields);
 CEED_EXTERN int CeedOperatorFieldGetElemRestriction(CeedOperatorField opfield,
     CeedElemRestriction *rstr);
 CEED_EXTERN int CeedOperatorFieldGetBasis(CeedOperatorField opfield,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -43,6 +43,7 @@ typedef struct {
 } objdelegate;
 
 struct Ceed_private {
+  const char *resource;
   Ceed delegate;
   Ceed parent;
   objdelegate *objdelegates;

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -114,6 +114,7 @@ typedef struct CeedQFunction_private *CeedQFunction;
 typedef struct CeedOperator_private *CeedOperator;
 
 CEED_EXTERN int CeedInit(const char *resource, Ceed *ceed);
+CEED_EXTERN int CeedGetResource(Ceed ceed, const char **resource);
 CEED_EXTERN int CeedDestroy(Ceed *ceed);
 
 CEED_EXTERN int CeedErrorImpl(Ceed, const char *, int, const char *, int,

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -122,8 +122,8 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt ncomp, CeedInt P1d,
   @ref Basic
 **/
 int CeedBasisCreateTensorH1Lagrange(Ceed ceed, CeedInt dim, CeedInt ncomp,
-                                    CeedInt P, CeedInt Q,
-                                    CeedQuadMode qmode, CeedBasis *basis) {
+                                    CeedInt P, CeedInt Q, CeedQuadMode qmode,
+                                    CeedBasis *basis) {
   // Allocate
   int ierr, i, j, k;
   CeedScalar c1, c2, c3, c4, dx, *nodes, *interp1d, *grad1d, *qref1d, *qweight1d;
@@ -206,8 +206,7 @@ int CeedBasisCreateTensorH1Lagrange(Ceed ceed, CeedInt dim, CeedInt ncomp,
   @ref Basic
 **/
 int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt ncomp,
-                      CeedInt nnodes, CeedInt nqpts,
-                      const CeedScalar *interp,
+                      CeedInt nnodes, CeedInt nqpts, const CeedScalar *interp,
                       const CeedScalar *grad, const CeedScalar *qref,
                       const CeedScalar *qweight, CeedBasis *basis) {
   int ierr;
@@ -1051,7 +1050,7 @@ int CeedBasisGetNumQuadraturePoints(CeedBasis basis, CeedInt *Q) {
 
   @ref Advanced
 **/
-int CeedBasisGetQRef(CeedBasis basis, CeedScalar* *qref) {
+int CeedBasisGetQRef(CeedBasis basis, CeedScalar **qref) {
   *qref = basis->qref1d;
   return 0;
 }
@@ -1067,7 +1066,7 @@ int CeedBasisGetQRef(CeedBasis basis, CeedScalar* *qref) {
 
   @ref Advanced
 **/
-int CeedBasisGetQWeights(CeedBasis basis, CeedScalar* *qweight) {
+int CeedBasisGetQWeights(CeedBasis basis, CeedScalar **qweight) {
   *qweight = basis->qweight1d;
   return 0;
 }
@@ -1082,7 +1081,7 @@ int CeedBasisGetQWeights(CeedBasis basis, CeedScalar* *qweight) {
 
   @ref Advanced
 **/
-int CeedBasisGetInterp(CeedBasis basis, CeedScalar* *interp) {
+int CeedBasisGetInterp(CeedBasis basis, CeedScalar **interp) {
   *interp = basis->interp1d;
   return 0;
 }
@@ -1097,7 +1096,7 @@ int CeedBasisGetInterp(CeedBasis basis, CeedScalar* *interp) {
 
   @ref Advanced
 **/
-int CeedBasisGetGrad(CeedBasis basis, CeedScalar* *grad) {
+int CeedBasisGetGrad(CeedBasis basis, CeedScalar **grad) {
   *grad = basis->grad1d;
   return 0;
 }
@@ -1105,8 +1104,7 @@ int CeedBasisGetGrad(CeedBasis basis, CeedScalar* *grad) {
 /**
   @brief Get value in CeedEvalMode matrix of a CeedBasis
 
-  @param basis       CeedBasis
-  @param[in] emode   CeedEvalMode to retrieve value
+  @param basis       CeedBasis  @param[in] emode   CeedEvalMode to retrieve value
   @param[in] node    Node (column) to retrieve value
   @param[in] qpt     Quadrature point (row) to retrieve value
   @param[in] dim     Dimension to retrieve value for, for CEED_EVAL_GRAD
@@ -1190,7 +1188,7 @@ int CeedBasisGetValue(CeedBasis basis, CeedEvalMode emode, CeedInt qpt,
 
   @ref Advanced
 **/
-int CeedBasisGetData(CeedBasis basis, void* *data) {
+int CeedBasisGetData(CeedBasis basis, void **data) {
   *data = basis->data;
   return 0;
 }
@@ -1205,7 +1203,7 @@ int CeedBasisGetData(CeedBasis basis, void* *data) {
 
   @ref Advanced
 **/
-int CeedBasisSetData(CeedBasis basis, void* *data) {
+int CeedBasisSetData(CeedBasis basis, void **data) {
   basis->data = *data;
   return 0;
 }

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -161,8 +161,8 @@ int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
   @ref Utility
 **/
 int CeedPermutePadIndices(const CeedInt *indices, CeedInt *blkindices,
-                          CeedInt nblk, CeedInt nelem,
-                          CeedInt blksize, CeedInt elemsize) {
+                          CeedInt nblk, CeedInt nelem, CeedInt blksize,
+                          CeedInt elemsize) {
   for (CeedInt e = 0; e < nblk*blksize; e+=blksize)
     for (int j = 0; j < blksize; j++)
       for (int k = 0; k < elemsize; k++)
@@ -305,8 +305,8 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *lvec,
   @ref Advanced
 **/
 int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
-                             CeedTransposeMode lmode,
-                             CeedVector u, CeedVector v, CeedRequest *request) {
+                             CeedTransposeMode lmode, CeedVector u,
+                             CeedVector v, CeedRequest *request) {
   CeedInt m,n;
   int ierr;
 
@@ -357,9 +357,8 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
 **/
 int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
                                   CeedTransposeMode tmode,
-                                  CeedTransposeMode lmode,
-                                  CeedVector u, CeedVector v,
-                                  CeedRequest *request) {
+                                  CeedTransposeMode lmode, CeedVector u,
+                                  CeedVector v, CeedRequest *request) {
   CeedInt m,n;
   int ierr;
 
@@ -544,7 +543,7 @@ int CeedElemRestrictionGetBlockSize(CeedElemRestriction rstr,
 
   @ref Advanced
 **/
-int CeedElemRestrictionGetData(CeedElemRestriction rstr, void* *data) {
+int CeedElemRestrictionGetData(CeedElemRestriction rstr, void **data) {
   *data = rstr->data;
   return 0;
 }
@@ -559,7 +558,7 @@ int CeedElemRestrictionGetData(CeedElemRestriction rstr, void* *data) {
 
   @ref Advanced
 **/
-int CeedElemRestrictionSetData(CeedElemRestriction rstr, void* *data) {
+int CeedElemRestrictionSetData(CeedElemRestriction rstr, void **data) {
   rstr->data = *data;
   return 0;
 }

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -230,8 +230,7 @@ found:
 
   @ref Basic
  */
-int CeedCompositeOperatorAddSub(CeedOperator compositeop,
-                                CeedOperator subop) {
+int CeedCompositeOperatorAddSub(CeedOperator compositeop, CeedOperator subop) {
   if (!compositeop->composite)
     // LCOV_EXCL_START
     return CeedError(compositeop->ceed, 1, "CeedOperator is not a composite "
@@ -523,8 +522,8 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
 
   @ref Basic
 **/
-int CeedOperatorApply(CeedOperator op, CeedVector in,
-                      CeedVector out, CeedRequest *request) {
+int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out,
+                      CeedRequest *request) {
   int ierr;
   Ceed ceed = op->ceed;
   CeedQFunction qf = op->qf;
@@ -706,7 +705,7 @@ int CeedOperatorGetNumSub(CeedOperator op, CeedInt *numsub) {
   @ref Advanced
 **/
 
-int CeedOperatorGetSubList(CeedOperator op, CeedOperator* *suboperators) {
+int CeedOperatorGetSubList(CeedOperator op, CeedOperator **suboperators) {
   if (!op->composite)
     // LCOV_EXCL_START
     return CeedError(op->ceed, 1, "Not a composite operator");
@@ -727,7 +726,7 @@ int CeedOperatorGetSubList(CeedOperator op, CeedOperator* *suboperators) {
   @ref Advanced
 **/
 
-int CeedOperatorSetData(CeedOperator op, void* *data) {
+int CeedOperatorSetData(CeedOperator op, void **data) {
   op->data = *data;
   return 0;
 }
@@ -743,7 +742,7 @@ int CeedOperatorSetData(CeedOperator op, void* *data) {
   @ref Advanced
 **/
 
-int CeedOperatorGetData(CeedOperator op, void* *data) {
+int CeedOperatorGetData(CeedOperator op, void **data) {
   *data = op->data;
   return 0;
 }
@@ -775,9 +774,8 @@ int CeedOperatorSetSetupDone(CeedOperator op) {
   @ref Advanced
 **/
 
-int CeedOperatorGetFields(CeedOperator op,
-                          CeedOperatorField* *inputfields,
-                          CeedOperatorField* *outputfields) {
+int CeedOperatorGetFields(CeedOperator op, CeedOperatorField **inputfields,
+                          CeedOperatorField **outputfields) {
   if (op->composite)
     // LCOV_EXCL_START
     return CeedError(op->ceed, 1, "Not defined for composite operator");
@@ -833,8 +831,7 @@ int CeedOperatorFieldGetElemRestriction(CeedOperatorField opfield,
   @ref Advanced
 **/
 
-int CeedOperatorFieldGetBasis(CeedOperatorField opfield,
-                              CeedBasis *basis) {
+int CeedOperatorFieldGetBasis(CeedOperatorField opfield, CeedBasis *basis) {
   *basis = opfield->basis;
   return 0;
 }
@@ -850,8 +847,7 @@ int CeedOperatorFieldGetBasis(CeedOperatorField opfield,
   @ref Advanced
 **/
 
-int CeedOperatorFieldGetVector(CeedOperatorField opfield,
-                               CeedVector *vec) {
+int CeedOperatorFieldGetVector(CeedOperatorField opfield, CeedVector *vec) {
   *vec = opfield->vec;
   return 0;
 }

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -56,8 +56,7 @@ static size_t num_qfunctions;
 
   @ref Basic
 **/
-int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength,
-                                CeedQFunctionUser f,
+int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vlength, CeedQFunctionUser f,
                                 const char *source, CeedQFunction *qf) {
   int ierr;
   char *source_copy;
@@ -356,7 +355,7 @@ int CeedQFunctionGetNumArgs(CeedQFunction qf, CeedInt *numinput,
   @ref Advanced
 **/
 
-int CeedQFunctionGetSourcePath(CeedQFunction qf, char* *source) {
+int CeedQFunctionGetSourcePath(CeedQFunction qf, char **source) {
   *source = (char *) qf->sourcepath;
   return 0;
 }
@@ -409,7 +408,7 @@ int CeedQFunctionGetContextSize(CeedQFunction qf, size_t *ctxsize) {
   @ref Advanced
 **/
 
-int CeedQFunctionGetContext(CeedQFunction qf, void* *ctx) {
+int CeedQFunctionGetContext(CeedQFunction qf, void **ctx) {
   *ctx = qf->ctx;
   return 0;
 }
@@ -457,7 +456,7 @@ int CeedQFunctionGetIdentityStatus(CeedQFunction qf, bool *identity) {
   @ref Advanced
 **/
 
-int CeedQFunctionGetInnerContext(CeedQFunction qf, void* *ctx) {
+int CeedQFunctionGetInnerContext(CeedQFunction qf, void **ctx) {
   if (qf->fortranstatus) {
     fContext *fctx = qf->ctx;
     *ctx = fctx->innerctx;
@@ -480,7 +479,7 @@ int CeedQFunctionGetInnerContext(CeedQFunction qf, void* *ctx) {
   @ref Advanced
 **/
 
-int CeedQFunctionGetData(CeedQFunction qf, void* *data) {
+int CeedQFunctionGetData(CeedQFunction qf, void **data) {
   *data = qf->data;
   return 0;
 }
@@ -496,7 +495,7 @@ int CeedQFunctionGetData(CeedQFunction qf, void* *data) {
   @ref Advanced
 **/
 
-int CeedQFunctionSetData(CeedQFunction qf, void* *data) {
+int CeedQFunctionSetData(CeedQFunction qf, void **data) {
   qf->data = *data;
   return 0;
 }
@@ -558,9 +557,8 @@ int CeedQFunctionApply(CeedQFunction qf, CeedInt Q,
   @ref Advanced
 **/
 
-int CeedQFunctionGetFields(CeedQFunction qf,
-                           CeedQFunctionField* *inputfields,
-                           CeedQFunctionField* *outputfields) {
+int CeedQFunctionGetFields(CeedQFunction qf, CeedQFunctionField **inputfields,
+                           CeedQFunctionField **outputfields) {
   if (inputfields)
     *inputfields = qf->inputfields;
   if (outputfields)
@@ -579,8 +577,7 @@ int CeedQFunctionGetFields(CeedQFunction qf,
   @ref Advanced
 **/
 
-int CeedQFunctionFieldGetName(CeedQFunctionField qffield,
-                              char* *fieldname) {
+int CeedQFunctionFieldGetName(CeedQFunctionField qffield, char **fieldname) {
   *fieldname = (char *)qffield->fieldname;
   return 0;
 }

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -124,7 +124,7 @@ int CeedTensorContractGetCeed(CeedTensorContract contract, Ceed *ceed) {
 
   @ref Advanced
 **/
-int CeedTensorContractGetData(CeedTensorContract contract, void* *data) {
+int CeedTensorContractGetData(CeedTensorContract contract, void **data) {
   *data = contract->data;
   return 0;
 }
@@ -139,7 +139,7 @@ int CeedTensorContractGetData(CeedTensorContract contract, void* *data) {
 
   @ref Advanced
 **/
-int CeedTensorContractSetData(CeedTensorContract contract, void* *data) {
+int CeedTensorContractSetData(CeedTensorContract contract, void **data) {
   contract->data = *data;
   return 0;
 }

--- a/interface/ceed-vec.c
+++ b/interface/ceed-vec.c
@@ -366,7 +366,7 @@ int CeedVectorGetState(CeedVector vec, uint64_t *state) {
 
   @ref Advanced
 **/
-int CeedVectorGetData(CeedVector vec, void* *data) {
+int CeedVectorGetData(CeedVector vec, void **data) {
   *data = vec->data;
   return 0;
 }
@@ -381,7 +381,7 @@ int CeedVectorGetData(CeedVector vec, void* *data) {
 
   @ref Advanced
 **/
-int CeedVectorSetData(CeedVector vec, void* *data) {
+int CeedVectorSetData(CeedVector vec, void **data) {
   vec->data = *data;
   return 0;
 }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -405,6 +405,13 @@ int CeedInit(const char *resource, Ceed *ceed) {
   // Backend specific setup
   ierr = backends[matchidx].init(resource, *ceed); CeedChk(ierr);
 
+  // Copy resource prefix, if backend setup sucessful
+  size_t len = strlen(backends[matchidx].prefix);
+  char *tmp;
+  ierr = CeedCalloc(len+1, &tmp); CeedChk(ierr);
+  memcpy(tmp, backends[matchidx].prefix, len+1);
+  (*ceed)->resource = tmp;
+
   return 0;
 }
 
@@ -637,6 +644,22 @@ int CeedSetData(Ceed ceed, void* *data) {
 }
 
 /**
+  @brief Get the full resource name for a CEED
+
+  @param ceed            Ceed to get resource name of
+  @param[out] resource   Variable to store resource name
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Basic
+**/
+
+int CeedGetResource(Ceed ceed, const char **resource) {
+  *resource = (const char *)ceed->resource;
+  return 0;
+}
+
+/**
   @brief Destroy a Ceed context
 
   @param ceed Address of Ceed context to destroy
@@ -664,6 +687,7 @@ int CeedDestroy(Ceed *ceed) {
     ierr = (*ceed)->Destroy(*ceed); CeedChk(ierr);
   }
   ierr = CeedFree(&(*ceed)->foffsets); CeedChk(ierr);
+  ierr = CeedFree(&(*ceed)->resource); CeedChk(ierr);
   ierr = CeedFree(ceed); CeedChk(ierr);
   return 0;
 }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -154,9 +154,8 @@ int CeedErrorAbort(Ceed ceed, const char *filename, int lineno,
 
   @ref Developer
 **/
-int CeedErrorExit(Ceed ceed, const char *filename, int lineno,
-                  const char *func, int ecode,
-                  const char *format, va_list args) {
+int CeedErrorExit(Ceed ceed, const char *filename, int lineno, const char *func,
+                  int ecode, const char *format, va_list args) {
   fprintf(stderr, "%s:%d in %s(): ", filename, lineno, func);
   vfprintf(stderr, format, args);
   fprintf(stderr, "\n");
@@ -195,8 +194,8 @@ int CeedSetErrorHandler(Ceed ceed,
 
   @ref Advanced
 **/
-int CeedRegister(const char *prefix,
-                 int (*init)(const char *, Ceed), unsigned int priority) {
+int CeedRegister(const char *prefix, int (*init)(const char *, Ceed),
+                 unsigned int priority) {
   if (num_backends >= sizeof(backends) / sizeof(backends[0]))
     // LCOV_EXCL_START
     return CeedError(NULL, 1, "Too many backends");
@@ -587,8 +586,7 @@ int CeedGetPreferredMemType(Ceed ceed, CeedMemType *type) {
 
   @ref Advanced
 **/
-int CeedSetBackendFunction(Ceed ceed,
-                           const char *type, void *object,
+int CeedSetBackendFunction(Ceed ceed, const char *type, void *object,
                            const char *fname, int (*f)()) {
   char lookupname[CEED_MAX_RESOURCE_LEN+1] = "";
 
@@ -602,7 +600,7 @@ int CeedSetBackendFunction(Ceed ceed,
   for (CeedInt i = 0; ceed->foffsets[i].fname; i++)
     if (!strcmp(ceed->foffsets[i].fname, lookupname)) {
       size_t offset = ceed->foffsets[i].offset;
-      int (**fpointer)(void) = (int (* *)(void))((char *)object + offset);
+      int (**fpointer)(void) = (int (**)(void))((char *)object + offset);
       *fpointer = f;
       return 0;
     }
@@ -623,7 +621,7 @@ int CeedSetBackendFunction(Ceed ceed,
 
   @ref Advanced
 **/
-int CeedGetData(Ceed ceed, void* *data) {
+int CeedGetData(Ceed ceed, void **data) {
   *data = ceed->data;
   return 0;
 }
@@ -638,7 +636,7 @@ int CeedGetData(Ceed ceed, void* *data) {
 
   @ref Advanced
 **/
-int CeedSetData(Ceed ceed, void* *data) {
+int CeedSetData(Ceed ceed, void **data) {
   ceed->data = *data;
   return 0;
 }

--- a/tests/t002-ceed.c
+++ b/tests/t002-ceed.c
@@ -1,0 +1,22 @@
+/// @file
+/// Test return of a CEED object full resource name
+/// \test Test return of a CEED object full resource name
+#include <string.h>
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  const char *resource;
+
+  CeedInit(argv[1], &ceed);
+
+  CeedGetResource(ceed, &resource);
+  if (strcmp(resource, argv[1]))
+    // LCOV_EXCL_START
+    return CeedError(ceed, 1, "Incorrect full resource name: %s != %s",
+                     resource, argv[1]);
+  // LCOV_EXCL_STOP
+
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
When the user specifies `/cpu/self` or `/gpu`, we should support a way to tell the user what backend is being used.

I didn't implement in Fortran and add a Fortran test because I didn't really want to fiddle with passing strings between C and F77, but I can work on it if it is desirable.