### PR TITLE
Add CeedOperatorApplyAdd

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -512,20 +512,6 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
     CeedChk(ierr);
   }
 
-  // Zero lvecs
-  for (CeedInt i=0; i<numoutputfields; i++) {
-    ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE) {
-      if (!impl->add) {
-        vec = outvec;
-        ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-      }
-    } else {
-      ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-    }
-  }
-  impl->add = false;
-
   // Output restriction
   for (CeedInt i=0; i<numoutputfields; i++) {
     // Restore evec
@@ -732,7 +718,7 @@ int CeedOperatorCreate_Blocked(CeedOperator op) {
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
                                 CeedOperatorAssembleLinearQFunction_Blocked);
   CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                 CeedOperatorApply_Blocked); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Blocked); CeedChk(ierr);

--- a/backends/blocked/ceed-blocked.h
+++ b/backends/blocked/ceed-blocked.h
@@ -22,7 +22,6 @@ typedef struct {
 } CeedBasis_Blocked;
 
 typedef struct {
-  bool add;
   bool identityqf;
   CeedElemRestriction *blkrestr; /// Blocked versions of restrictions
   CeedVector

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -28,8 +28,8 @@ static int CeedOperatorDestroy_Cuda_gen(CeedOperator op) {
   return 0;
 }
 
-static int CeedOperatorApply_Cuda_gen(CeedOperator op, CeedVector invec,
-                                      CeedVector outvec, CeedRequest *request) {
+static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
+                                         CeedVector outvec, CeedRequest *request) {
   int ierr;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
@@ -54,14 +54,6 @@ static int CeedOperatorApply_Cuda_gen(CeedOperator op, CeedVector invec,
 
   //Creation of the operator
   ierr = CeedCudaGenOperatorBuild(op); CeedChk(ierr);
-
-  // Zero lvecs
-  for (CeedInt i = 0; i < numoutputfields; i++) {
-    ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE)
-      vec = outvec;
-    ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-  }
 
   // Input vectors
   for (CeedInt i = 0; i < numinputfields; i++) {
@@ -174,8 +166,8 @@ int CeedOperatorCreate_Cuda_gen(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl);
 
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
-                                CeedOperatorApply_Cuda_gen); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
+                                CeedOperatorApplyAdd_Cuda_gen); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Cuda_gen); CeedChk(ierr);
   return 0;

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -157,6 +157,13 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
   return 0;
 }
 
+static int CeedOperatorAssembleLinearQFunction_Cuda(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement QFunction assembly");
+}
+
 int CeedOperatorCreate_Cuda_gen(CeedOperator op) {
   int ierr;
   Ceed ceed;
@@ -166,16 +173,12 @@ int CeedOperatorCreate_Cuda_gen(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl);
 
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
+                                CeedOperatorAssembleLinearQFunction_Cuda);
+  CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                 CeedOperatorApplyAdd_Cuda_gen); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Cuda_gen); CeedChk(ierr);
   return 0;
-}
-
-int CeedCompositeOperatorCreate_Cuda_gen(CeedOperator op) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  return CeedError(ceed, 1, "Backend does not implement composite operators");
 }

--- a/backends/cuda-gen/ceed-cuda-gen.c
+++ b/backends/cuda-gen/ceed-cuda-gen.c
@@ -53,9 +53,6 @@ static int CeedInit_Cuda_gen(const char *resource, Ceed ceed) {
                                 CeedQFunctionCreate_Cuda_gen); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Cuda_gen); CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "CompositeOperatorCreate",
-                                CeedCompositeOperatorCreate_Cuda_gen);
-  CeedChk(ierr);
   return 0;
 }
 

--- a/backends/cuda-reg/ceed-cuda-reg-restriction.c
+++ b/backends/cuda-reg/ceed-cuda-reg-restriction.c
@@ -67,8 +67,8 @@ extern "C" __global__ void noTrNoTrInterleaved(const CeedInt nelem,
       for (CeedInt node = 0; node < RESTRICTION_ELEMSIZE; ++node) {
         const CeedInt ind = indices[e * RESTRICTION_ELEMSIZE + node];
         for(CeedInt d = 0; d < RESTRICTION_NCOMP; ++d) {
-          v[tid + node*32 + bid*32*RESTRICTION_ELEMSIZE + d*esize] = u[ind +
-              RESTRICTION_NNODES * d]; // TODO: make sure at least 32 elements
+          v[tid + node*32 + bid*32*RESTRICTION_ELEMSIZE + d*esize] = 
+            u[ind + RESTRICTION_NNODES * d]; // TODO: make sure at least 32 elements
         }
       }
     }
@@ -175,7 +175,7 @@ extern "C" __global__ void trNoTr(const CeedInt *__restrict__ tindices,
         value[d] += u[(e*RESTRICTION_NCOMP + d)*RESTRICTION_ELEMSIZE + n];
     }
     for (CeedInt d = 0; d < RESTRICTION_NCOMP; ++d)
-      v[d*RESTRICTION_NNODES+i] = value[d];
+      v[d*RESTRICTION_NNODES+i] += value[d];
   }
 }
 
@@ -199,7 +199,7 @@ extern "C" __global__ void trTr(const CeedInt *__restrict__ tindices,
         value[d] += u[(e*RESTRICTION_NCOMP + d)*RESTRICTION_ELEMSIZE + n];
     }
     for (int d = 0; d < RESTRICTION_NCOMP; ++d)
-      v[d+RESTRICTION_NCOMP*i] = value[d];
+      v[d+RESTRICTION_NCOMP*i] += value[d];
   }
 }
 
@@ -212,7 +212,7 @@ extern "C" __global__ void trNoTrIdentity(const CeedInt nelem,
     const CeedInt d = (i / RESTRICTION_ELEMSIZE) % RESTRICTION_NCOMP;
     const CeedInt s = i % RESTRICTION_ELEMSIZE;
 
-    v[s + RESTRICTION_ELEMSIZE * e + RESTRICTION_NNODES * d] = u[i];
+    v[s + RESTRICTION_ELEMSIZE * e + RESTRICTION_NNODES * d] += u[i];
   }
 }
 
@@ -226,7 +226,7 @@ extern "C" __global__ void trTrIdentity(const CeedInt nelem,
     const CeedInt d = (i / RESTRICTION_ELEMSIZE) % RESTRICTION_NCOMP;
     const CeedInt s = i % RESTRICTION_ELEMSIZE;
 
-    v [ RESTRICTION_NCOMP * (s + RESTRICTION_ELEMSIZE * e) + d ] = u[i];
+    v [ RESTRICTION_NCOMP * (s + RESTRICTION_ELEMSIZE * e) + d ] += u[i];
   }
 }
 

--- a/backends/cuda-reg/ceed-cuda-reg.c
+++ b/backends/cuda-reg/ceed-cuda-reg.c
@@ -50,7 +50,8 @@ static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
                                 CeedElemRestrictionCreate_Cuda_reg); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed,
                                 "ElemRestrictionCreateBlocked",
-                                CeedElemRestrictionCreateBlocked_Cuda_reg); CeedChk(ierr);
+                                CeedElemRestrictionCreateBlocked_Cuda_reg);
+  CeedChk(ierr);
   return 0;
 }
 

--- a/backends/cuda-shared/ceed-cuda-shared.c
+++ b/backends/cuda-shared/ceed-cuda-shared.c
@@ -43,7 +43,8 @@ static int CeedInit_Cuda_shared(const char *resource, Ceed ceed) {
 
   ierr = CeedSetData(ceed,(void *)&data); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
-                                CeedBasisCreateTensorH1_Cuda_shared); CeedChk(ierr);
+                                CeedBasisCreateTensorH1_Cuda_shared);
+  CeedChk(ierr);
   return 0;
 }
 

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -359,6 +359,13 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
   return 0;
 }
 
+static int CeedOperatorAssembleLinearQFunction_Cuda(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement QFunction assembly");
+}
+
 int CeedOperatorCreate_Cuda(CeedOperator op) {
   int ierr;
   Ceed ceed;
@@ -368,16 +375,12 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl);
 
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
+                                CeedOperatorAssembleLinearQFunction_Cuda);
+  CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                 CeedOperatorApplyAdd_Cuda); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Cuda); CeedChk(ierr);
   return 0;
-}
-
-int CeedCompositeOperatorCreate_Cuda(CeedOperator op) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  return CeedError(ceed, 1, "Backend does not implement composite operators");
 }

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -172,8 +172,8 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
   return 0;
 }
 
-static int CeedOperatorApply_Cuda(CeedOperator op, CeedVector invec,
-                                  CeedVector outvec, CeedRequest *request) {
+static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
+                                     CeedVector outvec, CeedRequest *request) {
   int ierr;
   CeedOperator_Cuda *impl;
   ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
@@ -320,14 +320,6 @@ static int CeedOperatorApply_Cuda(CeedOperator op, CeedVector invec,
     }
   }
 
