### PR TITLE
Add Ceed_Cuda struct to Ceed_Cuda_ref/shared/gen.

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -828,10 +828,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
 
   // Add atomicAdd function for old NVidia architectures
   struct cudaDeviceProp prop;
-  Ceed delegate;
-  CeedGetDelegate(ceed, &delegate);
   Ceed_Cuda *ceed_data;
-  ierr = CeedGetData(delegate, (void **)&ceed_data); CeedChk(ierr);
+  ierr = CeedGetData(ceed, (void **)&ceed_data); CeedChk(ierr);
   ierr = cudaGetDeviceProperties(&prop, ceed_data->deviceId);
   if(prop.major<6){
     code << atomicAdd;

--- a/backends/cuda-gen/ceed-cuda-gen.c
+++ b/backends/cuda-gen/ceed-cuda-gen.c
@@ -37,16 +37,11 @@ static int CeedInit_Cuda_gen(const char *resource, Ceed ceed) {
   CeedInit("/gpu/cuda/shared", &ceedshared);
   ierr = CeedSetDelegate(ceed, ceedshared); CeedChk(ierr);
 
-  const int rlen = strlen(resource);
-  const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;
-  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : 0;
-
-  ierr = cudaSetDevice(deviceID); CeedChk(ierr);
-
   Ceed_Cuda_gen *data;
   ierr = CeedCalloc(1,&data); CeedChk(ierr);
-
   ierr = CeedSetData(ceed,(void *)&data); CeedChk(ierr);
+  ierr = CeedCudaInit(ceed, resource, nrc); CeedChk(ierr);
+
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "GetPreferredMemType",
                                 CeedGetPreferredMemType_Cuda_gen); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",

--- a/backends/cuda-gen/ceed-cuda-gen.h
+++ b/backends/cuda-gen/ceed-cuda-gen.h
@@ -17,6 +17,7 @@
 #include <ceed.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "../cuda/ceed-cuda.h"
 
 typedef struct { const CeedScalar *in[16]; CeedScalar *out[16]; } CudaFields;
 typedef struct { CeedInt *in[16]; CeedInt *out[16]; } CudaFieldsInt;
@@ -40,6 +41,7 @@ typedef struct {
 } CeedQFunction_Cuda_gen;
 
 typedef struct {
+  Ceed_Cuda base;
 } Ceed_Cuda_gen;
 
 CEED_INTERN int CeedQFunctionCreate_Cuda_gen(CeedQFunction qf);

--- a/backends/cuda-reg/ceed-cuda-reg.c
+++ b/backends/cuda-reg/ceed-cuda-reg.c
@@ -18,7 +18,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include "ceed-cuda-reg.h"
-#include "../cuda/ceed-cuda.h"
 
 static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
   int ierr;
@@ -30,20 +29,11 @@ static int CeedInit_Cuda_reg(const char *resource, Ceed ceed) {
   CeedInit("/gpu/cuda/ref", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
-  const int rlen = strlen(resource);
-  const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;
-  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : 0;
-
-  int currentDeviceID;
-  ierr = cudaGetDevice(&currentDeviceID); CeedChk_Cu(ceed,ierr);
-  if (currentDeviceID!=deviceID) {
-    ierr = cudaSetDevice(deviceID); CeedChk_Cu(ceed,ierr);
-  }
-
   Ceed_Cuda_reg *data;
   ierr = CeedCalloc(1,&data); CeedChk(ierr);
-
   ierr = CeedSetData(ceed,(void *)&data); CeedChk(ierr);
+  ierr = CeedCudaInit(ceed, resource, nrc); CeedChk(ierr);
+
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
                                 CeedBasisCreateTensorH1_Cuda_reg); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "ElemRestrictionCreate",

--- a/backends/cuda-reg/ceed-cuda-reg.h
+++ b/backends/cuda-reg/ceed-cuda-reg.h
@@ -18,6 +18,7 @@
 #include <nvrtc.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "../cuda/ceed-cuda.h"
 
 typedef struct {
   CUmodule module;
@@ -48,6 +49,7 @@ typedef struct {
 } CeedElemRestriction_Cuda_reg;
 
 typedef struct {
+  Ceed_Cuda base;
 } Ceed_Cuda_reg;
 
 CEED_INTERN int CeedBasisCreateTensorH1_Cuda_reg(CeedInt dim, CeedInt P1d,

--- a/backends/cuda-shared/ceed-cuda-shared.c
+++ b/backends/cuda-shared/ceed-cuda-shared.c
@@ -32,16 +32,11 @@ static int CeedInit_Cuda_shared(const char *resource, Ceed ceed) {
   CeedInit("/gpu/cuda/reg", &ceedreg);
   ierr = CeedSetDelegate(ceed, ceedreg); CeedChk(ierr);
 
-  const int rlen = strlen(resource);
-  const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;
-  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : 0;
-
-  ierr = cudaSetDevice(deviceID); CeedChk(ierr);
-
   Ceed_Cuda_shared *data;
   ierr = CeedCalloc(1,&data); CeedChk(ierr);
-
   ierr = CeedSetData(ceed,(void *)&data); CeedChk(ierr);
+  ierr = CeedCudaInit(ceed, resource, nrc); CeedChk(ierr);
+
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
                                 CeedBasisCreateTensorH1_Cuda_shared); CeedChk(ierr);
   return 0;

--- a/backends/cuda-shared/ceed-cuda-shared.h
+++ b/backends/cuda-shared/ceed-cuda-shared.h
@@ -18,6 +18,7 @@
 #include <nvrtc.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "../cuda/ceed-cuda.h"
 
 typedef struct {
   CUmodule module;
@@ -33,6 +34,7 @@ typedef struct {
 } CeedBasis_Cuda_shared;
 
 typedef struct {
+  Ceed_Cuda base;
 } Ceed_Cuda_shared;
 
 CEED_INTERN int CeedBasisCreateTensorH1_Cuda_shared(CeedInt dim, CeedInt P1d,

--- a/backends/cuda/ceed-cuda.h
+++ b/backends/cuda/ceed-cuda.h
@@ -13,6 +13,9 @@
 // the planning and preparation of a capable exascale ecosystem, including
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
+#ifndef _ceed_cuda_h
+#define _ceed_cuda_h
+
 #include <ceed-backend.h>
 #include <ceed.h>
 #include <nvrtc.h>
@@ -154,6 +157,8 @@ CEED_INTERN int run_kernel_dim_shared(Ceed ceed, CUfunction kernel,
                                       const int sharedMemSize,
                                       void **args);
 
+CEED_INTERN int CeedCudaInit(Ceed ceed, const char *resource, int nrc);
+
 CEED_INTERN int CeedVectorCreate_Cuda(CeedInt n, CeedVector vec);
 
 CEED_INTERN int CeedElemRestrictionCreate_Cuda(CeedMemType mtype,
@@ -187,3 +192,4 @@ CEED_INTERN int CeedQFunctionCreate_Cuda(CeedQFunction qf);
 CEED_INTERN int CeedOperatorCreate_Cuda(CeedOperator op);
 
 CEED_INTERN int CeedCompositeOperatorCreate_Cuda(CeedOperator op);
+#endif


### PR DESCRIPTION
While running with the backends /gpu/cuda/shared and /gpu/cuda/gen I got the CUDA_ERROR_INVALID_DEVICE error.
This was basically caused by casting the empty Ceed_Cuda_ref/shared/gen structs to the Ceed_Cuda struct and trying to access the deviceId member.

This PR adds the Ceed_Cuda struct to the Ceed_Cuda_ref/shared/gen structs so that the latter can be upcast to the former.