### PR TITLE
Tests - relax t412 tolerence and small style changes

### DIFF
--- a/tests/t411-qfunction.c
+++ b/tests/t411-qfunction.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
 
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
   for (CeedInt i=0; i<Q; i++)
-    if (fabs(v[i] - u[i])>1E-14)
+    if (fabs(v[i] - u[i])>1e-14)
       // LCOV_EXCL_START
       printf("[%d] v %f != u %f\n",i, v[i], u[i]);
   // LCOV_EXCL_STOP

--- a/tests/t412-qfunction-f.f90
+++ b/tests/t412-qfunction-f.f90
@@ -38,7 +38,7 @@
 
       call ceedvectorgetarrayread(v,ceed_mem_host,vv,voffset,err)
       do i=1,q*s
-        if (abs(vv(i+voffset)-(i-1)*(i-1)) > 1.0D-14) then
+        if (abs(vv(i+voffset)-(i-1)*(i-1)) > 1.0D-12) then
 ! LCOV_EXCL_START
           write(*,*) 'v(i)=',vv(i+voffset),', u(i)=',(i-1)*(i-1)
 ! LCOV_EXCL_STOP

--- a/tests/t412-qfunction.c
+++ b/tests/t412-qfunction.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
 
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
   for (CeedInt i=0; i<Q*size; i++)
-    if (fabs(v[i] - u[i])>1E-14)
+    if (fabs(v[i] - u[i])>1e-12)
       // LCOV_EXCL_START
       printf("[%d] v %f != u %f\n",i, v[i], u[i]);
   // LCOV_EXCL_STOP

--- a/tests/t530-operator.c
+++ b/tests/t530-operator.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
   CeedVectorGetArrayRead(A, CEED_MEM_HOST, &a);
   CeedVectorGetArrayRead(qdata, CEED_MEM_HOST, &q);
   for (CeedInt i=0; i<nqpts; i++)
-    if (fabs(q[i] - a[i]) > 1E-9)
+    if (fabs(q[i] - a[i]) > 1e-9)
       // LCOV_EXCL_START
       printf("Error: A[%d] = %f != %f\n", i, a[i], q[i]);
   // LCOV_EXCL_STOP
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ndofs; i++)
     area += vv[i];
   CeedVectorRestoreArrayRead(v, &vv);
-  if (fabs(area - 1.0) > 1E-14)
+  if (fabs(area - 1.0) > 1e-14)
     // LCOV_EXCL_START
     printf("Error: True operator computed area = %f != 1.0\n", area);
   // LCOV_EXCL_STOP
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ndofs; i++)
     area += vv[i];
   CeedVectorRestoreArrayRead(v, &vv);
-  if (fabs(area - 1.0) > 1E-10)
+  if (fabs(area - 1.0) > 1e-10)
     // LCOV_EXCL_START
     printf("Error: Linearized operator computed area = %f != 1.0\n", area);
   // LCOV_EXCL_STOP

--- a/tests/t531-operator.c
+++ b/tests/t531-operator.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
   const CeedScalar *vv;
   CeedVectorGetArrayRead(v, CEED_MEM_HOST, &vv);
   for (CeedInt i=0; i<ndofs; i++)
-    if (fabs(vv[i]) > 1E-14)
+    if (fabs(vv[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("Error: Operator computed v[i] = %f != 0.0\n", vv[i]);
   // LCOV_EXCL_STOP
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
   // Check output
   CeedVectorGetArrayRead(v, CEED_MEM_HOST, &vv);
   for (CeedInt i=0; i<ndofs; i++)
-    if (fabs(vv[i]) > 1E-14)
+    if (fabs(vv[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("Error: Linerized operator computed v[i] = %f != 0.0\n", vv[i]);
   // LCOV_EXCL_STOP

--- a/tests/t532-operator.c
+++ b/tests/t532-operator.c
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ndofs; i++)
     area += vv[i];
   CeedVectorRestoreArrayRead(v, &vv);
-  if (fabs(area - 1.0) > 1E-14)
+  if (fabs(area - 1.0) > 1e-14)
     // LCOV_EXCL_START
     printf("Error: True operator computed area = %f != 1.0\n", area);
   // LCOV_EXCL_STOP
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ndofs; i++)
     area += vv[i];
   CeedVectorRestoreArrayRead(v, &vv);
-  if (fabs(area - 1.0) > 1E-14)
+  if (fabs(area - 1.0) > 1e-14)
     // LCOV_EXCL_START
     printf("Error: Assembled operator computed area = %f != 1.0\n", area);
   // LCOV_EXCL_STOP

--- a/tests/t533-operator.c
+++ b/tests/t533-operator.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
   // Check output
   CeedVectorGetArrayRead(A, CEED_MEM_HOST, &a);
   for (int i=0; i<ndofs; i++)
-    if (fabs(a[i] - assembledTrue[i]) > 1E-14)
+    if (fabs(a[i] - assembledTrue[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP

--- a/tests/t534-operator.c
+++ b/tests/t534-operator.c
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
   // Check output
   CeedVectorGetArrayRead(A, CEED_MEM_HOST, &a);
   for (int i=0; i<ndofs; i++)
-    if (fabs(a[i] - assembledTrue[i]) > 1E-14)
+    if (fabs(a[i] - assembledTrue[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP

--- a/tests/t535-operator.c
+++ b/tests/t535-operator.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
   // Check output
   CeedVectorGetArrayRead(A, CEED_MEM_HOST, &a);
   for (int i=0; i<ndofs; i++)
-    if (fabs(a[i] - assembledTrue[i]) > 1E-14)
+    if (fabs(a[i] - assembledTrue[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP

--- a/tests/t536-operator.c
+++ b/tests/t536-operator.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
   // Check output
   CeedVectorGetArrayRead(A, CEED_MEM_HOST, &a);
   for (int i=0; i<ndofs; i++)
-    if (fabs(a[i] - assembledTrue[i]) > 1E-14)
+    if (fabs(a[i] - assembledTrue[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP


### PR DESCRIPTION
I relaxed the absolute tolerance. All of our tests use an absolute tolerance, so I left this one absolute to match.

I added a style fix too - I feel like perhaps we're at a point where we want to do less style churn soon? I really need to get on #396 so we can use `make style` without manual fixes.