### PR TITLE
Fix petsc/bp4&bp6 with OCCA

### DIFF
--- a/examples/petsc/qfunctions/bps/bp1.okl
+++ b/examples/petsc/qfunctions/bps/bp1.okl
@@ -24,11 +24,15 @@ typedef double CeedScalar;
 @kernel void SetupMassGeo(void *ctx, CeedInt Q,
                           const int *iOf7, const int *oOf7,
                           const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *J = in + iOf7[0],
 //    *w = in + iOf7[1];
+// Output
 //  CeedScalar
 //    *qdata = out + oOf7[0];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
     const CeedInt D = 3;
     CeedScalar det = (+ in[iOf7[0]+(0*D+0)*Q+i] *
@@ -41,20 +45,24 @@ typedef double CeedScalar;
                           (in[iOf7[0]+(1*D+0)*Q+i]*in[iOf7[0]+(2*D+1)*Q+i] -
                            in[iOf7[0]+(1*D+1)*Q+i]*in[iOf7[0]+(2*D+0)*Q+i]));
     out[oOf7[0]+i] = det * in[iOf7[1]+i];
-  }
+  } // End of Quadrature Point Loop
 }
 
 // *****************************************************************************
 @kernel void SetupMassRhs(void *ctx, CeedInt Q,
                           const int *iOf7, const int *oOf7,
                           const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *x = in + iOf7[0],
 //    *J = in + iOf7[1],
 //    *w = in + iOf7[2];
+// Oututs
 //  CeedScalar
-//    *target = out + oOf7[0],
-//    *rhs = out + oOf7[1];
+//    *true_soln = out + oOf7[0],
+//    *rhs       = out + oOf7[1];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
     const CeedInt D = 3;
     CeedScalar det = (+ in[iOf7[1]+(0*D+0)*Q+i] *
@@ -70,21 +78,25 @@ typedef double CeedScalar;
                           Sqr(in[iOf7[0]+1*Q+i]) +
                           Sqr(in[iOf7[0]+2*Q+i]));
     out[oOf7[1]+i] = det * in[iOf7[2]+i] *
-                       sqrt(Sqr(in[iOf7[0]+0*Q+i]) +
-                            Sqr(in[iOf7[0]+1*Q+i]) +
-                            Sqr(in[iOf7[0]+2*Q+i]));
-  }
+                     sqrt(Sqr(in[iOf7[0]+0*Q+i]) +
+                          Sqr(in[iOf7[0]+1*Q+i]) +
+                          Sqr(in[iOf7[0]+2*Q+i]));
+  } // End of Quadrature Point Loop
 }
 
 // *****************************************************************************
 @kernel void Mass(void *ctx, CeedInt Q,
                           const int *iOf7, const int *oOf7,
                           const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *u = in + iOf7[0],
-//    *qdata = in + iOf7[1],
+//    *qdata = in + iOf7[1];
+// Ouput
 //  CeedScalar *v = out + oOf7[0];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
     out[oOf7[0]+i] = in[iOf7[1]+i] * in[iOf7[0]+i];
-  }
+  } // End of Quadrature Point Loop
 }