-  // Zero lvecs
-  for (CeedInt i = 0; i < numoutputfields; i++) {
-    ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE)
-      vec = outvec;
-    ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-  }
-
   // Output restriction
   for (CeedInt i = 0; i < numoutputfields; i++) {
     // Restore evec
@@ -376,8 +368,8 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl);
 
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
-                                CeedOperatorApply_Cuda); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
+                                CeedOperatorApplyAdd_Cuda); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Cuda); CeedChk(ierr);
   return 0;

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -166,13 +166,12 @@ static int CeedInit_Cuda(const char *resource, Ceed ceed) {
                                 CeedElemRestrictionCreate_Cuda); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed,
                                 "ElemRestrictionCreateBlocked",
-                                CeedElemRestrictionCreateBlocked_Cuda); CeedChk(ierr);
+                                CeedElemRestrictionCreateBlocked_Cuda);
+  CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",
                                 CeedQFunctionCreate_Cuda); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Cuda); CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "CompositeOperatorCreate",
-                                CeedCompositeOperatorCreate_Cuda); CeedChk(ierr);
   return 0;
 }
 

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -486,14 +486,6 @@ static int CeedOperatorApply_Occa(CeedOperator op,
     }
   } // numelements
 
-  // Zero lvecs
-  for (CeedInt i=0; i<numoutputfields; i++) {
-    ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE)
-      vec = outvec;
-    ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-  }
-
   // Output restriction
   for (CeedInt i=0; i<numoutputfields; i++) {
     // Restore evec
@@ -543,7 +535,7 @@ int CeedOperatorCreate_Occa(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
 
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                 CeedOperatorApply_Occa); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Occa); CeedChk(ierr);

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -541,13 +541,3 @@ int CeedOperatorCreate_Occa(CeedOperator op) {
                                 CeedOperatorDestroy_Occa); CeedChk(ierr);
   return 0;
 }
-
-// *****************************************************************************
-// * Create a composite operator
-// *****************************************************************************
-int CeedCompositeOperatorCreate_Occa(CeedOperator op) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-  return CeedError(ceed, 1, "Backend does not implement composite operators");
-}

--- a/backends/occa/ceed-occa.c
+++ b/backends/occa/ceed-occa.c
@@ -126,8 +126,6 @@ static int CeedInit_Occa(const char *resource, Ceed ceed) {
                                 CeedQFunctionCreate_Occa); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Occa); CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "CompositeOperatorCreate",
-                                CeedCompositeOperatorCreate_Occa); CeedChk(ierr);
   ierr = CeedCalloc(1,&data); CeedChk(ierr);
   // push env variables CEED_DEBUG or DBG to our data
   data->debug=!!getenv("CEED_DEBUG") || !!getenv("DBG");

--- a/backends/occa/ceed-occa.h
+++ b/backends/occa/ceed-occa.h
@@ -155,8 +155,6 @@ CEED_INTERN int CeedBasisApplyElems_Occa(CeedBasis basis, CeedInt Q,
 // *****************************************************************************
 CEED_INTERN int CeedOperatorCreate_Occa(CeedOperator op);
 
-CEED_INTERN int CeedCompositeOperatorCreate_Occa(CeedOperator op);
-
 // *****************************************************************************
 CEED_INTERN int CeedQFunctionCreate_Occa(CeedQFunction qf);
 

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -495,7 +495,6 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
   ierr = CeedQFunctionGetFields(qf, &qfinputfields, &qfoutputfields);
   CeedChk(ierr);
   CeedEvalMode emode;
-  CeedVector vec;
 
   // Setup
   ierr = CeedOperatorSetup_Opt(op); CeedChk(ierr);
@@ -507,16 +506,6 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
 
   // Output Lvecs, Evecs, and Qvecs
   for (CeedInt i=0; i<numoutputfields; i++) {
-    // Zero Lvecs
-    ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE) {
-      if (!impl->add) {
-        vec = outvec;
-        ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-      }
-    } else {
-      ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
-    }
     // Set Qvec if needed
     ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
     CeedChk(ierr);
@@ -533,7 +522,6 @@ static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
       CeedChk(ierr);
     }
   }
-  impl->add = false;
 
   // Loop through elements
   for (CeedInt e=0; e<nblks*blksize; e+=blksize) {
@@ -751,7 +739,7 @@ int CeedOperatorCreate_Opt(CeedOperator op) {
     ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
                                   CeedOperatorAssembleLinearQFunction_Opt);
     CeedChk(ierr);
-    ierr = CeedSetBackendFunction(ceed, "Operator", op, "Apply",
+    ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                   CeedOperatorApply_Opt); CeedChk(ierr);
   } else {
     // LCOV_EXCL_START

--- a/backends/opt/ceed-opt.h
+++ b/backends/opt/ceed-opt.h
@@ -26,7 +26,6 @@ typedef struct {
 } CeedBasis_Opt;
 
 typedef struct {
-  bool add;
   bool identityqf;
   CeedElemRestriction *blkrestr; /// Blocked versions of restrictions
   CeedVector

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -512,24 +512,6 @@ static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
   return 0;
 }
 
-// Composite operators
-static int CeedCompositeOperatorApply_Ref(CeedOperator op, CeedVector invec,
-    CeedVector outvec,
-    CeedRequest *request) {
-  int ierr;
-  CeedInt numsub;
-  CeedOperator *suboperators;
-  ierr = CeedOperatorGetNumSub(op, &numsub); CeedChk(ierr);
-  ierr = CeedOperatorGetSubList(op, &suboperators); CeedChk(ierr);
-
-  for (CeedInt i=0; i<numsub; i++) {
-    ierr = CeedOperatorApplyAdd(suboperators[i], invec, outvec, request);
-    CeedChk(ierr);
-  }
-
-  return 0;
-}
-
 // Assemble Linear QFunction
 static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
     CeedVector *assembled, CeedElemRestriction *rstr, CeedRequest *request) {
@@ -702,15 +684,5 @@ int CeedOperatorCreate_Ref(CeedOperator op) {
                                 CeedOperatorApply_Ref); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Ref); CeedChk(ierr);
-  return 0;
-}
-
-int CeedCompositeOperatorCreate_Ref(CeedOperator op) {
-  int ierr;
-  Ceed ceed;
-  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
-                                CeedCompositeOperatorApply_Ref); CeedChk(ierr);
   return 0;
 }

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -41,8 +41,6 @@ static int CeedInit_Ref(const char *resource, Ceed ceed) {
                                 CeedQFunctionCreate_Ref); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Ref); CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "CompositeOperatorCreate",
