### PR TITLE
Delegate AssembleLinearQF to ref/serial when not impl

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -165,13 +165,6 @@ static int CeedOperatorApply_Cuda_gen(CeedOperator op, CeedVector invec,
   return 0;
 }
 
-static int CeedOperatorAssembleLinearQFunction_Cuda_gen(CeedOperator op) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  return CeedError(ceed, 1, "Backend does not implement QFunction assembly");
-}
-
 int CeedOperatorCreate_Cuda_gen(CeedOperator op) {
   int ierr;
   Ceed ceed;
@@ -181,9 +174,6 @@ int CeedOperatorCreate_Cuda_gen(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl);
 
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
-                                CeedOperatorAssembleLinearQFunction_Cuda_gen);
-  CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Cuda_gen); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -367,13 +367,6 @@ static int CeedOperatorApply_Cuda(CeedOperator op, CeedVector invec,
   return 0;
 }
 
-static int CeedOperatorAssembleLinearQFunction_Cuda(CeedOperator op) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  return CeedError(ceed, 1, "Backend does not implement QFunction assembly");
-}
-
 int CeedOperatorCreate_Cuda(CeedOperator op) {
   int ierr;
   Ceed ceed;
@@ -383,9 +376,6 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl);
 
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
-                                CeedOperatorAssembleLinearQFunction_Cuda);
-  CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Cuda); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -531,17 +531,6 @@ static int CeedOperatorApply_Occa(CeedOperator op,
 }
 
 // *****************************************************************************
-// * Assemble a linear QFunction
-// *****************************************************************************
-int CeedOperatorAssembleLinearQFunction_Occa(CeedOperator op,
-    CeedVector assembled, CeedElemRestriction *rstr, CeedRequest *request) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  return CeedError(ceed, 1, "Backend does not implement assembling QFunctions");
-}
-
-// *****************************************************************************
 // * Create an operator
 // *****************************************************************************
 int CeedOperatorCreate_Occa(CeedOperator op) {
@@ -554,9 +543,6 @@ int CeedOperatorCreate_Occa(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
 
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
-                                CeedOperatorAssembleLinearQFunction_Occa);
-  CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
                                 CeedOperatorApply_Occa); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",