--- a/examples/petsc/qfunctions/bps/bp2.okl
+++ b/examples/petsc/qfunctions/bps/bp2.okl
@@ -24,13 +24,17 @@ typedef double CeedScalar;
 @kernel void SetupMassRhs3(void *ctx, CeedInt Q,
                            const int *iOf7, const int *oOf7,
                            const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *x = in + iOf7[0],
 //    *J = in + iOf7[1],
 //    *w = in + iOf7[2];
+// Outputs
 //  CeedScalar
-//    *target = out + oOf7[0],
-//    *rhs = out + oOf7[1];
+//    *true_soln = out + oOf7[0],
+//    *rhs       = out + oOf7[1];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
     const CeedInt D = 3;
     CeedScalar det = (+ in[iOf7[1]+(0*D+0)*Q+i] *
@@ -50,25 +54,29 @@ typedef double CeedScalar;
     out[oOf7[0]+i+2*Q] = out[oOf7[0]+i+0*Q];
 
     out[oOf7[1]+i+0*Q] = det * in[iOf7[2]+i] *
-                           sqrt(Sqr(in[iOf7[0]+0*Q+i]) +
-                                Sqr(in[iOf7[0]+1*Q+i]) +
-                                Sqr(in[iOf7[0]+2*Q+i]));
+                         sqrt(Sqr(in[iOf7[0]+0*Q+i]) +
+                              Sqr(in[iOf7[0]+1*Q+i]) +
+                              Sqr(in[iOf7[0]+2*Q+i]));
     out[oOf7[1]+i+1*Q] = out[oOf7[1]+i+0*Q];
     out[oOf7[1]+i+2*Q] = out[oOf7[1]+i+0*Q];   
-  }
+  } // End of Quadrature Point Loop
 }
 
 // *****************************************************************************
 @kernel void Mass3(void *ctx, CeedInt Q,
                           const int *iOf7, const int *oOf7,
                           const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *u = in + iOf7[0],
-//    *qdata = in + iOf7[1],
+//    *qdata = in + iOf7[1];
+// Output
 //  CeedScalar *v = out + oOf7[0];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
     out[oOf7[0]+i+0*Q] = in[iOf7[1]+i] * in[iOf7[0]+i+0*Q];
     out[oOf7[0]+i+1*Q] = in[iOf7[1]+i] * in[iOf7[0]+i+1*Q];
     out[oOf7[0]+i+2*Q] = in[iOf7[1]+i] * in[iOf7[0]+i+2*Q];
-  }
+  } // End of Quadrature Point Loop
 }

--- a/examples/petsc/qfunctions/bps/bp3.okl
+++ b/examples/petsc/qfunctions/bps/bp3.okl
@@ -18,20 +18,20 @@
 typedef int CeedInt;
 typedef double CeedScalar;
 
-#define Sqr(a) ((a)*(a))
-
 // *****************************************************************************
 @kernel void SetupDiffGeo(void *ctx, CeedInt Q,
                           const int *iOf7, const int *oOf7,
                           const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *J = in + iOf7[0],
 //    *w = in + iOf7[1];
+// Output
 //  CeedScalar
 //    *qd = out + oOf7[0];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
-    const CeedScalar MPI = 3.14159265358979323846;
-    const CeedInt D = 3;
     const CeedScalar J11 = in[iOf7[0]+i+Q*0];
     const CeedScalar J21 = in[iOf7[0]+i+Q*1];
     const CeedScalar J31 = in[iOf7[0]+i+Q*2];
@@ -57,23 +57,25 @@ typedef double CeedScalar;
     out[oOf7[0]+i+Q*3] = w * (A21*A21 + A22*A22 + A23*A23);
     out[oOf7[0]+i+Q*4] = w * (A21*A31 + A22*A32 + A23*A33);
     out[oOf7[0]+i+Q*5] = w * (A31*A31 + A32*A32 + A33*A33);
-  }
+  } // End of Quadrature Point Loop
 }
 
 // *****************************************************************************
 @kernel void SetupDiffRhs(void *ctx, CeedInt Q,
                           const int *iOf7, const int *oOf7,
                           const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *x = in + iOf7[0],
 //    *J = in + iOf7[1],
 //    *w = in + iOf7[2];
+// Output
 //  CeedScalar
-//    *target = out + oOf7[0],
-//    *rhs = out + oOf7[1];
+//    *true_soln = out + oOf7[0],
+//    *rhs       = out + oOf7[1];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
-    const CeedScalar MPI = 3.14159265358979323846;
-    const CeedInt D = 3;
     const CeedScalar J11 = in[iOf7[1]+i+Q*0];
     const CeedScalar J21 = in[iOf7[1]+i+Q*1];
     const CeedScalar J31 = in[iOf7[1]+i+Q*2];
@@ -89,25 +91,32 @@ typedef double CeedScalar;
 
     const CeedScalar c[3] = { 0, 1., 2. };
     const CeedScalar k[3] = { 1., 2., 3. };
+
     out[oOf7[0]+i] = sin(M_PI*(c[0] + k[0]*in[iOf7[0]+0*Q+i])) *
-                       sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
-                       sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
+                     sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
+                     sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
+
     const CeedScalar rho = in[iOf7[2]+i] * (J11*A11 + J21*A12 + J31*A13);
+
     out[oOf7[1]+i] = rho * M_PI*M_PI * (k[0]*k[0] + k[1]*k[1] + k[2]*k[2]) *
-                       sin(M_PI*(c[0] + k[0]*in[iOf7[0]+0*Q+i])) *
-                       sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
-                       sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
-  }
+                     sin(M_PI*(c[0] + k[0]*in[iOf7[0]+0*Q+i])) *
+                     sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
+                     sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
+  } // End of Quadrature Point Loop
 }
 
 // *****************************************************************************
 @kernel void Diff(void *ctx, CeedInt Q,
-                          const int *iOf7, const int *oOf7,
-                          const CeedScalar *in, CeedScalar *out) {
+                  const int *iOf7, const int *oOf7,
+                  const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
-//    *u = in + iOf7[0],
-//    *qdata = in + iOf7[1],
+//    *u     = in + iOf7[0],
+//    *qdata = in + iOf7[1];
+// Output
 //  CeedScalar *v = out + oOf7[0];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
     const CeedScalar ug0 = in[iOf7[0]+i+Q*0];
     const CeedScalar ug1 = in[iOf7[0]+i+Q*1];
@@ -118,5 +127,5 @@ typedef double CeedScalar;
                            in[iOf7[1]+i+Q*3]*ug1 + in[iOf7[1]+i+Q*4]*ug2;
     out[oOf7[0]+i+Q*2] = in[iOf7[1]+i+Q*2]*ug0 +
                            in[iOf7[1]+i+Q*4]*ug1 + in[iOf7[1]+i+Q*5]*ug2;
-  }
+  } // End of Quadrature Point Loop
 }