-                                CeedCompositeOperatorCreate_Ref); CeedChk(ierr);
   return 0;
 }
 

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -79,5 +79,3 @@ CEED_INTERN int CeedTensorContractCreate_Ref(CeedBasis basis,
 CEED_INTERN int CeedQFunctionCreate_Ref(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Ref(CeedOperator op);
-
-CEED_INTERN int CeedCompositeOperatorCreate_Ref(CeedOperator op);

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -40,7 +40,6 @@ typedef struct {
 } CeedQFunction_Ref;
 
 typedef struct {
-  bool add;
   bool identityqf;
   CeedVector
   *evecs;   /// E-vectors needed to apply operator (input followed by outputs)

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -211,7 +211,9 @@ struct CeedOperator_private {
                                  CeedElemRestriction *, CeedRequest *);
   int (*AssembleLinearDiagonal)(CeedOperator, CeedVector *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
+  int (*ApplyComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyAdd)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
+  int (*ApplyAddComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyJacobian)(CeedOperator, CeedVector, CeedVector, CeedVector,
                        CeedVector, CeedRequest *);
   int (*Destroy)(CeedOperator);

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -211,6 +211,7 @@ struct CeedOperator_private {
                                  CeedElemRestriction *, CeedRequest *);
   int (*AssembleLinearDiagonal)(CeedOperator, CeedVector *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
+  int (*ApplyAdd)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyJacobian)(CeedOperator, CeedVector, CeedVector, CeedVector,
                        CeedVector, CeedRequest *);
   int (*Destroy)(CeedOperator);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -402,6 +402,8 @@ CEED_EXTERN int CeedOperatorAssembleLinearDiagonal(CeedOperator op,
 CEED_EXTERN int CeedOperatorView(CeedOperator op, FILE *stream);
 CEED_EXTERN int CeedOperatorApply(CeedOperator op, CeedVector in,
                                   CeedVector out, CeedRequest *request);
+CEED_EXTERN int CeedOperatorApplyAdd(CeedOperator op, CeedVector in,
+                                     CeedVector out, CeedRequest *request);
 CEED_EXTERN int CeedOperatorDestroy(CeedOperator *op);
 
 /**

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -244,8 +244,6 @@ CEED_EXTERN int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr,
     CeedVector u, CeedVector ru, CeedRequest *request);
 CEED_EXTERN int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
     CeedVector mult);
-CEED_EXTERN int CeedElemRestrictionCreateVector(CeedElemRestriction rstr,
-    CeedVector *lvec, CeedVector *evec);
 CEED_EXTERN int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream);
 CEED_EXTERN int CeedElemRestrictionDestroy(CeedElemRestriction *rstr);
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -100,22 +100,21 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
     Ceed delegate;
     ierr = CeedGetObjectDelegate(ceed, &delegate, "Operator"); CeedChk(ierr);
 
-    if (!delegate)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "Backend does not support "
-                       "CompositeOperatorCreate");
-    // LCOV_EXCL_STOP
-
-    ierr = CeedCompositeOperatorCreate(delegate, op); CeedChk(ierr);
-    return 0;
+    if (delegate) {
+      ierr = CeedCompositeOperatorCreate(delegate, op); CeedChk(ierr);
+      return 0;
+    }
   }
 
-  ierr = CeedCalloc(1,op); CeedChk(ierr);
+  ierr = CeedCalloc(1, op); CeedChk(ierr);
   (*op)->ceed = ceed;
   ceed->refcount++;
   (*op)->composite = true;
   ierr = CeedCalloc(16, &(*op)->suboperators); CeedChk(ierr);
-  ierr = ceed->CompositeOperatorCreate(*op); CeedChk(ierr);
+
+  if (ceed->CompositeOperatorCreate) {
+    ierr = ceed->CompositeOperatorCreate(*op); CeedChk(ierr);
+  }
   return 0;
 }
 
@@ -309,6 +308,46 @@ int CeedOperatorCreateFallback(CeedOperator op) {
 }
 
 /**
+  @brief Check if a CeedOperator is ready to be used.
+
+  @param[in] ceed Ceed object for error handling
+  @param[in] op   CeedOperator to check
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Basic
+**/
+static int CeedOperatorCheckReady(Ceed ceed, CeedOperator op) {
+  CeedQFunction qf = op->qf;
+
+  if (op->composite) {
+    if (!op->numsub)
+      // LCOV_EXCL_START
+      return CeedError(ceed, 1, "No suboperators set");
+    // LCOV_EXCL_STOP
+  } else {
+    if (op->nfields == 0)
+      // LCOV_EXCL_START
+      return CeedError(ceed, 1, "No operator fields set");
+    // LCOV_EXCL_STOP
+    if (op->nfields < qf->numinputfields + qf->numoutputfields)
+      // LCOV_EXCL_START
+      return CeedError(ceed, 1, "Not all operator fields set");
+    // LCOV_EXCL_STOP
+    if (!op->hasrestriction)
+      // LCOV_EXCL_START
+      return CeedError(ceed, 1,"At least one restriction required");
+    // LCOV_EXCL_STOP
+    if (op->numqpoints == 0)
+      // LCOV_EXCL_START
+      return CeedError(ceed, 1,"At least one non-collocated basis required");
+    // LCOV_EXCL_STOP
+  }
+
+  return 0;
+}
+
+/**
   @brief Assemble a linear CeedQFunction associated with a CeedOperator
 
   This returns a CeedVector containing a matrix at each quadrature point
@@ -340,30 +379,8 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
                                         CeedRequest *request) {
   int ierr;
   Ceed ceed = op->ceed;
-  CeedQFunction qf = op->qf;
+  ierr = CeedOperatorCheckReady(ceed, op); CeedChk(ierr);
 
-  if (op->composite) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, 1, "Cannot assemble QFunction for composite operator");
-    // LCOV_EXCL_STOP
-  } else {
-    if (op->nfields == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "No operator fields set");
-    // LCOV_EXCL_STOP
-    if (op->nfields < qf->numinputfields + qf->numoutputfields)
-      // LCOV_EXCL_START
-      return CeedError( ceed, 1, "Not all operator fields set");
-    // LCOV_EXCL_STOP
-    if (!op->hasrestriction)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "At least one restriction required");
-    // LCOV_EXCL_STOP
-    if (op->numqpoints == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "At least one non-collocated basis required");
-    // LCOV_EXCL_STOP
-  }
   if (op->AssembleLinearQFunction) {
     ierr = op->AssembleLinearQFunction(op, assembled, rstr, request);
     CeedChk(ierr);
@@ -376,6 +393,7 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
     ierr = op->opfallback->AssembleLinearQFunction(op->opfallback, assembled,
            rstr, request); CeedChk(ierr);
   }
+
   return 0;
 }
 
@@ -397,30 +415,7 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
                                        CeedRequest *request) {
   int ierr;
   Ceed ceed = op->ceed;
-  CeedQFunction qf = op->qf;
-
-  if (op->composite) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, 1, "Cannot assemble QFunction for composite operator");
-    // LCOV_EXCL_STOP
-  } else {
-    if (op->nfields == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "No operator fields set");
-    // LCOV_EXCL_STOP
-    if (op->nfields < qf->numinputfields + qf->numoutputfields)
-      // LCOV_EXCL_START
-      return CeedError( ceed, 1, "Not all operator fields set");
-    // LCOV_EXCL_STOP
-    if (!op->hasrestriction)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "At least one restriction required");
-    // LCOV_EXCL_STOP
-    if (op->numqpoints == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "At least one non-collocated basis required");
-    // LCOV_EXCL_STOP
-  }
+  ierr = CeedOperatorCheckReady(ceed, op); CeedChk(ierr);
 
   // Use backend version, if available
   if (op->AssembleLinearDiagonal) {
@@ -429,6 +424,7 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
   }
 
   // Assemble QFunction
+  CeedQFunction qf = op->qf;
   CeedVector assembledqf;
   CeedElemRestriction rstr;
   ierr = CeedOperatorAssembleLinearQFunction(op,  &assembledqf, &rstr, request);
@@ -596,55 +592,56 @@ int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out,
                       CeedRequest *request) {
   int ierr;
   Ceed ceed = op->ceed;
-  CeedQFunction qf = op->qf;
+  ierr = CeedOperatorCheckReady(ceed, op); CeedChk(ierr);
 
-  if (op->composite) {
-    if (!op->numsub)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "No suboperators set");
-    // LCOV_EXCL_STOP
-  } else {
-    if (op->nfields == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "No operator fields set");
-    // LCOV_EXCL_STOP
-    if (op->nfields < qf->numinputfields + qf->numoutputfields)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "Not all operator fields set");
-    // LCOV_EXCL_STOP
-    if (!op->hasrestriction)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1,"At least one restriction required");
-    // LCOV_EXCL_STOP
-    if (op->numqpoints == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1,"At least one non-collocated basis required");
-    // LCOV_EXCL_STOP
-  }
-  if (op->numelements || op->composite) {
+  if (op->numelements)  {
+    // Standard Operator
     if (op->Apply) {
-      ierr = op->Apply(op, in != CEED_VECTOR_NONE ? in : NULL,
-                       out != CEED_VECTOR_NONE ? out : NULL, request);
-      CeedChk(ierr);
+      ierr = op->Apply(op, in, out, request); CeedChk(ierr);
     } else {
       // Zero all output vectors
-      if (!op->composite) {
-        for (CeedInt i=0; i<qf->numoutputfields; i++) {
-          CeedVector vec = op->outputfields[i]->vec;
-          if (vec == CEED_VECTOR_ACTIVE)
-            vec = out;
-          if (vec != CEED_VECTOR_NONE) {
+      CeedQFunction qf = op->qf;
+      for (CeedInt i=0; i<qf->numoutputfields; i++) {
+        CeedVector vec = op->outputfields[i]->vec;
+        if (vec == CEED_VECTOR_ACTIVE)
+          vec = out;
+        if (vec != CEED_VECTOR_NONE) {
+          ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
+        }
+      }
+      // Apply
+      ierr = op->ApplyAdd(op, in, out, request); CeedChk(ierr);
+    }
+  } else if (op->composite) {
+    // Composite Operator
+    if (op->ApplyComposite) {
+      ierr = op->ApplyComposite(op, in, out, request); CeedChk(ierr);
+    } else {
+      CeedInt numsub;
+      ierr = CeedOperatorGetNumSub(op, &numsub); CeedChk(ierr);
+      CeedOperator *suboperators;
+      ierr = CeedOperatorGetSubList(op, &suboperators); CeedChk(ierr);
+
+      // Zero all output vectors
+      if (out != CEED_VECTOR_NONE) {
+        ierr = CeedVectorSetValue(out, 0.0); CeedChk(ierr);
+      }
+      for (CeedInt i=0; i<numsub; i++) {
+        for (CeedInt j=0; j<suboperators[i]->qf->numoutputfields; j++) {
+          CeedVector vec = suboperators[i]->outputfields[j]->vec;
+          if (vec != CEED_VECTOR_ACTIVE && vec != CEED_VECTOR_NONE) {
             ierr = CeedVectorSetValue(vec, 0.0); CeedChk(ierr);
           }
         }
-      } else if (out != CEED_VECTOR_NONE) { // Zero active output if composite
-        ierr = CeedVectorSetValue(out, 0.0); CeedChk(ierr);
       }
-      ierr = op->ApplyAdd(op, in != CEED_VECTOR_NONE ? in : NULL,
-                          out != CEED_VECTOR_NONE ? out : NULL, request);
-      CeedChk(ierr);
+      // Apply
+      for (CeedInt i=0; i<op->numsub; i++) {
+        ierr = CeedOperatorApplyAdd(op->suboperators[i], in, out, request);
+        CeedChk(ierr);
+      }
     }
   }
+
   return 0;
 }
 
@@ -671,36 +668,28 @@ int CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out,
                          CeedRequest *request) {
   int ierr;
   Ceed ceed = op->ceed;
-  CeedQFunction qf = op->qf;
+  ierr = CeedOperatorCheckReady(ceed, op); CeedChk(ierr);
 
-  if (op->composite) {
-    if (!op->numsub)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "No suboperators set");
-    // LCOV_EXCL_STOP
-  } else {
-    if (op->nfields == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "No operator fields set");
-    // LCOV_EXCL_STOP
-    if (op->nfields < qf->numinputfields + qf->numoutputfields)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1, "Not all operator fields set");
-    // LCOV_EXCL_STOP
-    if (!op->hasrestriction)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1,"At least one restriction required");
-    // LCOV_EXCL_STOP
-    if (op->numqpoints == 0)
-      // LCOV_EXCL_START
-      return CeedError(ceed, 1,"At least one non-collocated basis required");
-    // LCOV_EXCL_STOP
+  if (op->numelements)  {
+    // Standard Operator
+    ierr = op->ApplyAdd(op, in, out, request); CeedChk(ierr);
+  } else if (op->composite) {
+    // Composite Operator
+    if (op->ApplyAddComposite) {
+      ierr = op->ApplyAddComposite(op, in, out, request); CeedChk(ierr);
+    } else {
+      CeedInt numsub;
+      ierr = CeedOperatorGetNumSub(op, &numsub); CeedChk(ierr);
+      CeedOperator *suboperators;
+      ierr = CeedOperatorGetSubList(op, &suboperators); CeedChk(ierr);
+
+      for (CeedInt i=0; i<numsub; i++) {
+        ierr = CeedOperatorApplyAdd(suboperators[i], in, out, request);
+        CeedChk(ierr);
+      }
+    }
   }
-  if (op->numelements || op->composite) {
-    ierr = op->ApplyAdd(op, in != CEED_VECTOR_NONE ? in : NULL,
-                        out != CEED_VECTOR_NONE ? out : NULL, request);
-    CeedChk(ierr);
-  }
+
   return 0;
 }
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -393,7 +393,9 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearQFunction),
     CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearDiagonal),
     CEED_FTABLE_ENTRY(CeedOperator, Apply),
+    CEED_FTABLE_ENTRY(CeedOperator, ApplyComposite),
     CEED_FTABLE_ENTRY(CeedOperator, ApplyAdd),
+    CEED_FTABLE_ENTRY(CeedOperator, ApplyAddComposite),
     CEED_FTABLE_ENTRY(CeedOperator, ApplyJacobian),
     CEED_FTABLE_ENTRY(CeedOperator, Destroy),
     {NULL, 0} // End of lookup table - used in SetBackendFunction loop

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -393,6 +393,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearQFunction),
     CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearDiagonal),
     CEED_FTABLE_ENTRY(CeedOperator, Apply),
+    CEED_FTABLE_ENTRY(CeedOperator, ApplyAdd),
     CEED_FTABLE_ENTRY(CeedOperator, ApplyJacobian),
     CEED_FTABLE_ENTRY(CeedOperator, Destroy),
     {NULL, 0} // End of lookup table - used in SetBackendFunction loop

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -121,11 +121,13 @@ int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func,
 
   @ref Developer
 **/
+// LCOV_EXCL_START
 int CeedErrorReturn(Ceed ceed, const char *filename, int lineno,
                     const char *func, int ecode, const char *format,
                     va_list args) {
   return ecode;
 }
+// LCOV_EXCL_STOP
 
 /**
   @brief Error handler that prints to stderr and aborts
@@ -134,6 +136,7 @@ int CeedErrorReturn(Ceed ceed, const char *filename, int lineno,
 
   @ref Developer
 **/
+// LCOV_EXCL_START
 int CeedErrorAbort(Ceed ceed, const char *filename, int lineno,
                    const char *func, int ecode, const char *format,
                    va_list args) {
@@ -143,6 +146,7 @@ int CeedErrorAbort(Ceed ceed, const char *filename, int lineno,
   abort();
   return ecode;
 }
+// LCOV_EXCL_STOP
 
 /**
   @brief Error handler that prints to stderr and exits
@@ -333,7 +337,10 @@ int CeedInit(const char *resource, Ceed *ceed) {
 
   // Find matching backend
   if (!resource)
+    // LCOV_EXCL_START
     return CeedError(NULL, 1, "No resource provided");
+  // LCOV_EXCL_STOP
+
   for (size_t i=0; i<num_backends; i++) {
     size_t n;
     const char *prefix = backends[i].prefix;
@@ -346,10 +353,12 @@ int CeedInit(const char *resource, Ceed *ceed) {
     }
   }
   if (!matchlen)
+    // LCOV_EXCL_START
     return CeedError(NULL, 1, "No suitable backend");
+  // LCOV_EXCL_STOP
 
   // Setup Ceed
-  ierr = CeedCalloc(1,ceed); CeedChk(ierr);
+  ierr = CeedCalloc(1, ceed); CeedChk(ierr);
   const char *ceed_error_handler = getenv("CEED_ERROR_HANDLER");
   if (!ceed_error_handler)
     ceed_error_handler = "abort";

--- a/tests/t505-operator-f.f90
+++ b/tests/t505-operator-f.f90
@@ -1,0 +1,180 @@
+!-----------------------------------------------------------------------
+      subroutine setup(ctx,q,u1,u2,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14,&
+&           u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,ierr)
+      real*8 ctx
+      real*8 u1(1)
+      real*8 u2(1)
+      real*8 v1(1)
+      integer q,ierr
+
+      do i=1,q
+        v1(i)=u1(i)*u2(i)
+      enddo
+
+      ierr=0
+      end
+!-----------------------------------------------------------------------
+      subroutine mass(ctx,q,u1,u2,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14,&
+&           u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,ierr)
+      real*8 ctx
+      real*8 u1(1)
+      real*8 u2(1)
+      real*8 v1(1)
+      integer q,ierr
+
+      do i=1,q
+        v1(i)=u2(i)*u1(i)
+      enddo
+
+      ierr=0
+      end
+!-----------------------------------------------------------------------
+      program test
+
+      include 'ceedf.h'
+
+      integer ceed,err,i,j
+      integer erestrictx,erestrictu,erestrictxi,erestrictui
+      integer bx,bu
+      integer qf_setup,qf_mass
+      integer op_setup,op_mass
+      integer qdata,x,u,v
+      integer nelem,p,q
+      parameter(nelem=15)
+      parameter(p=5)
+      parameter(q=8)
+      integer nx,nu
+      parameter(nx=nelem+1)
+      parameter(nu=nelem*(p-1)+1)
+      integer indx(nelem*2)
+      integer indu(nelem*p)
+      real*8 arrx(nx)
+      integer*8 voffset,xoffset
+
+      real*8 hv(nu)
+      real*8 total
+
+      character arg*32
+
+      external setup,mass
+
+      call getarg(1,arg)
+      call ceedinit(trim(arg)//char(0),ceed,err)
+
+      do i=0,nx-1
+        arrx(i+1)=i/(nx-1.d0)
+      enddo
+      do i=0,nelem-1
+        indx(2*i+1)=i
+        indx(2*i+2)=i+1
+      enddo
+
+      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+     & ceed_use_pointer,indx,erestrictx,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+     & erestrictxi,err)
+
+      do i=0,nelem-1
+        do j=0,p-1
+          indu(p*i+j+1)=i*(p-1)+j
+        enddo
+      enddo
+
+      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,&
+     & ceed_use_pointer,indu,erestrictu,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+     & erestrictui,err)
+
+      call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
+      call ceedbasiscreatetensorh1lagrange(ceed,1,1,p,q,ceed_gauss,bu,err)
+
+      call ceedqfunctioncreateinterior(ceed,1,setup,&
+     &SOURCE_DIR&
+     &//'t500-operator.h:setup'//char(0),qf_setup,err)
+      call ceedqfunctionaddinput(qf_setup,'_weight',1,ceed_eval_weight,err)
+      call ceedqfunctionaddinput(qf_setup,'dx',1,ceed_eval_grad,err)
+      call ceedqfunctionaddoutput(qf_setup,'rho',1,ceed_eval_none,err)
+
+      call ceedqfunctioncreateinterior(ceed,1,mass,&
+     &SOURCE_DIR&
+     &//'t500-operator.h:mass'//char(0),qf_mass,err)
+      call ceedqfunctionaddinput(qf_mass,'rho',1,ceed_eval_none,err)
+      call ceedqfunctionaddinput(qf_mass,'u',1,ceed_eval_interp,err)
+      call ceedqfunctionaddoutput(qf_mass,'v',1,ceed_eval_interp,err)
+
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
+
+      call ceedvectorcreate(ceed,nx,x,err)
+      xoffset=0
+      call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
+      call ceedvectorcreate(ceed,nelem*q,qdata,err)
+
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
+     & ceed_notranspose,bx,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
+     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
+     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
+     & ceed_notranspose,ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
+     & ceed_notranspose,bu,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
+     & ceed_notranspose,bu,ceed_vector_active,err)
+
+      call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
+
+      call ceedvectorcreate(ceed,nu,u,err)
+      call ceedvectorsetvalue(u,1.d0,err)
+      call ceedvectorcreate(ceed,nu,v,err)
+      call ceedvectorsetvalue(v,0.d0,err)
+
+      call ceedoperatorapplyadd(op_mass,u,v,ceed_request_immediate,err)
+
+      call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
+      total=0.
+      do i=1,nu
+        total=total+hv(voffset+i)
+      enddo
+      if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
+        write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_STOP
+      endif
+      call ceedvectorrestorearrayread(v,hv,voffset,err)
+
+      call ceedvectorsetvalue(v,1.d0,err)
+      call ceedoperatorapplyadd(op_mass,u,v,ceed_request_immediate,err)
+
+      call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
+      total=-nu
+      do i=1,nu
+        total=total+hv(voffset+i)
+      enddo
+      if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
+        write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_STOP
+      endif
+      call ceedvectorrestorearrayread(v,hv,voffset,err)
+
+      call ceedvectordestroy(qdata,err)
+      call ceedvectordestroy(x,err)
+      call ceedvectordestroy(u,err)
+      call ceedvectordestroy(v,err)
+      call ceedoperatordestroy(op_mass,err)
+      call ceedoperatordestroy(op_setup,err)
+      call ceedqfunctiondestroy(qf_mass,err)
+      call ceedqfunctiondestroy(qf_setup,err)
+      call ceedbasisdestroy(bu,err)
+      call ceedbasisdestroy(bx,err)
+      call ceedelemrestrictiondestroy(erestrictu,err)
+      call ceedelemrestrictiondestroy(erestrictx,err)
+      call ceedelemrestrictiondestroy(erestrictui,err)
+      call ceedelemrestrictiondestroy(erestrictxi,err)
+      call ceeddestroy(ceed,err)
+      end
+!-----------------------------------------------------------------------

--- a/tests/t505-operator.c
+++ b/tests/t505-operator.c
@@ -1,0 +1,132 @@
+/// @file
+/// Test CeedOperatorApplyAdd
+/// \test Test CeedOperatorApplyAdd
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include "t500-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup, qf_mass;
+  CeedOperator op_setup, op_mass;
+  CeedVector qdata, X, U, V;
+  const CeedScalar *hv;
+  CeedInt nelem = 15, P = 5, Q = 8;
+  CeedInt Nx = nelem+1, Nu = nelem*(P-1)+1;
+  CeedInt indx[nelem*2], indu[nelem*P];
+  CeedScalar x[Nx];
+  CeedScalar sum;
+
+  CeedInit(argv[1], &ceed);
+
+  for (CeedInt i=0; i<Nx; i++)
+    x[i] = (CeedScalar) i / (Nx - 1);
+  for (CeedInt i=0; i<nelem; i++) {
+    indx[2*i+0] = i;
+    indx[2*i+1] = i+1;
+  }
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictx);
+  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+
+  for (CeedInt i=0; i<nelem; i++) {
+    for (CeedInt j=0; j<P; j++) {
+      indu[P*i+j] = i*(P-1) + j;
+    }
+  }
+  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 1, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indu, &Erestrictu);
+  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, P, Q, CEED_GAUSS, &bu);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", 1, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
+
+  CeedVectorCreate(ceed, Nx, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+  CeedVectorCreate(ceed, nelem*Q, &qdata);
+
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
+                       bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
+                       bu, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
+
+  CeedVectorCreate(ceed, Nu, &U);
+  CeedVectorSetValue(U, 1.0);
+  CeedVectorCreate(ceed, Nu, &V);
+  CeedVectorSetValue(V, 0.0);
+
+  // Apply with V = 0
+  CeedOperatorApplyAdd(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+  // Check output
+  CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
+  sum = 0.;
+  for (CeedInt i=0; i<Nu; i++)
+    sum += hv[i];
+  if (fabs(sum-1.)>1e-10) printf("Computed Area: %f != True Area: 1.0\n", sum);
+  CeedVectorRestoreArrayRead(V, &hv);
+
+  // Apply with V = 1
+  CeedVectorSetValue(V, 1.0);
+  CeedOperatorApplyAdd(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+  // Check output
+  CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
+  sum = -Nu;
+  for (CeedInt i=0; i<Nu; i++)
+    sum += hv[i];
+  if (fabs(sum-(1.))>1e-10) printf("Computed Area: %f != True Area: 1.0\n", sum);
+  CeedVectorRestoreArrayRead(V, &hv);
+
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedElemRestrictionDestroy(&Erestrictxi);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedVectorDestroy(&qdata);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -142,14 +142,14 @@
 ! -- QFunctions
       call ceedqfunctioncreateinterior(ceed,1,setup,&
      &SOURCE_DIR&
-     &//'t520-operator.h:setup'//char(0),qf_setuptet,err)
+     &//'t510-operator.h:setup'//char(0),qf_setuptet,err)
       call ceedqfunctionaddinput(qf_setuptet,'_weight',1,ceed_eval_weight,err)
       call ceedqfunctionaddinput(qf_setuptet,'dx',d*d,ceed_eval_grad,err)
       call ceedqfunctionaddoutput(qf_setuptet,'rho',1,ceed_eval_none,err)
 
       call ceedqfunctioncreateinterior(ceed,1,mass,&
      &SOURCE_DIR&
-     &//'t520-operator.h:mass'//char(0),qf_masstet,err)
+     &//'t510-operator.h:mass'//char(0),qf_masstet,err)
       call ceedqfunctionaddinput(qf_masstet,'rho',1,ceed_eval_none,err)
       call ceedqfunctionaddinput(qf_masstet,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_masstet,'v',1,ceed_eval_interp,err)

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -207,14 +207,14 @@
 ! -- QFunctions
       call ceedqfunctioncreateinterior(ceed,1,setup,&
      &SOURCE_DIR&
-     &//'t521-operator.h:setup'//char(0),qf_setuphex,err)
+     &//'t510-operator.h:setup'//char(0),qf_setuphex,err)
       call ceedqfunctionaddinput(qf_setuphex,'_weight',1,ceed_eval_weight,err)
       call ceedqfunctionaddinput(qf_setuphex,'dx',d*d,ceed_eval_grad,err)
       call ceedqfunctionaddoutput(qf_setuphex,'rho',1,ceed_eval_none,err)
 
       call ceedqfunctioncreateinterior(ceed,1,mass,&
      &SOURCE_DIR&
-     &//'t521-operator.h:mass'//char(0),qf_masshex,err)
+     &//'t510-operator.h:mass'//char(0),qf_masshex,err)
       call ceedqfunctionaddinput(qf_masshex,'rho',1,ceed_eval_none,err)
       call ceedqfunctionaddinput(qf_masshex,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_masshex,'v',1,ceed_eval_interp,err)

--- a/tests/t522-operator-f.f90
+++ b/tests/t522-operator-f.f90
@@ -213,7 +213,7 @@
 ! -- QFunctions
       call ceedqfunctioncreateinterior(ceed,1,setup,&
      &SOURCE_DIR&
-     &//'t521-operator.h:setup'//char(0),qf_setuphex,err)
+     &//'t522-operator.h:setup'//char(0),qf_setuphex,err)
       call ceedqfunctionaddinput(qf_setuphex,'_weight',1,ceed_eval_weight,err)
       call ceedqfunctionaddinput(qf_setuphex,'dx',d*d,ceed_eval_grad,err)
       call ceedqfunctionaddoutput(qf_setuphex,'rho',d*(d+1)/2,ceed_eval_none,&
@@ -221,7 +221,7 @@
 
       call ceedqfunctioncreateinterior(ceed,1,diff,&
      &SOURCE_DIR&
-     &//'t521-operator.h:diff'//char(0),qf_diffhex,err)
+     &//'t522-operator.h:diff'//char(0),qf_diffhex,err)
       call ceedqfunctionaddinput(qf_diffhex,'rho',d*(d+1)/2,ceed_eval_none,err)
       call ceedqfunctionaddinput(qf_diffhex,'u',d,ceed_eval_grad,err)
       call ceedqfunctionaddoutput(qf_diffhex,'v',d,ceed_eval_grad,err)

--- a/tests/t523-operator-f.f90
+++ b/tests/t523-operator-f.f90
@@ -135,14 +135,14 @@
 ! -- QFunctions
       call ceedqfunctioncreateinterior(ceed,1,setup,&
      &SOURCE_DIR&
-     &//'t520-operator.h:setup'//char(0),qf_setuptet,err)
+     &//'t510-operator.h:setup'//char(0),qf_setuptet,err)
       call ceedqfunctionaddinput(qf_setuptet,'_weight',1,ceed_eval_weight,err)
       call ceedqfunctionaddinput(qf_setuptet,'dx',d*d,ceed_eval_grad,err)
       call ceedqfunctionaddoutput(qf_setuptet,'rho',1,ceed_eval_none,err)
 
       call ceedqfunctioncreateinterior(ceed,1,mass,&
      &SOURCE_DIR&
-     &//'t520-operator.h:mass'//char(0),qf_masstet,err)
+     &//'t510-operator.h:mass'//char(0),qf_masstet,err)
       call ceedqfunctionaddinput(qf_masstet,'rho',1,ceed_eval_none,err)
       call ceedqfunctionaddinput(qf_masstet,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_masstet,'v',1,ceed_eval_interp,err)

--- a/tests/t524-operator-f.f90
+++ b/tests/t524-operator-f.f90
@@ -1,0 +1,324 @@
+!-----------------------------------------------------------------------
+! 
+! Header with common subroutine
+! 
+      include 't320-basis-f.h'
+!-----------------------------------------------------------------------
+      subroutine setup(ctx,q,u1,u2,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14,&
+&           u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,ierr)
+      real*8 ctx
+      real*8 u1(1)
+      real*8 u2(1)
+      real*8 v1(1)
+      integer q,ierr
+
+      do i=1,q
+        v1(i)=u1(i)*(u2(i+q*0)*u2(i+q*3)-u2(i+q*1)*u2(i+q*2))
+      enddo
+
+      ierr=0
+      end
+!-----------------------------------------------------------------------
+      subroutine mass(ctx,q,u1,u2,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14,&
+&           u15,u16,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,ierr)
+      real*8 ctx
+      real*8 u1(1)
+      real*8 u2(1)
+      real*8 v1(1)
+      integer q,ierr
+
+      do i=1,q
+        v1(i)=u2(i)*u1(i)
+      enddo
+
+      ierr=0
+      end
+!-----------------------------------------------------------------------
+      program test
+
+      include 'ceedf.h'
+
+      integer ceed,err,i,j,k
+      integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
+&             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
+      integer bxtet,butet,bxhex,buhex
+      integer qf_setuptet,qf_masstet,qf_setuphex,qf_masshex
+      integer op_setuptet,op_masstet,op_setuphex,op_masshex,op_setup,op_mass
+      integer qdatatet,qdatahex,x,u,v
+      integer nelemtet,nelemhex,ptet,phex,qtet,qhex,d
+      integer row,col,offset
+      parameter(nelemtet=6)
+      parameter(ptet=6)
+      parameter(qtet=4)
+      parameter(nelemhex=6)
+      parameter(phex=3)
+      parameter(qhex=4)
+      parameter(d=2)
+      integer ndofs,nqptstet,nqptshex,nqpts,nx,ny,nxtet,nytet,nxhex
+      parameter(nx=3)
+      parameter(ny=3)
+      parameter(nxtet=3)
+      parameter(nytet=1)
+      parameter(nxhex=3)
+      parameter(ndofs=(nx*2+1)*(ny*2+1))
+      parameter(nqptstet=nelemtet*qtet)
+      parameter(nqptshex=nelemhex*qhex*qhex)
+      parameter(nqpts=nqptstet+nqptshex)
+      integer indxtet(nelemtet*ptet),indxhex(nelemhex*phex*phex)
+      real*8 arrx(d*ndofs)
+      integer*8 voffset,xoffset
+
+      real*8 qref(d*qtet)
+      real*8 qweight(qtet)
+      real*8 interp(ptet*qtet)
+      real*8 grad(d*ptet*qtet)
+
+      real*8 hv(ndofs)
+      real*8 total
+
+      character arg*32
+
+      external setup,mass
+
+      call getarg(1,arg)
+
+      call ceedinit(trim(arg)//char(0),ceed,err)
+
+! DoF Coordinates
+      do i=0,ny*2
+        do j=0,nx*2
+          arrx(i+j*(ny*2+1)+0*ndofs+1)=1.d0*i/(2*ny)
+          arrx(i+j*(ny*2+1)+1*ndofs+1)=1.d0*j/(2*nx)
+        enddo
+      enddo
+
+      call ceedvectorcreate(ceed,d*ndofs,x,err)
+      xoffset=0
+      call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
+
+! Qdata Vectors
+      call ceedvectorcreate(ceed,nqptstet,qdatatet,err)
+      call ceedvectorcreate(ceed,nqptshex,qdatahex,err)
+
+! Tet Elements
+      do i=0,2
+        col=mod(i,nx)
+        row=i/nx
+        offset=col*2+row*(nx*2+1)*2
+
+        indxtet(i*2*ptet+1)=2+offset
+        indxtet(i*2*ptet+2)=9+offset
+        indxtet(i*2*ptet+3)=16+offset
+        indxtet(i*2*ptet+4)=1+offset
+        indxtet(i*2*ptet+5)=8+offset
+        indxtet(i*2*ptet+6)=0+offset
+
+        indxtet(i*2*ptet+7)=14+offset
+        indxtet(i*2*ptet+8)=7+offset
+        indxtet(i*2*ptet+9)=0+offset
+        indxtet(i*2*ptet+10)=15+offset
+        indxtet(i*2*ptet+11)=8+offset
+        indxtet(i*2*ptet+12)=16+offset
+      enddo
+
+! -- Restrictions
+      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,d,ceed_mem_host,&
+     & ceed_use_pointer,indxtet,erestrictxtet,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelemtet,ptet,nelemtet*ptet,&
+     & d,erestrictxitet,err)
+
+      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,1,ceed_mem_host,&
+     & ceed_use_pointer,indxtet,erestrictutet,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelemtet,qtet,nqptstet,1,&
+     & erestrictuitet,err)
+
+! -- Bases
+      call buildmats(qref,qweight,interp,grad)
+      call ceedbasiscreateh1(ceed,ceed_triangle,d,ptet,qtet,interp,grad,qref,&
+     & qweight,bxtet,err)
+      call buildmats(qref,qweight,interp,grad)
+      call ceedbasiscreateh1(ceed,ceed_triangle,1,ptet,qtet,interp,grad,qref,&
+     & qweight,butet,err)
+
+! -- QFunctions
+      call ceedqfunctioncreateinterior(ceed,1,setup,&
+     &SOURCE_DIR&
+     &//'t510-operator.h:setup'//char(0),qf_setuptet,err)
+      call ceedqfunctionaddinput(qf_setuptet,'_weight',1,ceed_eval_weight,err)
+      call ceedqfunctionaddinput(qf_setuptet,'dx',d*d,ceed_eval_grad,err)
+      call ceedqfunctionaddoutput(qf_setuptet,'rho',1,ceed_eval_none,err)
+
+      call ceedqfunctioncreateinterior(ceed,1,mass,&
+     &SOURCE_DIR&
+     &//'t510-operator.h:mass'//char(0),qf_masstet,err)
+      call ceedqfunctionaddinput(qf_masstet,'rho',1,ceed_eval_none,err)
+      call ceedqfunctionaddinput(qf_masstet,'u',1,ceed_eval_interp,err)
+      call ceedqfunctionaddoutput(qf_masstet,'v',1,ceed_eval_interp,err)
+
+! -- Operators
+! ---- Setup Tet
+      call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuptet,err)
+      call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
+     & ceed_notranspose,bxtet,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
+     & ceed_notranspose,bxtet,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
+     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+! ---- Mass Tet
+      call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_masstet,err)
+      call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
+     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+      call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
+     & ceed_notranspose,butet,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_masstet,'v',erestrictutet,&
+     & ceed_notranspose,butet,ceed_vector_active,err)
+
+! Hex Elements
+      do i=0,nelemhex-1
+        col=mod(i,nx)
+        row=i/nx
+        offset=(nxtet*2+1)*(nytet*2)*(1+row)+col*2
+        do j=0,phex-1
+          do k=0,phex-1
+            indxhex(phex*(phex*i+k)+j+1)=offset+k*(nxhex*2+1)+j
+          enddo
+        enddo
+      enddo
+
+! -- Restrictions
+      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,d,&
+     & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelemhex,phex*phex,&
+     & nelemhex*phex*phex,d,erestrictxihex,err)
+
+      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,1,&
+     & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
+      call ceedelemrestrictioncreateidentity(ceed,nelemhex,qhex*qhex,nqptshex,&
+     & 1,erestrictuihex,err)
+
+! -- Bases
+      call ceedbasiscreatetensorh1lagrange(ceed,d,d,phex,qhex,ceed_gauss,&
+     & bxhex,err)
+      call ceedbasiscreatetensorh1lagrange(ceed,d,1,phex,qhex,ceed_gauss,&
+     & buhex,err)
+
+! -- QFunctions
+      call ceedqfunctioncreateinterior(ceed,1,setup,&
+     &SOURCE_DIR&
+     &//'t521-operator.h:setup'//char(0),qf_setuphex,err)
+      call ceedqfunctionaddinput(qf_setuphex,'_weight',1,ceed_eval_weight,err)
+      call ceedqfunctionaddinput(qf_setuphex,'dx',d*d,ceed_eval_grad,err)
+      call ceedqfunctionaddoutput(qf_setuphex,'rho',1,ceed_eval_none,err)
+
+      call ceedqfunctioncreateinterior(ceed,1,mass,&
+     &SOURCE_DIR&
+     &//'t521-operator.h:mass'//char(0),qf_masshex,err)
+      call ceedqfunctionaddinput(qf_masshex,'rho',1,ceed_eval_none,err)
+      call ceedqfunctionaddinput(qf_masshex,'u',1,ceed_eval_interp,err)
+      call ceedqfunctionaddoutput(qf_masshex,'v',1,ceed_eval_interp,err)
+
+! -- Operators
+! ---- Setup Hex
+      call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuphex,&
+     & err)
+      call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
+     & ceed_notranspose,bxhex,ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
+     & ceed_notranspose,bxhex,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
+     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+! ---- Mass Hex
+      call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_masshex,&
+     & err)
+      call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
+     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+      call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&
+     & ceed_notranspose,buhex,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_masshex,'v',erestrictuhex,&
+     & ceed_notranspose,buhex,ceed_vector_active,err)
+
+! Composite Operators
+      call ceedcompositeoperatorcreate(ceed,op_setup,err)
+      call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
+      call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
+
+      call ceedcompositeoperatorcreate(ceed,op_mass,err)
+      call ceedcompositeoperatoraddsub(op_mass,op_masstet,err)
+      call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
+
+! Apply Setup Operator
+      call ceedoperatorapply(op_setup,x,ceed_vector_none,&
+     & ceed_request_immediate,err)
+
+! Apply Mass Operator
+      call ceedvectorcreate(ceed,ndofs,u,err)
+      call ceedvectorsetvalue(u,1.d0,err)
+      call ceedvectorcreate(ceed,ndofs,v,err)
+      call ceedvectorsetvalue(v,0.d0,err)
+
+      call ceedoperatorapplyadd(op_mass,u,v,ceed_request_immediate,err)
+
+! Check Output
+      call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
+      total=0.
+      do i=1,ndofs
+        total=total+hv(voffset+i)
+      enddo
+      if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
+        write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_STOP
+      endif
+      call ceedvectorrestorearrayread(v,hv,voffset,err)
+
+      call ceedvectorsetvalue(v,1.d0,err)
+      call ceedoperatorapplyadd(op_mass,u,v,ceed_request_immediate,err)
+
+! Check Output
+      call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)
+      total=-ndofs
+      do i=1,ndofs
+        total=total+hv(voffset+i)
+      enddo
+      if (abs(total-1.)>1.0d-10) then
+! LCOV_EXCL_START
+        write(*,*) 'Computed Area: ',total,' != True Area: 1.0'
+! LCOV_EXCL_STOP
+      endif
+      call ceedvectorrestorearrayread(v,hv,voffset,err)
+
+! Cleanup
+      call ceedqfunctiondestroy(qf_setuptet,err)
+      call ceedqfunctiondestroy(qf_masstet,err)
+      call ceedoperatordestroy(op_setuptet,err)
+      call ceedoperatordestroy(op_masstet,err)
+      call ceedqfunctiondestroy(qf_setuphex,err)
+      call ceedqfunctiondestroy(qf_masshex,err)
+      call ceedoperatordestroy(op_setuphex,err)
+      call ceedoperatordestroy(op_masshex,err)
+      call ceedoperatordestroy(op_setup,err)
+      call ceedoperatordestroy(op_mass,err)
+      call ceedelemrestrictiondestroy(erestrictutet,err)
+      call ceedelemrestrictiondestroy(erestrictxtet,err)
+      call ceedelemrestrictiondestroy(erestrictuitet,err)
+      call ceedelemrestrictiondestroy(erestrictxitet,err)
+      call ceedelemrestrictiondestroy(erestrictuhex,err)
+      call ceedelemrestrictiondestroy(erestrictxhex,err)
+      call ceedelemrestrictiondestroy(erestrictuihex,err)
+      call ceedelemrestrictiondestroy(erestrictxihex,err)
+      call ceedbasisdestroy(butet,err)
+      call ceedbasisdestroy(bxtet,err)
+      call ceedbasisdestroy(buhex,err)
+      call ceedbasisdestroy(bxhex,err)
+      call ceedvectordestroy(x,err)
+      call ceedvectordestroy(u,err)
+      call ceedvectordestroy(v,err)
+      call ceedvectordestroy(qdatatet,err)
+      call ceedvectordestroy(qdatahex,err)
+      call ceeddestroy(ceed,err)
+      end
+!-----------------------------------------------------------------------

--- a/tests/t524-operator-f.f90
+++ b/tests/t524-operator-f.f90
@@ -207,14 +207,14 @@
 ! -- QFunctions
       call ceedqfunctioncreateinterior(ceed,1,setup,&
      &SOURCE_DIR&
-     &//'t521-operator.h:setup'//char(0),qf_setuphex,err)
+     &//'t510-operator.h:setup'//char(0),qf_setuphex,err)
       call ceedqfunctionaddinput(qf_setuphex,'_weight',1,ceed_eval_weight,err)
       call ceedqfunctionaddinput(qf_setuphex,'dx',d*d,ceed_eval_grad,err)
       call ceedqfunctionaddoutput(qf_setuphex,'rho',1,ceed_eval_none,err)
 
       call ceedqfunctioncreateinterior(ceed,1,mass,&
      &SOURCE_DIR&
-     &//'t521-operator.h:mass'//char(0),qf_masshex,err)
+     &//'t510-operator.h:mass'//char(0),qf_masshex,err)
       call ceedqfunctionaddinput(qf_masshex,'rho',1,ceed_eval_none,err)
       call ceedqfunctionaddinput(qf_masshex,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_masshex,'v',1,ceed_eval_interp,err)

--- a/tests/t524-operator.c
+++ b/tests/t524-operator.c
@@ -1,0 +1,265 @@
+/// @file
+/// Test creation creation, action, and destruction for mass matrix operator
+/// \test Test creation creation, action, and destruction for mass matrix operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t320-basis.h"
+#include "t510-operator.h"
+
+/* The mesh comprises of two rows of 3 quadralaterals followed by one row
+     of 6 triangles:
+   _ _ _
+  |_|_|_|
+  |_|_|_|
+  |/|/|/|
+
+*/
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction ErestrictxTet, ErestrictuTet,
+                      ErestrictxiTet, ErestrictuiTet,
+                      ErestrictxHex, ErestrictuHex,
+                      ErestrictxiHex, ErestrictuiHex;
+  CeedBasis bxTet, buTet,
+            bxHex, buHex;
+  CeedQFunction qf_setupTet, qf_massTet,
+                qf_setupHex, qf_massHex;
+  CeedOperator op_setupTet, op_massTet,
+               op_setupHex, op_massHex,
+               op_setup, op_mass;
+  CeedVector qdataTet, qdataHex, X, U, V;
+  const CeedScalar *hv;
+  CeedInt nelemTet = 6, PTet = 6, QTet = 4,
+          nelemHex = 6, PHex = 3, QHex = 4, dim = 2;
+  CeedInt nx = 3, ny = 3,
+          nxTet = 3, nyTet = 1, nxHex = 3;
+  CeedInt row, col, offset;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1),
+          nqptsTet = nelemTet*QTet,
+          nqptsHex = nelemHex*QHex*QHex;
+  CeedInt indxTet[nelemTet*PTet],
+          indxHex[nelemHex*PHex*PHex];
+  CeedScalar x[dim*ndofs];
+  CeedScalar qref[dim*QTet], qweight[QTet];
+  CeedScalar interp[PTet*QTet], grad[dim*PTet*QTet];
+  CeedScalar sum;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<ny*2+1; i++)
+    for (CeedInt j=0; j<nx*2+1; j++) {
+      x[i+j*(ny*2+1)+0*ndofs] = (CeedScalar) i / (2*ny);
+      x[i+j*(ny*2+1)+1*ndofs] = (CeedScalar) j / (2*nx);
+    }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vectors
+  CeedVectorCreate(ceed, nqptsTet, &qdataTet);
+  CeedVectorCreate(ceed, nqptsHex, &qdataHex);
+
+  // Tet Elements
+  for (CeedInt i=0; i<nelemTet/2; i++) {
+    col = i % nxTet;
+    row = i / nxTet;
+    offset = col*2 + row*(nxTet*2+1)*2;
+
+    indxTet[i*2*PTet +  0] =  2 + offset;
+    indxTet[i*2*PTet +  1] =  9 + offset;
+    indxTet[i*2*PTet +  2] = 16 + offset;
+    indxTet[i*2*PTet +  3] =  1 + offset;
+    indxTet[i*2*PTet +  4] =  8 + offset;
+    indxTet[i*2*PTet +  5] =  0 + offset;
+
+    indxTet[i*2*PTet +  6] = 14 + offset;
+    indxTet[i*2*PTet +  7] =  7 + offset;
+    indxTet[i*2*PTet +  8] =  0 + offset;
+    indxTet[i*2*PTet +  9] = 15 + offset;
+    indxTet[i*2*PTet + 10] =  8 + offset;
+    indxTet[i*2*PTet + 11] = 16 + offset;
+  }
+
+  // -- Restrictions
+  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, dim, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indxTet, &ErestrictxTet);
+  CeedElemRestrictionCreateIdentity(ceed, nelemTet, PTet, nelemTet*PTet, dim,
+                                    &ErestrictxiTet);
+
+  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, 1, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indxTet, &ErestrictuTet);
+  CeedElemRestrictionCreateIdentity(ceed, nelemTet, QTet, nqptsTet, 1,
+                                    &ErestrictuiTet);
+
+  // -- Bases
+  buildmats(qref, qweight, interp, grad);
+  CeedBasisCreateH1(ceed, CEED_TRIANGLE, dim, PTet, QTet, interp, grad, qref,
+                    qweight, &bxTet);
+
+  buildmats(qref, qweight, interp, grad);
+  CeedBasisCreateH1(ceed, CEED_TRIANGLE, 1, PTet, QTet, interp, grad, qref,
+                    qweight, &buTet);
+
+  // -- QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setupTet);
+  CeedQFunctionAddInput(qf_setupTet, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setupTet, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setupTet, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_massTet);
+  CeedQFunctionAddInput(qf_massTet, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_massTet, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_massTet, "v", 1, CEED_EVAL_INTERP);
+
+  // -- Operators
+  // ---- Setup Tet
+  CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupTet);
+  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
+                       bxTet, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
+                       bxTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdataTet);
+  // ---- Mass Tet
+  CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_massTet);
+  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdataTet);
+  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
+                       buTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, CEED_NOTRANSPOSE,
+                       buTet, CEED_VECTOR_ACTIVE);
+
+  // Hex Elements
+  for (CeedInt i=0; i<nelemHex; i++) {
+    col = i % nxHex;
+    row = i / nxHex;
+    offset = (nxTet*2+1)*(nyTet*2)*(1+row) + col*2;
+    for (CeedInt j=0; j<PHex; j++)
+      for (CeedInt k=0; k<PHex; k++)
+        indxHex[PHex*(PHex*i+k)+j] = offset + k*(nxHex*2+1) + j;
+  }
+
+  // -- Restrictions
+  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, dim,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
+                            &ErestrictxHex);
+  CeedElemRestrictionCreateIdentity(ceed, nelemHex, PHex*PHex,
+                                    nelemHex*PHex*PHex, dim, &ErestrictxiHex);
+
+  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, 1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
+                            &ErestrictuHex);
+  CeedElemRestrictionCreateIdentity(ceed, nelemHex, QHex*QHex, nqptsHex, 1,
+                                    &ErestrictuiHex);
+
+  // -- Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, PHex, QHex, CEED_GAUSS,
+                                  &bxHex);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, PHex, QHex, CEED_GAUSS, &buHex);
+
+  // -- QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setupHex);
+  CeedQFunctionAddInput(qf_setupHex, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setupHex, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setupHex, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_massHex);
+  CeedQFunctionAddInput(qf_massHex, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_massHex, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_massHex, "v", 1, CEED_EVAL_INTERP);
+
+  // -- Operators
+  CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setupHex);
+  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
+                       bxHex, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
+                       bxHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdataHex);
+
+  CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_massHex);
+  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
+                       CEED_BASIS_COLLOCATED, qdataHex);
+  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,
+                       buHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, CEED_NOTRANSPOSE,
+                       buHex, CEED_VECTOR_ACTIVE);
+
+  // Composite Operators
+  CeedCompositeOperatorCreate(ceed, &op_setup);
+  CeedCompositeOperatorAddSub(op_setup, op_setupTet);
+  CeedCompositeOperatorAddSub(op_setup, op_setupHex);
+
+  CeedCompositeOperatorCreate(ceed, &op_mass);
+  CeedCompositeOperatorAddSub(op_mass, op_massTet);
+  CeedCompositeOperatorAddSub(op_mass, op_massHex);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, X, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);
+
+  // Apply Mass Operator
+  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorSetValue(U, 1.0);
+  CeedVectorCreate(ceed, ndofs, &V);
+  CeedVectorSetValue(V, 0.0);
+
+  // Apply
+  CeedOperatorApplyAdd(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+  // Check output
+  CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
+  sum = 0.;
+  for (CeedInt i=0; i<ndofs; i++)
+    sum += hv[i];
+  if (fabs(sum-1.)>1e-10) printf("Computed Area: %f != True Area: 1.0\n", sum);
+  CeedVectorRestoreArrayRead(V, &hv);
+
+  // Apply Add
+  CeedVectorSetValue(V, 1.0);
+  CeedOperatorApplyAdd(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+  // Check output
+  CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);
+  sum = -ndofs;
+  for (CeedInt i=0; i<ndofs; i++)
+    sum += hv[i];
+  if (fabs(sum-1.)>1e-10) printf("Computed Area: %f != True Area: 1.0\n", sum);
+  CeedVectorRestoreArrayRead(V, &hv);
+
+  // Cleanup
+  CeedQFunctionDestroy(&qf_setupTet);
+  CeedQFunctionDestroy(&qf_massTet);
+  CeedOperatorDestroy(&op_setupTet);
+  CeedOperatorDestroy(&op_massTet);
+  CeedQFunctionDestroy(&qf_setupHex);
+  CeedQFunctionDestroy(&qf_massHex);
+  CeedOperatorDestroy(&op_setupHex);
+  CeedOperatorDestroy(&op_massHex);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass);
+  CeedElemRestrictionDestroy(&ErestrictuTet);
+  CeedElemRestrictionDestroy(&ErestrictxTet);
+  CeedElemRestrictionDestroy(&ErestrictuiTet);
+  CeedElemRestrictionDestroy(&ErestrictxiTet);
+  CeedElemRestrictionDestroy(&ErestrictuHex);
+  CeedElemRestrictionDestroy(&ErestrictxHex);
+  CeedElemRestrictionDestroy(&ErestrictuiHex);
+  CeedElemRestrictionDestroy(&ErestrictxiHex);
+  CeedBasisDestroy(&buTet);
+  CeedBasisDestroy(&bxTet);
+  CeedBasisDestroy(&buHex);
+  CeedBasisDestroy(&bxHex);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedVectorDestroy(&qdataTet);
+  CeedVectorDestroy(&qdataHex);
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
Fixes #412

This works for `/cpu/self/*` and `/*/occa`

ToDo:
 - [x] CUDA backends
 - [x] Composite ApplyAdd test

I adopted the convention that all passive outputs are also overwritten or added into. It can be easily changed if desired.