### PR TITLE
Makefile - move --no-as-needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,9 +299,9 @@ ifneq ($(wildcard $(XSMM_DIR)/lib/libxsmm.*),)
     BLAS_LIB = -lblas
   else
     ifneq ($(MKLROOT),)
-      MKL_LINK = -L$(MKLROOT)/lib/intel64 -Wl,-rpath,$(MKLROOT)/lib/intel64 -Wl,--no-as-needed
+      MKL_LINK = -L$(MKLROOT)/lib/intel64 -Wl,-rpath,$(MKLROOT)/lib/intel64
     endif
-    BLAS_LIB = $(MKL_LINK) -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
+    BLAS_LIB = $(MKL_LINK) -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
   endif
   $(libceeds) : LDLIBS += $(BLAS_LIB)
   libceed.c += $(xsmm.c)


### PR DESCRIPTION
I might be doing something dumb, but on CU's machine with GCC:

BLAS
```
$ make MKLROOT= print-BLAS_LIB
[ variable name]: BLAS_LIB
[        origin]: file
[         value]: -lblas
[expanded value]: -lblas
```
MKL
```
$ make print-BLAS_LIB
[ variable name]: BLAS_LIB
[        origin]: file
[         value]: $(MKL_LINK)--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
[expanded value]: -L/curc/sw/intel/16.0.3/mkl/lib/intel64 -Wl,-rpath,/curc/sw/intel/16.0.3/mkl/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
```
MKL no MKLROOT
```
$ make MKLROOT= print-BLAS_LIB MKL=1
[ variable name]: BLAS_LIB
[        origin]: file
[         value]: $(MKL_LINK)--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
[expanded value]: --no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
```

When I try to build with MKL but no MKL root (expecting linking error, but get this instead)

GCC 6.1:
```
$ make MKLROOT= MKL=1 lib
make: 'lib' with optional backends: /cpu/self/avx/serial /cpu/self/avx/blocked /cpu/self/xsmm/serial /cpu/self/xsmm/blocked
...
        LINK lib/libceed.so
gcc: error: unrecognized command line option ‘--no-as-needed’; did you mean ‘--no-assert’?
make: *** [lib/libceed.so] Error 1
```

Intel 17.4:
```
$ make MKLROOT= MKL=1 lib
make: 'lib' with optional backends: /cpu/self/xsmm/serial /cpu/self/xsmm/blocked
...
        LINK lib/libceed.so
icc: command line warning #10006: ignoring unknown option '-fno-as-needed'
ld: cannot find -lmkl_intel_lp64
ld: cannot find -lmkl_sequential
ld: cannot find -lmkl_core
make: *** [lib/libceed.so] Error 1
```
(expected behavior, though Intel is also ignoring `no-as-needed`)

In both cases, the build is fine when `MKLROOT` is defined.