--- a/examples/petsc/qfunctions/bps/bp4.okl
+++ b/examples/petsc/qfunctions/bps/bp4.okl
@@ -21,19 +21,21 @@ typedef double CeedScalar;
 #define Sqr(a) ((a)*(a))
 
 // *****************************************************************************
-@kernel void SetupDiff3Rhs(void *ctx, CeedInt Q,
+@kernel void SetupDiffRhs3(void *ctx, CeedInt Q,
                            const int *iOf7, const int *oOf7,
                            const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
 //    *x = in + iOf7[0],
 //    *J = in + iOf7[1],
 //    *w = in + iOf7[2];
+// Outputs
 //  CeedScalar
-//    *target = out + oOf7[0],
-//    *rhs = out + oOf7[1];
+//    *true_soln = out + oOf7[0],
+//    *rhs       = out + oOf7[1];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
-    const CeedScalar MPI = 3.14159265358979323846;
-    const CeedInt D = 3;
     const CeedScalar J11 = in[iOf7[1]+i+Q*0];
     const CeedScalar J21 = in[iOf7[1]+i+Q*1];
     const CeedScalar J31 = in[iOf7[1]+i+Q*2];
@@ -47,64 +49,65 @@ typedef double CeedScalar;
     const CeedScalar A12 = J13*J32 - J12*J33;
     const CeedScalar A13 = J12*J23 - J13*J22;
 
-
     const CeedScalar c[3] = { 0, 1., 2. };
     const CeedScalar k[3] = { 1., 2., 3. };
 
     out[oOf7[0]+i+0*Q] = sin(M_PI*(c[0] + k[0]*in[iOf7[0]+0*Q+i])) *
-                       sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
-                       sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
-    out[oOf7[0]+i+1*Q] = out[oOf7[1]+i+0*Q];
-    out[oOf7[0]+i+2*Q] = out[oOf7[1]+i+0*Q];
+                         sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
+                         sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
+    out[oOf7[0]+i+1*Q] = out[oOf7[0]+i+0*Q];
+    out[oOf7[0]+i+2*Q] = out[oOf7[0]+i+0*Q];
 
     const CeedScalar rho = in[iOf7[2]+i] * (J11*A11 + J21*A12 + J31*A13);
 
-    out[oOf7[1]+i+0*Q] = rho * M_PI*M_PI * (k[0]*k[0] + k[1]*k[1] + k[2]*k[2]) *
-                           sin(M_PI*(c[0] + k[0]*in[iOf7[0]+0*Q+i])) *
-                           sin(M_PI*(c[1] + k[1]*in[iOf7[0]+1*Q+i])) *
-                           sin(M_PI*(c[2] + k[2]*in[iOf7[0]+2*Q+i]));
-    out[oOf7[1]+i+1*Q] = out[oOf7[2]+i+0*Q];
-    out[oOf7[1]+i+2*Q] = out[oOf7[2]+i+0*Q];
-  }
+    out[oOf7[1]+i+0*Q] = rho * Sqr(M_PI) * (Sqr(k[0]) + Sqr(k[1]) + Sqr(k[2])) *
+                         out[oOf7[0]+i+0*Q];
+    out[oOf7[1]+i+1*Q] = out[oOf7[1]+i+0*Q];
+    out[oOf7[1]+i+2*Q] = out[oOf7[1]+i+0*Q];
+  } // End of Quadrature Point Loop
 }
 
 // *****************************************************************************
 @kernel void Diff3(void *ctx, CeedInt Q,
-                          const int *iOf7, const int *oOf7,
-                          const CeedScalar *in, CeedScalar *out) {
+                   const int *iOf7, const int *oOf7,
+                   const CeedScalar *in, CeedScalar *out) {
+// Inputs
 //  const CeedScalar
-//    *u = in + iOf7[0],
-//    *qdata = in + iOf7[1],
-//  CeedScalar *v = out + oOf7[0];
+//    *ug    = in + iOf7[0],
+//    *qdata = in + iOf7[1];
+// Output
+//  CeedScalar *vg = out + oOf7[0];
+
+  // Quadrature Point Loop
   for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
-    const CeedScalar ug00 = in[iOf7[0]+i+Q*(0+0*3)];
-    const CeedScalar ug01 = in[iOf7[0]+i+Q*(0+1*3)];
-    const CeedScalar ug02 = in[iOf7[0]+i+Q*(0+2*3)];
-    out[oOf7[0]+i+Q*(0+0*3)] = in[iOf7[1]+i+Q*0]*ug00 +
-                           in[iOf7[1]+i+Q*1]*ug01 + in[iOf7[1]+i+Q*2]*ug02;
-    out[oOf7[0]+i+Q*(0+1*3)] = in[iOf7[1]+i+Q*1]*ug00 +
-                           in[iOf7[1]+i+Q*3]*ug01 + in[iOf7[1]+i+Q*4]*ug02;
-    out[oOf7[0]+i+Q*(0+2*3)] = in[iOf7[1]+i+Q*2]*ug00 +
-                           in[iOf7[1]+i+Q*4]*ug01 + in[iOf7[1]+i+Q*5]*ug02;
+    const CeedScalar uJ[3][3]        = {{in[iOf7[0]+i+Q*(0+0*3)],
+                                         in[iOf7[0]+i+Q*(0+1*3)],
+                                         in[iOf7[0]+i+Q*(0+2*3)]},
+                                        {in[iOf7[0]+i+Q*(1+0*3)],
+                                         in[iOf7[0]+i+Q*(1+1*3)],
+                                         in[iOf7[0]+i+Q*(1+2*3)]},
+                                        {in[iOf7[0]+i+Q*(2+0*3)],
+                                         in[iOf7[0]+i+Q*(2+1*3)],
+                                         in[iOf7[0]+i+Q*(2+2*3)]}
+                                       };
 
-    const CeedScalar ug10 = in[iOf7[0]+i+Q*(1+0*3)];
-    const CeedScalar ug11 = in[iOf7[0]+i+Q*(1+1*3)];
-    const CeedScalar ug12 = in[iOf7[0]+i+Q*(1+2*3)];
-    out[oOf7[0]+i+Q*(1+0*3)] = in[iOf7[1]+i+Q*0]*ug10 +
-                           in[iOf7[1]+i+Q*1]*ug11 + in[iOf7[1]+i+Q*2]*ug12;
-    out[oOf7[0]+i+Q*(1+1*3)] = in[iOf7[1]+i+Q*1]*ug10 +
-                           in[iOf7[1]+i+Q*3]*ug11 + in[iOf7[1]+i+Q*4]*ug12;
-    out[oOf7[0]+i+Q*(1+2*3)] = in[iOf7[1]+i+Q*2]*ug10 +
-                           in[iOf7[1]+i+Q*4]*ug11 + in[iOf7[1]+i+Q*5]*ug12;
+    // Read qdata (dXdxdXdxT symmetric matrix)
+    const CeedScalar dXdxdXdxT[3][3] = {{in[iOf7[1]+i+Q*0],
+                                         in[iOf7[1]+i+Q*1],
+                                         in[iOf7[1]+i+Q*2]},
+                                        {in[iOf7[1]+i+Q*1],
+                                         in[iOf7[1]+i+Q*3],
+                                         in[iOf7[1]+i+Q*4]},
+                                        {in[iOf7[1]+i+Q*2],
+                                         in[iOf7[1]+i+Q*4],
+                                         in[iOf7[1]+i+Q*5]}
+                                       };
 
-    const CeedScalar ug20 = in[iOf7[0]+i+Q*(2+0*3)];
-    const CeedScalar ug21 = in[iOf7[0]+i+Q*(2+1*3)];
-    const CeedScalar ug22 = in[iOf7[0]+i+Q*(2+2*3)];
-    out[oOf7[0]+i+Q*(2+0*3)] = in[iOf7[1]+i+Q*0]*ug20 +
-                           in[iOf7[1]+i+Q*1]*ug21 + in[iOf7[1]+i+Q*2]*ug22;
-    out[oOf7[0]+i+Q*(2+1*3)] = in[iOf7[1]+i+Q*1]*ug20 +
-                           in[iOf7[1]+i+Q*3]*ug21 + in[iOf7[1]+i+Q*4]*ug22;
-    out[oOf7[0]+i+Q*(2+2*3)] = in[iOf7[1]+i+Q*2]*ug20 +
-                           in[iOf7[1]+i+Q*4]*ug21 + in[iOf7[1]+i+Q*5]*ug22;
-  }
+    for (int k=0; k<3; k++) // k = component
+      for (int j=0; j<3; j++) // j = direction of vg
+        out[oOf7[0]+i+(k+j*3)*Q] = (uJ[k][0] * dXdxdXdxT[0][j] +
+                                    uJ[k][1] * dXdxdXdxT[1][j] +
+                                    uJ[k][2] * dXdxdXdxT[2][j]);
+  } // End of Quadrature Point Loop
 }
+// *****************************************************************************


### PR DESCRIPTION
While working on the BPs on the sphere, I noticed that our examples/petsc/bp4 and examples/petsc/bp6 are broken on master. 

The first bug I noticed and fixed, was the fact that the Qfunction was named `SetupDiff3Rhs` instead of the correct name `SetupDiffRhs3`. This allowed to run.

A second bug that I noticed and fixed, was the fact that for the second and third components of the true solution, we were erroneously using `out[oOf7[1]+i+0*Q]` instead of `out[oOf7[0]+i+0*Q];`, but it is still not producing the right results for both `bp4` and `bp6`, only with the OCCA backend. 

In attempt to further debug this, I made the `bp4.okl` file look more uniform and similar to its `bp4.h` counterpart, but still this didn't fix it. At this point I am really puzzled on what else could possibly be wrong. Since this is one of the few vector-valued examples with OCCA (BP2 though seems to work just fine!), I don't know if there is anything mysterious (to me) happening in the inner workings and ordering of multi-component variables for this backend.

Any clue? @jedbrown @jeremylt @dmed256 