### PR TITLE
Travis - use xcode11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 
 dist: xenial
 
-osx_image: xcode10.2
+osx_image: xcode11.2
 
 compiler:
   - gcc


### PR DESCRIPTION
Homebrew updating has been slowing down our Travis OSX builds by ~6 minutes. Switching to a newer OSX image helps fix this.