### PR TITLE
Travis - COVERAGE=1 only for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ install:
   - export PETSC_DIR=$PETSC_INSTALL
 
 script:
-  - export COVERAGE=1
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        export COVERAGE=1;
+    fi
   - make -j2
   - make -j2 prove-all PROVE_OPTS=-v
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
I think Travis OSX is not playing nice with some homebrew updates. I think this gets around the issue. (We aren't running codecov on OSX anyways for speed.)

I'll flag folks for review once Travis comes back good.