### PR TITLE
None Args

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -130,7 +130,8 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
       ierr = CeedOperatorFieldGetBasis(opfields[i], &basis); CeedChk(ierr);
       ierr = CeedVectorCreate(ceed, Q*blksize, &qvecs[i]); CeedChk(ierr);
       ierr = CeedBasisApply(basis, blksize, CEED_NOTRANSPOSE,
-                            CEED_EVAL_WEIGHT, NULL, qvecs[i]); CeedChk(ierr);
+                            CEED_EVAL_WEIGHT, CEED_VECTOR_NONE, qvecs[i]);
+      CeedChk(ierr);
 
       break;
     case CEED_EVAL_DIV:

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -833,7 +833,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   Ceed_Cuda *ceed_data;
   ierr = CeedGetData(delegate, (void **)&ceed_data); CeedChk(ierr);
   ierr = cudaGetDeviceProperties(&prop, ceed_data->deviceId);
-  if(prop.major<6){
+  if (prop.major<6){
     code << atomicAdd;
   }
 
@@ -1176,7 +1176,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   }
   string qFunctionName(qf_data->qFunctionName);
   code << "  "<<qFunctionName<<"(ctx, ";
-  if(dim!=3 || basis_data->d_collograd1d) {
+  if (dim != 3 || basis_data->d_collograd1d) {
     code << "1 ";
   }else{
     code << "Q1d ";

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -97,7 +97,7 @@ static int CeedOperatorApply_Cuda_gen(CeedOperator op, CeedVector invec,
   size_t ctxsize;
   ierr = CeedQFunctionGetContextSize(qf, &ctxsize); CeedChk(ierr);
   if (ctxsize > 0) {
-    if(!qf_data->d_c) {
+    if (!qf_data->d_c) {
       ierr = cudaMalloc(&qf_data->d_c, ctxsize); CeedChk_Cu(ceed, ierr);
     }
     void *ctx;

--- a/backends/cuda-gen/ceed-cuda-gen-qfunction.c
+++ b/backends/cuda-gen/ceed-cuda-gen-qfunction.c
@@ -60,7 +60,7 @@ static int loadCudaFunction(CeedQFunction qf, char *c_src_file) {
   char *buffer;
 
   fp = fopen ( cuda_file, "rb" );
-  if( !fp ) CeedError(ceed, 1, "Couldn't open the Cuda file for the QFunction.");
+  if (!fp) CeedError(ceed, 1, "Couldn't open the Cuda file for the QFunction.");
 
   fseek( fp, 0L, SEEK_END);
   lSize = ftell( fp );
@@ -70,7 +70,7 @@ static int loadCudaFunction(CeedQFunction qf, char *c_src_file) {
   ierr = CeedCalloc( lSize+1, &buffer ); CeedChk(ierr);
 
   /* copy the file into the buffer */
-  if( 1!=fread( buffer, lSize, 1, fp) ) {
+  if (1 != fread( buffer, lSize, 1, fp) ) {
     fclose(fp);
     CeedFree(&buffer);
     CeedError(ceed, 1, "Couldn't read the Cuda file for the QFunction.");
@@ -107,7 +107,7 @@ int CeedQFunctionCreate_Cuda_gen(CeedQFunction qf) {
 
   char *source;
   ierr = CeedQFunctionGetSourcePath(qf, &source); CeedChk(ierr);
-  const char *funname = strrchr(source, ':') + 1;
+  cons char *funname = strrchr(source, ':') + 1;
   data->qFunctionName = (char *)funname;
   const int filenamelen = funname - source;
   char filename[filenamelen];

--- a/backends/cuda-reg/ceed-cuda-reg-basis.c
+++ b/backends/cuda-reg/ceed-cuda-reg-basis.c
@@ -105,9 +105,9 @@ inline __device__ void interp1d(const CeedInt nelem, const int transpose,
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
 
-  if(bid*32+tid<nelem) {
+  if (bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         const int sizeU = P1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
         Contract1d(r_V, c_B, P1D, P1D, Q1D, r_t);
@@ -136,9 +136,9 @@ inline __device__ void grad1d(const CeedInt nelem, const int transpose,
   const int bid = blockIdx.x;
   int dim;
 
-  if(bid*32+tid<nelem) {
+  if (bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         const int sizeU = P1D;
         const int sizeV = Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
@@ -191,9 +191,9 @@ inline __device__ void interp2d(const CeedInt nelem, const int transpose,
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
 
-  if(bid*32+tid<nelem) {
+  if (bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         const int sizeU = P1D*P1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
         Contract2d(r_V, c_B, P1D, P1D, P1D, Q1D, r_t);
@@ -225,9 +225,9 @@ inline __device__ void grad2d(const CeedInt nelem, const int transpose,
   const int bid = blockIdx.x;
   int dim;
 
-  if(bid*32+tid<nelem) {
+  if (bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         const int sizeU = P1D*P1D;
         const int sizeV = Q1D*Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
@@ -293,9 +293,9 @@ inline __device__ void interp3d(const CeedInt nelem, const int transpose,
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
 
-  if(bid*32+tid<nelem) {
+  if (bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         const int sizeU = P1D*P1D*P1D;
         const int sizeV = Q1D*Q1D*Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_V);
@@ -329,9 +329,9 @@ inline __device__ void grad3d(const CeedInt nelem, const int transpose,
   const int bid = blockIdx.x;
   int dim;
 
-  if(bid*32+tid<nelem) {
+  if (bid*32+tid<nelem) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         const int sizeU = P1D*P1D*P1D;
         const int sizeV = Q1D*Q1D*Q1D;
         readDofs(bid, tid, comp, sizeU, nelem, d_U, r_U);
@@ -495,7 +495,7 @@ int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem,
 
   const CeedScalar *d_u;
   CeedScalar *d_v;
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
@@ -537,7 +537,7 @@ int CeedBasisApply_Cuda_reg(CeedBasis basis, const CeedInt nelem,
     ierr = CeedRunKernelCuda(ceed, data->weight, gridsize, blocksize, weightargs);
   }
 
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -103,7 +103,7 @@ inline __device__ void interp1d(const CeedInt nelem, const int transpose,
   for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
        elem += gridDim.x*blockDim.z) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         readDofs1d(elem, tidx, tidy, tidz, comp, nelem, d_U, slice);
         ContractX1d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
         writeQuads1d(elem, tidx, tidy, comp, 0, nelem, r_V, d_V);
@@ -132,7 +132,7 @@ inline __device__ void grad1d(const CeedInt nelem, const int transpose,
   for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
        elem += gridDim.x*blockDim.z) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {
+      if (!transpose) {
         readDofs1d(elem, tidx, tidy, tidz, comp, nelem, d_U, slice);
         ContractX1d(slice, tidx, tidy, tidz, r_U, c_G, r_V);
         dim = 0;
@@ -259,7 +259,7 @@ inline __device__ void interp2d(const CeedInt nelem, const int transpose,
     const int comp = tidz%BASIS_NCOMP;
     r_V = 0.0;
     r_t = 0.0;
-    if(!transpose) {
+    if (!transpose) {
       readDofs2d(elem, tidx, tidy, comp, nelem, d_U, r_V);
       ContractX2d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
       ContractY2d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
@@ -291,7 +291,7 @@ inline __device__ void grad2d(const CeedInt nelem, const int transpose,
 
   for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
        elem += gridDim.x*elemsPerBlock) {
-    if(!transpose) {
+    if (!transpose) {
       readDofs2d(elem, tidx, tidy, comp, nelem, d_U, r_U);
       ContractX2d(slice, tidx, tidy, tidz, r_U, c_G, r_t);
       ContractY2d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
@@ -472,7 +472,7 @@ inline __device__ void interp3d(const CeedInt nelem, const int transpose,
       r_V[i] = 0.0;
       r_t[i] = 0.0;
     }
-    if(!transpose) {
+    if (!transpose) {
       readDofs3d(elem, tidx, tidy, comp, nelem, d_U, r_V);
       ContractX3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
       ContractY3d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
@@ -508,7 +508,7 @@ inline __device__ void grad3d(const CeedInt nelem, const int transpose,
 
   for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
        elem += gridDim.x*elemsPerBlock) {
-    if(!transpose) {
+    if (!transpose) {
       readDofs3d(elem, tidx, tidy, comp, nelem, d_U, r_U);
       ContractX3d(slice, tidx, tidy, tidz, r_U, c_G, r_V);
       ContractY3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
@@ -656,7 +656,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
 
   const CeedScalar *d_u;
   CeedScalar *d_v;
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
@@ -747,14 +747,14 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     CeedInt Q1d;
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
     void *weightargs[] = {(void *) &nelem, (void *) &data->d_qweight1d, &d_v};
-    if(dim==1) {
+    if (dim == 1) {
       const CeedInt elemsPerBlock = 32/Q1d;
       const CeedInt gridsize = nelem/elemsPerBlock + ( (
                                  nelem/elemsPerBlock*elemsPerBlock<nelem)? 1 : 0 );
       ierr = CeedRunKernelDimCuda(ceed, data->weight, gridsize, Q1d,
                                   elemsPerBlock, 1, weightargs);
       CeedChk(ierr);
-    } else if(dim==2) {
+    } else if (dim == 2) {
       const CeedInt optElems = 32/(Q1d*Q1d);
       const CeedInt elemsPerBlock = optElems>0?optElems:1;
       const CeedInt gridsize = nelem/elemsPerBlock + ( (
@@ -762,7 +762,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       ierr = CeedRunKernelDimCuda(ceed, data->weight, gridsize, Q1d, Q1d,
                                   elemsPerBlock, weightargs);
       CeedChk(ierr);
-    } else if(dim==3) {
+    } else if (dim == 3) {
       const CeedInt gridsize = nelem;
       ierr = CeedRunKernelDimCuda(ceed, data->weight, gridsize, Q1d, Q1d, Q1d,
                                   weightargs);
@@ -770,7 +770,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     }
   }
 
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);

--- a/backends/cuda/ceed-cuda-basis.c
+++ b/backends/cuda/ceed-cuda-basis.c
@@ -360,7 +360,7 @@ extern "C" __global__ void interp(const CeedInt nelem, const int transpose,
   for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
        elem += gridDim.x*blockDim.z) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {//run with Q threads
+      if (!transpose) {//run with Q threads
         U = d_U + elem*BASIS_NCOMP*P + comp*P;
         V = 0.0;
         for (int i = 0; i < P; ++i) {
@@ -391,7 +391,7 @@ extern "C" __global__ void grad(const CeedInt nelem, const int transpose,
   for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
        elem += gridDim.x*blockDim.z) {
     for(int comp=0; comp<BASIS_NCOMP; comp++) {
-      if(!transpose) {//run with Q threads
+      if (!transpose) {//run with Q threads
         double V[BASIS_DIM];
         U = d_U + elem*BASIS_NCOMP*P + comp*P;
         for(int dim=0; dim<BASIS_DIM; dim++) {
@@ -449,7 +449,7 @@ int CeedBasisApply_Cuda(CeedBasis basis, const CeedInt nelem,
 
   const CeedScalar *d_u;
   CeedScalar *d_v;
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
@@ -488,7 +488,7 @@ int CeedBasisApply_Cuda(CeedBasis basis, const CeedInt nelem,
                              weightargs); CeedChk(ierr);
   }
 
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);
@@ -517,7 +517,7 @@ int CeedBasisApplyNonTensor_Cuda(CeedBasis basis, const CeedInt nelem,
 
   const CeedScalar *d_u;
   CeedScalar *d_v;
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
@@ -561,7 +561,7 @@ int CeedBasisApplyNonTensor_Cuda(CeedBasis basis, const CeedInt nelem,
     CeedChk(ierr);
   }
 
-  if(emode!=CEED_EVAL_WEIGHT) {
+  if (emode != CEED_EVAL_WEIGHT) {
     ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);

--- a/backends/occa/ceed-occa-basis.c
+++ b/backends/occa/ceed-occa-basis.c
@@ -239,7 +239,7 @@ static int CeedBasisApply_Occa(CeedBasis basis, CeedInt nelem,
   const CeedInt transpose = (tmode == CEED_TRANSPOSE);
   const CeedScalar *u;
   CeedScalar *v;
-  if (U) {
+  if (U != CEED_VECTOR_NONE) {
     ierr = CeedVectorGetArrayRead(U, CEED_MEM_HOST, &u); CeedChk(ierr);
   } else if (emode != CEED_EVAL_WEIGHT) {
     return CeedError(ceed, 1,
@@ -330,7 +330,7 @@ static int CeedBasisApply_Occa(CeedBasis basis, CeedInt nelem,
       }
     }
   }
-  if (U) {
+  if (U != CEED_VECTOR_NONE) {
     ierr = CeedVectorRestoreArrayRead(U, &u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(V, &v); CeedChk(ierr);

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -162,7 +162,7 @@ static int CeedOperatorSetupFields_Occa(CeedQFunction qf, CeedOperator op,
       ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
       ierr = CeedVectorCreate(ceed, Q, &qvecs[i]); CeedChk(ierr);
       ierr = CeedBasisApply(basis, 1, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT,
-                            NULL, qvecs[i]); CeedChk(ierr);
+                            CEED_VECTOR_NONE, qvecs[i]); CeedChk(ierr);
       assert(starte==0);
       break;
     case CEED_EVAL_DIV: break; // Not implemented

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -131,7 +131,8 @@ static int CeedOperatorSetupFields_Opt(CeedQFunction qf, CeedOperator op,
       ierr = CeedOperatorFieldGetBasis(opfields[i], &basis); CeedChk(ierr);
       ierr = CeedVectorCreate(ceed, Q*blksize, &qvecs[i]); CeedChk(ierr);
       ierr = CeedBasisApply(basis, blksize, CEED_NOTRANSPOSE,
-                            CEED_EVAL_WEIGHT, NULL, qvecs[i]); CeedChk(ierr);
+                            CEED_EVAL_WEIGHT, CEED_VECTOR_NONE, qvecs[i]);
+      CeedChk(ierr);
 
       break;
     case CEED_EVAL_DIV:

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -32,7 +32,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,
   const CeedInt add = (tmode == CEED_TRANSPOSE);
   const CeedScalar *u;
   CeedScalar *v;
-  if (U) {
+  if (U != CEED_VECTOR_NONE) {
     ierr = CeedVectorGetArrayRead(U, CEED_MEM_HOST, &u); CeedChk(ierr);
   } else if (emode != CEED_EVAL_WEIGHT) {
     // LCOV_EXCL_START
@@ -290,7 +290,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt nelem,
       // LCOV_EXCL_STOP
     }
   }
-  if (U) {
+  if (U != CEED_VECTOR_NONE) {
     ierr = CeedVectorRestoreArrayRead(U, &u); CeedChk(ierr);
   }
   ierr = CeedVectorRestoreArray(V, &v); CeedChk(ierr);

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -107,7 +107,7 @@ static int CeedOperatorSetupFields_Ref(CeedQFunction qf, CeedOperator op,
       ierr = CeedOperatorFieldGetBasis(opfields[i], &basis); CeedChk(ierr);
       ierr = CeedVectorCreate(ceed, Q, &qvecs[i]); CeedChk(ierr);
       ierr = CeedBasisApply(basis, 1, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT,
-                            NULL, qvecs[i]); CeedChk(ierr);
+                            CEED_VECTOR_NONE, qvecs[i]); CeedChk(ierr);
       break;
     case CEED_EVAL_DIV:
       break; // Not implemented

--- a/examples/ceed/ex1.c
+++ b/examples/ceed/ex1.c
@@ -200,7 +200,8 @@ int main(int argc, const char *argv[]) {
 
   // Create the operator that builds the quadrature data for the mass operator.
   CeedOperator build_oper;
-  CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
+  CeedOperatorCreate(ceed, build_qfunc, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &build_oper);
   CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
                        mesh_basis,CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
@@ -244,7 +245,8 @@ int main(int argc, const char *argv[]) {
 
   // Create the mass operator.
   CeedOperator oper;
-  CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
+  CeedOperatorCreate(ceed, apply_qfunc, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &oper);
   CeedOperatorSetField(oper, "u", sol_restr, CEED_NOTRANSPOSE,
                        sol_basis, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(oper, "qdata", sol_restr_i, CEED_NOTRANSPOSE,

--- a/examples/ceed/ex2.c
+++ b/examples/ceed/ex2.c
@@ -209,7 +209,8 @@ int main(int argc, const char *argv[]) {
   // Create the operator that builds the quadrature data for the diffusion
   // operator.
   CeedOperator build_oper;
-  CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
+  CeedOperatorCreate(ceed, build_qfunc, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &build_oper);
   CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
                        mesh_basis,CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
@@ -257,7 +258,8 @@ int main(int argc, const char *argv[]) {
 
   // Create the diffusion operator.
   CeedOperator oper;
-  CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
+  CeedOperatorCreate(ceed, apply_qfunc, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &oper);
   CeedOperatorSetField(oper, "du", sol_restr, CEED_NOTRANSPOSE,
                        sol_basis, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(oper, "qdata", qdata_restr_i, CEED_NOTRANSPOSE,

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -151,7 +151,8 @@ class CeedMassOperator : public mfem::Operator {
     CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));
 
     // Create the operator that builds the quadrature data for the mass operator.
-    CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
+    CeedOperatorCreate(ceed, build_qfunc, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &build_oper);
     CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
                          mesh_basis, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
@@ -171,7 +172,8 @@ class CeedMassOperator : public mfem::Operator {
     CeedQFunctionAddOutput(apply_qfunc, "v", 1, CEED_EVAL_INTERP);
 
     // Create the mass operator.
-    CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
+    CeedOperatorCreate(ceed, apply_qfunc, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &oper);
     CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
                          basis, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(oper, "qdata", restr_i, CEED_NOTRANSPOSE,

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -151,7 +151,8 @@ class CeedDiffusionOperator : public mfem::Operator {
     CeedQFunctionSetContext(build_qfunc, &build_ctx, sizeof(build_ctx));
 
     // Create the operator that builds the quadrature data for the diff operator.
-    CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
+    CeedOperatorCreate(ceed, build_qfunc, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &build_oper);
     CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
                          mesh_basis, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
@@ -172,7 +173,8 @@ class CeedDiffusionOperator : public mfem::Operator {
     CeedQFunctionSetContext(apply_qfunc, &build_ctx, sizeof(build_ctx));
 
     // Create the diff operator.
-    CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
+    CeedOperatorCreate(ceed, apply_qfunc, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &oper);
     CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
                          basis, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(oper, "qdata", restr_i, CEED_NOTRANSPOSE,

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -805,7 +805,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf, "dv", ncompq*dim, CEED_EVAL_GRAD);
 
   // Create the operator that builds the quadrature data for the NS operator
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
   CeedOperatorSetField(op_setup, "dx", restrictx, CEED_NOTRANSPOSE,
                        basisx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup, "weight", restrictxi, CEED_NOTRANSPOSE,
@@ -814,7 +815,8 @@ int main(int argc, char **argv) {
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Create the mass operator
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
   CeedOperatorSetField(op_mass, "q", restrictq, CEED_TRANSPOSE,
                        basisq, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_mass, "qdata", restrictqdi, CEED_NOTRANSPOSE,
@@ -823,7 +825,8 @@ int main(int argc, char **argv) {
                        basisq, CEED_VECTOR_ACTIVE);
 
   // Create the operator that sets the ICs
-  CeedOperatorCreate(ceed, qf_ics, NULL, NULL, &op_ics);
+  CeedOperatorCreate(ceed, qf_ics, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_ics);
   CeedOperatorSetField(op_ics, "x", restrictx, CEED_NOTRANSPOSE,
                        basisxc, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_ics, "q0", restrictq, CEED_TRANSPOSE,
@@ -832,7 +835,7 @@ int main(int argc, char **argv) {
                        CEED_BASIS_COLLOCATED, xceed);
 
   // Create the physics operator
-  CeedOperatorCreate(ceed, qf, NULL, NULL, &op);
+  CeedOperatorCreate(ceed, qf, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op);
   CeedOperatorSetField(op, "q", restrictq, CEED_TRANSPOSE,
                        basisq, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op, "dq", restrictq, CEED_TRANSPOSE,

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -835,7 +835,7 @@ C     Create ceed qfunctions for masssetupf and massf
 
 C     Create ceed operators
       call ceedoperatorcreate(ceed,qf_setup,
-     $  ceed_null,ceed_null,op_setup,err)
+     $  ceed_qfunction_none,ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'x',erstrctx,
      $  ceed_notranspose,basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'dx',erstrctx,
@@ -849,7 +849,7 @@ C     Create ceed operators
      $  ceed_notranspose,basisu,vec_rhs,err)
 
       call ceedoperatorcreate(ceed,qf_mass,
-     $  ceed_null,ceed_null,op_mass,err)
+     $  ceed_qfunction_none,ceed_qfunction_none,op_mass,err)
       call ceedoperatorsetfield(op_mass,'u',erstrctu,
      $  ceed_notranspose,basisu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'qdata',erstrctw,
@@ -1152,7 +1152,7 @@ C     Create ceed qfunctions for diffsetupf and diffusionf
 
 C     Create ceed operators
       call ceedoperatorcreate(ceed,qf_setup,
-     $  ceed_null,ceed_null,op_setup,err)
+     $  ceed_qfunction_none,ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'x',erstrctx,
      $  ceed_notranspose,basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'dx',erstrctx,
@@ -1166,7 +1166,7 @@ C     Create ceed operators
      $  ceed_notranspose,basisu,vec_rhs,err)
 
       call ceedoperatorcreate(ceed,qf_diffusion,
-     $  ceed_null,ceed_null,op_diffusion,err)
+     $  ceed_qfunction_none,ceed_qfunction_none,op_diffusion,err)
       call ceedoperatorsetfield(op_diffusion,'u',erstrctu,
      $  ceed_notranspose,basisu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diffusion,'qdata',erstrctw,

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -282,7 +282,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_apply, "v", ncompu, CEED_EVAL_INTERP);
 
   // Create the operator that builds the quadrature data for the operator
-  CeedOperatorCreate(ceed, qf_setupgeo, NULL, NULL, &op_setupgeo);
+  CeedOperatorCreate(ceed, qf_setupgeo, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupgeo);
   CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, CEED_TRANSPOSE,
                        basisx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -291,7 +292,8 @@ int main(int argc, char **argv) {
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Create the mass operator
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
   CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_TRANSPOSE,
                        basisu, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -206,7 +206,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_error, "error", ncompu, CEED_EVAL_NONE);
 
   // Create the error operator
-  CeedOperatorCreate(ceed, qf_error, NULL, NULL, &op_error);
+  CeedOperatorCreate(ceed, qf_error, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_error);
   CeedOperatorSetField(op_error, "u", ceeddata->Erestrictu,
                        CEED_TRANSPOSE, ceeddata->basisu,
                        CEED_VECTOR_ACTIVE);

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -671,7 +671,8 @@ int main(int argc, char **argv) {
   CeedVectorCreate(ceed, lsize*ncompu, &rhsceed);
 
   // Create the operator that builds the quadrature data for the ceed operator
-  CeedOperatorCreate(ceed, qf_setupgeo, NULL, NULL, &op_setupgeo);
+  CeedOperatorCreate(ceed, qf_setupgeo, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupgeo);
   CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, CEED_NOTRANSPOSE,
                        basisx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -680,7 +681,8 @@ int main(int argc, char **argv) {
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Create the operator that builds the RHS and true solution
-  CeedOperatorCreate(ceed, qf_setuprhs, NULL, NULL, &op_setuprhs);
+  CeedOperatorCreate(ceed, qf_setuprhs, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setuprhs);
   CeedOperatorSetField(op_setuprhs, "x", Erestrictx, CEED_NOTRANSPOSE,
                        basisx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setuprhs, "dx", Erestrictx, CEED_NOTRANSPOSE,
@@ -693,7 +695,8 @@ int main(int argc, char **argv) {
                        basisu, CEED_VECTOR_ACTIVE);
 
   // Create the mass or diff operator
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
   CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_TRANSPOSE,
                        basisu, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
@@ -702,7 +705,8 @@ int main(int argc, char **argv) {
                        basisu, CEED_VECTOR_ACTIVE);
 
   // Create the error operator
-  CeedOperatorCreate(ceed, qf_error, NULL, NULL, &op_error);
+  CeedOperatorCreate(ceed, qf_error, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_error);
   CeedOperatorSetField(op_error, "u", Erestrictu, CEED_TRANSPOSE,
                        basisu, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_error, "true_soln", Erestrictui, CEED_NOTRANSPOSE,

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -297,7 +297,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_error, "error", ncompu, CEED_EVAL_NONE);
 
   // Create the error operator
-  CeedOperatorCreate(ceed, qf_error, NULL, NULL, &op_error);
+  CeedOperatorCreate(ceed, qf_error, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_error);
   CeedOperatorSetField(op_error, "u", ceeddata[numlevels-1]->Erestrictu,
                        CEED_TRANSPOSE, ceeddata[numlevels-1]->basisu,
                        CEED_VECTOR_ACTIVE);

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -540,7 +540,8 @@ static int SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt dim,
                          bpOptions[bpChoice].outmode);
 
   // Create the operator that builds the quadrature data for the operator
-  CeedOperatorCreate(ceed, qf_setupgeo, NULL, NULL, &op_setupgeo);
+  CeedOperatorCreate(ceed, qf_setupgeo, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupgeo);
   CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, CEED_TRANSPOSE,
                        basisx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -549,7 +550,8 @@ static int SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt dim,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Create the operator
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
   CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_TRANSPOSE,
                        basisu, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
@@ -576,7 +578,8 @@ static int SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt dim,
     CeedQFunctionAddOutput(qf_setuprhs, "rhs", ncompu, CEED_EVAL_INTERP);
 
     // Create the operator that builds the RHS and true solution
-    CeedOperatorCreate(ceed, qf_setuprhs, NULL, NULL, &op_setuprhs);
+    CeedOperatorCreate(ceed, qf_setuprhs, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &op_setuprhs);
     CeedOperatorSetField(op_setuprhs, "x", Erestrictx, CEED_TRANSPOSE,
                          basisx, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(op_setuprhs, "dx", Erestrictx, CEED_TRANSPOSE,
@@ -642,7 +645,8 @@ static PetscErrorCode CeedLevelTransferSetup(Ceed ceed, CeedInt numlevels,
                                     CEED_GAUSS_LOBATTO, &basisctof);
 
     // Create the restriction operator
-    CeedOperatorCreate(ceed, qf_restrict, NULL, NULL, &op_restrict);
+    CeedOperatorCreate(ceed, qf_restrict, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &op_restrict);
     CeedOperatorSetField(op_restrict, "input", data[i]->Erestrictu,
                          CEED_NOTRANSPOSE, CEED_BASIS_COLLOCATED,
                          CEED_VECTOR_ACTIVE);
@@ -657,7 +661,8 @@ static PetscErrorCode CeedLevelTransferSetup(Ceed ceed, CeedInt numlevels,
     CeedOperator op_interp;
 
     // Create the prolongation operator
-    CeedOperatorCreate(ceed, qf_prolong, NULL, NULL, &op_interp);
+    CeedOperatorCreate(ceed, qf_prolong, CEED_QFUNCTION_NONE,
+                       CEED_QFUNCTION_NONE, &op_interp);
     CeedOperatorSetField(op_interp, "input", data[i-1]->Erestrictu,
                          CEED_NOTRANSPOSE, basisctof, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(op_interp, "output", data[i]->Erestrictu,

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -203,6 +203,12 @@ CEED_EXTERN CeedVector CEED_VECTOR_ACTIVE;
 /// @ingroup CeedVector
 CEED_EXTERN CeedVector CEED_VECTOR_NONE;
 
+/// Argument for CeedOperatorCreate that QFunction is not created by user.
+/// Only used for QFunctions dqf and dqfT. If implemented, a backend may
+/// attempt to provide the action of these QFunctions.
+/// @ingroup CeedQFunction
+CEED_EXTERN CeedQFunction CEED_QFUNCTION_NONE;
+
 /// Denotes whether a linear transformation or its transpose should be applied
 /// @ingroup CeedBasis
 typedef enum {

--- a/include/ceedf.h
+++ b/include/ceedf.h
@@ -110,7 +110,7 @@
       parameter(ceed_hex         = X'30006' )
 
 !-----------------------------------------------------------------------
-! OperatorFieldConstants
+! Operator and OperatorField Constants
 !-----------------------------------------------------------------------
 
       integer ceed_basis_collocated
@@ -121,3 +121,6 @@
 
       integer ceed_vector_none
       parameter(ceed_vector_none          = -2)
+
+      integer ceed_qfunction_none
+      parameter(ceed_qfunction_none       = -1)

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -12,6 +12,7 @@
 #define FORTRAN_BASIS_COLLOCATED -1
 #define FORTRAN_VECTOR_ACTIVE -1
 #define FORTRAN_VECTOR_NONE -2
+#define FORTRAN_QFUNCTION_NONE -1
 
 static Ceed *Ceed_dict = NULL;
 static int Ceed_count = 0;
@@ -746,9 +747,9 @@ void fCeedOperatorCreate(int *ceed,
 
   CeedOperator *op_ = &CeedOperator_dict[CeedOperator_count];
 
-  CeedQFunction dqf_  = NULL, dqfT_ = NULL;
-  if (*dqf  != FORTRAN_NULL) dqf_  = CeedQFunction_dict[*dqf ];
-  if (*dqfT != FORTRAN_NULL) dqfT_ = CeedQFunction_dict[*dqfT];
+  CeedQFunction dqf_  = CEED_QFUNCTION_NONE, dqfT_ = CEED_QFUNCTION_NONE;
+  if (*dqf  != FORTRAN_QFUNCTION_NONE) dqf_  = CeedQFunction_dict[*dqf ];
+  if (*dqfT != FORTRAN_QFUNCTION_NONE) dqfT_ = CeedQFunction_dict[*dqfT];
 
   *err = CeedOperatorCreate(Ceed_dict[*ceed], CeedQFunction_dict[*qf], dqf_,
                             dqfT_, op_);

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -468,7 +468,8 @@ void fCeedBasisGetCollocatedGrad(int *basis, CeedScalar *colograd1d,
 void fCeedBasisApply(int *basis, int *nelem, int *tmode, int *emode,
                      int *u, int *v, int *err) {
   *err = CeedBasisApply(CeedBasis_dict[*basis], *nelem, *tmode, *emode,
-                        *u==FORTRAN_NULL?NULL:CeedVector_dict[*u],
+                        *u==FORTRAN_VECTOR_NONE?
+                        CEED_VECTOR_NONE:CeedVector_dict[*u],
                         CeedVector_dict[*v]);
 }
 

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -915,10 +915,12 @@ void fCeedOperatorAssembleLinearDiagonal(int *op, int *assembledvec,
 #define fCeedOperatorApply FORTRAN_NAME(ceedoperatorapply, CEEDOPERATORAPPLY)
 void fCeedOperatorApply(int *op, int *ustatevec,
                         int *resvec, int *rqst, int *err) {
-  CeedVector ustatevec_ = *ustatevec == FORTRAN_NULL
-                          ? NULL : CeedVector_dict[*ustatevec];
-  CeedVector resvec_ = *resvec == FORTRAN_NULL
-                       ? NULL : CeedVector_dict[*resvec];
+  CeedVector ustatevec_ = (*ustatevec == FORTRAN_NULL) ?
+                          NULL : (*ustatevec == FORTRAN_VECTOR_NONE ?
+                          CEED_VECTOR_NONE : CeedVector_dict[*ustatevec]);
+  CeedVector resvec_ = (*resvec == FORTRAN_NULL) ?
+                       NULL : (*resvec == FORTRAN_VECTOR_NONE ?
+                       CEED_VECTOR_NONE : CeedVector_dict[*resvec]);
 
   int createRequest = 1;
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -917,10 +917,10 @@ void fCeedOperatorApply(int *op, int *ustatevec,
                         int *resvec, int *rqst, int *err) {
   CeedVector ustatevec_ = (*ustatevec == FORTRAN_NULL) ?
                           NULL : (*ustatevec == FORTRAN_VECTOR_NONE ?
-                          CEED_VECTOR_NONE : CeedVector_dict[*ustatevec]);
+                                  CEED_VECTOR_NONE : CeedVector_dict[*ustatevec]);
   CeedVector resvec_ = (*resvec == FORTRAN_NULL) ?
                        NULL : (*resvec == FORTRAN_VECTOR_NONE ?
-                       CEED_VECTOR_NONE : CeedVector_dict[*resvec]);
+                               CEED_VECTOR_NONE : CeedVector_dict[*resvec]);
 
   int createRequest = 1;
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -62,12 +62,20 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
   (*op)->ceed = ceed;
   ceed->refcount++;
   (*op)->refcount = 1;
+  if (qf == CEED_QFUNCTION_NONE)
+    // LCOV_EXCL_START
+    return CeedError(ceed, 1, "Operator must have a valid QFunction.");
+  // LCOV_EXCL_STOP
   (*op)->qf = qf;
   qf->refcount++;
-  (*op)->dqf = dqf;
-  if (dqf) dqf->refcount++;
-  (*op)->dqfT = dqfT;
-  if (dqfT) dqfT->refcount++;
+  if (dqf && dqf != CEED_QFUNCTION_NONE) {
+    (*op)->dqf = dqf;
+    dqf->refcount++;
+  }
+  if (dqfT && dqfT != CEED_QFUNCTION_NONE) {
+    (*op)->dqfT = dqfT;
+    dqfT->refcount++;
+  }
   ierr = CeedCalloc(16, &(*op)->inputfields); CeedChk(ierr);
   ierr = CeedCalloc(16, &(*op)->outputfields); CeedChk(ierr);
   ierr = ceed->OperatorCreate(*op); CeedChk(ierr);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -560,7 +560,9 @@ int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out,
     // LCOV_EXCL_STOP
   }
   if (op->numelements || op->composite) {
-    ierr = op->Apply(op, in, out, request); CeedChk(ierr);
+    ierr = op->Apply(op, in != CEED_VECTOR_NONE ? in : NULL,
+                     out != CEED_VECTOR_NONE ? out : NULL, request);
+    CeedChk(ierr);
   }
   return 0;
 }

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -20,6 +20,10 @@
 #include <limits.h>
 
 /// @cond DOXYGEN_SKIP
+static struct CeedQFunction_private ceed_qfunction_none;
+/// @endcond
+
+/// @cond DOXYGEN_SKIP
 static struct {
   char name[CEED_MAX_RESOURCE_LEN];
   char source[CEED_MAX_RESOURCE_LEN];
@@ -666,4 +670,8 @@ int CeedQFunctionDestroy(CeedQFunction *qf) {
   return 0;
 }
 
+/// @cond DOXYGEN_SKIP
+// Indicate that no QFunction is provided by the user
+CeedQFunction CEED_QFUNCTION_NONE = &ceed_qfunction_none;
+/// @endcond
 /// @}

--- a/tests/t312-basis.c
+++ b/tests/t312-basis.c
@@ -51,7 +51,8 @@ int main(int argc, char **argv) {
 
   CeedBasisApply(bxg, 1, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, X, Xq);
   CeedBasisApply(bug, 1, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, U, Uq);
-  CeedBasisApply(bug, 1, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, NULL, W);
+  CeedBasisApply(bug, 1, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT,
+                 CEED_VECTOR_NONE, W);
 
   CeedVectorGetArrayRead(W, CEED_MEM_HOST, &w);
   CeedVectorGetArrayRead(Uq, CEED_MEM_HOST, &uq);

--- a/tests/t322-basis-f.f90
+++ b/tests/t322-basis-f.f90
@@ -68,8 +68,8 @@
 
       call ceedbasisapply(b,1,ceed_notranspose,ceed_eval_interp,input,output,&
      & err)
-      call ceedbasisapply(b,1,ceed_notranspose,ceed_eval_weight,ceed_null,&
-     & weights,err)
+      call ceedbasisapply(b,1,ceed_notranspose,ceed_eval_weight,&
+     & ceed_vector_none,weights,err)
 
       call ceedvectorgetarrayread(output,ceed_mem_host,ooutput,offset1,err)
       call ceedvectorgetarrayread(weights,ceed_mem_host,wweights,offset2,err)

--- a/tests/t322-basis.c
+++ b/tests/t322-basis.c
@@ -39,7 +39,8 @@ int main(int argc, char **argv) {
   CeedVectorSetValue(Weights, 0);
 
   CeedBasisApply(b, 1, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, In, Out);
-  CeedBasisApply(b, 1, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, NULL, Weights);
+  CeedBasisApply(b, 1, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT,
+                 CEED_VECTOR_NONE, Weights);
 
   // Check values at quadrature points
   CeedVectorGetArrayRead(Out, CEED_MEM_HOST, &out);

--- a/tests/t500-operator-f.f90
+++ b/tests/t500-operator-f.f90
@@ -101,8 +101,10 @@
       call ceedqfunctionaddinput(qf_mass,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_mass,'v',1,ceed_eval_interp,err)
 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
 
       call ceedvectorcreate(ceed,nx,x,err)
       xoffset=0

--- a/tests/t500-operator.c
+++ b/tests/t500-operator.c
@@ -64,11 +64,13 @@ int main(int argc, char **argv) {
 //! [QFunction Create]
 
 //! [Setup Create]
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
 //! [Setup Create]
 
 //! [Operator Create]
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
 //! [Operator Create]
 
   CeedVectorCreate(ceed, Nx, &X);

--- a/tests/t501-operator-f.f90
+++ b/tests/t501-operator-f.f90
@@ -102,8 +102,10 @@
       call ceedqfunctionaddinput(qf_mass,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_mass,'v',1,ceed_eval_interp,err)
 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
 
       call ceedvectorcreate(ceed,nx,x,err)
       xoffset=0

--- a/tests/t501-operator.c
+++ b/tests/t501-operator.c
@@ -59,9 +59,11 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
 
   CeedVectorCreate(ceed, Nx, &X);
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);

--- a/tests/t502-operator-f.f90
+++ b/tests/t502-operator-f.f90
@@ -103,8 +103,10 @@
       call ceedqfunctionaddinput(qf_mass,'u',2,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_mass,'v',2,ceed_eval_interp,err)
 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
 
       call ceedvectorcreate(ceed,nx,x,err)
       xoffset=0

--- a/tests/t502-operator.c
+++ b/tests/t502-operator.c
@@ -60,9 +60,11 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 2, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
 
   CeedVectorCreate(ceed, Nx, &X);
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);

--- a/tests/t503-operator-f.f90
+++ b/tests/t503-operator-f.f90
@@ -112,8 +112,10 @@
       call ceedqfunctionaddinput(qf_mass,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_mass,'v',1,ceed_eval_interp,err)
 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
 
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
      & ceed_notranspose,bx,ceed_vector_none,err)

--- a/tests/t503-operator-f.f90
+++ b/tests/t503-operator-f.f90
@@ -130,9 +130,9 @@
       call ceedoperatorsetfield(op_mass,'v',erestrictu,&
      & ceed_notranspose,bu,v,err)
 
-      call ceedoperatorapply(op_setup,ceed_null,ceed_null,&
+      call ceedoperatorapply(op_setup,ceed_vector_none,ceed_vector_none,&
      & ceed_request_immediate,err)
-      call ceedoperatorapply(op_mass,ceed_null,ceed_null,&
+      call ceedoperatorapply(op_mass,ceed_vector_none,ceed_vector_none,&
      & ceed_request_immediate,err)
 
       call ceedvectorgetarrayread(v,ceed_mem_host,hv,voffset,err)

--- a/tests/t503-operator.c
+++ b/tests/t503-operator.c
@@ -89,8 +89,10 @@ int main(int argc, char **argv) {
 
   // Note - It is atypical to use only passive fields; this test is intended
   //   as a test for all passive input modes rather than as an example.
-  CeedOperatorApply(op_setup, NULL, NULL, CEED_REQUEST_IMMEDIATE);
-  CeedOperatorApply(op_mass, NULL, NULL, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup, CEED_VECTOR_NONE, CEED_VECTOR_NONE,
+                    CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_mass, CEED_VECTOR_NONE, CEED_VECTOR_NONE,
+                    CEED_REQUEST_IMMEDIATE);
 
   // Check output
   CeedVectorGetArrayRead(V, CEED_MEM_HOST, &hv);

--- a/tests/t503-operator.c
+++ b/tests/t503-operator.c
@@ -70,9 +70,11 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
 
   CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
                        bx, CEED_VECTOR_NONE);

--- a/tests/t510-operator-f.f90
+++ b/tests/t510-operator-f.f90
@@ -131,8 +131,10 @@
       call ceedqfunctionaddinput(qf_mass,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_mass,'v',1,ceed_eval_interp,err)
 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
 
       call ceedvectorcreate(ceed,d*ndofs,x,err)
       xoffset=0

--- a/tests/t510-operator.c
+++ b/tests/t510-operator.c
@@ -81,9 +81,11 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
 
   CeedVectorCreate(ceed, dim*Ndofs, &X);
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);

--- a/tests/t511-operator-f.f90
+++ b/tests/t511-operator-f.f90
@@ -132,8 +132,10 @@
       call ceedqfunctionaddinput(qf_mass,'u',1,ceed_eval_interp,err)
       call ceedqfunctionaddoutput(qf_mass,'v',1,ceed_eval_interp,err)
 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,err)
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
 
       call ceedvectorcreate(ceed,d*ndofs,x,err)
       xoffset=0

--- a/tests/t511-operator.c
+++ b/tests/t511-operator.c
@@ -82,9 +82,11 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
 
   CeedVectorCreate(ceed, dim*ndofs, &X);
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -248,7 +248,8 @@
       call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
 
 ! Apply Setup Operator
-      call ceedoperatorapply(op_setup,x,ceed_null,ceed_request_immediate,err)
+      call ceedoperatorapply(op_setup,x,ceed_vector_none,&
+     & ceed_request_immediate,err)
 
 ! Apply Mass Operator
       call ceedvectorcreate(ceed,ndofs,u,err)

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -156,8 +156,8 @@
 
 ! -- Operators
 ! ---- Setup Tet
-      call ceedoperatorcreate(ceed,qf_setuptet,ceed_null,ceed_null,op_setuptet,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
      & ceed_notranspose,bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
@@ -165,8 +165,8 @@
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
      & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
 ! ---- Mass Tet
-      call ceedoperatorcreate(ceed,qf_masstet,ceed_null,ceed_null,op_masstet,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_masstet,err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
      & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
@@ -220,8 +220,8 @@
 
 ! -- Operators
 ! ---- Setup Hex
-      call ceedoperatorcreate(ceed,qf_setuphex,ceed_null,ceed_null,op_setuphex,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
      & ceed_notranspose,bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
@@ -229,8 +229,8 @@
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
      & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
 ! ---- Mass Hex
-      call ceedoperatorcreate(ceed,qf_masshex,ceed_null,ceed_null,op_masshex,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_masshex,err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
      & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&

--- a/tests/t520-operator.c
+++ b/tests/t520-operator.c
@@ -204,7 +204,7 @@ int main(int argc, char **argv) {
   CeedCompositeOperatorAddSub(op_mass, op_massHex);
 
   // Apply Setup Operator
-  CeedOperatorApply(op_setup, X, NULL, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup, X, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);
 
   // Apply Mass Operator
   CeedVectorCreate(ceed, ndofs, &U);

--- a/tests/t520-operator.c
+++ b/tests/t520-operator.c
@@ -114,7 +114,8 @@ int main(int argc, char **argv) {
 
   // -- Operators
   // ---- Setup Tet
-  CeedOperatorCreate(ceed, qf_setupTet, NULL, NULL, &op_setupTet);
+  CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupTet);
   CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
                        bxTet, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
@@ -122,7 +123,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- Mass Tet
-  CeedOperatorCreate(ceed, qf_massTet, NULL, NULL, &op_massTet);
+  CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_massTet);
   CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataTet);
   CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
@@ -170,7 +172,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_massHex, "v", 1, CEED_EVAL_INTERP);
 
   // -- Operators
-  CeedOperatorCreate(ceed, qf_setupHex, NULL, NULL, &op_setupHex);
+  CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupHex);
   CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
                        bxHex, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
@@ -178,7 +181,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
-  CeedOperatorCreate(ceed, qf_massHex, NULL, NULL, &op_massHex);
+  CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_massHex);
   CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataHex);
   CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -249,7 +249,8 @@
       call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
 
 ! Apply Setup Operator
-      call ceedoperatorapply(op_setup,x,ceed_null,ceed_request_immediate,err)
+      call ceedoperatorapply(op_setup,x,ceed_vector_none,&
+     & ceed_request_immediate,err)
 
 ! Apply Mass Operator
       call ceedvectorcreate(ceed,ndofs,u,err)

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -157,8 +157,8 @@
 
 ! -- Operators
 ! ---- Setup Tet
-      call ceedoperatorcreate(ceed,qf_setuptet,ceed_null,ceed_null,op_setuptet,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
      & ceed_notranspose,bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
@@ -166,8 +166,8 @@
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
      & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
 ! ---- Mass Tet
-      call ceedoperatorcreate(ceed,qf_masstet,ceed_null,ceed_null,op_masstet,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_masstet,err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
      & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
@@ -221,8 +221,8 @@
 
 ! -- Operators
 ! ---- Setup Hex
-      call ceedoperatorcreate(ceed,qf_setuphex,ceed_null,ceed_null,op_setuphex,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
      & ceed_notranspose,bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
@@ -230,8 +230,8 @@
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
      & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
 ! ---- Mass Hex
-      call ceedoperatorcreate(ceed,qf_masshex,ceed_null,ceed_null,op_masshex,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_masshex,err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
      & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&

--- a/tests/t521-operator.c
+++ b/tests/t521-operator.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
   CeedCompositeOperatorAddSub(op_mass, op_massHex);
 
   // Apply Setup Operator
-  CeedOperatorApply(op_setup, X, NULL, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup, X, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);
 
   // Apply Mass Operator
   CeedVectorCreate(ceed, ndofs, &U);

--- a/tests/t521-operator.c
+++ b/tests/t521-operator.c
@@ -115,7 +115,8 @@ int main(int argc, char **argv) {
 
   // -- Operators
   // ---- Setup Tet
-  CeedOperatorCreate(ceed, qf_setupTet, NULL, NULL, &op_setupTet);
+  CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupTet);
   CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
                        bxTet, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
@@ -123,7 +124,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- Mass Tet
-  CeedOperatorCreate(ceed, qf_massTet, NULL, NULL, &op_massTet);
+  CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_massTet);
   CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataTet);
   CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
@@ -171,7 +173,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_massHex, "v", 1, CEED_EVAL_INTERP);
 
   // -- Operators
-  CeedOperatorCreate(ceed, qf_setupHex, NULL, NULL, &op_setupHex);
+  CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupHex);
   CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
                        bxHex, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
@@ -179,7 +182,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
-  CeedOperatorCreate(ceed, qf_massHex, NULL, NULL, &op_massHex);
+  CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_massHex);
   CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataHex);
   CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,

--- a/tests/t522-operator-f.f90
+++ b/tests/t522-operator-f.f90
@@ -256,7 +256,8 @@
       call ceedcompositeoperatoraddsub(op_diff,op_diffhex,err)
 
 ! Apply Setup Operator
-      call ceedoperatorapply(op_setup,x,ceed_null,ceed_request_immediate,err)
+      call ceedoperatorapply(op_setup,x,ceed_vector_none,&
+     & ceed_request_immediate,err)
 
 ! Apply diff Operator
       call ceedvectorcreate(ceed,ndofs,u,err)

--- a/tests/t522-operator-f.f90
+++ b/tests/t522-operator-f.f90
@@ -163,8 +163,8 @@
 
 ! -- Operators
 ! ---- Setup Tet
-      call ceedoperatorcreate(ceed,qf_setuptet,ceed_null,ceed_null,op_setuptet,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
      & ceed_notranspose,bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
@@ -172,8 +172,8 @@
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictqditet,&
      & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
 ! ---- diff Tet
-      call ceedoperatorcreate(ceed,qf_difftet,ceed_null,ceed_null,op_difftet,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_difftet,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_difftet,err)
       call ceedoperatorsetfield(op_difftet,'rho',erestrictqditet,&
      & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_difftet,'u',erestrictutet,&
@@ -228,8 +228,8 @@
 
 ! -- Operators
 ! ---- Setup Hex
-      call ceedoperatorcreate(ceed,qf_setuphex,ceed_null,ceed_null,op_setuphex,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
      & ceed_notranspose,bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
@@ -237,8 +237,8 @@
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictqdihex,&
      & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
 ! ---- diff Hex
-      call ceedoperatorcreate(ceed,qf_diffhex,ceed_null,ceed_null,op_diffhex,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_diffhex,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_diffhex,err)
       call ceedoperatorsetfield(op_diffhex,'rho',erestrictqdihex,&
      & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_diffhex,'u',erestrictuhex,&

--- a/tests/t522-operator.c
+++ b/tests/t522-operator.c
@@ -114,7 +114,8 @@ int main(int argc, char **argv) {
 
   // -- Operators
   // ---- Setup Tet
-  CeedOperatorCreate(ceed, qf_setupTet, NULL, NULL, &op_setupTet);
+  CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupTet);
   CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
                        bxTet, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
@@ -122,7 +123,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setupTet, "rho", ErestrictqdiTet, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- diff Tet
-  CeedOperatorCreate(ceed, qf_diffTet, NULL, NULL, &op_diffTet);
+  CeedOperatorCreate(ceed, qf_diffTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diffTet);
   CeedOperatorSetField(op_diffTet, "rho", ErestrictqdiTet, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataTet);
   CeedOperatorSetField(op_diffTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
@@ -171,7 +173,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_diffHex, "v", dim, CEED_EVAL_GRAD);
 
   // -- Operators
-  CeedOperatorCreate(ceed, qf_setupHex, NULL, NULL, &op_setupHex);
+  CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupHex);
   CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
                        bxHex, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
@@ -179,7 +182,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setupHex, "rho", ErestrictqdiHex, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
-  CeedOperatorCreate(ceed, qf_diffHex, NULL, NULL, &op_diffHex);
+  CeedOperatorCreate(ceed, qf_diffHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diffHex);
   CeedOperatorSetField(op_diffHex, "rho", ErestrictqdiHex, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdataHex);
   CeedOperatorSetField(op_diffHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,

--- a/tests/t522-operator.c
+++ b/tests/t522-operator.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
   CeedCompositeOperatorAddSub(op_diff, op_diffHex);
 
   // Apply Setup Operator
-  CeedOperatorApply(op_setup, X, NULL, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup, X, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);
 
   // Apply diff Operator
   CeedVectorCreate(ceed, ndofs, &U);

--- a/tests/t530-operator-f.f90
+++ b/tests/t530-operator-f.f90
@@ -124,8 +124,8 @@
 
 ! Operators
 ! -- Setup 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
      & ceed_notranspose,bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
@@ -133,8 +133,8 @@
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
      & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
 ! -- Mass
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
      & ceed_notranspose,ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_mass,'u',erestrictu,&

--- a/tests/t530-operator.c
+++ b/tests/t530-operator.c
@@ -72,7 +72,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
   CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
@@ -80,7 +81,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
   CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdata);
   CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE, bu,

--- a/tests/t531-operator-f.f90
+++ b/tests/t531-operator-f.f90
@@ -145,8 +145,8 @@
       call ceedqfunctionaddoutput(qf_setup,'qdata',d*(d+1)/2,ceed_eval_none,err)
 
 ! Operator - setup 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
@@ -166,8 +166,8 @@
       call ceedqfunctionaddoutput(qf_diff,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply
-      call ceedoperatorcreate(ceed,qf_diff,ceed_null,ceed_null,op_diff,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_diff,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_diff,err)
       call ceedoperatorsetfield(op_diff,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diff,'qdata',erestrictqi,&
@@ -206,8 +206,8 @@
       call ceedqfunctionaddoutput(qf_diff_lin,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply linearized
-      call ceedoperatorcreate(ceed,qf_diff_lin,ceed_null,ceed_null,op_diff_lin,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_diff_lin,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_diff_lin,err)
       call ceedoperatorsetfield(op_diff_lin,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diff_lin,'qdata',erestrictlini,&

--- a/tests/t531-operator.c
+++ b/tests/t531-operator.c
@@ -70,7 +70,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
 
   // Operator - setup
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
   CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
@@ -88,7 +89,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_diff, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply
-  CeedOperatorCreate(ceed, qf_diff, NULL, NULL, &op_diff);
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diff);
   CeedOperatorSetField(op_diff, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
@@ -124,7 +126,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_diff_lin, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply assembled
-  CeedOperatorCreate(ceed, qf_diff_lin, NULL, NULL, &op_diff_lin);
+  CeedOperatorCreate(ceed, qf_diff_lin, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_diff_lin);
   CeedOperatorSetField(op_diff_lin, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_diff_lin, "qdata", Erestrictlini, CEED_NOTRANSPOSE,

--- a/tests/t532-operator-f.f90
+++ b/tests/t532-operator-f.f90
@@ -172,8 +172,8 @@
       call ceedqfunctionaddoutput(qf_setup_mass,'qdata',1,ceed_eval_none,err)
 
 ! Operator - setup mass
-      call ceedoperatorcreate(ceed,qf_setup_mass,ceed_null,ceed_null,&
-     & op_setup_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
@@ -191,8 +191,8 @@
      & d*(d+1)/2,ceed_eval_none,err)
 
 ! Operator - setup diff
-      call ceedoperatorcreate(ceed,qf_setup_diff,ceed_null,ceed_null,&
-     & op_setup_diff,err)
+      call ceedoperatorcreate(ceed,qf_setup_diff,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup_diff,err)
       call ceedoperatorsetfield(op_setup_diff,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_diff,'_weight',erestrictxi,&
@@ -219,8 +219,8 @@
       call ceedqfunctionaddoutput(qf_apply,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply
-      call ceedoperatorcreate(ceed,qf_apply,ceed_null,ceed_null,op_apply,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictui,&
@@ -270,8 +270,8 @@
       call ceedqfunctionaddoutput(qf_apply_lin,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply linearized
-      call ceedoperatorcreate(ceed,qf_apply_lin,ceed_null,ceed_null,&
-     & op_apply_lin,err)
+      call ceedoperatorcreate(ceed,qf_apply_lin,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_apply_lin,err)
       call ceedoperatorsetfield(op_apply_lin,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply_lin,'qdata',erestrictlini,&

--- a/tests/t532-operator.c
+++ b/tests/t532-operator.c
@@ -72,7 +72,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup_mass, "qdata", 1, CEED_EVAL_NONE);
 
   // Operator - setup mass
-  CeedOperatorCreate(ceed, qf_setup_mass, NULL, NULL, &op_setup_mass);
+  CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_mass);
   CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -88,7 +89,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
 
   // Operator - setup diff
-  CeedOperatorCreate(ceed, qf_setup_diff, NULL, NULL, &op_setup_diff);
+  CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_diff);
   CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -110,7 +112,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
   CeedOperatorSetField(op_apply, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui, CEED_NOTRANSPOSE,
@@ -156,7 +159,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_apply_lin, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply assembled
-  CeedOperatorCreate(ceed, qf_apply_lin, NULL, NULL, &op_apply_lin);
+  CeedOperatorCreate(ceed, qf_apply_lin, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_apply_lin);
   CeedOperatorSetField(op_apply_lin, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply_lin, "qdata", Erestrictlini, CEED_NOTRANSPOSE,

--- a/tests/t533-operator-f.f90
+++ b/tests/t533-operator-f.f90
@@ -123,8 +123,8 @@
 
 ! Operators
 ! -- Setup 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
      & ceed_notranspose,bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
@@ -132,8 +132,8 @@
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
      & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
 ! -- Mass
-      call ceedoperatorcreate(ceed,qf_mass,ceed_null,ceed_null,op_mass,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_mass,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
      & ceed_notranspose,ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_mass,'u',erestrictu,&

--- a/tests/t533-operator.c
+++ b/tests/t533-operator.c
@@ -73,7 +73,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
 
   // Operators
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
   CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_NONE);
   CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
@@ -81,7 +82,8 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
-  CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass);
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
   CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
                        CEED_BASIS_COLLOCATED, qdata);
   CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE, bu,

--- a/tests/t534-operator-f.f90
+++ b/tests/t534-operator-f.f90
@@ -125,8 +125,8 @@
       call ceedqfunctionaddoutput(qf_setup,'qdata',d*(d+1)/2,ceed_eval_none,err)
 
 ! Operator - setup 
-      call ceedoperatorcreate(ceed,qf_setup,ceed_null,ceed_null,op_setup,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
@@ -146,8 +146,8 @@
       call ceedqfunctionaddoutput(qf_diff,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply
-      call ceedoperatorcreate(ceed,qf_diff,ceed_null,ceed_null,op_diff,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_diff,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_diff,err)
       call ceedoperatorsetfield(op_diff,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diff,'qdata',erestrictqi,&

--- a/tests/t534-operator.c
+++ b/tests/t534-operator.c
@@ -72,7 +72,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
 
   // Operator - setup
-  CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup);
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
   CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
@@ -90,7 +91,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_diff, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply
-  CeedOperatorCreate(ceed, qf_diff, NULL, NULL, &op_diff);
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diff);
   CeedOperatorSetField(op_diff, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_NOTRANSPOSE,

--- a/tests/t535-operator-f.f90
+++ b/tests/t535-operator-f.f90
@@ -147,8 +147,8 @@
       call ceedqfunctionaddoutput(qf_setup_mass,'qdata',1,ceed_eval_none,err)
 
 ! Operator - setup mass
-      call ceedoperatorcreate(ceed,qf_setup_mass,ceed_null,ceed_null,&
-     & op_setup_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
@@ -166,8 +166,8 @@
      & d*(d+1)/2,ceed_eval_none,err)
 
 ! Operator - setup diff
-      call ceedoperatorcreate(ceed,qf_setup_diff,ceed_null,ceed_null,&
-     & op_setup_diff,err)
+      call ceedoperatorcreate(ceed,qf_setup_diff,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup_diff,err)
       call ceedoperatorsetfield(op_setup_diff,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_diff,'_weight',erestrictxi,&
@@ -194,8 +194,8 @@
       call ceedqfunctionaddoutput(qf_apply,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply
-      call ceedoperatorcreate(ceed,qf_apply,ceed_null,ceed_null,op_apply,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictui,&

--- a/tests/t535-operator.c
+++ b/tests/t535-operator.c
@@ -74,7 +74,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup_mass, "qdata", 1, CEED_EVAL_NONE);
 
   // Operator - setup mass
-  CeedOperatorCreate(ceed, qf_setup_mass, NULL, NULL, &op_setup_mass);
+  CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_mass);
   CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -90,7 +91,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
 
   // Operator - setup diff
-  CeedOperatorCreate(ceed, qf_setup_diff, NULL, NULL, &op_setup_diff);
+  CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_diff);
   CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -112,7 +114,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
   CeedOperatorSetField(op_apply, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui, CEED_NOTRANSPOSE,

--- a/tests/t536-operator-f.f90
+++ b/tests/t536-operator-f.f90
@@ -170,8 +170,8 @@
       call ceedqfunctionaddoutput(qf_setup_mass,'qdata',1,ceed_eval_none,err)
 
 ! Operator - setup mass
-      call ceedoperatorcreate(ceed,qf_setup_mass,ceed_null,ceed_null,&
-     & op_setup_mass,err)
+      call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
@@ -189,8 +189,8 @@
      & d*(d+1)/2,ceed_eval_none,err)
 
 ! Operator - setup diff
-      call ceedoperatorcreate(ceed,qf_setup_diff,ceed_null,ceed_null,&
-     & op_setup_diff,err)
+      call ceedoperatorcreate(ceed,qf_setup_diff,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_setup_diff,err)
       call ceedoperatorsetfield(op_setup_diff,'dx',erestrictx,&
      & ceed_notranspose,bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_diff,'_weight',erestrictxi,&
@@ -217,8 +217,8 @@
       call ceedqfunctionaddoutput(qf_apply,'dv',d,ceed_eval_grad,err)
 
 ! Operator - apply
-      call ceedoperatorcreate(ceed,qf_apply,ceed_null,ceed_null,op_apply,&
-     & err)
+      call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
+     & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'du',erestrictu,&
      & ceed_notranspose,bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictui,&

--- a/tests/t536-operator.c
+++ b/tests/t536-operator.c
@@ -92,7 +92,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup_mass, "qdata", 1, CEED_EVAL_NONE);
 
   // Operator - setup mass
-  CeedOperatorCreate(ceed, qf_setup_mass, NULL, NULL, &op_setup_mass);
+  CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_mass);
   CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -108,7 +109,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
 
   // Operator - setup diff
-  CeedOperatorCreate(ceed, qf_setup_diff, NULL, NULL, &op_setup_diff);
+  CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_diff);
   CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
@@ -130,7 +132,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
 
   // Operator - apply
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
   CeedOperatorSetField(op_apply, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
                        CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui, CEED_NOTRANSPOSE,


### PR DESCRIPTION
This PR removes our use of  `NULL` in the API in a few places in favor of `CEED_VECTOR_NONE` and `CEED_QFUNCTION_NONE` for clarity and typechecking. This will also help the python API.