--- a/backends/occa/ceed-occa-restrict.okl
+++ b/backends/occa/ceed-occa-restrict.okl
@@ -61,7 +61,7 @@
   for (int i=0; i<nnodes; i++; @tile(TILE_SIZE,@outer,@inner)){
     const int rng1 = toffsets[i];
     const int rngN = toffsets[i+1];
-    double value = 0.0;
+    double value = vv[i];
     for (int j=rng1; j<rngN; ++j){
       const int tid = tindices[j];
       value += uu[tid];
@@ -80,7 +80,7 @@
     const int rng1 = toffsets[i];
     const int rngN = toffsets[i+1];
     for (int d = 0; d < ncomp; ++d) {
-      double value = 0.0;
+      double value = vv[d*nnodes+i];
       for (int j=rng1; j<rngN; ++j) {
         int n = tindices[j] % elemsize;
         int e = tindices[j] / elemsize;
@@ -101,7 +101,7 @@
     const int rng1 = toffsets[i];
     const int rngN = toffsets[i+1];
     for (int d = 0; d < ncomp; ++d) {
-      double value = 0.0;
+      double value = vv[d+i*ncomp];
       for (int j=rng1; j<rngN; ++j) {
         int n = tindices[j] % elemsize;
         int e = tindices[j] / elemsize;

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -576,7 +576,7 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   CeedScalar *a, *tmp;
   Ceed ceed, ceedparent;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  ierr = CeedOperatorFallbackGetParentCeed(op, &ceedparent); CeedChk(ierr);
+  ierr = CeedGetOperatorFallbackParentCeed(ceed, &ceedparent); CeedChk(ierr);
   ceedparent = ceedparent ? ceedparent : ceed;
 
   // Setup

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -574,8 +574,10 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   CeedInt numactivein = 0, numactiveout = 0;
   CeedVector *activein = NULL;
   CeedScalar *a, *tmp;
-  Ceed ceed;
+  Ceed ceed, ceedparent;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  ierr = CeedOperatorFallbackGetParentCeed(op, &ceedparent); CeedChk(ierr);
+  ceedparent = ceedparent ? ceedparent : ceed;
 
   // Setup
   ierr = CeedOperatorSetup_Ref(op); CeedChk(ierr);
@@ -633,10 +635,10 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   // LCOV_EXCL_STOP
 
   // Create output restriction
-  ierr = CeedElemRestrictionCreateIdentity(ceed, numelements, Q,
+  ierr = CeedElemRestrictionCreateIdentity(ceedparent, numelements, Q,
          numelements*Q, numactivein*numactiveout, rstr); CeedChk(ierr);
   // Create assembled vector
-  ierr = CeedVectorCreate(ceed, numelements*Q*numactivein*numactiveout,
+  ierr = CeedVectorCreate(ceedparent, numelements*Q*numactivein*numactiveout,
                           assembled); CeedChk(ierr);
   ierr = CeedVectorSetValue(*assembled, 0.0); CeedChk(ierr);
   ierr = CeedVectorGetArray(*assembled, CEED_MEM_HOST, &a); CeedChk(ierr);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -183,6 +183,7 @@ CEED_EXTERN int CeedOperatorGetFallbackResource(CeedOperator op,
     const char **resource);
 CEED_EXTERN int CeedOperatorSetFallbackResource(CeedOperator op,
     const char *resource);
+CEED_EXTERN int CeedOperatorFallbackGetParentCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -179,6 +179,10 @@ CEED_EXTERN int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf);
 CEED_EXTERN int CeedOperatorGetNumSub(CeedOperator op, CeedInt *numsub);
 CEED_EXTERN int CeedOperatorGetSubList(CeedOperator op,
                                        CeedOperator **suboperators);
+CEED_EXTERN int CeedOperatorGetFallbackResource(CeedOperator op,
+    const char **resource);
+CEED_EXTERN int CeedOperatorSetFallbackResource(CeedOperator op,
+    const char *resource);
 CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -65,6 +65,11 @@ CEED_EXTERN int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate,
                                       const char *objname);
 CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed delegate,
                                       const char *objname);
+CEED_EXTERN int CeedGetOperatorFallbackResource(Ceed ceed,
+    const char **resource);
+CEED_EXTERN int CeedSetOperatorFallbackResource(Ceed ceed,
+    const char *resource);
+CEED_EXTERN int CeedGetOperatorFallbackParentCeed(Ceed ceed, Ceed *parent);
 CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
                                        const char *type, void *object,
                                        const char *fname, int (*f)());
@@ -179,11 +184,6 @@ CEED_EXTERN int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf);
 CEED_EXTERN int CeedOperatorGetNumSub(CeedOperator op, CeedInt *numsub);
 CEED_EXTERN int CeedOperatorGetSubList(CeedOperator op,
                                        CeedOperator **suboperators);
-CEED_EXTERN int CeedOperatorGetFallbackResource(CeedOperator op,
-    const char **resource);
-CEED_EXTERN int CeedOperatorSetFallbackResource(CeedOperator op,
-    const char *resource);
-CEED_EXTERN int CeedOperatorFallbackGetParentCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void **data);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -201,7 +201,7 @@ struct CeedOperatorField_private {
 };
 
 struct CeedOperator_private {
-  Ceed ceed, fallbackceed;
+  Ceed ceed, fallbackceed, parentceed;
   const char *fallbackresource;
   CeedOperator fallback;
   CeedQFunction qffallback;

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -48,6 +48,8 @@ struct Ceed_private {
   Ceed parent;
   objdelegate *objdelegates;
   int objdelegatecount;
+  Ceed opfallbackceed, opfallbackparent;
+  const char *opfallbackresource;
   int (*Error)(Ceed, const char *, int, const char *, int, const char *,
                va_list);
   int (*GetPreferredMemType)(CeedMemType *);
@@ -201,9 +203,8 @@ struct CeedOperatorField_private {
 };
 
 struct CeedOperator_private {
-  Ceed ceed, fallbackceed, parentceed;
-  const char *fallbackresource;
-  CeedOperator fallback;
+  Ceed ceed;
+  CeedOperator opfallback;
   CeedQFunction qffallback;
   int refcount;
   int (*AssembleLinearQFunction)(CeedOperator, CeedVector *,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -201,7 +201,10 @@ struct CeedOperatorField_private {
 };
 
 struct CeedOperator_private {
-  Ceed ceed;
+  Ceed ceed, fallbackceed;
+  const char *fallbackresource;
+  CeedOperator fallback;
+  CeedQFunction qffallback;
   int refcount;
   int (*AssembleLinearQFunction)(CeedOperator, CeedVector *,
                                  CeedElemRestriction *, CeedRequest *);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -262,10 +262,18 @@ int CeedOperatorCreateFallback(CeedOperator op) {
   int ierr;
 
   // Fallback Ceed
-  const char *resource;
-  ierr = CeedGetOperatorFallbackResource(op->ceed, &resource);
+  const char *resource, *fallbackresource;
+  ierr = CeedGetResource(op->ceed, &resource); CeedChk(ierr);
+  ierr = CeedGetOperatorFallbackResource(op->ceed, &fallbackresource);
+  CeedChk(ierr);
+  if (!strcmp(resource, fallbackresource))
+    // LCOV_EXCL_START
+    return CeedError(op->ceed, 1, "Backend %s cannot create an operator"
+                     "fallback to resource %s", resource, fallbackresource);
+  // LCOV_EXCL_STOP
+
   Ceed ceedref;
-  ierr = CeedInit(resource, &ceedref); CeedChk(ierr);
+  ierr = CeedInit(fallbackresource, &ceedref); CeedChk(ierr);
   ceedref->opfallbackparent = op->ceed;
   op->ceed->opfallbackceed = ceedref;
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -344,7 +344,7 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
                               (CeedScalar *)vecarray); CeedChk(ierr);
     ierr = CeedVectorRestoreArrayRead(vecref, &vecarray); CeedChk(ierr);
     ierr = CeedElemRestrictionCreateIdentity(ceed, rstrref->nelem,
-         rstrref->elemsize, rstrref->nnodes, rstrref->ncomp, rstr);
+           rstrref->elemsize, rstrref->nnodes, rstrref->ncomp, rstr);
     CeedChk(ierr);
 
     // Cleanup

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -249,7 +249,7 @@ int CeedCompositeOperatorAddSub(CeedOperator compositeop, CeedOperator subop) {
 }
 
 /**
-  @brief Duplicate a CeedOperator with a refrence Ceed to fallback for advanced
+  @brief Duplicate a CeedOperator with a reference Ceed to fallback for advanced
            CeedOperator functionality
 
   @param op           CeedOperator to create fallback for

--- a/tests/t532-operator.h
+++ b/tests/t532-operator.h
@@ -59,7 +59,7 @@ CEED_QFUNCTION(apply)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
                       CeedScalar *const *out) {
   // in[0] is gradient u, shape [2, nc=1, Q]
   // in[1] is mass quadrature data, size (Q)
-  // in[2] is Poisson quadrature data, size (Q)
+  // in[2] is Poisson quadrature data, size (3*Q)
   // in[3] is u, size (Q)
   const CeedScalar *du = in[0], *qd_mass = in[1], *qd_diff = in[2], *u = in[3];
 
@@ -85,7 +85,7 @@ CEED_QFUNCTION(apply_lin)(void *ctx, const CeedInt Q,
                           const CeedScalar *const *in,
                           CeedScalar *const *out) {
   // in[0] is gradient u, shape [2, nc=1, Q]
-  // in[1] is mass quadrature data, size (9*Q)
+  // in[1] is assembled quadrature data, size (9*Q)
   // in[2] is u, size (Q)
   const CeedScalar *du = in[0], *qd = in[1], *u = in[2];
 

--- a/tests/t532-operator.okl
+++ b/tests/t532-operator.okl
@@ -93,10 +93,10 @@ typedef double CeedScalar;
     const CeedScalar ug0 = in[iOf7[0]+i+Q*0];
     const CeedScalar ug1 = in[iOf7[0]+i+Q*1];
     out[oOf7[0]+i] = in[iOf7[1]+i+Q*0]*ug0 + in[iOf7[1]+i+Q*3]*ug1 +
-                     in[iOf7[1]+i+Q*6]*in[iOf7[3]+i];
+                     in[iOf7[1]+i+Q*6]*in[iOf7[2]+i];
     out[oOf7[1]+i+Q*0] = in[iOf7[1]+i+Q*1]*ug0 + in[iOf7[1]+i+Q*4]*ug1 +
-                         in[iOf7[1]+i+Q*7]*in[iOf7[3]+i];
+                         in[iOf7[1]+i+Q*7]*in[iOf7[2]+i];
     out[oOf7[1]+i+Q*1] = in[iOf7[1]+i+Q*2]*ug0 + in[iOf7[1]+i+Q*5]*ug1 +
-                         in[iOf7[1]+i+Q*8]*in[iOf7[3]+i];
+                         in[iOf7[1]+i+Q*8]*in[iOf7[2]+i];
   }
 }

--- a/tests/t534-operator-f.f90
+++ b/tests/t534-operator-f.f90
@@ -30,8 +30,8 @@
       do i=1,q
         du0=u1(i+q*0)
         du1=u1(i+q*1)
-        v1(i+q*0)=u2(i+q*0)*du0+u2(i+q*1)*du1
-        v1(i+q*1)=u2(i+q*1)*du0+u2(i+q*2)*du1
+        v1(i+q*0)=u2(i+q*0)*du0+u2(i+q*2)*du1
+        v1(i+q*1)=u2(i+q*2)*du0+u2(i+q*1)*du1
       enddo
 
       ierr=0


### PR DESCRIPTION
This provides `AssembleLinearQF` to the GPU backends via `/cpu/self/ref/serial` so we can do diag based preconditioning for the GPU backends soon. I'll refactor `AssembleLinearDiag` downstream of this.

I also fixed an OCCA backend bug where they did not support multiple operator fields writing into the same output vector.