### PR TITLE
AssembleLinearDiag Optimizations

### DIFF
--- a/backends/memcheck/ceed-memcheck-serial.c
+++ b/backends/memcheck/ceed-memcheck-serial.c
@@ -21,8 +21,8 @@
 //------------------------------------------------------------------------------
 static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
   int ierr;
-  if (strcmp(resource, "/cpu/self/memcheck/serial") &&
-      strcmp(resource, "/cpu/self/memcheck"))
+  if (strcmp(resource, "/cpu/self/memcheck")
+      && strcmp(resource, "/cpu/self/memcheck/serial"))
     // LCOV_EXCL_START
     return CeedError(ceed, 1, "Valgrind Memcheck backend cannot use resource: %s",
                      resource);

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -752,18 +752,16 @@ int CeedOperatorCreate_Opt(CeedOperator op) {
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
 
-  if (blksize == 1 || blksize == 8) {
-    ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
-                                  CeedOperatorAssembleLinearQFunction_Opt);
-    CeedChk(ierr);
-    ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
-                                  CeedOperatorApply_Opt); CeedChk(ierr);
-  } else {
+  if (blksize != 1 && blksize != 8)
     // LCOV_EXCL_START
     return CeedError(ceed, 1, "Opt backend cannot use blocksize: %d", blksize);
-    // LCOV_EXCL_STOP
-  }
+  // LCOV_EXCL_STOP
 
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
+                                CeedOperatorAssembleLinearQFunction_Opt);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
+                                CeedOperatorApply_Opt); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Opt); CeedChk(ierr);
   return 0;

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -704,8 +704,7 @@ static int CeedOperatorAssembleLinearDiagonal_Ref(CeedOperator op,
     CeedVector vec;
     ierr = CeedOperatorFieldGetVector(opfields[i], &vec); CeedChk(ierr);
     if (vec == CEED_VECTOR_ACTIVE) {
-      ierr = CeedOperatorFieldGetBasis(opfields[i], &basisin);
-      CeedChk(ierr);
+      ierr = CeedOperatorFieldGetBasis(opfields[i], &basisin); CeedChk(ierr);
       ierr = CeedBasisGetNumComponents(basisin, &ncomp); CeedChk(ierr);
       ierr = CeedBasisGetDimension(basisin, &dim); CeedChk(ierr);
       ierr = CeedOperatorFieldGetElemRestriction(opfields[i], &rstrin);
@@ -746,15 +745,12 @@ static int CeedOperatorAssembleLinearDiagonal_Ref(CeedOperator op,
     CeedVector vec;
     ierr = CeedOperatorFieldGetVector(opfields[i], &vec); CeedChk(ierr);
     if (vec == CEED_VECTOR_ACTIVE) {
-      ierr = CeedOperatorFieldGetBasis(opfields[i], &basisout);
-      CeedChk(ierr);
+      ierr = CeedOperatorFieldGetBasis(opfields[i], &basisout); CeedChk(ierr);
       ierr = CeedOperatorFieldGetElemRestriction(opfields[i], &rstrout);
       CeedChk(ierr);
-      ierr = CeedOperatorFieldGetLMode(opfields[i], &lmodeout);
-      CeedChk(ierr);
+      ierr = CeedOperatorFieldGetLMode(opfields[i], &lmodeout); CeedChk(ierr);
       CeedEvalMode emode;
-      ierr = CeedQFunctionFieldGetEvalMode(qffields[i], &emode);
-      CeedChk(ierr);
+      ierr = CeedQFunctionFieldGetEvalMode(qffields[i], &emode); CeedChk(ierr);
       switch (emode) {
       case CEED_EVAL_NONE:
       case CEED_EVAL_INTERP:

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -895,7 +895,9 @@ int CeedOperatorCreateFDMElementInverse_Ref(CeedOperator op,
     }
   }
   if (!basis)
+    // LCOV_EXCL_START
     return CeedError(ceed, 1, "No active field set");
+  // LCOV_EXCL_STOP
   CeedInt P1d, Q1d, elemsize, nqpts, dim, ncomp = 1, nelem = 1, nnodes = 1;
   ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
   ierr = CeedBasisGetNumNodes(basis, &elemsize); CeedChk(ierr);
@@ -910,8 +912,10 @@ int CeedOperatorCreateFDMElementInverse_Ref(CeedOperator op,
   bool tensorbasis;
   ierr = CeedBasisGetTensorStatus(basis, &tensorbasis); CeedChk(ierr);
   if (!tensorbasis)
+    // LCOV_EXCL_START
     return CeedError(ceed, 1, "FDMElementInverse only supported for tensor "
                      "bases");
+  // LCOV_EXCL_STOP
   CeedScalar *work, *mass, *laplace, *x, *x2, *lambda;
   ierr = CeedMalloc(Q1d*P1d, &work); CeedChk(ierr);
   ierr = CeedMalloc(P1d*P1d, &mass); CeedChk(ierr);

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
     CeedVectorSetArray(ceeddata[i]->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
 
     // Multiplicity
-    CeedElemRestrictionGetMultiplicity(ceeddata[i]->Erestrictu,
+    CeedElemRestrictionGetMultiplicity(ceeddata[i]->Erestrictu, CEED_TRANSPOSE,
                                        ceeddata[i]->xceed);
 
     // Restore vector

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -648,7 +648,7 @@ static PetscErrorCode CeedLevelTransferSetup(Ceed ceed, CeedInt numlevels,
     CeedOperatorCreate(ceed, qf_restrict, CEED_QFUNCTION_NONE,
                        CEED_QFUNCTION_NONE, &op_restrict);
     CeedOperatorSetField(op_restrict, "input", data[i]->Erestrictu,
-                         CEED_NOTRANSPOSE, CEED_BASIS_COLLOCATED,
+                         CEED_TRANSPOSE, CEED_BASIS_COLLOCATED,
                          CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(op_restrict, "output", data[i-1]->Erestrictu,
                          CEED_TRANSPOSE, basisctof, CEED_VECTOR_ACTIVE);
@@ -664,7 +664,7 @@ static PetscErrorCode CeedLevelTransferSetup(Ceed ceed, CeedInt numlevels,
     CeedOperatorCreate(ceed, qf_prolong, CEED_QFUNCTION_NONE,
                        CEED_QFUNCTION_NONE, &op_interp);
     CeedOperatorSetField(op_interp, "input", data[i-1]->Erestrictu,
-                         CEED_NOTRANSPOSE, basisctof, CEED_VECTOR_ACTIVE);
+                         CEED_TRANSPOSE, basisctof, CEED_VECTOR_ACTIVE);
     CeedOperatorSetField(op_interp, "output", data[i]->Erestrictu,
                          CEED_TRANSPOSE, CEED_BASIS_COLLOCATED,
                          CEED_VECTOR_ACTIVE);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -248,7 +248,7 @@ CEED_EXTERN int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr,
     CeedInt block, CeedTransposeMode tmode, CeedTransposeMode lmode,
     CeedVector u, CeedVector ru, CeedRequest *request);
 CEED_EXTERN int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
-    CeedVector mult);
+    CeedTransposeMode lmode, CeedVector mult);
 CEED_EXTERN int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream);
 CEED_EXTERN int CeedElemRestrictionDestroy(CeedElemRestriction *rstr);
 

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -401,6 +401,12 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
   @brief Get the multiplicity of nodes in a CeedElemRestriction
 
   @param rstr             CeedElemRestriction
+  @param lmode            Ordering of the ncomp components, i.e. it specifies
+                            the ordering of the components of the l-vector used
+                            by this CeedElemRestriction. CEED_NOTRANSPOSE
+                            indicates the component is the outermost index and
+                            CEED_TRANSPOSE indicates the component is the
+                            innermost index in ordering of the l-vector
   @param[out] mult        Vector to store multiplicity (of size nnodes)
 
   @return An error code: 0 - success, otherwise - failure
@@ -408,6 +414,7 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
   @ref Advanced
 **/
 int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
+                                       CeedTransposeMode lmode,
                                        CeedVector mult) {
   int ierr;
   CeedVector evec;
@@ -417,8 +424,8 @@ int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
   ierr = CeedVectorSetValue(evec, 1.0); CeedChk(ierr);
 
   // Apply to get multiplicity
-  ierr = CeedElemRestrictionApply(rstr, CEED_TRANSPOSE, CEED_NOTRANSPOSE, evec,
-                                  mult, CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
+  ierr = CeedElemRestrictionApply(rstr, CEED_TRANSPOSE, lmode, evec, mult,
+                                  CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
 
   // Cleanup
   ierr = CeedVectorDestroy(&evec); CeedChk(ierr);

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -336,9 +336,10 @@ void fCeedElemRestrictionApplyBlock(int *elemr, int *block, int *tmode,
 
 #define fCeedElemRestrictionGetMultiplicity \
     FORTRAN_NAME(ceedelemrestrictiongetmultiplicity,CEEDELEMRESTRICTIONGETMULTIPLICITY)
-void fCeedElemRestrictionGetMultiplicity(int *elemr, int *mult, int *err) {
+void fCeedElemRestrictionGetMultiplicity(int *elemr, int *lmode, int *mult,
+                                         int *err) {
   *err = CeedElemRestrictionGetMultiplicity(CeedElemRestriction_dict[*elemr],
-         CeedVector_dict[*mult]);
+         *lmode, CeedVector_dict[*mult]);
 }
 
 #define fCeedElemRestrictionView \

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -281,10 +281,14 @@ int CeedOperatorCreateFallback(CeedOperator op) {
                      "fallback to resource %s", resource, fallbackresource);
   // LCOV_EXCL_STOP
 
+  // Fallback Ceed
   Ceed ceedref;
-  ierr = CeedInit(fallbackresource, &ceedref); CeedChk(ierr);
-  ceedref->opfallbackparent = op->ceed;
-  op->ceed->opfallbackceed = ceedref;
+  if (!op->ceed->opfallbackceed) {
+    ierr = CeedInit(fallbackresource, &ceedref); CeedChk(ierr);
+    ceedref->opfallbackparent = op->ceed;
+    op->ceed->opfallbackceed = ceedref;
+  }
+  ceedref = op->ceed->opfallbackceed;
 
   // Clone Op
   CeedOperator opref;

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -750,12 +750,13 @@ int CeedGetResource(Ceed ceed, const char **resource) {
 **/
 int CeedDestroy(Ceed *ceed) {
   int ierr;
-
   if (!*ceed || --(*ceed)->refcount > 0)
     return 0;
+
   if ((*ceed)->delegate) {
     ierr = CeedDestroy(&(*ceed)->delegate); CeedChk(ierr);
   }
+
   if ((*ceed)->objdelegatecount > 0) {
     for (int i=0; i<(*ceed)->objdelegatecount; i++) {
       ierr = CeedDestroy(&((*ceed)->objdelegates[i].delegate)); CeedChk(ierr);
@@ -763,9 +764,11 @@ int CeedDestroy(Ceed *ceed) {
     }
     ierr = CeedFree(&(*ceed)->objdelegates); CeedChk(ierr);
   }
+
   if ((*ceed)->Destroy) {
     ierr = (*ceed)->Destroy(*ceed); CeedChk(ierr);
   }
+
   ierr = CeedFree(&(*ceed)->foffsets); CeedChk(ierr);
   ierr = CeedFree(&(*ceed)->resource); CeedChk(ierr);
   ierr = CeedDestroy(&(*ceed)->opfallbackceed); CeedChk(ierr);

--- a/python/ceed_elemrestriction.py
+++ b/python/ceed_elemrestriction.py
@@ -116,7 +116,7 @@ class _ElemRestrictionBase(ABC):
     return [lvec, evec]
 
   # Get ElemRestriction multiplicity
-  def get_multiplicity(self):
+  def get_multiplicity(self, lmode=NOTRANSPOSE):
     """Get the multiplicity of nodes in an ElemRestriction.
 
        Returns:
@@ -127,7 +127,8 @@ class _ElemRestrictionBase(ABC):
     mult.set_value(0)
 
     # libCEED call
-    lib.CeedElemRestrictionGetMultiplicity(self._pointer[0], mult._pointer[0])
+    lib.CeedElemRestrictionGetMultiplicity(self._pointer[0], lmode,
+                                           mult._pointer[0])
 
     # Return
     return mult

--- a/tests/t209-elemrestriction-f.f90
+++ b/tests/t209-elemrestriction-f.f90
@@ -34,7 +34,7 @@
       call ceedelemrestrictioncreate(ceed,ne,4,3*ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
-      call ceedelemrestrictiongetmultiplicity(r,mult,err)
+      call ceedelemrestrictiongetmultiplicity(r,ceed_notranspose,mult,err)
 
       call ceedvectorgetarrayread(mult,ceed_mem_host,mm,moffset,err)
       do i=1,3*ne+1

--- a/tests/t209-elemrestriction.c
+++ b/tests/t209-elemrestriction.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreate(ceed, ne, 4, 3*ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
 
-  CeedElemRestrictionGetMultiplicity(r, mult);
+  CeedElemRestrictionGetMultiplicity(r, CEED_NOTRANSPOSE, mult);
 
   CeedVectorGetArrayRead(mult, CEED_MEM_HOST, &mm);
   for (CeedInt i=0; i<3*ne+1; i++)


### PR DESCRIPTION
I'm now down to 16-17 seconds for the test case. Some of the time is spent in DMPlex setting up the levels.

Top 4 functions in Perf for Multigrid:
```
  37.39%  multigrid  libpetsc.so.3.012.1     [.] PetscFEGetTabulation_Basic
  32.13%  multigrid  libceed.so              [.] CeedOperatorAssembleLinearDiagonal_Ref
   3.51%  multigrid  multigrid               [.] Diff
   2.11%  multigrid  libceed.so              [.] CeedElemRestrictionApplyBlock_Ref
```

Top 4 functions in Perf for BPs:
```
  59.79%  bps      libpetsc.so.3.012.1     [.] PetscFEGetTabulation_Basi
   5.09%  bps      bps                     [.] Diff
   3.20%  bps      libceed.so              [.] CeedElemRestrictionApplyB
   3.10%  bps      libpetsc.so.3.012.1     [.] daxpy_
```

Sample timing run for Multigrid:
```
$ time ./multigrid -cells 15,15,15 -degree 7 -coarsen logarithmic -ceed /cpu/self -problem bp3

-- CEED Benchmark Problem 3 -- libCEED + PETSc + PCMG --
  libCEED:
    libCEED Backend                    : /cpu/self/xsmm/blocked
  Mesh:
    Number of 1D Basis Nodes (p)       : 8
    Number of 1D Quadrature Points (q) : 9
    Global Nodes                       : 1124864
    Owned Nodes                        : 1124864
  Multigrid:
    Number of Levels                   : 4
    Level 0 (coarse):
      Number of 1D Basis Nodes (p)     : 2
      Global Nodes                     : 2744
      Owned Nodes                      : 2744
    Level 3 (fine):
      Number of 1D Basis Nodes (p)     : 8
      Global Nodes                     : 1124864
      Owned Nodes                      : 1124864
  KSP:
    KSP Type                           : cg
    KSP Convergence                    : CONVERGED_RTOL
    Total KSP Iterations               : 6
    Final rnorm                        : 1.280058e-10
  PCMG:
    PCMG Type                          : MULTIPLICATIVE
    PCMG Cycle Type                    : v
  Performance:
    Pointwise Error (max)              : 2.924760e-11
    CG Solve Time                      : 3.4297 (3.4297) sec

real	0m16.817s
user	0m16.412s
sys	0m0.367s
```
Sample timing run for BPs:
```
$ time ./bps -cells 15,15,15 -degree 7 -ceed /cpu/self -problem bp3

-- CEED Benchmark Problem 3 -- libCEED + PETSc --
  libCEED:
    libCEED Backend                    : /cpu/self/xsmm/blocked
  Mesh:
    Number of 1D Basis Nodes (p)       : 8
    Number of 1D Quadrature Points (q) : 9
    Global nodes                       : 1124864
    Owned nodes                        : 1124864
  KSP:
    KSP Type                           : cg
    KSP Convergence                    : CONVERGED_RTOL
    Total KSP Iterations               : 80
    Final rnorm                        : 4.706493e-12
  Performance:
    Pointwise Error (max)              : 2.839518e-11
    CG Solve Time                      : 3.50599 (3.50599) sec

real	0m10.099s
user	0m9.900s
sys	0m0.174s
```