### PR TITLE
ElemRestriction Lmode in Create over Apply

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -59,13 +59,13 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
       Ceed ceed;
       ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
       CeedInt nelem, elemsize, nnodes;
-      CeedTransposeMode lmode;
-      ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+      CeedInterlaceMode imode;
+      ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumElements(r, &nelem); CeedChk(ierr);
       ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumNodes(r, &nnodes); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
-      ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, nelem, elemsize,
+      ierr = CeedElemRestrictionCreateBlocked(ceed, imode, nelem, elemsize,
                                               blksize, nnodes, ncomp,
                                               CEED_MEM_HOST, CEED_COPY_VALUES,
                                               data->indices, &blkrestr[i+starte]);
@@ -602,8 +602,8 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
   ierr = CeedVectorGetArray(lvec, CEED_MEM_HOST, &a); CeedChk(ierr);
 
   // Create output restriction
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-  ierr = CeedElemRestrictionCreateIdentity(ceed, lmode, numelements, Q,
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
+  ierr = CeedElemRestrictionCreateIdentity(ceed, imode, numelements, Q,
          numelements*Q, numactivein*numactiveout, rstr); CeedChk(ierr);
   // Create assembled vector
   ierr = CeedVectorCreate(ceed, numelements*Q*numactivein*numactiveout,
@@ -664,7 +664,7 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
   ierr = CeedVectorRestoreArray(lvec, &a); CeedChk(ierr);
   ierr = CeedVectorSetValue(*assembled, 0.0); CeedChk(ierr);
   CeedElemRestriction blkrstr;
-  ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, numelements, Q, blksize,
+  ierr = CeedElemRestrictionCreateBlocked(ceed, imode, numelements, Q, blksize,
                                           numelements*Q,
                                           numactivein*numactiveout,
                                           CEED_MEM_HOST, CEED_COPY_VALUES,

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -59,11 +59,13 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
       Ceed ceed;
       ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
       CeedInt nelem, elemsize, nnodes;
+      CeedTransposeMode lmode;
+      ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumElements(r, &nelem); CeedChk(ierr);
       ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumNodes(r, &nnodes); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
-      ierr = CeedElemRestrictionCreateBlocked(ceed, nelem, elemsize,
+      ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, nelem, elemsize,
                                               blksize, nnodes, ncomp,
                                               CEED_MEM_HOST, CEED_COPY_VALUES,
                                               data->indices, &blkrestr[i+starte]);
@@ -200,7 +202,6 @@ static inline int CeedOperatorSetupInputs_Blocked(CeedInt numinputfields,
   CeedInt ierr;
   CeedEvalMode emode;
   CeedVector vec;
-  CeedTransposeMode lmode;
   uint64_t state;
 
   for (CeedInt i=0; i<numinputfields; i++) {
@@ -220,11 +221,9 @@ static inline int CeedOperatorSetupInputs_Blocked(CeedInt numinputfields,
       // Restrict
       ierr = CeedVectorGetState(vec, &state); CeedChk(ierr);
       if (state != impl->inputstate[i] || vec == invec) {
-        ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode);
-        CeedChk(ierr);
         ierr = CeedElemRestrictionApply(impl->blkrestr[i], CEED_NOTRANSPOSE,
-                                        lmode, vec, impl->evecs[i],
-                                        request); CeedChk(ierr); CeedChk(ierr);
+                                        vec, impl->evecs[i], request);
+        CeedChk(ierr);
         impl->inputstate[i] = state;
       }
       // Get evec
@@ -431,7 +430,6 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
   ierr= CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
   CeedChk(ierr);
-  CeedTransposeMode lmode;
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -500,10 +498,9 @@ static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
     if (vec == CEED_VECTOR_ACTIVE)
       vec = outvec;
     // Restrict
-    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
-    ierr = CeedElemRestrictionApply(impl->blkrestr[i+impl->numein], CEED_TRANSPOSE,
-                                    lmode, impl->evecs[i+impl->numein], vec,
-                                    request); CeedChk(ierr);
+    ierr = CeedElemRestrictionApply(impl->blkrestr[i+impl->numein],
+                                    CEED_TRANSPOSE, impl->evecs[i+impl->numein],
+                                    vec, request); CeedChk(ierr);
 
   }
 
@@ -605,7 +602,8 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
   ierr = CeedVectorGetArray(lvec, CEED_MEM_HOST, &a); CeedChk(ierr);
 
   // Create output restriction
-  ierr = CeedElemRestrictionCreateIdentity(ceed, numelements, Q,
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  ierr = CeedElemRestrictionCreateIdentity(ceed, lmode, numelements, Q,
          numelements*Q, numactivein*numactiveout, rstr); CeedChk(ierr);
   // Create assembled vector
   ierr = CeedVectorCreate(ceed, numelements*Q*numactivein*numactiveout,
@@ -666,13 +664,13 @@ static int CeedOperatorAssembleLinearQFunction_Blocked(CeedOperator op,
   ierr = CeedVectorRestoreArray(lvec, &a); CeedChk(ierr);
   ierr = CeedVectorSetValue(*assembled, 0.0); CeedChk(ierr);
   CeedElemRestriction blkrstr;
-  ierr = CeedElemRestrictionCreateBlocked(ceed, numelements, Q, blksize,
+  ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, numelements, Q, blksize,
                                           numelements*Q,
                                           numactivein*numactiveout,
                                           CEED_MEM_HOST, CEED_COPY_VALUES,
                                           NULL, &blkrstr); CeedChk(ierr);
-  ierr = CeedElemRestrictionApply(blkrstr, CEED_TRANSPOSE, CEED_NOTRANSPOSE,
-                                  lvec, *assembled, request); CeedChk(ierr);
+  ierr = CeedElemRestrictionApply(blkrstr, CEED_TRANSPOSE, lvec, *assembled,
+                                  request); CeedChk(ierr);
 
   // Cleanup
   for (CeedInt i=0; i<numactivein; i++) {

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -817,7 +817,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   ierr = CeedQFunctionGetFields(qf, &qfinputfields, &qfoutputfields);
   CeedChk(ierr);
   CeedEvalMode emode;
-  CeedTransposeMode lmode;
+  CeedInterlaceMode imode;
   CeedBasis basis;
   CeedBasis_Cuda_shared *basis_data;
   CeedElemRestriction Erestrict;
@@ -963,7 +963,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     case CEED_EVAL_NONE:
       code << "  const CeedInt ncomp_out_"<<i<<" = "<<ncomp<<";\n";
       ierr = CeedElemRestrictionGetNumNodes(Erestrict, &nnodes); CeedChk(ierr);
-      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
       code << "  const CeedInt nquads_out_"<<i<<" = "<<nnodes<<";\n";
       break; // No action
     case CEED_EVAL_INTERP:
@@ -1033,25 +1033,25 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     case CEED_EVAL_NONE:
       if (!basis_data->d_collograd1d) {
         code << "  CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Q1d];\n";
-        ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
-        code << "  readQuads"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",Q1d>(data, nquads_in_"<<i<<", elem, d_u"<<i<<", r_t"<<i<<");\n";
+        ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
+        code << "  readQuads"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",Q1d>(data, nquads_in_"<<i<<", elem, d_u"<<i<<", r_t"<<i<<");\n";
       }
       break;
     case CEED_EVAL_INTERP:
       code << "  CeedScalar r_u"<<i<<"[ncomp_in_"<<i<<"*P_in_"<<i<<"];\n";
-      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.in[i] = restr_data->d_ind;
-      code << "  readDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<">(data, nnodes_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
+      code << "  readDofs"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<">(data, nnodes_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
       code << "  CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Q1d];\n";
       code << "  interp"<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<",Q1d>(data, r_u"<<i<<", s_B_in_"<<i<<", r_t"<<i<<");\n";
       break;
     case CEED_EVAL_GRAD:
       code << "  CeedScalar r_u"<<i<<"[ncomp_in_"<<i<<"*P_in_"<<i<<"];\n";
-      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.in[i] = restr_data->d_ind;
-      code << "  readDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<">(data, nnodes_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
+      code << "  readDofs"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<">(data, nnodes_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
       if (basis_data->d_collograd1d) {
         code << "  CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Q1d];\n";
         code << "  interp"<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<",Q1d>(data, r_u"<<i<<", s_B_in_"<<i<<", r_t"<<i<<");\n";
@@ -1112,8 +1112,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       switch (emode) {
       case CEED_EVAL_NONE:
         code << "  CeedScalar r_q"<<i<<"[ncomp_in_"<<i<<"];\n";
-        ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
-        code << "  readSliceQuads"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<"3d<ncomp_in_"<<i<<",Q1d>(data, nquads_in_"<<i<<", elem, q, d_u"<<i<<", r_q"<<i<<");\n";
+        ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
+        code << "  readSliceQuads"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<"3d<ncomp_in_"<<i<<",Q1d>(data, nquads_in_"<<i<<", elem, q, d_u"<<i<<", r_q"<<i<<");\n";
         break;
       case CEED_EVAL_INTERP:
         code << "  CeedScalar r_q"<<i<<"[ncomp_in_"<<i<<"];\n";
@@ -1229,16 +1229,16 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     // Basis action
     switch (emode) {
     case CEED_EVAL_NONE:
-      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
-      code << "  writeQuads"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",Q1d>(data, nquads_out_"<<i<<", elem, r_tt"<<i<<", d_v"<<i<<");\n";
+      ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
+      code << "  writeQuads"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",Q1d>(data, nquads_out_"<<i<<", elem, r_tt"<<i<<", d_v"<<i<<");\n";
       break; // No action
     case CEED_EVAL_INTERP:
       code << "  CeedScalar r_v"<<i<<"[ncomp_out_"<<i<<"*P_out_"<<i<<"];\n";
       code << "  interpTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", r_v"<<i<<");\n";
-      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.out[i] = restr_data->d_ind;
-      code << "  writeDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<">(data, nnodes_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";
+      code << "  writeDofs"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<">(data, nnodes_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";
       break;
     case CEED_EVAL_GRAD:
       code << "  CeedScalar r_v"<<i<<"[ncomp_out_"<<i<<"*P_out_"<<i<<"];\n";
@@ -1247,10 +1247,10 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       } else {
         code << "  gradTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", s_G_out_"<<i<<", r_v"<<i<<");\n";
       }
-      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetIMode(Erestrict, &imode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.out[i] = restr_data->d_ind;
-      code << "  writeDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<">(data, nnodes_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";
+      code << "  writeDofs"<<(imode==CEED_NONINTERLACED?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<">(data, nnodes_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";
       break;
     case CEED_EVAL_WEIGHT: {
       Ceed ceed;

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -963,7 +963,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     case CEED_EVAL_NONE:
       code << "  const CeedInt ncomp_out_"<<i<<" = "<<ncomp<<";\n";
       ierr = CeedElemRestrictionGetNumNodes(Erestrict, &nnodes); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
       code << "  const CeedInt nquads_out_"<<i<<" = "<<nnodes<<";\n";
       break; // No action
     case CEED_EVAL_INTERP:
@@ -1033,13 +1033,13 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     case CEED_EVAL_NONE:
       if (!basis_data->d_collograd1d) {
         code << "  CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Q1d];\n";
-        ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
+        ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
         code << "  readQuads"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",Q1d>(data, nquads_in_"<<i<<", elem, d_u"<<i<<", r_t"<<i<<");\n";
       }
       break;
     case CEED_EVAL_INTERP:
       code << "  CeedScalar r_u"<<i<<"[ncomp_in_"<<i<<"*P_in_"<<i<<"];\n";
-      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.in[i] = restr_data->d_ind;
       code << "  readDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<">(data, nnodes_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
@@ -1048,7 +1048,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       break;
     case CEED_EVAL_GRAD:
       code << "  CeedScalar r_u"<<i<<"[ncomp_in_"<<i<<"*P_in_"<<i<<"];\n";
-      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.in[i] = restr_data->d_ind;
       code << "  readDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<">(data, nnodes_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
@@ -1112,7 +1112,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       switch (emode) {
       case CEED_EVAL_NONE:
         code << "  CeedScalar r_q"<<i<<"[ncomp_in_"<<i<<"];\n";
-        ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
+        ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
         code << "  readSliceQuads"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<"3d<ncomp_in_"<<i<<",Q1d>(data, nquads_in_"<<i<<", elem, q, d_u"<<i<<", r_q"<<i<<");\n";
         break;
       case CEED_EVAL_INTERP:
@@ -1229,13 +1229,13 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     // Basis action
     switch (emode) {
     case CEED_EVAL_NONE:
-      ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
       code << "  writeQuads"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",Q1d>(data, nquads_out_"<<i<<", elem, r_tt"<<i<<", d_v"<<i<<");\n";
       break; // No action
     case CEED_EVAL_INTERP:
       code << "  CeedScalar r_v"<<i<<"[ncomp_out_"<<i<<"*P_out_"<<i<<"];\n";
       code << "  interpTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", r_v"<<i<<");\n";
-      ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.out[i] = restr_data->d_ind;
       code << "  writeDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<">(data, nnodes_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";
@@ -1247,7 +1247,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       } else {
         code << "  gradTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", s_G_out_"<<i<<", r_v"<<i<<");\n";
       }
-      ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
+      ierr = CeedElemRestrictionGetLMode(Erestrict, &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetData(Erestrict, (void **)&restr_data); CeedChk(ierr);
       data->indices.out[i] = restr_data->d_ind;
       code << "  writeDofs"<<(lmode==CEED_NOTRANSPOSE?"":"Transpose")<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<">(data, nnodes_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";

--- a/backends/cuda-reg/ceed-cuda-reg-restriction.c
+++ b/backends/cuda-reg/ceed-cuda-reg-restriction.c
@@ -240,8 +240,8 @@ static int CeedElemRestrictionApply_Cuda_reg(CeedElemRestriction r,
   ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
   Ceed ceed;
   ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
-  CeedLayoutMode lmode;
-  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+  CeedInterlaceMode imode;
+  ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
   Ceed_Cuda_reg *data;
   ierr = CeedGetData(ceed, (void *)&data); CeedChk(ierr);
   const CeedScalar *d_u;
@@ -256,7 +256,7 @@ static int CeedElemRestrictionApply_Cuda_reg(CeedElemRestriction r,
   ierr = CeedElemRestrictionGetNumNodes(r, &nnodes); CeedChk(ierr);
   CUfunction kernel;
   if (tmode == CEED_NOTRANSPOSE) {
-    if (lmode == CEED_NOTRANSPOSE) {
+    if (imode == CEED_NONINTERLACED) {
       kernel = impl->noTrNoTr;
     } else {
       kernel = impl->noTrTr;
@@ -269,7 +269,7 @@ static int CeedElemRestrictionApply_Cuda_reg(CeedElemRestriction r,
                              blocksize, args); CeedChk(ierr);
   } else {
     if (impl->d_ind) {
-      if (lmode == CEED_NOTRANSPOSE) {
+      if (imode == CEED_NONINTERLACED) {
         kernel = impl->trNoTr;
       } else {
         kernel = impl->trTr;
@@ -278,7 +278,7 @@ static int CeedElemRestrictionApply_Cuda_reg(CeedElemRestriction r,
       ierr = CeedRunKernelCuda(ceed, kernel, CeedDivUpInt(nnodes, blocksize),
                                blocksize, args); CeedChk(ierr);
     } else {
-      if (lmode == CEED_NOTRANSPOSE) {
+      if (imode == CEED_NONINTERLACED) {
         kernel = impl->trNoTrIdentity;
       } else {
         kernel = impl->trTrIdentity;

--- a/backends/cuda-reg/ceed-cuda-reg-restriction.c
+++ b/backends/cuda-reg/ceed-cuda-reg-restriction.c
@@ -234,13 +234,14 @@ extern "C" __global__ void trTrIdentity(const CeedInt nelem,
 // *INDENT-ON*
 
 static int CeedElemRestrictionApply_Cuda_reg(CeedElemRestriction r,
-    CeedTransposeMode tmode, CeedTransposeMode lmode,
-    CeedVector u, CeedVector v, CeedRequest *request) {
+    CeedTransposeMode tmode, CeedVector u, CeedVector v, CeedRequest *request) {
   int ierr;
   CeedElemRestriction_Cuda_reg *impl;
   ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
   Ceed ceed;
   ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  CeedLayoutMode lmode;
+  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
   Ceed_Cuda_reg *data;
   ierr = CeedGetData(ceed, (void *)&data); CeedChk(ierr);
   const CeedScalar *d_u;

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -184,7 +184,6 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
   ierr = CeedOperatorGetNumElements(op, &numelements); CeedChk(ierr);
   ierr = CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
   CeedChk(ierr);
-  CeedTransposeMode lmode;
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -212,10 +211,8 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
       // Restrict
       ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict);
       CeedChk(ierr);
-      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
-      ierr = CeedElemRestrictionApply(Erestrict, CEED_NOTRANSPOSE,
-                                      lmode, vec, impl->evecs[i],
-                                      request); CeedChk(ierr);
+      ierr = CeedElemRestrictionApply(Erestrict, CEED_NOTRANSPOSE, vec,
+                                      impl->evecs[i], request); CeedChk(ierr);
       // Get evec
       ierr = CeedVectorGetArrayRead(impl->evecs[i], CEED_MEM_DEVICE,
                                     (const CeedScalar **) &impl->edata[i]);
@@ -338,9 +335,8 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
     // Restrict
     ierr = CeedOperatorFieldGetElemRestriction(opoutputfields[i], &Erestrict);
     CeedChk(ierr);
-    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
     ierr = CeedElemRestrictionApply(Erestrict, CEED_TRANSPOSE,
-                                    lmode, impl->evecs[i + impl->numein], vec,
+                                    impl->evecs[i + impl->numein], vec,
                                     request); CeedChk(ierr);
   }
 

--- a/backends/cuda/ceed-cuda-restriction.c
+++ b/backends/cuda/ceed-cuda-restriction.c
@@ -147,13 +147,14 @@ extern "C" __global__ void trTr(const CeedInt nelem,
 // *INDENT-ON*
 
 static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r,
-    CeedTransposeMode tmode, CeedTransposeMode lmode,
-    CeedVector u, CeedVector v, CeedRequest *request) {
+    CeedTransposeMode tmode, CeedVector u, CeedVector v, CeedRequest *request) {
   int ierr;
   CeedElemRestriction_Cuda *impl;
   ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
   Ceed ceed;
   ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
+  CeedTransposeMode lmode;
+  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
   Ceed_Cuda *data;
   ierr = CeedGetData(ceed, (void *)&data); CeedChk(ierr);
   const CeedScalar *d_u;

--- a/backends/cuda/ceed-cuda-restriction.c
+++ b/backends/cuda/ceed-cuda-restriction.c
@@ -153,8 +153,8 @@ static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r,
   ierr = CeedElemRestrictionGetData(r, (void *)&impl); CeedChk(ierr);
   Ceed ceed;
   ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
-  CeedTransposeMode lmode;
-  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+  CeedInterlaceMode imode;
+  ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
   Ceed_Cuda *data;
   ierr = CeedGetData(ceed, (void *)&data); CeedChk(ierr);
   const CeedScalar *d_u;
@@ -163,13 +163,13 @@ static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r,
   ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
   CUfunction kernel;
   if (tmode == CEED_NOTRANSPOSE) {
-    if (lmode == CEED_NOTRANSPOSE) {
+    if (imode == CEED_NONINTERLACED) {
       kernel = impl->noTrNoTr;
     } else {
       kernel = impl->noTrTr;
     }
   } else {
-    if (lmode == CEED_NOTRANSPOSE) {
+    if (imode == CEED_NONINTERLACED) {
       kernel = impl->trNoTr;
     } else {
       kernel = impl->trTr;
@@ -190,9 +190,9 @@ static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r,
   return 0;
 }
 
-int CeedElemRestrictionApplyBlock_Cuda(CeedElemRestriction r,
-                                       CeedInt block, CeedTransposeMode tmode,
-                                       CeedTransposeMode lmode, CeedVector u,
+int CeedElemRestrictionApplyBlock_Cuda(CeedElemRestriction r, CeedInt block,
+                                       CeedTransposeMode tmode,
+                                       CeedInterlaceMode imode, CeedVector u,
                                        CeedVector v, CeedRequest *request) {
   int ierr;
   Ceed ceed;

--- a/backends/magma/ceed-magma-restriction_cuda.cu
+++ b/backends/magma/ceed-magma-restriction_cuda.cu
@@ -1,9 +1,0 @@
-#include <ceed.h>                       
-
-#include "atomics.cuh"                       
-#include "magma_check_cudaerror.h"         
-
-#define  MAX_TB_XDIM      2147483647           
-#define  MAX_THREADS_PTB  1024                 
-#define  OUR_THREADS_PTB  512                
-

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -281,7 +281,6 @@ static int CeedOperatorApply_Occa(CeedOperator op,
   ierr = CeedOperatorGetNumElements(op, &numelements); CeedChk(ierr);
   CeedQFunction qf;
   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
-  CeedTransposeMode lmode;
   CeedOperatorField *opinputfields, *opoutputfields;
   ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
   CeedChk(ierr);
@@ -321,10 +320,9 @@ static int CeedOperatorApply_Occa(CeedOperator op,
       // Restrict
       ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict);
       CeedChk(ierr);
-      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionApply(Erestrict, CEED_NOTRANSPOSE,
-                                      lmode, vec, data->Evecs[i],
-                                      request); CeedChk(ierr);
+                                      vec, data->Evecs[i], request);
+      CeedChk(ierr);
       // Get evec
       ierr = CeedVectorGetArrayRead(data->Evecs[i], CEED_MEM_HOST,
                                     (const CeedScalar **) &data->Edata[i]);
@@ -500,10 +498,9 @@ static int CeedOperatorApply_Occa(CeedOperator op,
     // Restrict
     ierr = CeedOperatorFieldGetElemRestriction(opoutputfields[i], &Erestrict);
     CeedChk(ierr);
-    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode); CeedChk(ierr);
     ierr = CeedElemRestrictionApply(Erestrict, CEED_TRANSPOSE,
-                                    lmode, data->Evecs[i+data->numein], vec,
-                                    request); CeedChk(ierr);
+                                    data->Evecs[i+data->numein], vec, request);
+    CeedChk(ierr);
     ierr = SyncToHostPointer(vec); CeedChk(ierr);
   }
 

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -33,7 +33,6 @@ static inline size_t bytes(const CeedElemRestriction res) {
 static
 int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
                                   CeedTransposeMode tmode,
-                                  CeedTransposeMode lmode,
                                   CeedVector u, CeedVector v,
                                   CeedRequest *request) {
   int ierr;
@@ -42,6 +41,8 @@ int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
   CeedInt ncomp;
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   dbg("[CeedElemRestriction][Apply]");
+  CeedTransposeMode lmode;
+  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
   CeedElemRestriction_Occa *data;
   ierr = CeedElemRestrictionGetData(r, (void *)&data); CeedChk(ierr);
   const occaMemory id = data->d_indices;

--- a/backends/occa/ceed-occa-restrict.c
+++ b/backends/occa/ceed-occa-restrict.c
@@ -41,8 +41,8 @@ int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
   CeedInt ncomp;
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   dbg("[CeedElemRestriction][Apply]");
-  CeedTransposeMode lmode;
-  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+  CeedInterlaceMode imode;
+  ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
   CeedElemRestriction_Occa *data;
   ierr = CeedElemRestrictionGetData(r, (void *)&data); CeedChk(ierr);
   const occaMemory id = data->d_indices;
@@ -55,7 +55,7 @@ int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
   const occaMemory ud = u_data->d_array;
   const occaMemory vd = v_data->d_array;
   const CeedTransposeMode restriction = (tmode == CEED_NOTRANSPOSE);
-  const CeedTransposeMode ordering = (lmode == CEED_NOTRANSPOSE);
+  const CeedTransposeMode ordering = (imode == CEED_NONINTERLACED);
   const bool identity = data->identity;
   // ***************************************************************************
   if (identity) {
@@ -103,8 +103,9 @@ int CeedElemRestrictionApply_Occa(CeedElemRestriction r,
 
 // *****************************************************************************
 int CeedElemRestrictionApplyBlock_Occa(CeedElemRestriction r,
-                                       CeedInt block, CeedTransposeMode tmode, CeedTransposeMode lmode,
-                                       CeedVector u, CeedVector v, CeedRequest *request) {
+                                       CeedInt block, CeedTransposeMode tmode,
+                                       CeedInterlaceMode imode, CeedVector u,
+                                       CeedVector v, CeedRequest *request) {
   int ierr;
   Ceed ceed;
   ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -59,13 +59,13 @@ static int CeedOperatorSetupFields_Opt(CeedQFunction qf, CeedOperator op,
       Ceed ceed;
       ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
       CeedInt nelem, elemsize, nnodes;
-      CeedTransposeMode lmode;
-      ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+      CeedInterlaceMode imode;
+      ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumElements(r, &nelem); CeedChk(ierr);
       ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumNodes(r, &nnodes); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
-      ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, nelem, elemsize,
+      ierr = CeedElemRestrictionCreateBlocked(ceed, imode, nelem, elemsize,
                                               blksize, nnodes, ncomp,
                                               CEED_MEM_HOST, CEED_COPY_VALUES,
                                               data->indices, &blkrestr[i+starte]);
@@ -614,8 +614,8 @@ static int CeedOperatorAssembleLinearQFunction_Opt(CeedOperator op,
   ierr = CeedVectorGetArray(lvec, CEED_MEM_HOST, &a); CeedChk(ierr);
 
   // Create output restriction
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-  ierr = CeedElemRestrictionCreateIdentity(ceed, lmode, numelements, Q,
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
+  ierr = CeedElemRestrictionCreateIdentity(ceed, imode, numelements, Q,
          numelements*Q, numactivein*numactiveout, rstr); CeedChk(ierr);
   // Create assembled vector
   ierr = CeedVectorCreate(ceed, numelements*Q*numactivein*numactiveout,
@@ -677,7 +677,7 @@ static int CeedOperatorAssembleLinearQFunction_Opt(CeedOperator op,
   ierr = CeedVectorRestoreArray(lvec, &a); CeedChk(ierr);
   ierr = CeedVectorSetValue(*assembled, 0.0); CeedChk(ierr);
   CeedElemRestriction blkrstr;
-  ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, numelements, Q, blksize,
+  ierr = CeedElemRestrictionCreateBlocked(ceed, imode, numelements, Q, blksize,
                                           numelements*Q,
                                           numactivein*numactiveout,
                                           CEED_MEM_HOST, CEED_COPY_VALUES,

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -59,11 +59,13 @@ static int CeedOperatorSetupFields_Opt(CeedQFunction qf, CeedOperator op,
       Ceed ceed;
       ierr = CeedElemRestrictionGetCeed(r, &ceed); CeedChk(ierr);
       CeedInt nelem, elemsize, nnodes;
+      CeedTransposeMode lmode;
+      ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumElements(r, &nelem); CeedChk(ierr);
       ierr = CeedElemRestrictionGetElementSize(r, &elemsize); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumNodes(r, &nnodes); CeedChk(ierr);
       ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
-      ierr = CeedElemRestrictionCreateBlocked(ceed, nelem, elemsize,
+      ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, nelem, elemsize,
                                               blksize, nnodes, ncomp,
                                               CEED_MEM_HOST, CEED_COPY_VALUES,
                                               data->indices, &blkrestr[i+starte]);
@@ -203,7 +205,6 @@ static inline int CeedOperatorSetupInputs_Opt(CeedInt numinputfields,
   CeedInt ierr;
   CeedEvalMode emode;
   CeedVector vec;
-  CeedTransposeMode lmode;
   uint64_t state;
 
   for (CeedInt i=0; i<numinputfields; i++) {
@@ -217,10 +218,8 @@ static inline int CeedOperatorSetupInputs_Opt(CeedInt numinputfields,
         // Restrict
         ierr = CeedVectorGetState(vec, &state); CeedChk(ierr);
         if (state != impl->inputstate[i]) {
-          ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode);
-          CeedChk(ierr);
           ierr = CeedElemRestrictionApply(impl->blkrestr[i], CEED_NOTRANSPOSE,
-                                          lmode, vec, impl->evecs[i], request);
+                                          vec, impl->evecs[i], request);
           CeedChk(ierr);
           impl->inputstate[i] = state;
         }
@@ -258,7 +257,6 @@ static inline int CeedOperatorInputBasis_Opt(CeedInt e, CeedInt Q,
   CeedEvalMode emode;
   CeedBasis basis;
   CeedVector vec;
-  CeedTransposeMode lmode;
 
   for (CeedInt i=0; i<numinputfields; i++) {
     ierr = CeedOperatorFieldGetVector(opinputfields[i], &vec); CeedChk(ierr);
@@ -279,10 +277,8 @@ static inline int CeedOperatorInputBasis_Opt(CeedInt e, CeedInt Q,
     ierr = CeedQFunctionFieldGetSize(qfinputfields[i], &size); CeedChk(ierr);
     // Restrict block active input
     if (vec == CEED_VECTOR_ACTIVE) {
-      ierr = CeedOperatorFieldGetLMode(opinputfields[i], &lmode);
-      CeedChk(ierr);
       ierr = CeedElemRestrictionApplyBlock(impl->blkrestr[i], e/blksize,
-                                           CEED_NOTRANSPOSE, lmode, invec,
+                                           CEED_NOTRANSPOSE, invec,
                                            impl->evecsin[i], request);
       CeedChk(ierr);
       activein = 1;
@@ -354,7 +350,6 @@ static inline int CeedOperatorOutputBasis_Opt(CeedInt e, CeedInt Q,
   CeedEvalMode emode;
   CeedBasis basis;
   CeedVector vec;
-  CeedTransposeMode lmode;
 
   for (CeedInt i=0; i<numoutputfields; i++) {
     // Get elemsize, emode, size
@@ -405,12 +400,10 @@ static inline int CeedOperatorOutputBasis_Opt(CeedInt e, CeedInt Q,
     if (vec == CEED_VECTOR_ACTIVE)
       vec = outvec;
     // Restrict
-    ierr = CeedOperatorFieldGetLMode(opoutputfields[i], &lmode);
-    CeedChk(ierr);
     ierr = CeedElemRestrictionApplyBlock(impl->blkrestr[i+impl->numein],
                                          e/blksize, CEED_TRANSPOSE,
-                                         lmode, impl->evecsout[i],
-                                         vec, request); CeedChk(ierr);
+                                         impl->evecsout[i], vec, request);
+    CeedChk(ierr);
   }
   return 0;
 }
@@ -621,7 +614,8 @@ static int CeedOperatorAssembleLinearQFunction_Opt(CeedOperator op,
   ierr = CeedVectorGetArray(lvec, CEED_MEM_HOST, &a); CeedChk(ierr);
 
   // Create output restriction
-  ierr = CeedElemRestrictionCreateIdentity(ceed, numelements, Q,
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  ierr = CeedElemRestrictionCreateIdentity(ceed, lmode, numelements, Q,
          numelements*Q, numactivein*numactiveout, rstr); CeedChk(ierr);
   // Create assembled vector
   ierr = CeedVectorCreate(ceed, numelements*Q*numactivein*numactiveout,
@@ -683,13 +677,13 @@ static int CeedOperatorAssembleLinearQFunction_Opt(CeedOperator op,
   ierr = CeedVectorRestoreArray(lvec, &a); CeedChk(ierr);
   ierr = CeedVectorSetValue(*assembled, 0.0); CeedChk(ierr);
   CeedElemRestriction blkrstr;
-  ierr = CeedElemRestrictionCreateBlocked(ceed, numelements, Q, blksize,
+  ierr = CeedElemRestrictionCreateBlocked(ceed, lmode, numelements, Q, blksize,
                                           numelements*Q,
                                           numactivein*numactiveout,
                                           CEED_MEM_HOST, CEED_COPY_VALUES,
                                           NULL, &blkrstr); CeedChk(ierr);
-  ierr = CeedElemRestrictionApply(blkrstr, CEED_TRANSPOSE, CEED_NOTRANSPOSE,
-                                  lvec, *assembled, request); CeedChk(ierr);
+  ierr = CeedElemRestrictionApply(blkrstr, CEED_TRANSPOSE, lvec, *assembled,
+                                  request); CeedChk(ierr);
 
   // Cleanup
   for (CeedInt i=0; i<numactivein; i++) {

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -571,8 +571,8 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   // LCOV_EXCL_STOP
 
   // Create output restriction
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-  ierr = CeedElemRestrictionCreateIdentity(ceedparent, lmode, numelements, Q,
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
+  ierr = CeedElemRestrictionCreateIdentity(ceedparent, imode, numelements, Q,
          numelements*Q, numactivein*numactiveout, rstr); CeedChk(ierr);
   // Create assembled vector
   ierr = CeedVectorCreate(ceedparent, numelements*Q*numactivein*numactiveout,
@@ -1027,8 +1027,8 @@ int CeedOperatorCreateFDMElementInverse_Ref(CeedOperator op,
 
   // -- Restriction
   CeedElemRestriction rstr_i;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-  ierr = CeedElemRestrictionCreateIdentity(ceedparent, lmode, nelem, nnodes,
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
+  ierr = CeedElemRestrictionCreateIdentity(ceedparent, imode, nelem, nnodes,
          nnodes*nelem, ncomp, &rstr_i); CeedChk(ierr);
   // -- QFunction
   CeedQFunction mass_qf;

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -131,14 +131,15 @@ static int CeedElemRestrictionApply_Ref_38(CeedElemRestriction r,
 // ElemRestriction Apply
 //------------------------------------------------------------------------------
 static int CeedElemRestrictionApply_Ref(CeedElemRestriction r,
-                                        CeedTransposeMode tmode,
-                                        CeedTransposeMode lmode, CeedVector u,
+                                        CeedTransposeMode tmode, CeedVector u,
                                         CeedVector v, CeedRequest *request) {
   int ierr;
   CeedInt numblk, ncomp, blksize;
+  CeedTransposeMode lmode;
   ierr = CeedElemRestrictionGetNumBlocks(r, &numblk); CeedChk(ierr);
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   ierr = CeedElemRestrictionGetBlockSize(r, &blksize); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
 
   CeedInt idx = -1;
   if (blksize < 10)
@@ -172,12 +173,14 @@ static int CeedElemRestrictionApply_Ref(CeedElemRestriction r,
 // ElemRestriction Apply Block
 //------------------------------------------------------------------------------
 static int CeedElemRestrictionApplyBlock_Ref(CeedElemRestriction r,
-    CeedInt block, CeedTransposeMode tmode, CeedTransposeMode lmode,
-    CeedVector u, CeedVector v, CeedRequest *request) {
+    CeedInt block, CeedTransposeMode tmode, CeedVector u, CeedVector v,
+    CeedRequest *request) {
   int ierr;
   CeedInt ncomp, blksize;
+  CeedTransposeMode lmode;
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   ierr = CeedElemRestrictionGetBlockSize(r, &blksize); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
 
   CeedInt idx = -1;
   if (blksize < 10)

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -21,7 +21,7 @@
 //------------------------------------------------------------------------------
 static inline int CeedElemRestrictionApply_Ref_Core(CeedElemRestriction r,
     const CeedInt blksize, const CeedInt ncomp, CeedInt start, CeedInt stop,
-    CeedTransposeMode tmode, CeedTransposeMode lmode, CeedVector u,
+    CeedTransposeMode tmode, CeedInterlaceMode imode, CeedVector u,
     CeedVector v, CeedRequest *request) {
   int ierr;
   CeedElemRestriction_Ref *impl;
@@ -58,7 +58,7 @@ static inline int CeedElemRestrictionApply_Ref_Core(CeedElemRestriction r,
           CeedPragmaSIMD
           for (CeedInt i = 0; i < elemsize*blksize; i++)
             vv[elemsize*(d*blksize+ncomp*e) + i - voffset]
-              = uu[lmode == CEED_NOTRANSPOSE
+              = uu[imode == CEED_NONINTERLACED
                          ? impl->indices[i+elemsize*e]+nnodes*d
                          : d+ncomp*impl->indices[i+elemsize*e]];
     }
@@ -82,7 +82,7 @@ static inline int CeedElemRestrictionApply_Ref_Core(CeedElemRestriction r,
           for (CeedInt i = 0; i < elemsize*blksize; i+=blksize)
             // Iteration bound set to discard padding elements
             for (CeedInt j = i; j < i+CeedIntMin(blksize, nelem-e); j++)
-              vv[lmode == CEED_NOTRANSPOSE
+              vv[imode == CEED_NONINTERLACED
                        ? impl->indices[j+e*elemsize]+nnodes*d
                        : d+ncomp*impl->indices[j+e*elemsize]]
               += uu[elemsize*(d*blksize+ncomp*e) + j - voffset];
@@ -100,30 +100,30 @@ static inline int CeedElemRestrictionApply_Ref_Core(CeedElemRestriction r,
 //------------------------------------------------------------------------------
 static int CeedElemRestrictionApply_Ref_11(CeedElemRestriction r,
     CeedInt start, CeedInt stop, CeedTransposeMode tmode,
-    CeedTransposeMode lmode, CeedVector u, CeedVector v, CeedRequest *request) {
-  return CeedElemRestrictionApply_Ref_Core(r, 1, 1, start, stop, tmode, lmode,
+    CeedInterlaceMode imode, CeedVector u, CeedVector v, CeedRequest *request) {
+  return CeedElemRestrictionApply_Ref_Core(r, 1, 1, start, stop, tmode, imode,
          u, v, request);
 }
 
 static int CeedElemRestrictionApply_Ref_18(CeedElemRestriction r,
     CeedInt start, CeedInt stop, CeedTransposeMode tmode,
-    CeedTransposeMode lmode, CeedVector u, CeedVector v, CeedRequest *request) {
-  return CeedElemRestrictionApply_Ref_Core(r, 8, 1, start, stop, tmode, lmode,
+    CeedInterlaceMode imode, CeedVector u, CeedVector v, CeedRequest *request) {
+  return CeedElemRestrictionApply_Ref_Core(r, 8, 1, start, stop, tmode, imode,
          u, v, request);
 
 }
 
 static int CeedElemRestrictionApply_Ref_31(CeedElemRestriction r,
     CeedInt start, CeedInt stop, CeedTransposeMode tmode,
-    CeedTransposeMode lmode, CeedVector u, CeedVector v, CeedRequest *request) {
-  return CeedElemRestrictionApply_Ref_Core(r, 1, 3, start, stop, tmode, lmode,
+    CeedInterlaceMode imode, CeedVector u, CeedVector v, CeedRequest *request) {
+  return CeedElemRestrictionApply_Ref_Core(r, 1, 3, start, stop, tmode, imode,
          u, v, request);
 }
 
 static int CeedElemRestrictionApply_Ref_38(CeedElemRestriction r,
     CeedInt start, CeedInt stop, CeedTransposeMode tmode,
-    CeedTransposeMode lmode, CeedVector u, CeedVector v, CeedRequest *request) {
-  return CeedElemRestrictionApply_Ref_Core(r, 8, 3, start, stop, tmode, lmode,
+    CeedInterlaceMode imode, CeedVector u, CeedVector v, CeedRequest *request) {
+  return CeedElemRestrictionApply_Ref_Core(r, 8, 3, start, stop, tmode, imode,
          u, v, request);
 }
 
@@ -135,36 +135,36 @@ static int CeedElemRestrictionApply_Ref(CeedElemRestriction r,
                                         CeedVector v, CeedRequest *request) {
   int ierr;
   CeedInt numblk, ncomp, blksize;
-  CeedTransposeMode lmode;
+  CeedInterlaceMode imode;
   ierr = CeedElemRestrictionGetNumBlocks(r, &numblk); CeedChk(ierr);
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   ierr = CeedElemRestrictionGetBlockSize(r, &blksize); CeedChk(ierr);
-  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
 
   CeedInt idx = -1;
   if (blksize < 10)
     idx = 10*ncomp + blksize;
   switch (idx) {
   case 11:
-    return CeedElemRestrictionApply_Ref_11(r, 0, numblk, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_11(r, 0, numblk, tmode, imode,
                                            u, v, request);
     break;
   case 18:
-    return CeedElemRestrictionApply_Ref_18(r, 0, numblk, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_18(r, 0, numblk, tmode, imode,
                                            u, v, request);
     break;
   case 31:
-    return CeedElemRestrictionApply_Ref_31(r, 0, numblk, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_31(r, 0, numblk, tmode, imode,
                                            u, v, request);
     break;
   case 38:
-    return CeedElemRestrictionApply_Ref_38(r, 0, numblk, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_38(r, 0, numblk, tmode, imode,
                                            u, v, request);
     break;
   default:
     // LCOV_EXCL_START
     return CeedElemRestrictionApply_Ref_Core(r, blksize, ncomp, 0, numblk,
-           tmode, lmode, u, v, request);
+           tmode, imode, u, v, request);
     // LCOV_EXCL_STOP
   }
 }
@@ -177,35 +177,35 @@ static int CeedElemRestrictionApplyBlock_Ref(CeedElemRestriction r,
     CeedRequest *request) {
   int ierr;
   CeedInt ncomp, blksize;
-  CeedTransposeMode lmode;
+  CeedInterlaceMode imode;
   ierr = CeedElemRestrictionGetNumComponents(r, &ncomp); CeedChk(ierr);
   ierr = CeedElemRestrictionGetBlockSize(r, &blksize); CeedChk(ierr);
-  ierr = CeedElemRestrictionGetLMode(r, &lmode); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetIMode(r, &imode); CeedChk(ierr);
 
   CeedInt idx = -1;
   if (blksize < 10)
     idx = 10*ncomp + blksize;
   switch (idx) {
   case 11:
-    return CeedElemRestrictionApply_Ref_11(r, block, block+1, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_11(r, block, block+1, tmode, imode,
                                            u, v, request);
     break;
   case 18:
-    return CeedElemRestrictionApply_Ref_18(r, block, block+1, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_18(r, block, block+1, tmode, imode,
                                            u, v, request);
     break;
   case 31:
-    return CeedElemRestrictionApply_Ref_31(r, block, block+1, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_31(r, block, block+1, tmode, imode,
                                            u, v, request);
     break;
   case 38:
-    return CeedElemRestrictionApply_Ref_38(r, block, block+1, tmode, lmode,
+    return CeedElemRestrictionApply_Ref_38(r, block, block+1, tmode, imode,
                                            u, v, request);
     break;
   default:
     // LCOV_EXCL_START
     return CeedElemRestrictionApply_Ref_Core(r, blksize, ncomp, block, block+1,
-           tmode, lmode, u, v, request);
+           tmode, imode, u, v, request);
     // LCOV_EXCL_STOP
   }
 }

--- a/examples/ceed/ex1-volume.c
+++ b/examples/ceed/ex1-volume.c
@@ -346,7 +346,7 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[dim], int order,
   // nnodes:   0   1    p-1  p  p+1       2*p             n*p
   CeedInt *el_nodes = malloc(sizeof(CeedInt)*num_elem*nnodes);
   for (CeedInt e = 0; e < num_elem; e++) {
-    CeedInt exyz[3], re = e;
+    CeedInt exyz[3] = {1, 1, 1}, re = e;
     for (int d = 0; d < dim; d++) { exyz[d] = re%nxyz[d]; re /= nxyz[d]; }
     CeedInt *loc_el_nodes = el_nodes + e*nnodes;
     for (int lnodes = 0; lnodes < nnodes; lnodes++) {

--- a/examples/ceed/ex1-volume.c
+++ b/examples/ceed/ex1-volume.c
@@ -330,7 +330,7 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[dim], int order,
                               int ncomp, CeedInt *size, CeedInt num_qpts,
                               CeedElemRestriction *restr,
                               CeedElemRestriction *restr_i) {
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedInt p = order, pp1 = p+1;
   CeedInt nnodes = CeedIntPow(pp1, dim); // number of scal. nodes per element
   CeedInt elem_qpts = CeedIntPow(num_qpts, dim); // number of qpts per element
@@ -359,10 +359,10 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[dim], int order,
       loc_el_nodes[lnodes] = gnodes;
     }
   }
-  CeedElemRestrictionCreate(ceed, lmode, num_elem, nnodes, scalar_size,
+  CeedElemRestrictionCreate(ceed, imode, num_elem, nnodes, scalar_size,
                             ncomp, CEED_MEM_HOST, CEED_COPY_VALUES, el_nodes,
                             restr);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, num_elem, elem_qpts,
+  CeedElemRestrictionCreateIdentity(ceed, imode, num_elem, elem_qpts,
                                     elem_qpts*num_elem, ncomp, restr_i);
   free(el_nodes);
   return 0;

--- a/examples/ceed/ex1-volume.c
+++ b/examples/ceed/ex1-volume.c
@@ -202,12 +202,12 @@ int main(int argc, const char *argv[]) {
   CeedOperator build_oper;
   CeedOperatorCreate(ceed, build_qfunc, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &build_oper);
-  CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
-                       mesh_basis,CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
-                       mesh_basis, CEED_VECTOR_NONE);
-  CeedOperatorSetField(build_oper, "qdata", sol_restr_i, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(build_oper, "dx", mesh_restr, mesh_basis,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(build_oper, "weights", mesh_restr_i, mesh_basis,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(build_oper, "qdata", sol_restr_i, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
   // Compute the quadrature data for the mass operator.
   CeedVector qdata;
@@ -247,12 +247,10 @@ int main(int argc, const char *argv[]) {
   CeedOperator oper;
   CeedOperatorCreate(ceed, apply_qfunc, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &oper);
-  CeedOperatorSetField(oper, "u", sol_restr, CEED_NOTRANSPOSE,
-                       sol_basis, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(oper, "qdata", sol_restr_i, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(oper, "v", sol_restr, CEED_NOTRANSPOSE,
-                       sol_basis, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(oper, "u", sol_restr, sol_basis, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(oper, "qdata", sol_restr_i, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(oper, "v", sol_restr, sol_basis, CEED_VECTOR_ACTIVE);
 
   // Compute the mesh volume using the mass operator: vol = 1^T \cdot M \cdot 1
   if (!test) {
@@ -332,6 +330,7 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[dim], int order,
                               int ncomp, CeedInt *size, CeedInt num_qpts,
                               CeedElemRestriction *restr,
                               CeedElemRestriction *restr_i) {
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedInt p = order, pp1 = p+1;
   CeedInt nnodes = CeedIntPow(pp1, dim); // number of scal. nodes per element
   CeedInt elem_qpts = CeedIntPow(num_qpts, dim); // number of qpts per element
@@ -360,12 +359,11 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[dim], int order,
       loc_el_nodes[lnodes] = gnodes;
     }
   }
-  CeedElemRestrictionCreate(ceed, num_elem, nnodes, scalar_size,
-                            ncomp, CEED_MEM_HOST,
-                            CEED_COPY_VALUES, el_nodes, restr);
-  CeedElemRestrictionCreateIdentity(ceed, num_elem, elem_qpts,
-                                    elem_qpts*num_elem,
-                                    ncomp, restr_i);
+  CeedElemRestrictionCreate(ceed, lmode, num_elem, nnodes, scalar_size,
+                            ncomp, CEED_MEM_HOST, CEED_COPY_VALUES, el_nodes,
+                            restr);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, num_elem, elem_qpts,
+                                    elem_qpts*num_elem, ncomp, restr_i);
   free(el_nodes);
   return 0;
 }

--- a/examples/ceed/ex2-surface.c
+++ b/examples/ceed/ex2-surface.c
@@ -371,7 +371,7 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[3], int order,
   // nnodes:   0   1    p-1  p  p+1       2*p             n*p
   CeedInt *el_nodes = malloc(sizeof(CeedInt)*num_elem*nnodes);
   for (CeedInt e = 0; e < num_elem; e++) {
-    CeedInt exyz[3], re = e;
+    CeedInt exyz[3] = {1, 1, 1}, re = e;
     for (int d = 0; d < dim; d++) { exyz[d] = re%nxyz[d]; re /= nxyz[d]; }
     CeedInt *loc_el_nodes = el_nodes + e*nnodes;
     for (int lnodes = 0; lnodes < nnodes; lnodes++) {

--- a/examples/ceed/ex2-surface.c
+++ b/examples/ceed/ex2-surface.c
@@ -355,7 +355,7 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[3], int order,
                               int ncomp, CeedInt *size, CeedInt num_qpts,
                               CeedElemRestriction *restr,
                               CeedElemRestriction *restr_i) {
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedInt p = order, pp1 = p+1;
   CeedInt nnodes = CeedIntPow(pp1, dim); // number of scal. nodes per element
   CeedInt elem_qpts = CeedIntPow(num_qpts, dim); // number of qpts per element
@@ -385,11 +385,11 @@ int BuildCartesianRestriction(Ceed ceed, int dim, int nxyz[3], int order,
     }
   }
   if (restr)
-    CeedElemRestrictionCreate(ceed, lmode, num_elem, nnodes, scalar_size,
+    CeedElemRestrictionCreate(ceed, imode, num_elem, nnodes, scalar_size,
                               ncomp, CEED_MEM_HOST, CEED_COPY_VALUES, el_nodes,
                               restr);
   if (restr_i)
-    CeedElemRestrictionCreateIdentity(ceed, lmode, num_elem, elem_qpts,
+    CeedElemRestrictionCreateIdentity(ceed, imode, num_elem, elem_qpts,
                                       elem_qpts*num_elem, ncomp, restr_i);
   free(el_nodes);
   return 0;

--- a/examples/mfem/bp1.hpp
+++ b/examples/mfem/bp1.hpp
@@ -100,8 +100,8 @@ class CeedMassOperator : public mfem::Operator {
         tp_el_dof[j + el_offset] = el_dof.GetJ()[dof_map[j] + el_offset];
       }
     }
-    CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-    CeedElemRestrictionCreate(ceed, lmode, mesh->GetNE(), fe->GetDof(),
+    CeedInterlaceMode imode = CEED_NONINTERLACED;
+    CeedElemRestrictionCreate(ceed, imode, mesh->GetNE(), fe->GetDof(),
                               fes->GetNDofs(), fes->GetVDim(), CEED_MEM_HOST,
                               CEED_COPY_VALUES, tp_el_dof.GetData(), restr);
   }
@@ -126,10 +126,10 @@ class CeedMassOperator : public mfem::Operator {
     FESpace2Ceed(mesh_fes, ir, ceed, &mesh_basis, &mesh_restr);
     CeedBasisGetNumQuadraturePoints(basis, &nqpts);
 
-    CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-    CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, nqpts,
+    CeedInterlaceMode imode = CEED_NONINTERLACED;
+    CeedElemRestrictionCreateIdentity(ceed, imode, nelem, nqpts,
                                       nqpts*nelem, 1, &restr_i);
-    CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, nqpts,
+    CeedElemRestrictionCreateIdentity(ceed, imode, nelem, nqpts,
                                       nqpts*nelem, 1, &mesh_restr_i);
 
     CeedVectorCreate(ceed, mesh->GetNodes()->Size(), &node_coords);

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -101,7 +101,8 @@ class CeedDiffusionOperator : public mfem::Operator {
         tp_el_dof[j + el_offset] = el_dof.GetJ()[dof_map[j] + el_offset];
       }
     }
-    CeedElemRestrictionCreate(ceed, mesh->GetNE(), fe->GetDof(),
+    CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+    CeedElemRestrictionCreate(ceed, lmode, mesh->GetNE(), fe->GetDof(),
                               fes->GetNDofs(), fes->GetVDim(), CEED_MEM_HOST,
                               CEED_COPY_VALUES, tp_el_dof.GetData(), restr);
   }
@@ -126,9 +127,10 @@ class CeedDiffusionOperator : public mfem::Operator {
     FESpace2Ceed(mesh_fes, ir, ceed, &mesh_basis, &mesh_restr);
     CeedBasisGetNumQuadraturePoints(basis, &nqpts);
 
-    CeedElemRestrictionCreateIdentity(ceed, nelem, nqpts,
+    CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+    CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, nqpts,
                                       nqpts*nelem, dim*(dim+1)/2, &restr_i);
-    CeedElemRestrictionCreateIdentity(ceed, nelem, nqpts,
+    CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, nqpts,
                                       nqpts*nelem, 1, &mesh_restr_i);
 
     CeedVectorCreate(ceed, mesh->GetNodes()->Size(), &node_coords);
@@ -153,12 +155,12 @@ class CeedDiffusionOperator : public mfem::Operator {
     // Create the operator that builds the quadrature data for the diff operator.
     CeedOperatorCreate(ceed, build_qfunc, CEED_QFUNCTION_NONE,
                        CEED_QFUNCTION_NONE, &build_oper);
-    CeedOperatorSetField(build_oper, "dx", mesh_restr, CEED_NOTRANSPOSE,
-                         mesh_basis, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(build_oper, "weights", mesh_restr_i, CEED_NOTRANSPOSE,
-                         mesh_basis, CEED_VECTOR_NONE);
-    CeedOperatorSetField(build_oper, "qdata", restr_i, CEED_NOTRANSPOSE,
-                         CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(build_oper, "dx", mesh_restr, mesh_basis,
+                         CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(build_oper, "weights", mesh_restr_i, mesh_basis,
+                         CEED_VECTOR_NONE);
+    CeedOperatorSetField(build_oper, "qdata", restr_i, CEED_BASIS_COLLOCATED,
+                         CEED_VECTOR_ACTIVE);
 
     // Compute the quadrature data for the diff operator.
     CeedOperatorApply(build_oper, node_coords, qdata,
@@ -175,12 +177,9 @@ class CeedDiffusionOperator : public mfem::Operator {
     // Create the diff operator.
     CeedOperatorCreate(ceed, apply_qfunc, CEED_QFUNCTION_NONE,
                        CEED_QFUNCTION_NONE, &oper);
-    CeedOperatorSetField(oper, "u", restr, CEED_NOTRANSPOSE,
-                         basis, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetField(oper, "qdata", restr_i, CEED_NOTRANSPOSE,
-                         CEED_BASIS_COLLOCATED, qdata);
-    CeedOperatorSetField(oper, "v", restr, CEED_NOTRANSPOSE,
-                         basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(oper, "u", restr, basis, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetField(oper, "qdata", restr_i, CEED_BASIS_COLLOCATED, qdata);
+    CeedOperatorSetField(oper, "v", restr, basis, CEED_VECTOR_ACTIVE);
 
     CeedVectorCreate(ceed, fes->GetNDofs(), &u);
     CeedVectorCreate(ceed, fes->GetNDofs(), &v);

--- a/examples/mfem/bp3.hpp
+++ b/examples/mfem/bp3.hpp
@@ -101,8 +101,8 @@ class CeedDiffusionOperator : public mfem::Operator {
         tp_el_dof[j + el_offset] = el_dof.GetJ()[dof_map[j] + el_offset];
       }
     }
-    CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-    CeedElemRestrictionCreate(ceed, lmode, mesh->GetNE(), fe->GetDof(),
+    CeedInterlaceMode imode = CEED_NONINTERLACED;
+    CeedElemRestrictionCreate(ceed, imode, mesh->GetNE(), fe->GetDof(),
                               fes->GetNDofs(), fes->GetVDim(), CEED_MEM_HOST,
                               CEED_COPY_VALUES, tp_el_dof.GetData(), restr);
   }
@@ -127,10 +127,10 @@ class CeedDiffusionOperator : public mfem::Operator {
     FESpace2Ceed(mesh_fes, ir, ceed, &mesh_basis, &mesh_restr);
     CeedBasisGetNumQuadraturePoints(basis, &nqpts);
 
-    CeedTransposeMode lmode = CEED_NOTRANSPOSE;
-    CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, nqpts,
+    CeedInterlaceMode imode = CEED_NONINTERLACED;
+    CeedElemRestrictionCreateIdentity(ceed, imode, nelem, nqpts,
                                       nqpts*nelem, dim*(dim+1)/2, &restr_i);
-    CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, nqpts,
+    CeedElemRestrictionCreateIdentity(ceed, imode, nelem, nqpts,
                                       nqpts*nelem, 1, &mesh_restr_i);
 
     CeedVectorCreate(ceed, mesh->GetNodes()->Size(), &node_coords);

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -115,7 +115,7 @@ static PetscInt GlobalStart(const PetscInt p[3], const PetscInt irank[3],
 }
 
 // Utility function to create local CEED restriction
-static int CreateRestriction(Ceed ceed, CeedTransposeMode lmode,
+static int CreateRestriction(Ceed ceed, CeedInterlaceMode imode,
                              const CeedInt melem[3], CeedInt P, CeedInt ncomp,
                              CeedElemRestriction *Erestrict) {
   const PetscInt Nelem = melem[0]*melem[1]*melem[2];
@@ -144,7 +144,7 @@ static int CreateRestriction(Ceed ceed, CeedTransposeMode lmode,
       }
     }
   }
-  CeedElemRestrictionCreate(ceed, lmode, Nelem, P*P*P,
+  CeedElemRestrictionCreate(ceed, imode, Nelem, P*P*P,
                             mnode[0]*mnode[1]*mnode[2], ncomp, CEED_MEM_HOST,
                             CEED_OWN_POINTER, idx, Erestrict);
   PetscFunctionReturn(0);
@@ -356,7 +356,9 @@ int main(int argc, char **argv) {
   const CeedInt dim = 3, ncompx = 3, ncompq = 5;
   CeedVector xcorners, xceed, qdata, q0ceed, mceed, onesvec, multlvec;
   CeedBasis basisx, basisxc, basisq;
-  CeedTransposeMode lmodeceed = CEED_NOTRANSPOSE, lmodepetsc = CEED_TRANSPOSE;
+
+  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
+                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction restrictx, restrictxc, restrictxi,
                       restrictq, restrictqdi, restrictmult;
   CeedQFunction qf_setup, qf_mass, qf_ics, qf;
@@ -725,15 +727,15 @@ int main(int argc, char **argv) {
                                   CEED_GAUSS_LOBATTO, &basisxc);
 
   // CEED Restrictions
-  CreateRestriction(ceed, lmodeceed, melem, 2, dim, &restrictx);
-  CreateRestriction(ceed, lmodepetsc, melem, numP, dim, &restrictxc);
-  CreateRestriction(ceed, lmodepetsc, melem, numP, 1, &restrictmult);
-  CreateRestriction(ceed, lmodepetsc, melem, numP, ncompq, &restrictq);
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, localNelem,
+  CreateRestriction(ceed, imodeceed, melem, 2, dim, &restrictx);
+  CreateRestriction(ceed, imodepetsc, melem, numP, dim, &restrictxc);
+  CreateRestriction(ceed, imodepetsc, melem, numP, 1, &restrictmult);
+  CreateRestriction(ceed, imodepetsc, melem, numP, ncompq, &restrictq);
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, localNelem,
                                     10*numQ*numQ*numQ,
                                     10*localNelem*numQ*numQ*numQ, 1,
                                     &restrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, localNelem, numQ*numQ*numQ,
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, localNelem, numQ*numQ*numQ,
                                     localNelem*numQ*numQ*numQ, 1,
                                     &restrictxi);
 

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -115,8 +115,8 @@ static PetscInt GlobalStart(const PetscInt p[3], const PetscInt irank[3],
 }
 
 // Utility function to create local CEED restriction
-static int CreateRestriction(Ceed ceed, const CeedInt melem[3],
-                             CeedInt P, CeedInt ncomp,
+static int CreateRestriction(Ceed ceed, CeedTransposeMode lmode,
+                             const CeedInt melem[3], CeedInt P, CeedInt ncomp,
                              CeedElemRestriction *Erestrict) {
   const PetscInt Nelem = melem[0]*melem[1]*melem[2];
   PetscInt mnode[3], *idx, *idxp;
@@ -144,8 +144,9 @@ static int CreateRestriction(Ceed ceed, const CeedInt melem[3],
       }
     }
   }
-  CeedElemRestrictionCreate(ceed, Nelem, P*P*P, mnode[0]*mnode[1]*mnode[2], ncomp,
-                            CEED_MEM_HOST, CEED_OWN_POINTER, idx, Erestrict);
+  CeedElemRestrictionCreate(ceed, lmode, Nelem, P*P*P,
+                            mnode[0]*mnode[1]*mnode[2], ncomp, CEED_MEM_HOST,
+                            CEED_OWN_POINTER, idx, Erestrict);
   PetscFunctionReturn(0);
 }
 
@@ -353,9 +354,9 @@ int main(int argc, char **argv) {
   Ceed ceed;
   CeedInt numP, numQ;
   const CeedInt dim = 3, ncompx = 3, ncompq = 5;
-  CeedVector xcorners, xceed, qdata, q0ceed, mceed,
-             onesvec, multevec, multlvec;
+  CeedVector xcorners, xceed, qdata, q0ceed, mceed, onesvec, multlvec;
   CeedBasis basisx, basisxc, basisq;
+  CeedTransposeMode lmodeceed = CEED_NOTRANSPOSE, lmodepetsc = CEED_TRANSPOSE;
   CeedElemRestriction restrictx, restrictxc, restrictxi,
                       restrictq, restrictqdi, restrictmult;
   CeedQFunction qf_setup, qf_mass, qf_ics, qf;
@@ -724,14 +725,15 @@ int main(int argc, char **argv) {
                                   CEED_GAUSS_LOBATTO, &basisxc);
 
   // CEED Restrictions
-  CreateRestriction(ceed, melem, numP, ncompq, &restrictq);
-  CreateRestriction(ceed, melem, 2, dim, &restrictx);
-  CreateRestriction(ceed, melem, numP, dim, &restrictxc);
-  CreateRestriction(ceed, melem, numP, 1, &restrictmult);
-  CeedElemRestrictionCreateIdentity(ceed, localNelem, 10*numQ*numQ*numQ,
+  CreateRestriction(ceed, lmodeceed, melem, 2, dim, &restrictx);
+  CreateRestriction(ceed, lmodepetsc, melem, numP, dim, &restrictxc);
+  CreateRestriction(ceed, lmodepetsc, melem, numP, 1, &restrictmult);
+  CreateRestriction(ceed, lmodepetsc, melem, numP, ncompq, &restrictq);
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, localNelem,
+                                    10*numQ*numQ*numQ,
                                     10*localNelem*numQ*numQ*numQ, 1,
                                     &restrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, localNelem, numQ*numQ*numQ,
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, localNelem, numQ*numQ*numQ,
                                     localNelem*numQ*numQ*numQ, 1,
                                     &restrictxi);
 
@@ -767,13 +769,10 @@ int main(int argc, char **argv) {
   CeedVectorCreate(ceed, ncompq*lsize, &onesvec);
   CeedVectorCreate(ceed, ncompx*lsize, &xceed);
   CeedVectorCreate(ceed, lsize, &multlvec);
-  CeedVectorCreate(ceed, localNelem*Nnodes, &multevec);
 
   // Find multiplicity of each local point
-  CeedVectorSetValue(multevec, 1.0);
   CeedVectorSetValue(multlvec, 0.);
-  CeedElemRestrictionApply(restrictmult, CEED_TRANSPOSE, CEED_TRANSPOSE,
-                           multevec, multlvec, CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionGetMultiplicity(restrictmult, multlvec);
 
   // Create the Q-function that builds the quadrature data for the NS operator
   CeedQFunctionCreateInterior(ceed, 1, Setup, Setup_loc, &qf_setup);
@@ -807,47 +806,36 @@ int main(int argc, char **argv) {
   // Create the operator that builds the quadrature data for the NS operator
   CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_setup);
-  CeedOperatorSetField(op_setup, "dx", restrictx, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "weight", restrictxi, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "qdata", restrictqdi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "dx", restrictx, basisx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "weight", restrictxi, basisx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "qdata", restrictqdi, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
   // Create the mass operator
   CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_mass);
-  CeedOperatorSetField(op_mass, "q", restrictq, CEED_TRANSPOSE,
-                       basisq, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "qdata", restrictqdi, CEED_NOTRANSPOSE,
-                       basisx, qdata);
-  CeedOperatorSetField(op_mass, "v", restrictq, CEED_TRANSPOSE,
-                       basisq, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "q", restrictq, basisq, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "qdata", restrictqdi, basisx, qdata);
+  CeedOperatorSetField(op_mass, "v", restrictq, basisq, CEED_VECTOR_ACTIVE);
 
   // Create the operator that sets the ICs
   CeedOperatorCreate(ceed, qf_ics, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_ics);
-  CeedOperatorSetField(op_ics, "x", restrictx, CEED_NOTRANSPOSE,
-                       basisxc, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_ics, "q0", restrictq, CEED_TRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_ics, "coords", restrictxc, CEED_TRANSPOSE,
-                       CEED_BASIS_COLLOCATED, xceed);
+  CeedOperatorSetField(op_ics, "x", restrictx, basisxc, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_ics, "q0", restrictq, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_ics, "coords", restrictxc, CEED_BASIS_COLLOCATED,
+                       xceed);
 
   // Create the physics operator
   CeedOperatorCreate(ceed, qf, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op);
-  CeedOperatorSetField(op, "q", restrictq, CEED_TRANSPOSE,
-                       basisq, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op, "dq", restrictq, CEED_TRANSPOSE,
-                       basisq, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op, "qdata", restrictqdi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op, "x", restrictx, CEED_NOTRANSPOSE,
-                       basisx, xcorners);
-  CeedOperatorSetField(op, "v", restrictq, CEED_TRANSPOSE,
-                       basisq, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op, "dv", restrictq, CEED_TRANSPOSE,
-                       basisq, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op, "q", restrictq, basisq, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op, "dq", restrictq, basisq, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op, "qdata", restrictqdi, CEED_BASIS_COLLOCATED, qdata);
+  CeedOperatorSetField(op, "x", restrictx, basisx, xcorners);
+  CeedOperatorSetField(op, "v", restrictq, basisq, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op, "dv", restrictq, basisq, CEED_VECTOR_ACTIVE);
 
   // Set up the libCEED context
   CeedScalar ctxSetup[15] = {theta0, thetaC, P0, N, cv, cp, Rd, g, rc,
@@ -930,7 +918,6 @@ int main(int argc, char **argv) {
 
   // Destroy coordinate and mult vecs
   CeedVectorDestroy(&xceed);
-  CeedVectorDestroy(&multevec);
   CeedVectorDestroy(&multlvec);
 
   // Gather initial Q values

--- a/examples/navier-stokes/navierstokes.c
+++ b/examples/navier-stokes/navierstokes.c
@@ -356,9 +356,6 @@ int main(int argc, char **argv) {
   const CeedInt dim = 3, ncompx = 3, ncompq = 5;
   CeedVector xcorners, xceed, qdata, q0ceed, mceed, onesvec, multlvec;
   CeedBasis basisx, basisxc, basisq;
-
-  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
-                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction restrictx, restrictxc, restrictxi,
                       restrictq, restrictqdi, restrictmult;
   CeedQFunction qf_setup, qf_mass, qf_ics, qf;
@@ -727,17 +724,17 @@ int main(int argc, char **argv) {
                                   CEED_GAUSS_LOBATTO, &basisxc);
 
   // CEED Restrictions
-  CreateRestriction(ceed, imodeceed, melem, 2, dim, &restrictx);
-  CreateRestriction(ceed, imodepetsc, melem, numP, dim, &restrictxc);
-  CreateRestriction(ceed, imodepetsc, melem, numP, 1, &restrictmult);
-  CreateRestriction(ceed, imodepetsc, melem, numP, ncompq, &restrictq);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, localNelem,
+  CreateRestriction(ceed, CEED_NONINTERLACED, melem, 2, dim, &restrictx);
+  CreateRestriction(ceed, CEED_INTERLACED, melem, numP, dim, &restrictxc);
+  CreateRestriction(ceed, CEED_INTERLACED, melem, numP, 1, &restrictmult);
+  CreateRestriction(ceed, CEED_INTERLACED, melem, numP, ncompq, &restrictq);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, localNelem,
                                     10*numQ*numQ*numQ,
                                     10*localNelem*numQ*numQ*numQ, 1,
                                     &restrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, localNelem, numQ*numQ*numQ,
-                                    localNelem*numQ*numQ*numQ, 1,
-                                    &restrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, localNelem,
+                                    numQ*numQ*numQ, localNelem*numQ*numQ*numQ,
+                                    1, &restrictxi);
 
   // Find physical cordinates of the corners of local elements
   {

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -790,12 +790,15 @@ C     Create ceed basis for mesh and computation
 C     Create ceed element restrictions for mesh and computation
       enode=p**ldim
       lnode=enode*nelt*ncompu
-      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
-     $  enode,lnode,ldim,erstrctx,err)
-      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
-     $  enode,lnode,ncompu,erstrctu,err)
-      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
-     $  q**ldim,nelt*q**ldim,1,erstrctw,err)
+      call ceedelemrestrictioncreateidentity(ceed,
+     $  ceed_noninterlaced,
+     $  nelt,enode,lnode,ldim,erstrctx,err)
+      call ceedelemrestrictioncreateidentity(ceed,
+     $  ceed_noninterlaced,
+     $  nelt,enode,lnode,ncompu,erstrctu,err)
+      call ceedelemrestrictioncreateidentity(ceed,
+     $  ceed_noninterlaced,
+     $  nelt,q**ldim,nelt*q**ldim,1,erstrctw,err)
 
 C     Create ceed vectors
       call ceedvectorcreate(ceed,lnode,vec_p1,err)
@@ -1105,12 +1108,15 @@ C     Create ceed element restrictions for mesh and computation
       enode=p**ldim
       lnode=enode*nelt*ncompu
       ngeo=(ldim*(ldim+1))/2
-      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
-     $  enode,lnode,ldim,erstrctx,err)
-      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
-     $  enode,lnode,ncompu,erstrctu,err)
-      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
-     $  q**ldim,nelt*q**ldim,ngeo,erstrctw,err)
+      call ceedelemrestrictioncreateidentity(ceed,
+     $  ceed_noninterlaced,
+     $  nelt,enode,lnode,ldim,erstrctx,err)
+      call ceedelemrestrictioncreateidentity(ceed,
+     $  ceed_noninterlaced,
+     $  nelt,enode,lnode,ncompu,erstrctu,err)
+      call ceedelemrestrictioncreateidentity(ceed,
+     $  ceed_noninterlaced,
+     $  nelt,q**ldim,nelt*q**ldim,ngeo,erstrctw,err)
 
 C     Create ceed vectors
       call ceedvectorcreate(ceed,lnode,vec_p1,err)
@@ -1163,7 +1169,7 @@ C     Create ceed operators
      $  basisu,vec_rhs,err)
 
       call ceedoperatorcreate(ceed,qf_diffusion,
-     $  ceed_qfunction_none,op_diffusion,err)
+     $  ceed_qfunction_none,ceed_qfunction_none,op_diffusion,err)
       call ceedoperatorsetfield(op_diffusion,'u',erstrctu,
      $  basisu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diffusion,'qdata',erstrctw,
@@ -1290,17 +1296,17 @@ C     Output
         endif
       endif
 
-      nx     = nx1-1
-      nnode   = nelgt           ! nnodes
+      nx      = nx1-1
+      nnode   = nelgt            ! nnodes
       nnode   = nnode*(nx**ldim) ! nnodes
-      nppp   = nnode/np         ! nnodes/proc
+      nppp    = nnode/np         ! nnodes/proc
 
-      nodepss = nnode/telaps     ! DOF/sec - scalar form
-      titers = telaps/maxits   ! time per iteration
-      tppp_s = titers/nppp     ! time per iteraton per local point
+      dofps   = nnode/telaps     ! DOF/sec - scalar form
+      titers  = telaps/maxits    ! time per iteration
+      tppp_s  = titers/nppp      ! time per iteraton per local point
 
       if (nid.eq.0) write(6,1) 'case scalar:'
-     $ ,np,nx,nelt,nelgt,nnode,nppp,maxits,telaps,nodepss,titers,tppp_s
+     $ ,np,nx,nelt,nelgt,nnode,nppp,maxits,telaps,dofps,titers,tppp_s
 
     1 format(a12,i7,i3,i7,i10,i14,i10,i4,1p4e13.5)
     3 format(i3,i9,e12.4,1x,a8,i9)
@@ -1687,3 +1693,4 @@ C     Input:                        Output: test
       return
       end
 C-----------------------------------------------------------------------
+

--- a/examples/nek/bps/bps.usr
+++ b/examples/nek/bps/bps.usr
@@ -790,12 +790,12 @@ C     Create ceed basis for mesh and computation
 C     Create ceed element restrictions for mesh and computation
       enode=p**ldim
       lnode=enode*nelt*ncompu
-      call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
-     $  ldim,erstrctx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
-     $  ncompu,erstrctu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelt,q**ldim,
-     $  nelt*q**ldim,1,erstrctw,err)
+      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
+     $  enode,lnode,ldim,erstrctx,err)
+      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
+     $  enode,lnode,ncompu,erstrctu,err)
+      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
+     $  q**ldim,nelt*q**ldim,1,erstrctw,err)
 
 C     Create ceed vectors
       call ceedvectorcreate(ceed,lnode,vec_p1,err)
@@ -837,26 +837,24 @@ C     Create ceed operators
       call ceedoperatorcreate(ceed,qf_setup,
      $  ceed_qfunction_none,ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'x',erstrctx,
-     $  ceed_notranspose,basisx,ceed_vector_active,err)
+     $  basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'dx',erstrctx,
-     $  ceed_notranspose,basisx,ceed_vector_active,err)
+     $  basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'weight',erstrctx,
-     $  ceed_notranspose,basisx,ceed_vector_none,err)
+     $  basisx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'qdata',erstrctw,
-     $  ceed_notranspose,ceed_basis_collocated,
-     $  ceed_vector_active,err)
+     $  ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rhs',erstrctu,
-     $  ceed_notranspose,basisu,vec_rhs,err)
+     $  basisu,vec_rhs,err)
 
       call ceedoperatorcreate(ceed,qf_mass,
      $  ceed_qfunction_none,ceed_qfunction_none,op_mass,err)
       call ceedoperatorsetfield(op_mass,'u',erstrctu,
-     $  ceed_notranspose,basisu,ceed_vector_active,err)
+     $  basisu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'qdata',erstrctw,
-     $  ceed_notranspose,ceed_basis_collocated,
-     $  vec_qdata,err)
+     $  ceed_basis_collocated,vec_qdata,err)
       call ceedoperatorsetfield(op_mass,'v',erstrctu,
-     $  ceed_notranspose,basisu,ceed_vector_active,err)
+     $  basisu,ceed_vector_active,err)
 
 C     Compute setup data
       call ceedvectorsetarray(vec_rhs,ceed_mem_host,
@@ -1107,12 +1105,12 @@ C     Create ceed element restrictions for mesh and computation
       enode=p**ldim
       lnode=enode*nelt*ncompu
       ngeo=(ldim*(ldim+1))/2
-      call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
-     $  ldim,erstrctx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelt,enode,lnode,
-     $  ncompu,erstrctu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelt,q**ldim,
-     $  nelt*q**ldim,ngeo,erstrctw,err)
+      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
+     $  enode,lnode,ldim,erstrctx,err)
+      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
+     $  enode,lnode,ncompu,erstrctu,err)
+      call ceedelemrestrictioncreateidentity(ceed,ceed_notranspose,nelt,
+     $  q**ldim,nelt*q**ldim,ngeo,erstrctw,err)
 
 C     Create ceed vectors
       call ceedvectorcreate(ceed,lnode,vec_p1,err)
@@ -1154,26 +1152,24 @@ C     Create ceed operators
       call ceedoperatorcreate(ceed,qf_setup,
      $  ceed_qfunction_none,ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'x',erstrctx,
-     $  ceed_notranspose,basisx,ceed_vector_active,err)
+     $  basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'dx',erstrctx,
-     $  ceed_notranspose,basisx,ceed_vector_active,err)
+     $  basisx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'weight',erstrctx,
-     $  ceed_notranspose,basisx,ceed_vector_none,err)
+     $  basisx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'qdata',erstrctw,
-     $  ceed_notranspose,ceed_basis_collocated,
-     $  ceed_vector_active,err)
+     $  ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rhs',erstrctu,
-     $  ceed_notranspose,basisu,vec_rhs,err)
+     $  basisu,vec_rhs,err)
 
       call ceedoperatorcreate(ceed,qf_diffusion,
-     $  ceed_qfunction_none,ceed_qfunction_none,op_diffusion,err)
+     $  ceed_qfunction_none,op_diffusion,err)
       call ceedoperatorsetfield(op_diffusion,'u',erstrctu,
-     $  ceed_notranspose,basisu,ceed_vector_active,err)
+     $  basisu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diffusion,'qdata',erstrctw,
-     $  ceed_notranspose,ceed_basis_collocated,
-     $  vec_qdata,err)
+     $  ceed_basis_collocated,vec_qdata,err)
       call ceedoperatorsetfield(op_diffusion,'v',erstrctu,
-     $  ceed_notranspose,basisu,ceed_vector_active,err)
+     $  basisu,ceed_vector_active,err)
 
 C     Compute setup data
       call ceedvectorsetarray(vec_rhs,ceed_mem_host,

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -60,7 +60,7 @@ static const char help[] =
 #endif
 
 // Auxiliary function to define CEED restrictions from DMPlex data
-static int CreateRestrictionPlex(Ceed ceed, CeedTransposeMode lmode, CeedInt P,
+static int CreateRestrictionPlex(Ceed ceed, CeedInterlaceMode imode, CeedInt P,
                                  CeedInt ncomp, CeedElemRestriction *Erestrict,
                                  DM dm) {
   PetscInt ierr;
@@ -100,7 +100,7 @@ static int CreateRestrictionPlex(Ceed ceed, CeedTransposeMode lmode, CeedInt P,
   ierr = VecGetLocalSize(Uloc, &nnodes); CHKERRQ(ierr);
 
   ierr = DMRestoreLocalVector(dm, &Uloc); CHKERRQ(ierr);
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, nnodes/ncomp, ncomp,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, nnodes/ncomp, ncomp,
                             CEED_MEM_HOST, CEED_COPY_VALUES, erestrict,
                             Erestrict);
   ierr = PetscFree(erestrict); CHKERRQ(ierr);
@@ -154,7 +154,8 @@ int main(int argc, char **argv) {
   CeedOperator op_setupgeo, op_apply;
   CeedQFunction qf_setupgeo, qf_apply;
   CeedBasis basisx, basisu;
-  CeedTransposeMode lmodeceed = CEED_NOTRANSPOSE, lmodepetsc = CEED_TRANSPOSE;
+  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
+                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi,
                       Erestrictqdi;
   PetscFunctionList geomfactorlist = NULL;
@@ -296,9 +297,9 @@ int main(int argc, char **argv) {
   ierr = DMPlexSetClosurePermutationTensor(dmcoord, PETSC_DETERMINE, NULL);
   CHKERRQ(ierr);
 
-  CreateRestrictionPlex(ceed, lmodepetsc, 2, ncompx, &Erestrictx, dmcoord);
+  CreateRestrictionPlex(ceed, imodepetsc, 2, ncompx, &Erestrictx, dmcoord);
   CHKERRQ(ierr);
-  CreateRestrictionPlex(ceed, lmodepetsc, P, ncompu, &Erestrictu, dm);
+  CreateRestrictionPlex(ceed, imodepetsc, P, ncompu, &Erestrictu, dm);
   CHKERRQ(ierr);
 
   CeedInt cStart, cEnd;
@@ -307,9 +308,9 @@ int main(int argc, char **argv) {
 
   // CEED identity restrictions
   const CeedInt qdatasize = 1;
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q, nelem*Q*Q,
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q, nelem*Q*Q,
                                     qdatasize, &Erestrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q, nelem*Q*Q, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q, nelem*Q*Q, 1,
                                     &Erestrictxi);
 
   // Element coordinates

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -154,8 +154,6 @@ int main(int argc, char **argv) {
   CeedOperator op_setupgeo, op_apply;
   CeedQFunction qf_setupgeo, qf_apply;
   CeedBasis basisx, basisu;
-  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
-                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi,
                       Erestrictqdi;
   PetscFunctionList geomfactorlist = NULL;
@@ -297,9 +295,9 @@ int main(int argc, char **argv) {
   ierr = DMPlexSetClosurePermutationTensor(dmcoord, PETSC_DETERMINE, NULL);
   CHKERRQ(ierr);
 
-  CreateRestrictionPlex(ceed, imodepetsc, 2, ncompx, &Erestrictx, dmcoord);
+  CreateRestrictionPlex(ceed, CEED_INTERLACED, 2, ncompx, &Erestrictx, dmcoord);
   CHKERRQ(ierr);
-  CreateRestrictionPlex(ceed, imodepetsc, P, ncompu, &Erestrictu, dm);
+  CreateRestrictionPlex(ceed, CEED_INTERLACED, P, ncompu, &Erestrictu, dm);
   CHKERRQ(ierr);
 
   CeedInt cStart, cEnd;
@@ -308,10 +306,10 @@ int main(int argc, char **argv) {
 
   // CEED identity restrictions
   const CeedInt qdatasize = 1;
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q, nelem*Q*Q,
-                                    qdatasize, &Erestrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q, nelem*Q*Q, 1,
-                                    &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q,
+                                    nelem*Q*Q, qdatasize, &Erestrictqdi);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q,
+                                    nelem*Q*Q, 1, &Erestrictxi);
 
   // Element coordinates
   Vec coords;

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -60,8 +60,9 @@ static const char help[] =
 #endif
 
 // Auxiliary function to define CEED restrictions from DMPlex data
-static int CreateRestrictionPlex(Ceed ceed, CeedInt P, CeedInt ncomp,
-                                 CeedElemRestriction *Erestrict, DM dm) {
+static int CreateRestrictionPlex(Ceed ceed, CeedTransposeMode lmode, CeedInt P,
+                                 CeedInt ncomp, CeedElemRestriction *Erestrict,
+                                 DM dm) {
   PetscInt ierr;
   PetscInt c, cStart, cEnd, nelem, nnodes, *erestrict, eoffset;
   PetscSection section;
@@ -99,7 +100,7 @@ static int CreateRestrictionPlex(Ceed ceed, CeedInt P, CeedInt ncomp,
   ierr = VecGetLocalSize(Uloc, &nnodes); CHKERRQ(ierr);
 
   ierr = DMRestoreLocalVector(dm, &Uloc); CHKERRQ(ierr);
-  CeedElemRestrictionCreate(ceed, nelem, P*P, nnodes/ncomp, ncomp,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, nnodes/ncomp, ncomp,
                             CEED_MEM_HOST, CEED_COPY_VALUES, erestrict,
                             Erestrict);
   ierr = PetscFree(erestrict); CHKERRQ(ierr);
@@ -153,6 +154,7 @@ int main(int argc, char **argv) {
   CeedOperator op_setupgeo, op_apply;
   CeedQFunction qf_setupgeo, qf_apply;
   CeedBasis basisx, basisu;
+  CeedTransposeMode lmodeceed = CEED_NOTRANSPOSE, lmodepetsc = CEED_TRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi,
                       Erestrictqdi;
   PetscFunctionList geomfactorlist = NULL;
@@ -294,8 +296,10 @@ int main(int argc, char **argv) {
   ierr = DMPlexSetClosurePermutationTensor(dmcoord, PETSC_DETERMINE, NULL);
   CHKERRQ(ierr);
 
-  CreateRestrictionPlex(ceed, 2, ncompx, &Erestrictx, dmcoord); CHKERRQ(ierr);
-  CreateRestrictionPlex(ceed, P, ncompu, &Erestrictu, dm); CHKERRQ(ierr);
+  CreateRestrictionPlex(ceed, lmodepetsc, 2, ncompx, &Erestrictx, dmcoord);
+  CHKERRQ(ierr);
+  CreateRestrictionPlex(ceed, lmodepetsc, P, ncompu, &Erestrictu, dm);
+  CHKERRQ(ierr);
 
   CeedInt cStart, cEnd;
   ierr = DMPlexGetHeightStratum(dm, 0, &cStart, &cEnd); CHKERRQ(ierr);
@@ -303,9 +307,9 @@ int main(int argc, char **argv) {
 
   // CEED identity restrictions
   const CeedInt qdatasize = 1;
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nelem*Q*Q,
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q, nelem*Q*Q,
                                     qdatasize, &Erestrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nelem*Q*Q, 1,
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q, nelem*Q*Q, 1,
                                     &Erestrictxi);
 
   // Element coordinates
@@ -346,23 +350,21 @@ int main(int argc, char **argv) {
 
   // Create the operator that builds the quadrature data for the operator
   CeedOperatorCreate(ceed, qf_setupgeo, NULL, NULL, &op_setupgeo);
-  CeedOperatorSetField(op_setupgeo, "x", Erestrictx, CEED_TRANSPOSE,
-                       basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, CEED_TRANSPOSE,
-                       basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupgeo, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupgeo, "x", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, basisx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupgeo, "qdata", Erestrictqdi,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Create the mass operator
   CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
-  CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_TRANSPOSE,
-                       basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_apply, "v", Erestrictu, CEED_TRANSPOSE,
-                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
 
   // Compute the quadrature data for the mass operator
   CeedOperatorApply(op_setupgeo, xcoord, qdata, CEED_REQUEST_IMMEDIATE);

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -210,13 +210,11 @@ int main(int argc, char **argv) {
   CeedOperatorCreate(ceed, qf_error, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_error);
   CeedOperatorSetField(op_error, "u", ceeddata->Erestrictu,
-                       CEED_TRANSPOSE, ceeddata->basisu,
-                       CEED_VECTOR_ACTIVE);
+                       ceeddata->basisu, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_error, "true_soln", ceeddata->Erestrictui,
-                       CEED_NOTRANSPOSE, CEED_BASIS_COLLOCATED, target);
+                       CEED_BASIS_COLLOCATED, target);
   CeedOperatorSetField(op_error, "error", ceeddata->Erestrictui,
-                       CEED_NOTRANSPOSE, CEED_BASIS_COLLOCATED,
-                       CEED_VECTOR_ACTIVE);
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Set up Mat
   userO->comm = comm;

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -400,8 +400,6 @@ int main(int argc, char **argv) {
   User user;
   Ceed ceed;
   CeedBasis basisx, basisu;
-  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
-                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui,
                       Erestrictqdi;
   CeedQFunction qf_setupgeo, qf_setuprhs, qf_apply, qf_error;
@@ -599,16 +597,16 @@ int main(int argc, char **argv) {
                                   bpOptions[bpChoice].qmode, &basisx);
 
   // CEED restrictions
-  CreateRestriction(ceed, imodepetsc, melem, P, ncompu, &Erestrictu);
-  CreateRestriction(ceed, imodeceed, melem, 2, dim, &Erestrictx);
+  CreateRestriction(ceed, CEED_INTERLACED, melem, P, ncompu, &Erestrictu);
+  CreateRestriction(ceed, CEED_NONINTERLACED, melem, 2, dim, &Erestrictx);
   CeedInt nelem = melem[0]*melem[1]*melem[2];
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
-                                    ncompu, &Erestrictui);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
-                                    bpOptions[bpChoice].qdatasize,
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q*Q,
+                                    nelem*Q*Q*Q, ncompu, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q*Q,
+                                    nelem*Q*Q*Q, bpOptions[bpChoice].qdatasize,
                                     &Erestrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
-                                    1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q*Q,
+                                    nelem*Q*Q*Q, 1, &Erestrictxi);
   {
     CeedScalar *xloc;
     CeedInt shape[3] = {melem[0]+1, melem[1]+1, melem[2]+1}, len =

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -89,8 +89,8 @@ static PetscInt GlobalStart(const PetscInt p[3], const PetscInt irank[3],
   }
   return -1;
 }
-static int CreateRestriction(Ceed ceed, const CeedInt melem[3],
-                             CeedInt P, CeedInt ncomp,
+static int CreateRestriction(Ceed ceed, CeedTransposeMode lmode,
+                             const CeedInt melem[3], CeedInt P, CeedInt ncomp,
                              CeedElemRestriction *Erestrict) {
   const PetscInt nelem = melem[0]*melem[1]*melem[2];
   PetscInt mnodes[3], *idx, *idxp;
@@ -116,9 +116,9 @@ static int CreateRestriction(Ceed ceed, const CeedInt melem[3],
             }
 
   // Setup CEED restriction
-  CeedElemRestrictionCreate(ceed, nelem, P*P*P, mnodes[0]*mnodes[1]*mnodes[2],
-                            ncomp, CEED_MEM_HOST, CEED_OWN_POINTER, idx,
-                            Erestrict);
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P*P,
+                            mnodes[0]*mnodes[1]*mnodes[2], ncomp,
+                            CEED_MEM_HOST, CEED_OWN_POINTER, idx, Erestrict);
 
   PetscFunctionReturn(0);
 }
@@ -400,6 +400,7 @@ int main(int argc, char **argv) {
   User user;
   Ceed ceed;
   CeedBasis basisx, basisu;
+  CeedTransposeMode lmodeceed = CEED_NOTRANSPOSE, lmodepetsc = CEED_TRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui,
                       Erestrictqdi;
   CeedQFunction qf_setupgeo, qf_setuprhs, qf_apply, qf_error;
@@ -597,17 +598,16 @@ int main(int argc, char **argv) {
                                   bpOptions[bpChoice].qmode, &basisx);
 
   // CEED restrictions
-  CreateRestriction(ceed, melem, P, ncompu, &Erestrictu);
-  CreateRestriction(ceed, melem, 2, dim, &Erestrictx);
+  CreateRestriction(ceed, lmodepetsc, melem, P, ncompu, &Erestrictu);
+  CreateRestriction(ceed, lmodeceed, melem, 2, dim, &Erestrictx);
   CeedInt nelem = melem[0]*melem[1]*melem[2];
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, ncompu,
-                                    &Erestrictui);
-  CeedElemRestrictionCreateIdentity(ceed, nelem,
-                                    Q*Q*Q,
-                                    nelem*Q*Q*Q,
-                                    bpOptions[bpChoice].qdatasize, &Erestrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q*Q, nelem*Q*Q*Q, 1,
-                                    &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
+                                    ncompu, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
+                                    bpOptions[bpChoice].qdatasize,
+                                    &Erestrictqdi);
+  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
+                                    1, &Erestrictxi);
   {
     CeedScalar *xloc;
     CeedInt shape[3] = {melem[0]+1, melem[1]+1, melem[2]+1}, len =
@@ -676,46 +676,43 @@ int main(int argc, char **argv) {
   // Create the operator that builds the quadrature data for the ceed operator
   CeedOperatorCreate(ceed, qf_setupgeo, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupgeo);
-  CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupgeo, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupgeo, "weight", Erestrictxi, basisx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupgeo, "qdata", Erestrictqdi,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Create the operator that builds the RHS and true solution
   CeedOperatorCreate(ceed, qf_setuprhs, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setuprhs);
-  CeedOperatorSetField(op_setuprhs, "x", Erestrictx, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setuprhs, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setuprhs, "weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       basisx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setuprhs, "true_soln", Erestrictui, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setuprhs, "x", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setuprhs, "dx", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setuprhs, "weight", Erestrictxi, basisx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setuprhs, "true_soln", Erestrictui,
                        CEED_BASIS_COLLOCATED, target);
-  CeedOperatorSetField(op_setuprhs, "rhs", Erestrictu, CEED_TRANSPOSE,
-                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setuprhs, "rhs", Erestrictu, basisu,
+                       CEED_VECTOR_ACTIVE);
 
   // Create the mass or diff operator
   CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_apply);
-  CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_TRANSPOSE,
-                       basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_apply, "v", Erestrictu, CEED_TRANSPOSE,
-                       basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
 
   // Create the error operator
   CeedOperatorCreate(ceed, qf_error, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_error);
-  CeedOperatorSetField(op_error, "u", Erestrictu, CEED_TRANSPOSE,
-                       basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_error, "true_soln", Erestrictui, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_error, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_error, "true_soln", Erestrictui,
                        CEED_BASIS_COLLOCATED, target);
-  CeedOperatorSetField(op_error, "error", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_error, "error", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
   // Set up Mat
   ierr = PetscMalloc1(1, &user); CHKERRQ(ierr);

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -89,7 +89,7 @@ static PetscInt GlobalStart(const PetscInt p[3], const PetscInt irank[3],
   }
   return -1;
 }
-static int CreateRestriction(Ceed ceed, CeedTransposeMode lmode,
+static int CreateRestriction(Ceed ceed, CeedInterlaceMode imode,
                              const CeedInt melem[3], CeedInt P, CeedInt ncomp,
                              CeedElemRestriction *Erestrict) {
   const PetscInt nelem = melem[0]*melem[1]*melem[2];
@@ -116,7 +116,7 @@ static int CreateRestriction(Ceed ceed, CeedTransposeMode lmode,
             }
 
   // Setup CEED restriction
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P*P,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P*P,
                             mnodes[0]*mnodes[1]*mnodes[2], ncomp,
                             CEED_MEM_HOST, CEED_OWN_POINTER, idx, Erestrict);
 
@@ -400,7 +400,8 @@ int main(int argc, char **argv) {
   User user;
   Ceed ceed;
   CeedBasis basisx, basisu;
-  CeedTransposeMode lmodeceed = CEED_NOTRANSPOSE, lmodepetsc = CEED_TRANSPOSE;
+  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
+                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui,
                       Erestrictqdi;
   CeedQFunction qf_setupgeo, qf_setuprhs, qf_apply, qf_error;
@@ -598,15 +599,15 @@ int main(int argc, char **argv) {
                                   bpOptions[bpChoice].qmode, &basisx);
 
   // CEED restrictions
-  CreateRestriction(ceed, lmodepetsc, melem, P, ncompu, &Erestrictu);
-  CreateRestriction(ceed, lmodeceed, melem, 2, dim, &Erestrictx);
+  CreateRestriction(ceed, imodepetsc, melem, P, ncompu, &Erestrictu);
+  CreateRestriction(ceed, imodeceed, melem, 2, dim, &Erestrictx);
   CeedInt nelem = melem[0]*melem[1]*melem[2];
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
                                     ncompu, &Erestrictui);
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
                                     bpOptions[bpChoice].qdatasize,
                                     &Erestrictqdi);
-  CeedElemRestrictionCreateIdentity(ceed, lmodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
+  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
                                     1, &Erestrictxi);
   {
     CeedScalar *xloc;

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -301,13 +301,11 @@ int main(int argc, char **argv) {
   CeedOperatorCreate(ceed, qf_error, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_error);
   CeedOperatorSetField(op_error, "u", ceeddata[numlevels-1]->Erestrictu,
-                       CEED_TRANSPOSE, ceeddata[numlevels-1]->basisu,
-                       CEED_VECTOR_ACTIVE);
+                       ceeddata[numlevels-1]->basisu, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_error, "true_soln", ceeddata[numlevels-1]->Erestrictui,
-                       CEED_NOTRANSPOSE, CEED_BASIS_COLLOCATED, target);
+                       CEED_BASIS_COLLOCATED, target);
   CeedOperatorSetField(op_error, "error", ceeddata[numlevels-1]->Erestrictui,
-                       CEED_NOTRANSPOSE, CEED_BASIS_COLLOCATED,
-                       CEED_VECTOR_ACTIVE);
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Calculate multiplicity
   for (int i=0; i<numlevels; i++) {
@@ -318,7 +316,7 @@ int main(int argc, char **argv) {
     CeedVectorSetArray(ceeddata[i]->xceed, CEED_MEM_HOST, CEED_USE_POINTER, x);
 
     // Multiplicity
-    CeedElemRestrictionGetMultiplicity(ceeddata[i]->Erestrictu, CEED_TRANSPOSE,
+    CeedElemRestrictionGetMultiplicity(ceeddata[i]->Erestrictu,
                                        ceeddata[i]->xceed);
 
     // Restore vector

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -470,8 +470,6 @@ static int SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt dim,
   Vec coords;
   const PetscScalar *coordArray;
   CeedBasis basisx, basisu;
-  CeedInterlaceMode imodeceed = CEED_NONINTERLACED,
-                    imodepetsc = CEED_INTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi,
                       Erestrictui, Erestrictqdi;
   CeedQFunction qf_setupgeo, qf_apply;
@@ -493,18 +491,21 @@ static int SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt dim,
   ierr = DMPlexSetClosurePermutationTensor(dmcoord, PETSC_DETERMINE, NULL);
   CHKERRQ(ierr);
 
-  CreateRestrictionPlex(ceed, imodepetsc, 2, ncompx, &Erestrictx, dmcoord);
-  CreateRestrictionPlex(ceed, imodepetsc, P, ncompu, &Erestrictu, dm);
+  CreateRestrictionPlex(ceed, CEED_INTERLACED, 2, ncompx, &Erestrictx, dmcoord);
+  CreateRestrictionPlex(ceed, CEED_INTERLACED, P, ncompu, &Erestrictu, dm);
 
   ierr = DMPlexGetHeightStratum(dm, 0, &cStart, &cEnd); CHKERRQ(ierr);
   nelem = cEnd - cStart;
 
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
-                                    ncompu, &Erestrictui); CHKERRQ(ierr);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
-                                    qdatasize, &Erestrictqdi); CHKERRQ(ierr);
-  CeedElemRestrictionCreateIdentity(ceed, imodeceed, nelem, Q*Q*Q, nelem*Q*Q*Q,
-                                    ncompx, &Erestrictxi); CHKERRQ(ierr);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q*Q,
+                                    nelem*Q*Q*Q, ncompu, &Erestrictui);
+  CHKERRQ(ierr);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q*Q,
+                                    nelem*Q*Q*Q, qdatasize, &Erestrictqdi);
+  CHKERRQ(ierr);
+  CeedElemRestrictionCreateIdentity(ceed, CEED_NONINTERLACED, nelem, Q*Q*Q,
+                                    nelem*Q*Q*Q, ncompx, &Erestrictxi);
+  CHKERRQ(ierr);
 
   // Element coordinates
   ierr = DMGetCoordinatesLocal(dm, &coords); CHKERRQ(ierr);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -85,6 +85,8 @@ CEED_EXTERN int CeedVectorSetData(CeedVector vec, void **data);
 
 CEED_EXTERN int CeedElemRestrictionGetCeed(CeedElemRestriction rstr,
     Ceed *ceed);
+CEED_EXTERN int CeedElemRestrictionGetLMode(CeedElemRestriction rstr,
+    CeedTransposeMode *lmode);
 CEED_EXTERN int CeedElemRestrictionGetNumElements(CeedElemRestriction rstr,
     CeedInt *numelem);
 CEED_EXTERN int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr,
@@ -195,8 +197,6 @@ CEED_EXTERN int CeedOperatorFieldGetElemRestriction(CeedOperatorField opfield,
     CeedElemRestriction *rstr);
 CEED_EXTERN int CeedOperatorFieldGetBasis(CeedOperatorField opfield,
     CeedBasis *basis);
-CEED_EXTERN int CeedOperatorFieldGetLMode(CeedOperatorField opfield,
-    CeedTransposeMode *lmode);
 CEED_EXTERN int CeedOperatorFieldGetVector(CeedOperatorField opfield,
     CeedVector *vec);
 

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -85,8 +85,8 @@ CEED_EXTERN int CeedVectorSetData(CeedVector vec, void **data);
 
 CEED_EXTERN int CeedElemRestrictionGetCeed(CeedElemRestriction rstr,
     Ceed *ceed);
-CEED_EXTERN int CeedElemRestrictionGetLMode(CeedElemRestriction rstr,
-    CeedTransposeMode *lmode);
+CEED_EXTERN int CeedElemRestrictionGetIMode(CeedElemRestriction rstr,
+    CeedInterlaceMode *Imode);
 CEED_EXTERN int CeedElemRestrictionGetNumElements(CeedElemRestriction rstr,
     CeedInt *numelem);
 CEED_EXTERN int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -94,7 +94,7 @@ struct CeedElemRestriction_private {
                     CeedVector, CeedRequest *);
   int (*Destroy)(CeedElemRestriction);
   int refcount;
-  CeedTransposeMode lmode;  /* Transpose mode for L-vector ordering */
+  CeedInterlaceMode imode;  /* Interlacing mode for L-vector ordering */
   CeedInt nelem;            /* number of elements */
   CeedInt elemsize;         /* number of nodes per element */
   CeedInt nnodes;           /* size of the L-vector, can be used for checking

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -88,10 +88,10 @@ struct CeedVector_private {
 
 struct CeedElemRestriction_private {
   Ceed ceed;
-  int (*Apply)(CeedElemRestriction, CeedTransposeMode, CeedTransposeMode,
-               CeedVector, CeedVector, CeedRequest *);
-  int (*ApplyBlock)(CeedElemRestriction, CeedInt, CeedTransposeMode,
-                    CeedTransposeMode, CeedVector, CeedVector, CeedRequest *);
+  int (*Apply)(CeedElemRestriction, CeedTransposeMode, CeedVector, CeedVector,
+               CeedRequest *);
+  int (*ApplyBlock)(CeedElemRestriction, CeedInt, CeedTransposeMode, CeedVector,
+                    CeedVector, CeedRequest *);
   int (*Destroy)(CeedElemRestriction);
   int refcount;
   CeedTransposeMode lmode;  /* Transpose mode for L-vector ordering */

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -94,14 +94,15 @@ struct CeedElemRestriction_private {
                     CeedTransposeMode, CeedVector, CeedVector, CeedRequest *);
   int (*Destroy)(CeedElemRestriction);
   int refcount;
-  CeedInt nelem;    /* number of elements */
-  CeedInt elemsize; /* number of nodes per element */
-  CeedInt nnodes;   /* size of the L-vector, can be used for checking for
-                      correct vector sizes */
-  CeedInt ncomp;    /* number of components */
-  CeedInt blksize;  /* number of elements in a batch */
-  CeedInt nblk;     /* number of blocks of elements */
-  void *data;       /* place for the backend to store any data */
+  CeedTransposeMode lmode;  /* Transpose mode for L-vector ordering */
+  CeedInt nelem;            /* number of elements */
+  CeedInt elemsize;         /* number of nodes per element */
+  CeedInt nnodes;           /* size of the L-vector, can be used for checking
+                                 for correct vector sizes */
+  CeedInt ncomp;            /* number of components */
+  CeedInt blksize;          /* number of elements in a batch */
+  CeedInt nblk;             /* number of blocks of elements */
+  void *data;               /* place for the backend to store any data */
 };
 
 struct CeedBasis_private {
@@ -118,23 +119,24 @@ struct CeedBasis_private {
   CeedInt P;             /* total number of nodes */
   CeedInt Q;             /* total number of quadrature points */
   CeedScalar *qref1d;    /* Array of length Q1d holding the locations of
-                            quadrature points on the 1D reference element [-1, 1] */
+                              quadrature points on the 1D reference
+                              element [-1, 1] */
   CeedScalar *qweight1d; /* array of length Q1d holding the quadrature weights on
-                            the reference element */
+                              the reference element */
   CeedScalar
   *interp;    /* row-major matrix of shape [Q, P] expressing the values of
-                            nodal basis functions at quadrature points */
+                   nodal basis functions at quadrature points */
   CeedScalar
   *interp1d;  /* row-major matrix of shape [Q1d, P1d] expressing the values of
-                            nodal basis functions at quadrature points */
+                   nodal basis functions at quadrature points */
   CeedScalar
-  *grad;      /* row-major matrix of shape [dim*Q, P] matrix expressing derivatives of
-                            nodal basis functions at quadrature points */
+  *grad;      /* row-major matrix of shape [dim*Q, P] matrix expressing
+                   derivatives of nodal basis functions at quadrature points */
   CeedScalar
-  *grad1d;    /* row-major matrix of shape [Q1d, P1d] matrix expressing derivatives of
-                            nodal basis functions at quadrature points */
+  *grad1d;    /* row-major matrix of shape [Q1d, P1d] matrix expressing
+                   derivatives of nodal basis functions at quadrature points */
   CeedTensorContract contract; /* tensor contraction object */
-  void *data;            /* place for the backend to store any data */
+  void *data;                  /* place for the backend to store any data */
 };
 
 struct CeedTensorContract_private {
@@ -158,7 +160,8 @@ struct CeedQFunction_private {
   int (*Apply)(CeedQFunction, CeedInt, CeedVector *, CeedVector *);
   int (*Destroy)(CeedQFunction);
   int refcount;
-  CeedInt vlength;    // Number of quadrature points must be padded to a multiple of vlength
+  CeedInt vlength;    /* Number of quadrature points must be padded to a
+                           multiple of vlength */
   CeedQFunctionField *inputfields;
   CeedQFunctionField *outputfields;
   CeedInt numinputfields, numoutputfields;
@@ -169,7 +172,7 @@ struct CeedQFunction_private {
   bool identity;
   void *ctx;      /* user context for function */
   size_t ctxsize; /* size of user context; may be used to copy to a device */
-  void *data;     /* backend data */
+  void *data;     /* place for the backend to store any data */
 };
 
 /// Struct to handle the context data to use the Fortran QFunction stub
@@ -195,11 +198,11 @@ typedef struct {
 } fContext;
 
 struct CeedOperatorField_private {
-  CeedElemRestriction Erestrict; /// Restriction from L-vector or NULL if identity
-  CeedTransposeMode lmode;       /// Transpose mode for lvector ordering
-  CeedBasis basis;               /// Basis or NULL for collocated fields
-  CeedVector
-  vec;                /// State vector for passive fields, NULL for active fields
+  CeedElemRestriction Erestrict; /* Restriction from L-vector */
+  CeedBasis basis;               /* Basis or CEED_BASIS_COLLOCATED for
+                                      collocated fields */
+  CeedVector vec;                /* State vector for passive fields or
+                                      CEED_VECTOR_NONE for no vector */
 };
 
 struct CeedOperator_private {

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -242,26 +242,26 @@ typedef enum {
 
 CEED_EXTERN const char *const CeedTransposeModes[];
 
-CEED_EXTERN int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem,
-    CeedInt elemsize, CeedInt nnodes, CeedInt ncomp, CeedMemType mtype,
-    CeedCopyMode cmode,
+CEED_EXTERN int CeedElemRestrictionCreate(Ceed ceed, CeedTransposeMode lmode,
+    CeedInt nelem, CeedInt elemsize, CeedInt nnodes, CeedInt ncomp,
+    CeedMemType mtype, CeedCopyMode cmode, const CeedInt *indices,
+    CeedElemRestriction *rstr);
+CEED_EXTERN int CeedElemRestrictionCreateIdentity(Ceed ceed,
+    CeedTransposeMode lmode,CeedInt nelem, CeedInt elemsize, CeedInt nnodes,
+    CeedInt ncomp, CeedElemRestriction *rstr);
+CEED_EXTERN int CeedElemRestrictionCreateBlocked(Ceed ceed,
+    CeedTransposeMode lmode,CeedInt nelem, CeedInt elemsize, CeedInt blksize,
+    CeedInt nnodes, CeedInt ncomp, CeedMemType mtype, CeedCopyMode cmode,
     const CeedInt *indices, CeedElemRestriction *rstr);
-CEED_EXTERN int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
-    CeedInt elemsize, CeedInt nnodes, CeedInt ncomp, CeedElemRestriction *rstr);
-CEED_EXTERN int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem,
-    CeedInt elemsize, CeedInt blksize, CeedInt nnodes, CeedInt ncomp,
-    CeedMemType mtype,
-    CeedCopyMode cmode, const CeedInt *indices, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedElemRestrictionCreateVector(CeedElemRestriction rstr,
     CeedVector *lvec, CeedVector *evec);
 CEED_EXTERN int CeedElemRestrictionApply(CeedElemRestriction rstr,
-    CeedTransposeMode tmode, CeedTransposeMode lmode, CeedVector u,
-    CeedVector ru, CeedRequest *request);
+    CeedTransposeMode tmode, CeedVector u, CeedVector ru, CeedRequest *request);
 CEED_EXTERN int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr,
-    CeedInt block, CeedTransposeMode tmode, CeedTransposeMode lmode,
-    CeedVector u, CeedVector ru, CeedRequest *request);
+    CeedInt block, CeedTransposeMode tmode, CeedVector u, CeedVector ru,
+    CeedRequest *request);
 CEED_EXTERN int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
-    CeedTransposeMode lmode, CeedVector mult);
+    CeedVector mult);
 CEED_EXTERN int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream);
 CEED_EXTERN int CeedElemRestrictionDestroy(CeedElemRestriction *rstr);
 
@@ -409,8 +409,7 @@ CEED_EXTERN int CeedOperatorCreate(Ceed ceed, CeedQFunction qf,
                                    CeedOperator *op);
 CEED_EXTERN int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op);
 CEED_EXTERN int CeedOperatorSetField(CeedOperator op, const char *fieldname,
-                                     CeedElemRestriction r,
-                                     CeedTransposeMode lmode, CeedBasis b,
+                                     CeedElemRestriction r, CeedBasis b,
                                      CeedVector v);
 CEED_EXTERN int CeedCompositeOperatorAddSub(CeedOperator compositeop,
     CeedOperator subop);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -242,15 +242,27 @@ typedef enum {
 
 CEED_EXTERN const char *const CeedTransposeModes[];
 
-CEED_EXTERN int CeedElemRestrictionCreate(Ceed ceed, CeedTransposeMode lmode,
+/// Denotes whether a L-vector is ordered [component, node] or [node, component]
+///   with the right-most index being contiguous in memory
+/// @ingroup CeedElemRestriction
+typedef enum {
+  /// L-vector data is not interlaced, ordered [component, node]
+  CEED_NONINTERLACED,
+  /// L-vector data is interlaced, ordered [node, component]
+  CEED_INTERLACED
+} CeedInterlaceMode;
+
+CEED_EXTERN const char *const CeedInterlaceModes[];
+
+CEED_EXTERN int CeedElemRestrictionCreate(Ceed ceed, CeedInterlaceMode imode,
     CeedInt nelem, CeedInt elemsize, CeedInt nnodes, CeedInt ncomp,
     CeedMemType mtype, CeedCopyMode cmode, const CeedInt *indices,
     CeedElemRestriction *rstr);
 CEED_EXTERN int CeedElemRestrictionCreateIdentity(Ceed ceed,
-    CeedTransposeMode lmode,CeedInt nelem, CeedInt elemsize, CeedInt nnodes,
+    CeedInterlaceMode imode,CeedInt nelem, CeedInt elemsize, CeedInt nnodes,
     CeedInt ncomp, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedElemRestrictionCreateBlocked(Ceed ceed,
-    CeedTransposeMode lmode,CeedInt nelem, CeedInt elemsize, CeedInt blksize,
+    CeedInterlaceMode imode,CeedInt nelem, CeedInt elemsize, CeedInt blksize,
     CeedInt nnodes, CeedInt ncomp, CeedMemType mtype, CeedCopyMode cmode,
     const CeedInt *indices, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedElemRestrictionCreateVector(CeedElemRestriction rstr,

--- a/include/ceedf.h
+++ b/include/ceedf.h
@@ -74,6 +74,16 @@
       parameter(ceed_norm_max    = 2 )
 
 !-----------------------------------------------------------------------
+! CeedInterlaceMode
+!-----------------------------------------------------------------------
+
+      integer ceed_noninterlaced
+      parameter(ceed_noninterlaced = 0)
+
+      integer ceed_interlaced
+      parameter(ceed_interlaced = 1)
+
+!-----------------------------------------------------------------------
 ! CeedTransposeMode
 !-----------------------------------------------------------------------
 

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -348,7 +348,7 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
     return CeedError(rstr->ceed, 2, "Output vector size %d not compatible with "
                      "element restriction (%d, %d)", ru->length, m, n);
   // LCOV_EXCL_STOP
-  ierr = rstr->Apply(rstr, tmode, rstr->lmode, u, ru, request); CeedChk(ierr);
+  ierr = rstr->Apply(rstr, tmode, u, ru, request); CeedChk(ierr);
 
   return 0;
 }
@@ -401,7 +401,7 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
                      "total elements %d", block, rstr->blksize*block,
                      rstr->nelem);
   // LCOV_EXCL_STOP
-  ierr = rstr->ApplyBlock(rstr, block, tmode, rstr->lmode, u, ru, request);
+  ierr = rstr->ApplyBlock(rstr, block, tmode, u, ru, request);
   CeedChk(ierr);
 
   return 0;

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -27,10 +27,10 @@
   @brief Create a CeedElemRestriction
 
   @param ceed       A Ceed object where the CeedElemRestriction will be created
-  @param lmode      Ordering of the ncomp components, i.e. it specifies
+  @param imode      Ordering of the ncomp components, i.e. it specifies
                       the ordering of the components of the L-vector used
-                      by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                      the component is the outermost index and CEED_TRANSPOSE
+                      by this CeedElemRestriction. CEED_NONINTERLACED indicates
+                      the component is the outermost index and CEED_INTERLACED
                       indicates the component is the innermost index in
                       ordering of the L-vector.
   @param nelem      Number of elements described in the @a indices array
@@ -56,10 +56,11 @@
 
   @ref Basic
 **/
-int CeedElemRestrictionCreate(Ceed ceed,  CeedTransposeMode lmode,
-                              CeedInt nelem, CeedInt elemsize, CeedInt nnodes,
-                              CeedInt ncomp, CeedMemType mtype,
-                              CeedCopyMode cmode, const CeedInt *indices,
+int CeedElemRestrictionCreate(Ceed ceed,  CeedInterlaceMode imode,
+                              CeedInt nelem,
+                              CeedInt elemsize, CeedInt nnodes, CeedInt ncomp,
+                              CeedMemType mtype, CeedCopyMode cmode,
+                              const CeedInt *indices,
                               CeedElemRestriction *rstr) {
   int ierr;
 
@@ -73,7 +74,7 @@ int CeedElemRestrictionCreate(Ceed ceed,  CeedTransposeMode lmode,
       return CeedError(ceed, 1, "Backend does not support ElemRestrictionCreate");
     // LCOV_EXCL_STOP
 
-    ierr = CeedElemRestrictionCreate(delegate, lmode, nelem, elemsize,
+    ierr = CeedElemRestrictionCreate(delegate, imode, nelem, elemsize,
                                      nnodes, ncomp, mtype, cmode,
                                      indices, rstr); CeedChk(ierr);
     return 0;
@@ -83,7 +84,7 @@ int CeedElemRestrictionCreate(Ceed ceed,  CeedTransposeMode lmode,
   (*rstr)->ceed = ceed;
   ceed->refcount++;
   (*rstr)->refcount = 1;
-  (*rstr)->lmode = lmode;
+  (*rstr)->imode = imode;
   (*rstr)->nelem = nelem;
   (*rstr)->elemsize = elemsize;
   (*rstr)->nnodes = nnodes;
@@ -98,10 +99,10 @@ int CeedElemRestrictionCreate(Ceed ceed,  CeedTransposeMode lmode,
   @brief Create an identity CeedElemRestriction
 
   @param ceed       A Ceed object where the CeedElemRestriction will be created
-  @param lmode      Ordering of the ncomp components, i.e. it specifies
+  @param imode      Ordering of the ncomp components, i.e. it specifies
                       the ordering of the components of the L-vector used
-                      by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                      the component is the outermost index and CEED_TRANSPOSE
+                      by this CeedElemRestriction. CEED_NONINTERLACED indicates
+                      the component is the outermost index and CEED_INTERLACED
                       indicates the component is the innermost index in
                       ordering of the L-vector.
   @param nelem      Number of elements described in the @a indices array
@@ -120,7 +121,7 @@ int CeedElemRestrictionCreate(Ceed ceed,  CeedTransposeMode lmode,
 
   @ref Basic
 **/
-int CeedElemRestrictionCreateIdentity(Ceed ceed,  CeedTransposeMode lmode,
+int CeedElemRestrictionCreateIdentity(Ceed ceed,  CeedInterlaceMode imode,
                                       CeedInt nelem, CeedInt elemsize,
                                       CeedInt nnodes, CeedInt ncomp,
                                       CeedElemRestriction *rstr) {
@@ -136,7 +137,7 @@ int CeedElemRestrictionCreateIdentity(Ceed ceed,  CeedTransposeMode lmode,
       return CeedError(ceed, 1, "Backend does not support ElemRestrictionCreate");
     // LCOV_EXCL_STOP
 
-    ierr = CeedElemRestrictionCreateIdentity(delegate, lmode, nelem, elemsize,
+    ierr = CeedElemRestrictionCreateIdentity(delegate, imode, nelem, elemsize,
            nnodes, ncomp, rstr); CeedChk(ierr);
     return 0;
   }
@@ -145,7 +146,7 @@ int CeedElemRestrictionCreateIdentity(Ceed ceed,  CeedTransposeMode lmode,
   (*rstr)->ceed = ceed;
   ceed->refcount++;
   (*rstr)->refcount = 1;
-  (*rstr)->lmode = lmode;
+  (*rstr)->imode = imode;
   (*rstr)->nelem = nelem;
   (*rstr)->elemsize = elemsize;
   (*rstr)->nnodes = nnodes;
@@ -192,10 +193,10 @@ int CeedPermutePadIndices(const CeedInt *indices, CeedInt *blkindices,
   @brief Create a blocked CeedElemRestriction, typically only called by backends
 
   @param ceed       A Ceed object where the CeedElemRestriction will be created.
-  @param lmode      Ordering of the ncomp components, i.e. it specifies
+  @param imode      Ordering of the ncomp components, i.e. it specifies
                       the ordering of the components of the L-vector used
-                      by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                      the component is the outermost index and CEED_TRANSPOSE
+                      by this CeedElemRestriction. CEED_NONINTERLACED indicates
+                      the component is the outermost index and CEED_INTERLACED
                       indicates the component is the innermost index in
                       ordering of the L-vector.
   @param nelem      Number of elements described in the @a indices array.
@@ -225,7 +226,7 @@ int CeedPermutePadIndices(const CeedInt *indices, CeedInt *blkindices,
 
   @ref Advanced
  **/
-int CeedElemRestrictionCreateBlocked(Ceed ceed,  CeedTransposeMode lmode,
+int CeedElemRestrictionCreateBlocked(Ceed ceed,  CeedInterlaceMode imode,
                                      CeedInt nelem, CeedInt elemsize,
                                      CeedInt blksize, CeedInt nnodes,
                                      CeedInt ncomp, CeedMemType mtype,
@@ -246,7 +247,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed,  CeedTransposeMode lmode,
                        "ElemRestrictionCreateBlocked");
     // LCOV_EXCL_STOP
 
-    ierr = CeedElemRestrictionCreateBlocked(delegate, lmode, nelem, elemsize,
+    ierr = CeedElemRestrictionCreateBlocked(delegate, imode, nelem, elemsize,
                                             blksize, nnodes, ncomp, mtype, cmode,
                                             indices, rstr); CeedChk(ierr);
     return 0;
@@ -266,7 +267,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed,  CeedTransposeMode lmode,
   (*rstr)->ceed = ceed;
   ceed->refcount++;
   (*rstr)->refcount = 1;
-  (*rstr)->lmode = lmode;
+  (*rstr)->imode = imode;
   (*rstr)->nelem = nelem;
   (*rstr)->elemsize = elemsize;
   (*rstr)->nnodes = nnodes;
@@ -315,7 +316,7 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *lvec,
   @param rstr    CeedElemRestriction
   @param tmode   Apply restriction or transpose
   @param u       Input vector (of shape [@a nnodes, @a ncomp] when
-                   tmode=CEED_NOTRANSPOSE, lmode=CEED_TRANSPOSE)
+                   tmode=CEED_NOTRANSPOSE, imode=CEED_INTERLACED)
   @param ru      Output vector (of shape [@a nelem * @a elemsize] when
                    tmode=CEED_NOTRANSPOSE). Ordering of the e-vector is decided
                    by the backend.
@@ -362,7 +363,7 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
                    [3*blksize : 4*blksize]
   @param tmode   Apply restriction or transpose
   @param u       Input vector (of shape [@a nnodes, @a ncomp] when
-                   tmode=CEED_NOTRANSPOSE, lmode=CEED_TRANSPOSE)
+                   tmode=CEED_NOTRANSPOSE, imode=CEED_INTERLACED)
   @param ru      Output vector (of shape [@a blksize * @a elemsize] when
                    tmode=CEED_NOTRANSPOSE). Ordering of the e-vector is decided
                    by the backend.
@@ -452,18 +453,18 @@ int CeedElemRestrictionGetCeed(CeedElemRestriction rstr, Ceed *ceed) {
 }
 
 /**
-  @brief Get the L-vector layout mode of a CeedElemRestriction
+  @brief Get the L-vector interlaced mode of a CeedElemRestriction
 
   @param rstr             CeedElemRestriction
-  @param[out] lmode       Variable to store lmode
+  @param[out] imode       Variable to store imode
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Advanced
 **/
-int CeedElemRestrictionGetLMode(CeedElemRestriction rstr,
-                                CeedTransposeMode *lmode) {
-  *lmode = rstr->lmode;
+int CeedElemRestrictionGetIMode(CeedElemRestriction rstr,
+                                CeedInterlaceMode *imode) {
+  *imode = rstr->imode;
   return 0;
 }
 
@@ -607,9 +608,8 @@ int CeedElemRestrictionSetData(CeedElemRestriction rstr, void **data) {
 **/
 int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream) {
   fprintf(stream, "CeedElemRestriction from (%d, %d) to %d elements with %d "
-          "nodes each and L-vector layout %s\n", rstr->nnodes, rstr->ncomp,
-          rstr->nelem, rstr->elemsize, rstr->lmode == CEED_NOTRANSPOSE ?
-          "CEED_NOTRANSPOSE" : "CEED_TRANSPOSE");
+          "nodes each and L-vector components %s\n", rstr->nnodes, rstr->ncomp,
+          rstr->nelem, rstr->elemsize, CeedInterlaceModes[rstr->imode]);
   return 0;
 }
 

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -27,6 +27,12 @@
   @brief Create a CeedElemRestriction
 
   @param ceed       A Ceed object where the CeedElemRestriction will be created
+  @param lmode      Ordering of the ncomp components, i.e. it specifies
+                      the ordering of the components of the L-vector used
+                      by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
+                      the component is the outermost index and CEED_TRANSPOSE
+                      indicates the component is the innermost index in
+                      ordering of the L-vector.
   @param nelem      Number of elements described in the @a indices array
   @param elemsize   Size (number of "nodes") per element
   @param nnodes     The number of nodes in the L-vector. The input CeedVector
@@ -50,8 +56,9 @@
 
   @ref Basic
 **/
-int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
-                              CeedInt nnodes, CeedInt ncomp, CeedMemType mtype,
+int CeedElemRestrictionCreate(Ceed ceed,  CeedTransposeMode lmode,
+                              CeedInt nelem, CeedInt elemsize, CeedInt nnodes,
+                              CeedInt ncomp, CeedMemType mtype,
                               CeedCopyMode cmode, const CeedInt *indices,
                               CeedElemRestriction *rstr) {
   int ierr;
@@ -66,7 +73,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
       return CeedError(ceed, 1, "Backend does not support ElemRestrictionCreate");
     // LCOV_EXCL_STOP
 
-    ierr = CeedElemRestrictionCreate(delegate, nelem, elemsize,
+    ierr = CeedElemRestrictionCreate(delegate, lmode, nelem, elemsize,
                                      nnodes, ncomp, mtype, cmode,
                                      indices, rstr); CeedChk(ierr);
     return 0;
@@ -76,6 +83,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
   (*rstr)->ceed = ceed;
   ceed->refcount++;
   (*rstr)->refcount = 1;
+  (*rstr)->lmode = lmode;
   (*rstr)->nelem = nelem;
   (*rstr)->elemsize = elemsize;
   (*rstr)->nnodes = nnodes;
@@ -90,6 +98,12 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
   @brief Create an identity CeedElemRestriction
 
   @param ceed       A Ceed object where the CeedElemRestriction will be created
+  @param lmode      Ordering of the ncomp components, i.e. it specifies
+                      the ordering of the components of the L-vector used
+                      by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
+                      the component is the outermost index and CEED_TRANSPOSE
+                      indicates the component is the innermost index in
+                      ordering of the L-vector.
   @param nelem      Number of elements described in the @a indices array
   @param elemsize   Size (number of "nodes") per element
   @param nnodes     The number of nodes in the L-vector. The input CeedVector
@@ -106,9 +120,9 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt nelem, CeedInt elemsize,
 
   @ref Basic
 **/
-int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
-                                      CeedInt elemsize, CeedInt nnodes,
-                                      CeedInt ncomp,
+int CeedElemRestrictionCreateIdentity(Ceed ceed,  CeedTransposeMode lmode,
+                                      CeedInt nelem, CeedInt elemsize,
+                                      CeedInt nnodes, CeedInt ncomp,
                                       CeedElemRestriction *rstr) {
   int ierr;
 
@@ -122,7 +136,7 @@ int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
       return CeedError(ceed, 1, "Backend does not support ElemRestrictionCreate");
     // LCOV_EXCL_STOP
 
-    ierr = CeedElemRestrictionCreateIdentity(delegate, nelem, elemsize,
+    ierr = CeedElemRestrictionCreateIdentity(delegate, lmode, nelem, elemsize,
            nnodes, ncomp, rstr); CeedChk(ierr);
     return 0;
   }
@@ -131,6 +145,7 @@ int CeedElemRestrictionCreateIdentity(Ceed ceed, CeedInt nelem,
   (*rstr)->ceed = ceed;
   ceed->refcount++;
   (*rstr)->refcount = 1;
+  (*rstr)->lmode = lmode;
   (*rstr)->nelem = nelem;
   (*rstr)->elemsize = elemsize;
   (*rstr)->nnodes = nnodes;
@@ -177,6 +192,12 @@ int CeedPermutePadIndices(const CeedInt *indices, CeedInt *blkindices,
   @brief Create a blocked CeedElemRestriction, typically only called by backends
 
   @param ceed       A Ceed object where the CeedElemRestriction will be created.
+  @param lmode      Ordering of the ncomp components, i.e. it specifies
+                      the ordering of the components of the L-vector used
+                      by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
+                      the component is the outermost index and CEED_TRANSPOSE
+                      indicates the component is the innermost index in
+                      ordering of the L-vector.
   @param nelem      Number of elements described in the @a indices array.
   @param elemsize   Size (number of unknowns) per element
   @param blksize    Number of elements in a block
@@ -204,7 +225,8 @@ int CeedPermutePadIndices(const CeedInt *indices, CeedInt *blkindices,
 
   @ref Advanced
  **/
-int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem, CeedInt elemsize,
+int CeedElemRestrictionCreateBlocked(Ceed ceed,  CeedTransposeMode lmode,
+                                     CeedInt nelem, CeedInt elemsize,
                                      CeedInt blksize, CeedInt nnodes,
                                      CeedInt ncomp, CeedMemType mtype,
                                      CeedCopyMode cmode, const CeedInt *indices,
@@ -224,7 +246,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem, CeedInt elemsize,
                        "ElemRestrictionCreateBlocked");
     // LCOV_EXCL_STOP
 
-    ierr = CeedElemRestrictionCreateBlocked(delegate, nelem, elemsize,
+    ierr = CeedElemRestrictionCreateBlocked(delegate, lmode, nelem, elemsize,
                                             blksize, nnodes, ncomp, mtype, cmode,
                                             indices, rstr); CeedChk(ierr);
     return 0;
@@ -244,6 +266,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt nelem, CeedInt elemsize,
   (*rstr)->ceed = ceed;
   ceed->refcount++;
   (*rstr)->refcount = 1;
+  (*rstr)->lmode = lmode;
   (*rstr)->nelem = nelem;
   (*rstr)->elemsize = elemsize;
   (*rstr)->nnodes = nnodes;
@@ -291,15 +314,9 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *lvec,
 
   @param rstr    CeedElemRestriction
   @param tmode   Apply restriction or transpose
-  @param lmode   Ordering of the ncomp components, i.e. it specifies
-                   the ordering of the components of the l-vector used
-                   by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                   the component is the outermost index and CEED_TRANSPOSE
-                   indicates the component is the innermost index in
-                   ordering of the l-vector
   @param u       Input vector (of shape [@a nnodes, @a ncomp] when
                    tmode=CEED_NOTRANSPOSE, lmode=CEED_TRANSPOSE)
-  @param v       Output vector (of shape [@a nelem * @a elemsize] when
+  @param ru      Output vector (of shape [@a nelem * @a elemsize] when
                    tmode=CEED_NOTRANSPOSE). Ordering of the e-vector is decided
                    by the backend.
   @param request Request or CEED_REQUEST_IMMEDIATE
@@ -309,8 +326,8 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *lvec,
   @ref Advanced
 **/
 int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
-                             CeedTransposeMode lmode, CeedVector u,
-                             CeedVector v, CeedRequest *request) {
+                             CeedVector u, CeedVector ru,
+                             CeedRequest *request) {
   CeedInt m,n;
   int ierr;
 
@@ -326,12 +343,12 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
     return CeedError(rstr->ceed, 2, "Input vector size %d not compatible with "
                      "element restriction (%d, %d)", u->length, m, n);
   // LCOV_EXCL_STOP
-  if (m != v->length)
+  if (m != ru->length)
     // LCOV_EXCL_START
     return CeedError(rstr->ceed, 2, "Output vector size %d not compatible with "
-                     "element restriction (%d, %d)", v->length, m, n);
+                     "element restriction (%d, %d)", ru->length, m, n);
   // LCOV_EXCL_STOP
-  ierr = rstr->Apply(rstr, tmode, lmode, u, v, request); CeedChk(ierr);
+  ierr = rstr->Apply(rstr, tmode, rstr->lmode, u, ru, request); CeedChk(ierr);
 
   return 0;
 }
@@ -344,15 +361,9 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
                    elements [0 : blksize] and block=3 will handle elements
                    [3*blksize : 4*blksize]
   @param tmode   Apply restriction or transpose
-  @param lmode   Ordering of the ncomp components, i.e. it specifies
-                   the ordering of the components of the l-vector used
-                   by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                   the component is the outermost index and CEED_TRANSPOSE
-                   indicates the component is the innermost index in
-                   ordering of the l-vector
   @param u       Input vector (of shape [@a nnodes, @a ncomp] when
                    tmode=CEED_NOTRANSPOSE, lmode=CEED_TRANSPOSE)
-  @param v       Output vector (of shape [@a blksize * @a elemsize] when
+  @param ru      Output vector (of shape [@a blksize * @a elemsize] when
                    tmode=CEED_NOTRANSPOSE). Ordering of the e-vector is decided
                    by the backend.
   @param request Request or CEED_REQUEST_IMMEDIATE
@@ -362,9 +373,8 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
   @ref Advanced
 **/
 int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
-                                  CeedTransposeMode tmode,
-                                  CeedTransposeMode lmode, CeedVector u,
-                                  CeedVector v, CeedRequest *request) {
+                                  CeedTransposeMode tmode, CeedVector u,
+                                  CeedVector ru, CeedRequest *request) {
   CeedInt m,n;
   int ierr;
 
@@ -380,10 +390,10 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
     return CeedError(rstr->ceed, 2, "Input vector size %d not compatible with "
                      "element restriction (%d, %d)", u->length, m, n);
   // LCOV_EXCL_STOP
-  if (m != v->length)
+  if (m != ru->length)
     // LCOV_EXCL_START
     return CeedError(rstr->ceed, 2, "Output vector size %d not compatible with "
-                     "element restriction (%d, %d)", v->length, m, n);
+                     "element restriction (%d, %d)", ru->length, m, n);
   // LCOV_EXCL_STOP
   if (rstr->blksize*block > rstr->nelem)
     // LCOV_EXCL_START
@@ -391,7 +401,7 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
                      "total elements %d", block, rstr->blksize*block,
                      rstr->nelem);
   // LCOV_EXCL_STOP
-  ierr = rstr->ApplyBlock(rstr, block, tmode, lmode, u, v, request);
+  ierr = rstr->ApplyBlock(rstr, block, tmode, rstr->lmode, u, ru, request);
   CeedChk(ierr);
 
   return 0;
@@ -401,12 +411,6 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
   @brief Get the multiplicity of nodes in a CeedElemRestriction
 
   @param rstr             CeedElemRestriction
-  @param lmode            Ordering of the ncomp components, i.e. it specifies
-                            the ordering of the components of the l-vector used
-                            by this CeedElemRestriction. CEED_NOTRANSPOSE
-                            indicates the component is the outermost index and
-                            CEED_TRANSPOSE indicates the component is the
-                            innermost index in ordering of the l-vector
   @param[out] mult        Vector to store multiplicity (of size nnodes)
 
   @return An error code: 0 - success, otherwise - failure
@@ -414,7 +418,6 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block,
   @ref Advanced
 **/
 int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
-                                       CeedTransposeMode lmode,
                                        CeedVector mult) {
   int ierr;
   CeedVector evec;
@@ -424,7 +427,7 @@ int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
   ierr = CeedVectorSetValue(evec, 1.0); CeedChk(ierr);
 
   // Apply to get multiplicity
-  ierr = CeedElemRestrictionApply(rstr, CEED_TRANSPOSE, lmode, evec, mult,
+  ierr = CeedElemRestrictionApply(rstr, CEED_TRANSPOSE, evec, mult,
                                   CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
 
   // Cleanup
@@ -445,6 +448,22 @@ int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr,
 **/
 int CeedElemRestrictionGetCeed(CeedElemRestriction rstr, Ceed *ceed) {
   *ceed = rstr->ceed;
+  return 0;
+}
+
+/**
+  @brief Get the L-vector layout mode of a CeedElemRestriction
+
+  @param rstr             CeedElemRestriction
+  @param[out] lmode       Variable to store lmode
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+int CeedElemRestrictionGetLMode(CeedElemRestriction rstr,
+                                CeedTransposeMode *lmode) {
+  *lmode = rstr->lmode;
   return 0;
 }
 
@@ -588,8 +607,9 @@ int CeedElemRestrictionSetData(CeedElemRestriction rstr, void **data) {
 **/
 int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream) {
   fprintf(stream, "CeedElemRestriction from (%d, %d) to %d elements with %d "
-          "nodes each\n", rstr->nnodes, rstr->ncomp, rstr->nelem,
-          rstr->elemsize);
+          "nodes each and L-vector layout %s\n", rstr->nnodes, rstr->ncomp,
+          rstr->nelem, rstr->elemsize, rstr->lmode == CEED_NOTRANSPOSE ?
+          "CEED_NOTRANSPOSE" : "CEED_TRANSPOSE");
   return 0;
 }
 

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -207,7 +207,7 @@ static int CeedElemRestriction_count_max = 0;
 
 #define fCeedElemRestrictionCreate \
     FORTRAN_NAME(ceedelemrestrictioncreate, CEEDELEMRESTRICTIONCREATE)
-void fCeedElemRestrictionCreate(int *ceed, int *nelements,
+void fCeedElemRestrictionCreate(int *ceed, int *lmode, int *nelements,
                                 int *esize, int *nnodes, int *ncomp,
                                 int *memtype, int *copymode, const int *indices,
                                 int *elemrestriction, int *err) {
@@ -220,7 +220,7 @@ void fCeedElemRestrictionCreate(int *ceed, int *nelements,
 
   CeedElemRestriction *elemrestriction_ =
     &CeedElemRestriction_dict[CeedElemRestriction_count];
-  *err = CeedElemRestrictionCreate(Ceed_dict[*ceed], *nelements, *esize,
+  *err = CeedElemRestrictionCreate(Ceed_dict[*ceed], *lmode, *nelements, *esize,
                                    *nnodes, *ncomp, *memtype, *copymode,
                                    indices_, elemrestriction_);
 
@@ -232,7 +232,7 @@ void fCeedElemRestrictionCreate(int *ceed, int *nelements,
 
 #define fCeedElemRestrictionCreateIdentity \
     FORTRAN_NAME(ceedelemrestrictioncreateidentity, CEEDELEMRESTRICTIONCREATEIDENTITY)
-void fCeedElemRestrictionCreateIdentity(int *ceed, int *nelements,
+void fCeedElemRestrictionCreateIdentity(int *ceed, int *lmode, int *nelements,
                                         int *esize, int *nnodes, int *ncomp,
                                         int *elemrestriction, int *err) {
   if (CeedElemRestriction_count == CeedElemRestriction_count_max) {
@@ -242,8 +242,8 @@ void fCeedElemRestrictionCreateIdentity(int *ceed, int *nelements,
 
   CeedElemRestriction *elemrestriction_ =
     &CeedElemRestriction_dict[CeedElemRestriction_count];
-  *err = CeedElemRestrictionCreateIdentity(Ceed_dict[*ceed], *nelements, *esize,
-         *nnodes, *ncomp, elemrestriction_);
+  *err = CeedElemRestrictionCreateIdentity(Ceed_dict[*ceed], *lmode, *nelements,
+         *esize, *nnodes, *ncomp, elemrestriction_);
 
   if (*err == 0) {
     *elemrestriction = CeedElemRestriction_count++;
@@ -253,7 +253,7 @@ void fCeedElemRestrictionCreateIdentity(int *ceed, int *nelements,
 
 #define fCeedElemRestrictionCreateBlocked \
     FORTRAN_NAME(ceedelemrestrictioncreateblocked,CEEDELEMRESTRICTIONCREATEBLOCKED)
-void fCeedElemRestrictionCreateBlocked(int *ceed, int *nelements,
+void fCeedElemRestrictionCreateBlocked(int *ceed, int *lmode, int *nelements,
                                        int *esize, int *blocksize, int *nnodes,
                                        int *ncomp, int *mtype, int *cmode,
                                        int *blkindices, int *elemrestriction,
@@ -266,9 +266,10 @@ void fCeedElemRestrictionCreateBlocked(int *ceed, int *nelements,
 
   CeedElemRestriction *elemrestriction_ =
     &CeedElemRestriction_dict[CeedElemRestriction_count];
-  *err = CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *nelements, *esize,
-                                          *blocksize, *nnodes, *ncomp, *mtype,
-                                          *cmode, blkindices, elemrestriction_);
+  *err = CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *lmode, *nelements,
+                                          *esize, *blocksize, *nnodes, *ncomp,
+                                          *mtype, *cmode, blkindices,
+                                          elemrestriction_);
 
   if (*err == 0) {
     *elemrestriction = CeedElemRestriction_count++;
@@ -283,8 +284,8 @@ static int CeedRequest_count_max = 0;
 
 #define fCeedElemRestrictionApply \
     FORTRAN_NAME(ceedelemrestrictionapply,CEEDELEMRESTRICTIONAPPLY)
-void fCeedElemRestrictionApply(int *elemr, int *tmode, int *lmode,
-                               int *uvec, int *ruvec, int *rqst, int *err) {
+void fCeedElemRestrictionApply(int *elemr, int *tmode, int *uvec, int *ruvec,
+                               int *rqst, int *err) {
   int createRequest = 1;
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*rqst == FORTRAN_REQUEST_IMMEDIATE || *rqst == FORTRAN_REQUEST_ORDERED)
@@ -301,7 +302,7 @@ void fCeedElemRestrictionApply(int *elemr, int *tmode, int *lmode,
   else rqst_ = &CeedRequest_dict[CeedRequest_count];
 
   *err = CeedElemRestrictionApply(CeedElemRestriction_dict[*elemr], *tmode,
-                                  *lmode, CeedVector_dict[*uvec],
+                                  CeedVector_dict[*uvec],
                                   CeedVector_dict[*ruvec], rqst_);
 
   if (*err == 0 && createRequest) {
@@ -313,7 +314,6 @@ void fCeedElemRestrictionApply(int *elemr, int *tmode, int *lmode,
 #define fCeedElemRestrictionApplyBlock \
     FORTRAN_NAME(ceedelemrestrictionapplyblock,CEEDELEMRESTRICTIONAPPLYBLOCK)
 void fCeedElemRestrictionApplyBlock(int *elemr, int *block, int *tmode,
-                                    int *lmode,
                                     int *uvec, int *ruvec, int *rqst, int *err) {
   int createRequest = 1;
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
@@ -331,7 +331,7 @@ void fCeedElemRestrictionApplyBlock(int *elemr, int *block, int *tmode,
   else rqst_ = &CeedRequest_dict[CeedRequest_count];
 
   *err = CeedElemRestrictionApplyBlock(CeedElemRestriction_dict[*elemr], *block,
-                                       *tmode, *lmode, CeedVector_dict[*uvec],
+                                       *tmode, CeedVector_dict[*uvec],
                                        CeedVector_dict[*ruvec], rqst_);
 
   if (*err == 0 && createRequest) {
@@ -342,10 +342,9 @@ void fCeedElemRestrictionApplyBlock(int *elemr, int *block, int *tmode,
 
 #define fCeedElemRestrictionGetMultiplicity \
     FORTRAN_NAME(ceedelemrestrictiongetmultiplicity,CEEDELEMRESTRICTIONGETMULTIPLICITY)
-void fCeedElemRestrictionGetMultiplicity(int *elemr, int *lmode, int *mult,
-    int *err) {
+void fCeedElemRestrictionGetMultiplicity(int *elemr, int *mult, int *err) {
   *err = CeedElemRestrictionGetMultiplicity(CeedElemRestriction_dict[*elemr],
-         *lmode, CeedVector_dict[*mult]);
+         CeedVector_dict[*mult]);
 }
 
 #define fCeedElemRestrictionView \
@@ -807,9 +806,8 @@ void fCeedCompositeOperatorCreate(int *ceed, int *op, int *err) {
 
 #define fCeedOperatorSetField \
     FORTRAN_NAME(ceedoperatorsetfield,CEEDOPERATORSETFIELD)
-void fCeedOperatorSetField(int *op, const char *fieldname,
-                           int *r, int *lmode, int *b, int *v, int *err,
-                           fortran_charlen_t fieldname_len) {
+void fCeedOperatorSetField(int *op, const char *fieldname, int *r, int *b,
+                           int *v, int *err, fortran_charlen_t fieldname_len) {
   FIX_STRING(fieldname);
   CeedElemRestriction r_;
   CeedBasis b_;
@@ -840,7 +838,7 @@ void fCeedOperatorSetField(int *op, const char *fieldname,
     v_ = CeedVector_dict[*v];
   }
 
-  *err = CeedOperatorSetField(op_, fieldname_c, r_, *lmode, b_, v_);
+  *err = CeedOperatorSetField(op_, fieldname_c, r_, b_, v_);
 }
 
 #define fCeedCompositeOperatorAddSub \

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -207,7 +207,7 @@ static int CeedElemRestriction_count_max = 0;
 
 #define fCeedElemRestrictionCreate \
     FORTRAN_NAME(ceedelemrestrictioncreate, CEEDELEMRESTRICTIONCREATE)
-void fCeedElemRestrictionCreate(int *ceed, int *lmode, int *nelements,
+void fCeedElemRestrictionCreate(int *ceed, int *imode, int *nelements,
                                 int *esize, int *nnodes, int *ncomp,
                                 int *memtype, int *copymode, const int *indices,
                                 int *elemrestriction, int *err) {
@@ -220,7 +220,7 @@ void fCeedElemRestrictionCreate(int *ceed, int *lmode, int *nelements,
 
   CeedElemRestriction *elemrestriction_ =
     &CeedElemRestriction_dict[CeedElemRestriction_count];
-  *err = CeedElemRestrictionCreate(Ceed_dict[*ceed], *lmode, *nelements, *esize,
+  *err = CeedElemRestrictionCreate(Ceed_dict[*ceed], *imode, *nelements, *esize,
                                    *nnodes, *ncomp, *memtype, *copymode,
                                    indices_, elemrestriction_);
 
@@ -232,7 +232,7 @@ void fCeedElemRestrictionCreate(int *ceed, int *lmode, int *nelements,
 
 #define fCeedElemRestrictionCreateIdentity \
     FORTRAN_NAME(ceedelemrestrictioncreateidentity, CEEDELEMRESTRICTIONCREATEIDENTITY)
-void fCeedElemRestrictionCreateIdentity(int *ceed, int *lmode, int *nelements,
+void fCeedElemRestrictionCreateIdentity(int *ceed, int *imode, int *nelements,
                                         int *esize, int *nnodes, int *ncomp,
                                         int *elemrestriction, int *err) {
   if (CeedElemRestriction_count == CeedElemRestriction_count_max) {
@@ -242,9 +242,8 @@ void fCeedElemRestrictionCreateIdentity(int *ceed, int *lmode, int *nelements,
 
   CeedElemRestriction *elemrestriction_ =
     &CeedElemRestriction_dict[CeedElemRestriction_count];
-  *err = CeedElemRestrictionCreateIdentity(Ceed_dict[*ceed], *lmode, *nelements,
+  *err = CeedElemRestrictionCreateIdentity(Ceed_dict[*ceed], *imode, *nelements,
          *esize, *nnodes, *ncomp, elemrestriction_);
-
   if (*err == 0) {
     *elemrestriction = CeedElemRestriction_count++;
     CeedElemRestriction_n++;
@@ -253,7 +252,7 @@ void fCeedElemRestrictionCreateIdentity(int *ceed, int *lmode, int *nelements,
 
 #define fCeedElemRestrictionCreateBlocked \
     FORTRAN_NAME(ceedelemrestrictioncreateblocked,CEEDELEMRESTRICTIONCREATEBLOCKED)
-void fCeedElemRestrictionCreateBlocked(int *ceed, int *lmode, int *nelements,
+void fCeedElemRestrictionCreateBlocked(int *ceed, int *imode, int *nelements,
                                        int *esize, int *blocksize, int *nnodes,
                                        int *ncomp, int *mtype, int *cmode,
                                        int *blkindices, int *elemrestriction,
@@ -266,7 +265,7 @@ void fCeedElemRestrictionCreateBlocked(int *ceed, int *lmode, int *nelements,
 
   CeedElemRestriction *elemrestriction_ =
     &CeedElemRestriction_dict[CeedElemRestriction_count];
-  *err = CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *lmode, *nelements,
+  *err = CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *imode, *nelements,
                                           *esize, *blocksize, *nnodes, *ncomp,
                                           *mtype, *cmode, blkindices,
                                           elemrestriction_);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -135,11 +135,6 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
   @param fieldname  Name of the field (to be matched with the name used by
                       CeedQFunction)
   @param r          CeedElemRestriction
-  @param lmode      CeedTransposeMode which specifies the ordering of the
-                      components of the l-vector used by this CeedOperatorField,
-                      CEED_NOTRANSPOSE indicates the component is the
-                      outermost index and CEED_TRANSPOSE indicates the component
-                      is the innermost index in ordering of the l-vector
   @param b          CeedBasis in which the field resides or CEED_BASIS_COLLOCATED
                       if collocated with quadrature points
   @param v          CeedVector to be used by CeedOperator or CEED_VECTOR_ACTIVE
@@ -151,8 +146,7 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
   @ref Basic
 **/
 int CeedOperatorSetField(CeedOperator op, const char *fieldname,
-                         CeedElemRestriction r, CeedTransposeMode lmode,
-                         CeedBasis b, CeedVector v) {
+                         CeedElemRestriction r, CeedBasis b, CeedVector v) {
   int ierr;
   if (op->composite)
     // LCOV_EXCL_START
@@ -218,7 +212,6 @@ found:
   ierr = CeedCalloc(1, ofield); CeedChk(ierr);
   (*ofield)->Erestrict = r;
   r->refcount += 1;
-  (*ofield)->lmode = lmode;
   (*ofield)->basis = b;
   if (b != CEED_BASIS_COLLOCATED)
     b->refcount += 1;
@@ -835,10 +828,8 @@ static int CeedOperatorFieldView(CeedOperatorField field,
   const char *inout = in ? "Input" : "Output";
 
   fprintf(stream, "%s    %s Field [%d]:\n"
-          "%s      Name: \"%s\"\n"
-          "%s      Lmode: \"%s\"\n",
-          pre, inout, fieldnumber, pre, qffield->fieldname,
-          pre, CeedTransposeModes[field->lmode]);
+          "%s      Name: \"%s\"\n",
+          pre, inout, fieldnumber, pre, qffield->fieldname);
 
   if (field->basis == CEED_BASIS_COLLOCATED)
     fprintf(stream, "%s      Collocated basis\n", pre);
@@ -938,23 +929,6 @@ int CeedOperatorGetFields(CeedOperator op, CeedOperatorField **inputfields,
 
   if (inputfields) *inputfields = op->inputfields;
   if (outputfields) *outputfields = op->outputfields;
-  return 0;
-}
-
-/**
-  @brief Get the L vector CeedTransposeMode of a CeedOperatorField
-
-  @param opfield         CeedOperatorField
-  @param[out] lmode      Variable to store CeedTransposeMode
-
-  @return An error code: 0 - success, otherwise - failure
-
-  @ref Advanced
-**/
-
-int CeedOperatorFieldGetLMode(CeedOperatorField opfield,
-                              CeedTransposeMode *lmode) {
-  *lmode = opfield->lmode;
   return 0;
 }
 

--- a/interface/ceed-types.c
+++ b/interface/ceed-types.c
@@ -32,6 +32,11 @@ const char *const CeedTransposeModes[] = {
   [CEED_NOTRANSPOSE] = "no transpose",
 };
 
+const char *const CeedInterlaceModes[] = {
+  [CEED_NONINTERLACED] = "not interlaced",
+  [CEED_INTERLACED] = "interlaced"
+};
+
 const char *const CeedEvalModes[] = {
   [CEED_EVAL_NONE] = "none",
   [CEED_EVAL_INTERP] = "interpolation",

--- a/python/ceed.py
+++ b/python/ceed.py
@@ -85,7 +85,7 @@ class Ceed():
   # CeedElemRestriction
   def ElemRestriction(self, nelem, elemsize, nnodes, ncomp, indices,
                       memtype=lib.CEED_MEM_HOST, cmode=lib.CEED_COPY_VALUES,
-                      lmode=lib.CEED_NOTRANSPOSE):
+                      imode=lib.CEED_NONINTERLACED):
     """Ceed ElemRestriction: restriction from local vectors to elements.
 
        Args:
@@ -104,21 +104,21 @@ class Ceed():
                       [0, nnodes - 1].
          **memtype: memory type of the indices array, default CEED_MEM_HOST
          **cmode: copy mode for the indices array, default CEED_COPY_VALUES
-         **lmode: ordering of the ncomp components, i.e. it specifies
+         **imode: ordering of the ncomp components, i.e. it specifies
                     the ordering of the components of the local vector used
-                    by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                    the component is the outermost index and CEED_TRANSPOSE
+                    by this CeedElemRestriction. CEED_NONINTERLACED indicates
+                    the component is the outermost index and CEED_INTERLACED
                     indicates the component is the innermost index in
-                    ordering of the local vector, default CEED_NOTRANSPOSE
+                    ordering of the local vector, default CEED_NONINTERLACED
 
        Returns:
          elemrestriction: Ceed ElemRestiction"""
 
     return ElemRestriction(self, nelem, elemsize, nnodes, ncomp, indices,
-                           memtype=memtype, cmode=cmode, lmode=lmode)
+                           memtype=memtype, cmode=cmode, imode=imode)
 
   def IdentityElemRestriction(self, nelem, elemsize, nnodes, ncomp,
-                              lmode=lib.CEED_NOTRANSPOSE):
+                              imode=lib.CEED_NONINTERLACED):
     """Ceed Identity ElemRestriction: identity restriction from local vectors to elements.
 
        Args:
@@ -131,23 +131,23 @@ class Ceed():
                    different types of elements.
          ncomp: number of field components per interpolation node
                   (1 for scalar fields)
-         **lmode: ordering of the ncomp components, i.e. it specifies
+         **imode: ordering of the ncomp components, i.e. it specifies
                     the ordering of the components of the local vector used
-                    by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                    the component is the outermost index and CEED_TRANSPOSE
+                    by this CeedElemRestriction. CEED_NONINTERLACED indicates
+                    the component is the outermost index and CEED_INTERLACED
                     indicates the component is the innermost index in
-                    ordering of the local vector, default CEED_NOTRANSPOSE
+                    ordering of the local vector, default CEED_NONINTERLACED
 
        Returns:
          elemrestriction: Ceed Identity ElemRestiction"""
 
     return IdentityElemRestriction(self, nelem, elemsize, nnodes, ncomp,
-                                   lmode=lmode)
+                                   imode=imode)
 
   def BlockedElemRestriction(self, nelem, elemsize, blksize, nnodes, ncomp,
                              indices, memtype=lib.CEED_MEM_HOST,
                              cmode=lib.CEED_COPY_VALUES,
-                             lmode=lib.CEED_NOTRANSPOSE):
+                             imode=lib.CEED_NONINTERLACED):
     """Ceed Blocked ElemRestriction: blocked restriction from local vectors to elements.
 
        Args:
@@ -170,19 +170,19 @@ class Ceed():
                       to interlace elements.
          **memtype: memory type of the indices array, default CEED_MEM_HOST
          **cmode: copy mode for the indices array, default CEED_COPY_VALUES
-         **lmode: ordering of the ncomp components, i.e. it specifies
+         **imode: ordering of the ncomp components, i.e. it specifies
                     the ordering of the components of the local vector used
-                    by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
-                    the component is the outermost index and CEED_TRANSPOSE
+                    by this CeedElemRestriction. CEED_NONINTERLACED indicates
+                    the component is the outermost index and CEED_INTERLACED
                     indicates the component is the innermost index in
-                    ordering of the local vector, default CEED_NOTRANSPOSE
+                    ordering of the local vector, default CEED_NONINTERLACED
 
        Returns:
          elemrestriction: Ceed Blocked ElemRestiction"""
 
     return BlockedElemRestriction(self, nelem, elemsize, blksize, nnodes,
                                   ncomp, indices, memtype=memtype,
-                                  cmode=cmode, lmode=lmode)
+                                  cmode=cmode, imode=imode)
 
   # CeedBasis
   def BasisTensorH1(self, dim, ncomp, P1d, Q1d, interp1d, grad1d,

--- a/python/ceed.py
+++ b/python/ceed.py
@@ -84,7 +84,8 @@ class Ceed():
 
   # CeedElemRestriction
   def ElemRestriction(self, nelem, elemsize, nnodes, ncomp, indices,
-                      memtype=lib.CEED_MEM_HOST, cmode=lib.CEED_COPY_VALUES):
+                      memtype=lib.CEED_MEM_HOST, cmode=lib.CEED_COPY_VALUES,
+                      lmode=lib.CEED_NOTRANSPOSE):
     """Ceed ElemRestriction: restriction from local vectors to elements.
 
        Args:
@@ -103,14 +104,21 @@ class Ceed():
                       [0, nnodes - 1].
          **memtype: memory type of the indices array, default CEED_MEM_HOST
          **cmode: copy mode for the indices array, default CEED_COPY_VALUES
+         **lmode: ordering of the ncomp components, i.e. it specifies
+                    the ordering of the components of the local vector used
+                    by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
+                    the component is the outermost index and CEED_TRANSPOSE
+                    indicates the component is the innermost index in
+                    ordering of the local vector, default CEED_NOTRANSPOSE
 
        Returns:
          elemrestriction: Ceed ElemRestiction"""
 
     return ElemRestriction(self, nelem, elemsize, nnodes, ncomp, indices,
-                           memtype=memtype, cmode=cmode)
+                           memtype=memtype, cmode=cmode, lmode=lmode)
 
-  def IdentityElemRestriction(self, nelem, elemsize, nnodes, ncomp):
+  def IdentityElemRestriction(self, nelem, elemsize, nnodes, ncomp,
+                              lmode=lib.CEED_NOTRANSPOSE):
     """Ceed Identity ElemRestriction: identity restriction from local vectors to elements.
 
        Args:
@@ -121,16 +129,25 @@ class Ceed():
                    (nnodes * ncomp). This size may include data
                    used by other Ceed ElemRestriction objects describing
                    different types of elements.
-         ncomp: number of field components per interpolation node (1 for scalar fields)
+         ncomp: number of field components per interpolation node
+                  (1 for scalar fields)
+         **lmode: ordering of the ncomp components, i.e. it specifies
+                    the ordering of the components of the local vector used
+                    by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
+                    the component is the outermost index and CEED_TRANSPOSE
+                    indicates the component is the innermost index in
+                    ordering of the local vector, default CEED_NOTRANSPOSE
 
        Returns:
          elemrestriction: Ceed Identity ElemRestiction"""
 
-    return IdentityElemRestriction(self, nelem, elemsize, nnodes, ncomp)
+    return IdentityElemRestriction(self, nelem, elemsize, nnodes, ncomp,
+                                   lmode=lmode)
 
   def BlockedElemRestriction(self, nelem, elemsize, blksize, nnodes, ncomp,
                              indices, memtype=lib.CEED_MEM_HOST,
-                             cmode=lib.CEED_COPY_VALUES):
+                             cmode=lib.CEED_COPY_VALUES,
+                             lmode=lib.CEED_NOTRANSPOSE):
     """Ceed Blocked ElemRestriction: blocked restriction from local vectors to elements.
 
        Args:
@@ -153,13 +170,19 @@ class Ceed():
                       to interlace elements.
          **memtype: memory type of the indices array, default CEED_MEM_HOST
          **cmode: copy mode for the indices array, default CEED_COPY_VALUES
+         **lmode: ordering of the ncomp components, i.e. it specifies
+                    the ordering of the components of the local vector used
+                    by this CeedElemRestriction. CEED_NOTRANSPOSE indicates
+                    the component is the outermost index and CEED_TRANSPOSE
+                    indicates the component is the innermost index in
+                    ordering of the local vector, default CEED_NOTRANSPOSE
 
        Returns:
          elemrestriction: Ceed Blocked ElemRestiction"""
 
     return BlockedElemRestriction(self, nelem, elemsize, blksize, nnodes,
                                   ncomp, indices, memtype=memtype,
-                                  cmode=cmode)
+                                  cmode=cmode, lmode=lmode)
 
   # CeedBasis
   def BasisTensorH1(self, dim, ncomp, P1d, Q1d, interp1d, grad1d,

--- a/python/ceed_constants.py
+++ b/python/ceed_constants.py
@@ -23,16 +23,22 @@ from abc import ABC
 # CeedMemType
 MEM_HOST        = lib.CEED_MEM_HOST
 MEM_DEVICE      = lib.CEED_MEM_DEVICE
-mem_types       = {MEM_HOST:      "host",
-                   MEM_DEVICE:    "device"}
+mem_types       = {MEM_HOST:       "host",
+                   MEM_DEVICE:     "device"}
 
 # CeedCopyMode
 COPY_VALUES     = lib.CEED_COPY_VALUES
 USE_POINTER     = lib.CEED_USE_POINTER
 OWN_POINTER     = lib.CEED_OWN_POINTER
-copy_modes      = {COPY_VALUES:   "copy values",
-                   USE_POINTER:   "use pointer",
-                   OWN_POINTER:   "own pointer"}
+copy_modes      = {COPY_VALUES:    "copy values",
+                   USE_POINTER:    "use pointer",
+                   OWN_POINTER:    "own pointer"}
+
+# CeedLayoutMode
+NONINTERLACED   = lib.CEED_NONINTERLACED
+INTERLACED      = lib.CEED_INTERLACED
+layout_modes    = {NONINTERLACED:  "not interlaced",
+                   INTERLACED:     "interlaced"}
 
 # CeedNormType
 NORM_1          = lib.CEED_NORM_1
@@ -45,8 +51,8 @@ norm_types      = {NORM_1:        "L1 norm",
 # CeedTransposeMode
 TRANSPOSE       = lib.CEED_TRANSPOSE
 NOTRANSPOSE     = lib.CEED_NOTRANSPOSE
-transpose_modes = {TRANSPOSE:     "transpose",
-                   NOTRANSPOSE:   "no transpose"}
+transpose_modes = {TRANSPOSE:      "transpose",
+                   NOTRANSPOSE:    "no transpose"}
 
 # CeedEvalMode
 EVAL_NONE       = lib.CEED_EVAL_NONE
@@ -55,18 +61,18 @@ EVAL_GRAD       = lib.CEED_EVAL_GRAD
 EVAL_DIV        = lib.CEED_EVAL_DIV
 EVAL_CURL       = lib.CEED_EVAL_CURL
 EVAL_WEIGHT     = lib.CEED_EVAL_WEIGHT
-eval_modes      = {EVAL_NONE:     "none",
-                   EVAL_INTERP:   "interpolation",
-                   EVAL_GRAD:     "gradient",
-                   EVAL_DIV:      "divergence",
-                   EVAL_CURL:     "curl",
-                   EVAL_WEIGHT:   "quadrature weights"}
+eval_modes      = {EVAL_NONE:      "none",
+                   EVAL_INTERP:    "interpolation",
+                   EVAL_GRAD:      "gradient",
+                   EVAL_DIV:       "divergence",
+                   EVAL_CURL:      "curl",
+                   EVAL_WEIGHT:    "quadrature weights"}
 
 # CeedQuadMode
 GAUSS           = lib.CEED_GAUSS
 GAUSS_LOBATTO   = lib.CEED_GAUSS_LOBATTO
-quad_modes      = {GAUSS:         "Gauss",
-                   GAUSS_LOBATTO: "Gauss Lobatto"}
+quad_modes      = {GAUSS:          "Gauss",
+                   GAUSS_LOBATTO:  "Gauss Lobatto"}
 
 # CeedElemTopology
 LINE            = lib.CEED_LINE
@@ -76,13 +82,13 @@ TET             = lib.CEED_TET
 PYRAMID         = lib.CEED_PYRAMID
 PRISM           = lib.CEED_PRISM
 HEX             = lib.CEED_HEX
-elem_topologies = {LINE:          "line",
-                   TRIANGLE:      "triangle",
-                   QUAD:          "quadrilateral",
-                   TET:           "tetrahedron",
-                   PYRAMID:       "pyramid",
-                   PRISM:         "prism",
-                   HEX:           "hexahedron"}
+elem_topologies = {LINE:           "line",
+                   TRIANGLE:       "triangle",
+                   QUAD:           "quadrilateral",
+                   TET:            "tetrahedron",
+                   PYRAMID:        "pyramid",
+                   PRISM:          "prism",
+                   HEX:            "hexahedron"}
 
 # ------------------------------------------------------------------------------
 # Ceed Constants

--- a/python/ceed_elemrestriction.py
+++ b/python/ceed_elemrestriction.py
@@ -18,7 +18,7 @@ from _ceed_cffi import ffi, lib
 import tempfile
 import numpy as np
 from abc import ABC
-from .ceed_constants import REQUEST_IMMEDIATE, REQUEST_ORDERED, MEM_HOST, COPY_VALUES, TRANSPOSE, NOTRANSPOSE
+from .ceed_constants import REQUEST_IMMEDIATE, REQUEST_ORDERED, MEM_HOST, COPY_VALUES, TRANSPOSE, NOTRANSPOSE, INTERLACED, NONINTERLACED
 from .ceed_vector import _VectorWrap
 
 # ------------------------------------------------------------------------------
@@ -131,7 +131,7 @@ class ElemRestriction(_ElemRestrictionBase):
 
   # Constructor
   def __init__(self, ceed, nelem, elemsize, nnodes, ncomp, indices,
-               memtype=MEM_HOST, cmode=COPY_VALUES, lmode=NOTRANSPOSE):
+               memtype=MEM_HOST, cmode=COPY_VALUES, imode=NONINTERLACED):
     # CeedVector object
     self._pointer = ffi.new("CeedElemRestriction *")
 
@@ -144,7 +144,7 @@ class ElemRestriction(_ElemRestrictionBase):
                                indices.__array_interface__['data'][0])
 
     # libCEED call
-    lib.CeedElemRestrictionCreate(self._ceed._pointer[0], lmode, nelem,
+    lib.CeedElemRestrictionCreate(self._ceed._pointer[0], imode, nelem,
                                   elemsize, nnodes, ncomp, memtype, cmode,
                                   indices_pointer, self._pointer)
 
@@ -153,7 +153,7 @@ class IdentityElemRestriction(_ElemRestrictionBase):
   """Ceed Identity ElemRestriction: identity restriction from local vectors to elements."""
 
   # Constructor
-  def __init__(self, ceed, nelem, elemsize, nnodes, ncomp, lmode=NOTRANSPOSE):
+  def __init__(self, ceed, nelem, elemsize, nnodes, ncomp, imode=NONINTERLACED):
     # CeedVector object
     self._pointer = ffi.new("CeedElemRestriction *")
 
@@ -161,7 +161,7 @@ class IdentityElemRestriction(_ElemRestrictionBase):
     self._ceed = ceed
 
     # libCEED call
-    lib.CeedElemRestrictionCreateIdentity(self._ceed._pointer[0], lmode, nelem,
+    lib.CeedElemRestrictionCreateIdentity(self._ceed._pointer[0], imode, nelem,
                                           elemsize, nnodes, ncomp,
                                           self._pointer)
 
@@ -171,7 +171,7 @@ class BlockedElemRestriction(_ElemRestrictionBase):
 
   # Constructor
   def __init__(self, ceed, nelem, elemsize, blksize, nnodes, ncomp, indices,
-               memtype=MEM_HOST, cmode=COPY_VALUES, lmode=NOTRANSPOSE):
+               memtype=MEM_HOST, cmode=COPY_VALUES, imode=NONINTERLACED):
     # CeedVector object
     self._pointer = ffi.new("CeedElemRestriction *")
 
@@ -184,7 +184,7 @@ class BlockedElemRestriction(_ElemRestrictionBase):
                                indices.__array_interface__['data'][0])
 
     # libCEED call
-    lib.CeedElemRestrictionCreateBlocked(self._ceed._pointer[0], lmode, nelem,
+    lib.CeedElemRestrictionCreateBlocked(self._ceed._pointer[0], imode, nelem,
                                          elemsize, blksize, nnodes, ncomp,
                                          memtype, cmode, indices_pointer,
                                          self._pointer)

--- a/python/ceed_operator.py
+++ b/python/ceed_operator.py
@@ -101,7 +101,7 @@ class Operator(_OperatorBase):
                            self._pointer)
 
   # Add field to CeedOperator
-  def set_field(self, fieldname, restriction, basis, vector, lmode=NOTRANSPOSE):
+  def set_field(self, fieldname, restriction, basis, vector):
     """Provide a field to an Operator for use by its QFunction.
 
        Args:
@@ -112,18 +112,12 @@ class Operator(_OperatorBase):
                   if collocated with quadrature points
          vector: Vector to be used by Operator or CEED_VECTOR_ACTIVE
                    if field is active or CEED_VECTOR_NONE if using
-                   CEED_EVAL_WEIGHT in the QFunction
-         **lmode: CeedTransposeMode which specifies the ordering of the
-                    components of the l-vector used by this CeedOperatorField,
-                    CEED_NOTRANSPOSE indicates the component is the
-                    outermost index and CEED_TRANSPOSE indicates the component
-                    is the innermost index in ordering of the local vector,
-                    default CEED_NOTRANSPOSE"""
+                   CEED_EVAL_WEIGHT in the QFunction"""
 
     # libCEED call
     fieldnameAscii = ffi.new("char[]", fieldname.encode('ascii'))
     lib.CeedOperatorSetField(self._pointer[0], fieldnameAscii,
-                             restriction._pointer[0], lmode, basis._pointer[0],
+                             restriction._pointer[0], basis._pointer[0],
                              vector._pointer[0])
 
 # ------------------------------------------------------------------------------

--- a/tests/output/t210-elemrestriction-f.out
+++ b/tests/output/t210-elemrestriction-f.out
@@ -1,1 +1,1 @@
-CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each
+CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector layout CEED_NOTRANSPOSE

--- a/tests/output/t210-elemrestriction-f.out
+++ b/tests/output/t210-elemrestriction-f.out
@@ -1,1 +1,1 @@
-CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector layout CEED_NOTRANSPOSE
+CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector components not interlaced

--- a/tests/output/t210-elemrestriction.out
+++ b/tests/output/t210-elemrestriction.out
@@ -1,1 +1,1 @@
-CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each
+CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector layout CEED_NOTRANSPOSE

--- a/tests/output/t210-elemrestriction.out
+++ b/tests/output/t210-elemrestriction.out
@@ -1,1 +1,1 @@
-CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector layout CEED_NOTRANSPOSE
+CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector components not interlaced

--- a/tests/output/t504-operator-f.out
+++ b/tests/output/t504-operator-f.out
@@ -3,16 +3,13 @@ CeedOperator
   2 Input Fields:
     Input Field [0]:
       Name: "_weight"
-      Lmode: "no transpose"
       No vector
     Input Field [1]:
       Name: "dx"
-      Lmode: "no transpose"
       Active vector
   1 Output Field:
     Output Field [0]:
       Name: "_weight"
-      Lmode: "no transpose"
       Collocated basis
       Active vector
 CeedOperator
@@ -20,14 +17,11 @@ CeedOperator
   2 Input Fields:
     Input Field [0]:
       Name: "rho"
-      Lmode: "no transpose"
       Collocated basis
     Input Field [1]:
       Name: "u"
-      Lmode: "transpose"
       Active vector
   1 Output Field:
     Output Field [0]:
       Name: "rho"
-      Lmode: "transpose"
       Active vector

--- a/tests/output/t504-operator.out
+++ b/tests/output/t504-operator.out
@@ -3,16 +3,13 @@ CeedOperator
   2 Input Fields:
     Input Field [0]:
       Name: "_weight"
-      Lmode: "no transpose"
       No vector
     Input Field [1]:
       Name: "dx"
-      Lmode: "no transpose"
       Active vector
   1 Output Field:
     Output Field [0]:
       Name: "_weight"
-      Lmode: "no transpose"
       Collocated basis
       Active vector
 CeedOperator
@@ -20,14 +17,11 @@ CeedOperator
   2 Input Fields:
     Input Field [0]:
       Name: "rho"
-      Lmode: "no transpose"
       Collocated basis
     Input Field [1]:
       Name: "u"
-      Lmode: "transpose"
       Active vector
   1 Output Field:
     Output Field [0]:
       Name: "rho"
-      Lmode: "transpose"
       Active vector

--- a/tests/output/t523-operator-f.out
+++ b/tests/output/t523-operator-f.out
@@ -4,32 +4,26 @@ Composite CeedOperator
     2 Input Fields:
       Input Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         No vector
       Input Field [1]:
         Name: "dx"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         Collocated basis
   SubOperator [1]:
     3 Fields
     2 Input Fields:
       Input Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         No vector
       Input Field [1]:
         Name: "dx"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         Collocated basis
 Composite CeedOperator
   SubOperator [0]:
@@ -37,30 +31,24 @@ Composite CeedOperator
     2 Input Fields:
       Input Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Collocated basis
       Input Field [1]:
         Name: "u"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Active vector
   SubOperator [1]:
     3 Fields
     2 Input Fields:
       Input Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Collocated basis
       Input Field [1]:
         Name: "u"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Active vector

--- a/tests/output/t523-operator.out
+++ b/tests/output/t523-operator.out
@@ -4,32 +4,26 @@ Composite CeedOperator
     2 Input Fields:
       Input Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         No vector
       Input Field [1]:
         Name: "dx"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         Collocated basis
   SubOperator [1]:
     3 Fields
     2 Input Fields:
       Input Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         No vector
       Input Field [1]:
         Name: "dx"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "_weight"
-        Lmode: "no transpose"
         Collocated basis
 Composite CeedOperator
   SubOperator [0]:
@@ -37,30 +31,24 @@ Composite CeedOperator
     2 Input Fields:
       Input Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Collocated basis
       Input Field [1]:
         Name: "u"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Active vector
   SubOperator [1]:
     3 Fields
     2 Input Fields:
       Input Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Collocated basis
       Input Field [1]:
         Name: "u"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Active vector

--- a/tests/python/output/test_210.out
+++ b/tests/python/output/test_210.out
@@ -1,2 +1,2 @@
-CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector layout CEED_NOTRANSPOSE
+CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector components not interlaced
 

--- a/tests/python/output/test_210.out
+++ b/tests/python/output/test_210.out
@@ -1,2 +1,2 @@
-CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each
+CeedElemRestriction from (4, 1) to 3 elements with 2 nodes each and L-vector layout CEED_NOTRANSPOSE
 

--- a/tests/python/output/test_504.out
+++ b/tests/python/output/test_504.out
@@ -3,16 +3,13 @@ CeedOperator
   2 Input Fields:
     Input Field [0]:
       Name: "weights"
-      Lmode: "no transpose"
       No vector
     Input Field [1]:
       Name: "dx"
-      Lmode: "no transpose"
       Active vector
   1 Output Field:
     Output Field [0]:
       Name: "weights"
-      Lmode: "no transpose"
       Collocated basis
       Active vector
 
@@ -21,15 +18,12 @@ CeedOperator
   2 Input Fields:
     Input Field [0]:
       Name: "rho"
-      Lmode: "no transpose"
       Collocated basis
     Input Field [1]:
       Name: "u"
-      Lmode: "no transpose"
       Active vector
   1 Output Field:
     Output Field [0]:
       Name: "rho"
-      Lmode: "no transpose"
       Active vector
 

--- a/tests/python/output/test_523.out
+++ b/tests/python/output/test_523.out
@@ -4,32 +4,26 @@ Composite CeedOperator
     2 Input Fields:
       Input Field [0]:
         Name: "weights"
-        Lmode: "no transpose"
         No vector
       Input Field [1]:
         Name: "dx"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "weights"
-        Lmode: "no transpose"
         Collocated basis
   SubOperator [1]:
     3 Fields
     2 Input Fields:
       Input Field [0]:
         Name: "weights"
-        Lmode: "no transpose"
         No vector
       Input Field [1]:
         Name: "dx"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "weights"
-        Lmode: "no transpose"
         Collocated basis
 
 Composite CeedOperator
@@ -38,31 +32,25 @@ Composite CeedOperator
     2 Input Fields:
       Input Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Collocated basis
       Input Field [1]:
         Name: "u"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Active vector
   SubOperator [1]:
     3 Fields
     2 Input Fields:
       Input Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Collocated basis
       Input Field [1]:
         Name: "u"
-        Lmode: "no transpose"
         Active vector
     1 Output Field:
       Output Field [0]:
         Name: "rho"
-        Lmode: "no transpose"
         Active vector
 

--- a/tests/python/test-5-operator.py
+++ b/tests/python/test-5-operator.py
@@ -247,7 +247,7 @@ def test_502(ceed_resource):
     for j in range(p):
       indu[p*i+j] = i*(p-1) + j
   ru = ceed.ElemRestriction(nelem, p, nu, 2, indu, cmode=libceed.USE_POINTER,
-                            lmode=libceed.TRANSPOSE)
+                            imode=libceed.INTERLACED)
   rui = ceed.IdentityElemRestriction(nelem, q, q*nelem, 1)
 
   # Bases
@@ -342,7 +342,7 @@ def test_503(ceed_resource):
     for j in range(p):
       indu[p*i+j] = i*(p-1) + j
   ru = ceed.ElemRestriction(nelem, p, nu, 1, indu, cmode=libceed.USE_POINTER,
-                            lmode=libceed.TRANSPOSE)
+                            imode=libceed.INTERLACED)
   rui = ceed.IdentityElemRestriction(nelem, q, q*nelem, 1)
 
   # Bases

--- a/tests/python/test-5-operator.py
+++ b/tests/python/test-5-operator.py
@@ -246,7 +246,8 @@ def test_502(ceed_resource):
   for i in range(nelem):
     for j in range(p):
       indu[p*i+j] = i*(p-1) + j
-  ru = ceed.ElemRestriction(nelem, p, nu, 2, indu, cmode=libceed.USE_POINTER)
+  ru = ceed.ElemRestriction(nelem, p, nu, 2, indu, cmode=libceed.USE_POINTER,
+                            lmode=libceed.TRANSPOSE)
   rui = ceed.IdentityElemRestriction(nelem, q, q*nelem, 1)
 
   # Bases
@@ -278,8 +279,8 @@ def test_502(ceed_resource):
 
   op_mass = ceed.Operator(qf_mass)
   op_mass.set_field("rho", rui, libceed.BASIS_COLLOCATED, qdata)
-  op_mass.set_field("u", ru, bu, libceed.VECTOR_ACTIVE, lmode=libceed.TRANSPOSE)
-  op_mass.set_field("v", ru, bu, libceed.VECTOR_ACTIVE, lmode=libceed.TRANSPOSE)
+  op_mass.set_field("u", ru, bu, libceed.VECTOR_ACTIVE)
+  op_mass.set_field("v", ru, bu, libceed.VECTOR_ACTIVE)
 
   # Setup
   op_setup.apply(x, qdata)
@@ -340,7 +341,8 @@ def test_503(ceed_resource):
   for i in range(nelem):
     for j in range(p):
       indu[p*i+j] = i*(p-1) + j
-  ru = ceed.ElemRestriction(nelem, p, nu, 1, indu, cmode=libceed.USE_POINTER)
+  ru = ceed.ElemRestriction(nelem, p, nu, 1, indu, cmode=libceed.USE_POINTER,
+                            lmode=libceed.TRANSPOSE)
   rui = ceed.IdentityElemRestriction(nelem, q, q*nelem, 1)
 
   # Bases
@@ -372,8 +374,8 @@ def test_503(ceed_resource):
 
   op_mass = ceed.Operator(qf_mass)
   op_mass.set_field("rho", rui, libceed.BASIS_COLLOCATED, qdata)
-  op_mass.set_field("u", ru, bu, u, lmode=libceed.TRANSPOSE)
-  op_mass.set_field("v", ru, bu, v, lmode=libceed.TRANSPOSE)
+  op_mass.set_field("u", ru, bu, u)
+  op_mass.set_field("v", ru, bu, v)
 
   # Setup
   op_setup.apply(x, qdata)

--- a/tests/t200-elemrestriction-f.f90
+++ b/tests/t200-elemrestriction-f.f90
@@ -11,6 +11,8 @@
 
       integer ne
       parameter(ne=3)
+      integer lmode
+      parameter(lmode=ceed_notranspose)
 
       integer*4 ind(2*ne)
       real*8 a(ne+1)
@@ -36,12 +38,12 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,ne,2,ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,2*ne,y,err);
       call ceedvectorsetvalue(y,0.d0,err);
-      call ceedelemrestrictionapply(r,ceed_notranspose,ceed_notranspose,x,y,&
+      call ceedelemrestrictionapply(r,ceed_notranspose,x,y,&
      & ceed_request_immediate,err)
 
       call ceedvectorgetarrayread(y,ceed_mem_host,yy,yoffset,err)

--- a/tests/t200-elemrestriction-f.f90
+++ b/tests/t200-elemrestriction-f.f90
@@ -11,8 +11,8 @@
 
       integer ne
       parameter(ne=3)
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
 
       integer*4 ind(2*ne)
       real*8 a(ne+1)
@@ -38,7 +38,7 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,ne,2,ne+1,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,ne,2,ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,2*ne,y,err);

--- a/tests/t200-elemrestriction.c
+++ b/tests/t200-elemrestriction.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[ne+1];
   const CeedScalar *yy;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -23,12 +24,11 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, ne*2, &y);
   CeedVectorSetValue(y, 0); // Allocates array
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
 
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
   for (CeedInt i=0; i<ne*2; i++)

--- a/tests/t200-elemrestriction.c
+++ b/tests/t200-elemrestriction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[ne+1];
   const CeedScalar *yy;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 2, ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, ne*2, &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t201-elemrestriction-f.f90
+++ b/tests/t201-elemrestriction-f.f90
@@ -9,8 +9,8 @@
 
       integer ne
       parameter(ne=3)
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
 
       real*8 a(2*ne)
       real*8 yy(2*ne)
@@ -31,7 +31,7 @@
       aoffset=0
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,aoffset,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,ne,2,2*ne,1,r,err)
+      call ceedelemrestrictioncreateidentity(ceed,imode,ne,2,2*ne,1,r,err)
 
       call ceedvectorcreate(ceed,2*ne,y,err);
       call ceedvectorsetvalue(y,0.d0,err);

--- a/tests/t201-elemrestriction-f.f90
+++ b/tests/t201-elemrestriction-f.f90
@@ -9,6 +9,8 @@
 
       integer ne
       parameter(ne=3)
+      integer lmode
+      parameter(lmode=ceed_notranspose)
 
       real*8 a(2*ne)
       real*8 yy(2*ne)
@@ -29,11 +31,11 @@
       aoffset=0
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,a,aoffset,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,ne,2,2*ne,1,r,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,ne,2,2*ne,1,r,err)
 
       call ceedvectorcreate(ceed,2*ne,y,err);
       call ceedvectorsetvalue(y,0.d0,err);
-      call ceedelemrestrictionapply(r,ceed_notranspose,ceed_notranspose,x,y,&
+      call ceedelemrestrictionapply(r,ceed_notranspose,x,y,&
      & ceed_request_immediate,err)
 
       call ceedvectorgetarrayread(y,ceed_mem_host,yy,yoffset,err)

--- a/tests/t201-elemrestriction.c
+++ b/tests/t201-elemrestriction.c
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
   CeedScalar a[ne*2];
   const CeedScalar *yy;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     a[i] = 10 + i;
   CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, ne, 2, ne*2, 1, &r);
+  CeedElemRestrictionCreateIdentity(ceed, imode, ne, 2, ne*2, 1, &r);
   CeedVectorCreate(ceed, ne*2, &y);
   CeedVectorSetValue(y, 0); // Allocates array
   CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);

--- a/tests/t201-elemrestriction.c
+++ b/tests/t201-elemrestriction.c
@@ -10,6 +10,7 @@ int main(int argc, char **argv) {
   CeedScalar a[ne*2];
   const CeedScalar *yy;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -18,11 +19,10 @@ int main(int argc, char **argv) {
     a[i] = 10 + i;
   CeedVectorSetArray(x, CEED_MEM_HOST, CEED_USE_POINTER, a);
 
-  CeedElemRestrictionCreateIdentity(ceed, ne, 2, ne*2, 1, &r);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, ne, 2, ne*2, 1, &r);
   CeedVectorCreate(ceed, ne*2, &y);
   CeedVectorSetValue(y, 0); // Allocates array
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
 
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);
   for (CeedInt i=0; i<ne*2; i++)

--- a/tests/t202-elemrestriction-f.f90
+++ b/tests/t202-elemrestriction-f.f90
@@ -9,8 +9,8 @@
 
       integer ne
       parameter(ne=8)
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer blksize
       parameter(blksize=5)
 
@@ -37,7 +37,7 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreateblocked(ceed,lmode,ne,2,blksize,ne+1,1,&
+      call ceedelemrestrictioncreateblocked(ceed,imode,ne,2,blksize,ne+1,1,&
      & ceed_mem_host,ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,2*blksize*2,y,err);

--- a/tests/t202-elemrestriction-f.f90
+++ b/tests/t202-elemrestriction-f.f90
@@ -9,6 +9,8 @@
 
       integer ne
       parameter(ne=8)
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer blksize
       parameter(blksize=5)
 
@@ -35,14 +37,14 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreateblocked(ceed,ne,2,blksize,ne+1,1,&
+      call ceedelemrestrictioncreateblocked(ceed,lmode,ne,2,blksize,ne+1,1,&
      & ceed_mem_host,ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,2*blksize*2,y,err);
       call ceedvectorsetvalue(y,0.d0,err);
 
 !    No Transpose
-      call ceedelemrestrictionapply(r,ceed_notranspose,ceed_notranspose,x,y,&
+      call ceedelemrestrictionapply(r,ceed_notranspose,x,y,&
      & ceed_request_immediate,err)
       call ceedvectorview(y,err)
 
@@ -53,7 +55,7 @@
       enddo
       call ceedvectorrestorearray(x,a,aoffset,err)
       
-      call ceedelemrestrictionapply(r,ceed_transpose,ceed_notranspose,y,x,&
+      call ceedelemrestrictionapply(r,ceed_transpose,y,x,&
      & ceed_request_immediate,err)
 
       call ceedvectorview(x,err)

--- a/tests/t202-elemrestriction.c
+++ b/tests/t202-elemrestriction.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
   CeedInt ind[2*ne];
   CeedScalar a[ne+1];
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -23,14 +24,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreateBlocked(ceed, ne, 2, blksize, ne+1, 1, CEED_MEM_HOST,
-                                   CEED_USE_POINTER, ind, &r);
+  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, 2, blksize, ne+1, 1,
+                                   CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2, &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // NoTranspose
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
   CeedVectorView(y, "%12.8f", stdout);
 
   // Transpose
@@ -38,8 +38,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ne+1; i++)
     a[i] = 0;
   CeedVectorRestoreArray(x, (CeedScalar **)&a);
-  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_NOTRANSPOSE, y, x,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, y, x, CEED_REQUEST_IMMEDIATE);
   CeedVectorView(x, "%12.8f", stdout);
 
   CeedVectorDestroy(&x);

--- a/tests/t202-elemrestriction.c
+++ b/tests/t202-elemrestriction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedInt ind[2*ne];
   CeedScalar a[ne+1];
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, 2, blksize, ne+1, 1,
+  CeedElemRestrictionCreateBlocked(ceed, imode, ne, 2, blksize, ne+1, 1,
                                    CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2, &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t203-elemrestriction.c
+++ b/tests/t203-elemrestriction.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
   CeedInt ind[2*ne];
   CeedScalar a[ncomp*(ne+1)];
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, 2, blksize, ne+1, ncomp,
+  CeedElemRestrictionCreateBlocked(ceed, imode, ne, 2, blksize, ne+1, ncomp,
                                    CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2*ncomp, &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t203-elemrestriction.c
+++ b/tests/t203-elemrestriction.c
@@ -12,6 +12,7 @@ int main(int argc, char **argv) {
   CeedInt ind[2*ne];
   CeedScalar a[ncomp*(ne+1)];
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -27,14 +28,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreateBlocked(ceed, ne, 2, blksize, ne+1, ncomp,
+  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, 2, blksize, ne+1, ncomp,
                                    CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2*ncomp, &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // NoTranspose
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
   CeedVectorView(y, "%12.8f", stdout);
 
   // Transpose
@@ -42,8 +42,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<(ne+1)*ncomp; i++)
     a[i] = 0;
   CeedVectorRestoreArray(x, (CeedScalar **)&a);
-  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_NOTRANSPOSE, y, x,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, y, x, CEED_REQUEST_IMMEDIATE);
   CeedVectorView(x, "%12.8f", stdout);
 
   CeedVectorDestroy(&x);

--- a/tests/t204-elemrestriction.c
+++ b/tests/t204-elemrestriction.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne+1)];
   const CeedScalar *yy;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -26,14 +27,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne*2), &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // Restrict
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
 
   // Check
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);

--- a/tests/t204-elemrestriction.c
+++ b/tests/t204-elemrestriction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne+1)];
   const CeedScalar *yy;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne*2), &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t205-elemrestriction.c
+++ b/tests/t205-elemrestriction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne+1)];
   const CeedScalar *yy;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_TRANSPOSE;
+  CeedInterlaceMode imode = CEED_INTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne*2), &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t205-elemrestriction.c
+++ b/tests/t205-elemrestriction.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne+1)];
   const CeedScalar *yy;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_TRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -26,14 +27,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne*2), &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // Restrict
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_TRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
 
   // Check
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);

--- a/tests/t206-elemrestriction.c
+++ b/tests/t206-elemrestriction.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne*2)];
   const CeedScalar *yy;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -27,14 +28,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne+1), &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // Restrict
-  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
 
   // Check
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);

--- a/tests/t206-elemrestriction.c
+++ b/tests/t206-elemrestriction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne*2)];
   const CeedScalar *yy;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne+1), &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t207-elemrestriction.c
+++ b/tests/t207-elemrestriction.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne*2)];
   const CeedScalar *yy;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_TRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -28,14 +29,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne+1), &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // Restrict
-  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_TRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
 
   // Check
   CeedVectorGetArrayRead(y, CEED_MEM_HOST, &yy);

--- a/tests/t207-elemrestriction.c
+++ b/tests/t207-elemrestriction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedScalar a[2*(ne*2)];
   const CeedScalar *yy;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_TRANSPOSE;
+  CeedInterlaceMode imode = CEED_INTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 2, ne+1, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*(ne+1), &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t208-elemrestriction-f.f90
+++ b/tests/t208-elemrestriction-f.f90
@@ -9,8 +9,8 @@
 
       integer ne
       parameter(ne=8)
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer blksize
       parameter(blksize=5)
 
@@ -37,7 +37,7 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreateblocked(ceed,lmode,ne,2,blksize,ne+1,1,&
+      call ceedelemrestrictioncreateblocked(ceed,imode,ne,2,blksize,ne+1,1,&
      & ceed_mem_host,ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,blksize*2,y,err);

--- a/tests/t208-elemrestriction-f.f90
+++ b/tests/t208-elemrestriction-f.f90
@@ -9,6 +9,8 @@
 
       integer ne
       parameter(ne=8)
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer blksize
       parameter(blksize=5)
 
@@ -35,14 +37,14 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreateblocked(ceed,ne,2,blksize,ne+1,1,&
+      call ceedelemrestrictioncreateblocked(ceed,lmode,ne,2,blksize,ne+1,1,&
      & ceed_mem_host,ceed_use_pointer,ind,r,err)
 
       call ceedvectorcreate(ceed,blksize*2,y,err);
       call ceedvectorsetvalue(y,0.d0,err);
 
 !    No Transpose
-      call ceedelemrestrictionapplyblock(r,1,ceed_notranspose,ceed_notranspose,&
+      call ceedelemrestrictionapplyblock(r,1,ceed_notranspose,&
      & x,y,ceed_request_immediate,err)
       call ceedvectorview(y,err)
 
@@ -53,7 +55,7 @@
       enddo
       call ceedvectorrestorearray(x,a,aoffset,err)
       
-      call ceedelemrestrictionapplyblock(r,1,ceed_transpose,ceed_notranspose,&
+      call ceedelemrestrictionapplyblock(r,1,ceed_transpose,&
      & y,x,ceed_request_immediate,err)
 
       call ceedvectorview(x,err)

--- a/tests/t208-elemrestriction.c
+++ b/tests/t208-elemrestriction.c
@@ -13,6 +13,7 @@ int main(int argc, char **argv) {
   CeedScalar a[ne+1];
   CeedElemRestriction r;
   CeedScalar *y_array;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -26,14 +27,14 @@ int main(int argc, char **argv) {
       ind[elemsize*i+k] = i+k;
     }
   }
-  CeedElemRestrictionCreateBlocked(ceed, ne, elemsize, blksize, ne+1, 1, CEED_MEM_HOST,
-                                   CEED_USE_POINTER, ind, &r);
+  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, elemsize, blksize, ne+1, 1,
+                                   CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
 
   CeedVectorCreate(ceed, blksize*elemsize, &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // NoTranspose
-  CeedElemRestrictionApplyBlock(r, 1, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
+  CeedElemRestrictionApplyBlock(r, 1, CEED_NOTRANSPOSE, x, y,
                                 CEED_REQUEST_IMMEDIATE);
 
   // Zero padded entries
@@ -49,7 +50,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<ne+1; i++)
     a[i] = 0;
   CeedVectorRestoreArray(x, (CeedScalar **)&a);
-  CeedElemRestrictionApplyBlock(r, 1, CEED_TRANSPOSE, CEED_NOTRANSPOSE, y, x,
+  CeedElemRestrictionApplyBlock(r, 1, CEED_TRANSPOSE, y, x,
                                 CEED_REQUEST_IMMEDIATE);
   CeedVectorView(x, "%12.8f", stdout);
 

--- a/tests/t208-elemrestriction.c
+++ b/tests/t208-elemrestriction.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
   CeedScalar a[ne+1];
   CeedElemRestriction r;
   CeedScalar *y_array;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -27,7 +27,8 @@ int main(int argc, char **argv) {
       ind[elemsize*i+k] = i+k;
     }
   }
-  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, elemsize, blksize, ne+1, 1,
+
+  CeedElemRestrictionCreateBlocked(ceed, imode, ne, elemsize, blksize, ne+1, 1,
                                    CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
 
   CeedVectorCreate(ceed, blksize*elemsize, &y);

--- a/tests/t209-elemrestriction-f.f90
+++ b/tests/t209-elemrestriction-f.f90
@@ -11,8 +11,8 @@
 
       integer ne
       parameter(ne=3)
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
 
       integer*4 ind(4*ne)
       real*8 mm(3*ne+1)
@@ -33,7 +33,7 @@
         ind(4*i-1)=3*i-1
         ind(4*i-0)=3*i-0
       enddo
-      call ceedelemrestrictioncreate(ceed,lmode,ne,4,3*ne+1,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,ne,4,3*ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
       call ceedelemrestrictiongetmultiplicity(r,mult,err)

--- a/tests/t209-elemrestriction-f.f90
+++ b/tests/t209-elemrestriction-f.f90
@@ -11,6 +11,8 @@
 
       integer ne
       parameter(ne=3)
+      integer lmode
+      parameter(lmode=ceed_notranspose)
 
       integer*4 ind(4*ne)
       real*8 mm(3*ne+1)
@@ -31,10 +33,10 @@
         ind(4*i-1)=3*i-1
         ind(4*i-0)=3*i-0
       enddo
-      call ceedelemrestrictioncreate(ceed,ne,4,3*ne+1,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,ne,4,3*ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
-      call ceedelemrestrictiongetmultiplicity(r,ceed_notranspose,mult,err)
+      call ceedelemrestrictiongetmultiplicity(r,mult,err)
 
       call ceedvectorgetarrayread(mult,ceed_mem_host,mm,moffset,err)
       do i=1,3*ne+1

--- a/tests/t209-elemrestriction.c
+++ b/tests/t209-elemrestriction.c
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
   CeedInt ind[4*ne];
   const CeedScalar *mm;
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     ind[4*i+2] = i*3+2;
     ind[4*i+3] = i*3+3;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 4, 3*ne+1, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 4, 3*ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
 
   CeedElemRestrictionGetMultiplicity(r, mult);

--- a/tests/t209-elemrestriction.c
+++ b/tests/t209-elemrestriction.c
@@ -10,6 +10,7 @@ int main(int argc, char **argv) {
   CeedInt ind[4*ne];
   const CeedScalar *mm;
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -22,10 +23,10 @@ int main(int argc, char **argv) {
     ind[4*i+2] = i*3+2;
     ind[4*i+3] = i*3+3;
   }
-  CeedElemRestrictionCreate(ceed, ne, 4, 3*ne+1, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 4, 3*ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
 
-  CeedElemRestrictionGetMultiplicity(r, CEED_NOTRANSPOSE, mult);
+  CeedElemRestrictionGetMultiplicity(r, mult);
 
   CeedVectorGetArrayRead(mult, CEED_MEM_HOST, &mm);
   for (CeedInt i=0; i<3*ne+1; i++)

--- a/tests/t210-elemrestriction-f.f90
+++ b/tests/t210-elemrestriction-f.f90
@@ -9,8 +9,8 @@
 
       integer ne
       parameter(ne=3)
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
 
       integer*4 ind(2*ne)
 
@@ -24,7 +24,7 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,ne,2,ne+1,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,ne,2,ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
       call ceedelemrestrictionview(r,err)

--- a/tests/t210-elemrestriction-f.f90
+++ b/tests/t210-elemrestriction-f.f90
@@ -9,6 +9,8 @@
 
       integer ne
       parameter(ne=3)
+      integer lmode
+      parameter(lmode=ceed_notranspose)
 
       integer*4 ind(2*ne)
 
@@ -22,7 +24,7 @@
         ind(2*i  )=i
       enddo
 
-      call ceedelemrestrictioncreate(ceed,ne,2,ne+1,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,ne,2,ne+1,1,ceed_mem_host,&
      & ceed_use_pointer,ind,r,err)
 
       call ceedelemrestrictionview(r,err)

--- a/tests/t210-elemrestriction.c
+++ b/tests/t210-elemrestriction.c
@@ -10,6 +10,7 @@ int main(int argc, char **argv) {
   CeedInt ind[2*ne];
 
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -17,7 +18,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, ne, 2, ne+1, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
 
   CeedElemRestrictionView(r, stdout);

--- a/tests/t210-elemrestriction.c
+++ b/tests/t210-elemrestriction.c
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
   CeedInt ind[2*ne];
 
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, ne, 2, ne+1, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, ne, 2, ne+1, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, ind, &r);
 
   CeedElemRestrictionView(r, stdout);

--- a/tests/t211-elemrestriction.c
+++ b/tests/t211-elemrestriction.c
@@ -13,6 +13,7 @@ int main(int argc, char **argv) {
   CeedInt *ind = malloc(sizeof(CeedInt)*2*ne);
   CeedScalar a[ncomp*(ne+1)];
   CeedElemRestriction r;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
 
   CeedInit(argv[1], &ceed);
 
@@ -28,14 +29,13 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreateBlocked(ceed, ne, 2, blksize, ne+1, ncomp,
+  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, 2, blksize, ne+1, ncomp,
                                    CEED_MEM_HOST, CEED_OWN_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2*ncomp, &y);
   CeedVectorSetValue(y, 0); // Allocates array
 
   // NoTranspose
-  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, x, y,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_NOTRANSPOSE, x, y, CEED_REQUEST_IMMEDIATE);
   CeedVectorView(y, "%12.8f", stdout);
 
   // Transpose
@@ -43,8 +43,7 @@ int main(int argc, char **argv) {
   for (CeedInt i=0; i<(ne+1)*ncomp; i++)
     a[i] = 0;
   CeedVectorRestoreArray(x, (CeedScalar **)&a);
-  CeedElemRestrictionApply(r, CEED_TRANSPOSE, CEED_NOTRANSPOSE, y, x,
-                           CEED_REQUEST_IMMEDIATE);
+  CeedElemRestrictionApply(r, CEED_TRANSPOSE, y, x, CEED_REQUEST_IMMEDIATE);
   CeedVectorView(x, "%12.8f", stdout);
 
   CeedVectorDestroy(&x);

--- a/tests/t211-elemrestriction.c
+++ b/tests/t211-elemrestriction.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
   CeedInt *ind = malloc(sizeof(CeedInt)*2*ne);
   CeedScalar a[ncomp*(ne+1)];
   CeedElemRestriction r;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
 
   CeedInit(argv[1], &ceed);
 
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     ind[2*i+0] = i;
     ind[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreateBlocked(ceed, lmode, ne, 2, blksize, ne+1, ncomp,
+  CeedElemRestrictionCreateBlocked(ceed, imode, ne, 2, blksize, ne+1, ncomp,
                                    CEED_MEM_HOST, CEED_OWN_POINTER, ind, &r);
   CeedVectorCreate(ceed, 2*blksize*2*ncomp, &y);
   CeedVectorSetValue(y, 0); // Allocates array

--- a/tests/t500-operator-f.f90
+++ b/tests/t500-operator-f.f90
@@ -34,6 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -68,9 +70,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -79,9 +81,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
@@ -111,18 +113,18 @@
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
 

--- a/tests/t500-operator-f.f90
+++ b/tests/t500-operator-f.f90
@@ -34,8 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -70,9 +70,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -81,9 +81,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)

--- a/tests/t500-operator.c
+++ b/tests/t500-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -30,9 +31,10 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
 //! [ElemRestr Create]
-  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+                                    &Erestrictxi);
 //! [ElemRestr Create]
 
   for (CeedInt i=0; i<nelem; i++) {
@@ -41,9 +43,10 @@ int main(int argc, char **argv) {
     }
   }
 //! [ElemRestrU Create]
-  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+                                    &Erestrictui);
 //! [ElemRestrU Create]
 
 //! [Basis Create]
@@ -78,21 +81,17 @@ int main(int argc, char **argv) {
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
 //! [Setup Set]
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 //! [Setup Set]
 
 //! [Operator Set]
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui,CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 //! [Operator Set]
 
 //! [Setup Apply]

--- a/tests/t500-operator.c
+++ b/tests/t500-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -31,9 +31,9 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
 //! [ElemRestr Create]
-  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2, nelem*2, 1,
                                     &Erestrictxi);
 //! [ElemRestr Create]
 
@@ -43,9 +43,9 @@ int main(int argc, char **argv) {
     }
   }
 //! [ElemRestrU Create]
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Q*nelem, 1,
                                     &Erestrictui);
 //! [ElemRestrU Create]
 

--- a/tests/t501-operator-f.f90
+++ b/tests/t501-operator-f.f90
@@ -34,6 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -69,9 +71,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -80,9 +82,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
@@ -112,18 +114,18 @@
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
 

--- a/tests/t501-operator-f.f90
+++ b/tests/t501-operator-f.f90
@@ -34,8 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -71,9 +71,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -82,9 +82,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)

--- a/tests/t501-operator.c
+++ b/tests/t501-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -31,9 +31,9 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2, nelem*2, 1,
                                     &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Q*nelem, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t501-operator.c
+++ b/tests/t501-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -30,18 +31,20 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+                                    &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
     for (CeedInt j=0; j<P; j++) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+                                    &Erestrictui);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
@@ -69,19 +72,15 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t502-operator-f.f90
+++ b/tests/t502-operator-f.f90
@@ -35,10 +35,10 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer lmode
-      parameter(lmode=ceed_notranspose)
-      integer lmodeu
-      parameter(lmodeu=ceed_transpose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
+      integer imodeu
+      parameter(imodeu=ceed_interlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -74,9 +74,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -85,9 +85,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmodeu,nelem,p,nu,2,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imodeu,nelem,p,nu,2,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)

--- a/tests/t502-operator-f.f90
+++ b/tests/t502-operator-f.f90
@@ -35,6 +35,10 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
+      integer lmode
+      parameter(lmode=ceed_notranspose)
+      integer lmodeu
+      parameter(lmodeu=ceed_transpose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -70,9 +74,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -81,9 +85,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,2,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmodeu,nelem,p,nu,2,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
@@ -113,18 +117,18 @@
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_transpose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_transpose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
 

--- a/tests/t502-operator.c
+++ b/tests/t502-operator.c
@@ -9,7 +9,8 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE, lmodeu = CEED_TRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED,
+                    imodeu = CEED_INTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -32,9 +33,9 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2, nelem*2, 1,
                                     &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
@@ -42,9 +43,9 @@ int main(int argc, char **argv) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, lmodeu, nelem, P, Nu, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imodeu, nelem, P, Nu, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Q*nelem, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t502-operator.c
+++ b/tests/t502-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE, lmodeu = CEED_TRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -31,18 +32,20 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+                                    &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
     for (CeedInt j=0; j<P; j++) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmodeu, nelem, P, Nu, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+                                    &Erestrictui);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
@@ -70,19 +73,15 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_TRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_TRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t503-operator-f.f90
+++ b/tests/t503-operator-f.f90
@@ -34,6 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -79,9 +81,9 @@
         indx(2*i+1)=i
         indx(2*i+2)=i+1
       enddo
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -90,9 +92,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
@@ -117,18 +119,15 @@
       call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_mass,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,x,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,bx,x,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
+     & ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,u,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,v,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,u,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,v,err)
 
       call ceedoperatorapply(op_setup,ceed_vector_none,ceed_vector_none,&
      & ceed_request_immediate,err)

--- a/tests/t503-operator-f.f90
+++ b/tests/t503-operator-f.f90
@@ -34,8 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -81,9 +81,9 @@
         indx(2*i+1)=i
         indx(2*i+2)=i+1
       enddo
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -92,9 +92,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)

--- a/tests/t503-operator.c
+++ b/tests/t503-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -42,9 +42,9 @@ int main(int argc, char **argv) {
     indx[2*i+0] = i;
     indx[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2, nelem*2, 1,
                                     &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
@@ -52,9 +52,9 @@ int main(int argc, char **argv) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Q*nelem, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t503-operator.c
+++ b/tests/t503-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -41,18 +42,20 @@ int main(int argc, char **argv) {
     indx[2*i+0] = i;
     indx[2*i+1] = i+1;
   }
-  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+                                    &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
     for (CeedInt j=0; j<P; j++) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+                                    &Erestrictui);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
@@ -76,16 +79,15 @@ int main(int argc, char **argv) {
   CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_mass);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx, X);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, X);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE, bu, U);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE, bu, V);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, U);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, V);
 
   // Note - It is atypical to use only passive fields; this test is intended
   //   as a test for all passive input modes rather than as an example.

--- a/tests/t504-operator-f.f90
+++ b/tests/t504-operator-f.f90
@@ -38,8 +38,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -69,9 +69,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -80,9 +80,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)

--- a/tests/t504-operator-f.f90
+++ b/tests/t504-operator-f.f90
@@ -38,6 +38,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -67,9 +69,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -78,9 +80,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
@@ -108,18 +110,18 @@
       call ceedvectorcreate(ceed,nx,x,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_transpose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_transpose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorview(op_setup,err)
       call ceedoperatorview(op_mass,err)

--- a/tests/t504-operator.c
+++ b/tests/t504-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -26,9 +26,9 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2, nelem*2, 1,
                                     &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
@@ -36,9 +36,9 @@ int main(int argc, char **argv) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Nu, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Q*nelem, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t504-operator.c
+++ b/tests/t504-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -25,18 +26,20 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+                                    &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
     for (CeedInt j=0; j<P; j++) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 2, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 2, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+                                    &Erestrictui);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
@@ -62,19 +65,15 @@ int main(int argc, char **argv) {
 
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_TRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_TRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorView(op_setup, stdout);
   CeedOperatorView(op_mass, stdout);

--- a/tests/t505-operator-f.f90
+++ b/tests/t505-operator-f.f90
@@ -34,6 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -69,9 +71,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -80,9 +82,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)
@@ -112,18 +114,18 @@
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
       call ceedvectorcreate(ceed,nelem*q,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'dx',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
 

--- a/tests/t505-operator-f.f90
+++ b/tests/t505-operator-f.f90
@@ -34,8 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -71,9 +71,9 @@
         indx(2*i+2)=i+1
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,2,nx,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,2,nx,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2,2*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2,2*nelem,1,&
      & erestrictxi,err)
 
       do i=0,nelem-1
@@ -82,9 +82,9 @@
         enddo
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,nu,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,nu,1,ceed_mem_host,&
      & ceed_use_pointer,indu,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,q*nelem,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,q*nelem,1,&
      & erestrictui,err)
 
       call ceedbasiscreatetensorh1lagrange(ceed,1,1,2,q,ceed_gauss,bx,err)

--- a/tests/t505-operator.c
+++ b/tests/t505-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -31,9 +31,9 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2, nelem*2, 1,
                                     &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Q*nelem, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t505-operator.c
+++ b/tests/t505-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -30,18 +31,20 @@ int main(int argc, char **argv) {
     indx[2*i+1] = i+1;
   }
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, 2, Nx, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, 2, Nx, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, 2, nelem*2, 1, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2, nelem*2, 1,
+                                    &Erestrictxi);
 
   for (CeedInt i=0; i<nelem; i++) {
     for (CeedInt j=0; j<P; j++) {
       indu[P*i+j] = i*(P-1) + j;
     }
   }
-  CeedElemRestrictionCreate(ceed, nelem, P, Nu, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Nu, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indu, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Q*nelem, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Q*nelem, 1,
+                                    &Erestrictui);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 2, Q, CEED_GAUSS, &bx);
@@ -69,19 +72,15 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, nelem*Q, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t510-operator-f.f90
+++ b/tests/t510-operator-f.f90
@@ -39,6 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -100,14 +102,14 @@
         indx(i*2*p+12)=16+offset
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,ndofs,d,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,d,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p,nelem*p,d,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p,nelem*p,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,ndofs,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,1,&
      & erestrictui,err)
 
       call buildmats(qref,qweight,interp,grad)
@@ -141,18 +143,18 @@
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
       call ceedvectorcreate(ceed,nqpts,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'x',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
 

--- a/tests/t510-operator-f.f90
+++ b/tests/t510-operator-f.f90
@@ -39,8 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -102,14 +102,14 @@
         indx(i*2*p+12)=16+offset
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,d,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,ndofs,d,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p,nelem*p,d,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p,nelem*p,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,ndofs,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,nqpts,1,&
      & erestrictui,err)
 
       call buildmats(qref,qweight,interp,grad)

--- a/tests/t510-operator.c
+++ b/tests/t510-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -51,13 +52,15 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P, Ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P, nelem*P, dim, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P, nelem*P, dim,
+                                    &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P, Ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, Nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Nqpts, 1,
+                                    &Erestrictui);
 
 
   // Bases
@@ -91,19 +94,15 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, Nqpts, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t510-operator.c
+++ b/tests/t510-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -52,14 +52,14 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P, nelem*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P, nelem*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, Ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, Ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, Nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, Nqpts, 1,
                                     &Erestrictui);
 
 

--- a/tests/t511-operator-f.f90
+++ b/tests/t511-operator-f.f90
@@ -39,6 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -101,14 +103,14 @@
         indx(i*2*p+12)=16+offset
       enddo
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,ndofs,d,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,d,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p,nelem*p,d,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p,nelem*p,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,ndofs,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,1,&
      & erestrictui,err)
 
       call buildmats(qref,qweight,interp,grad)
@@ -142,18 +144,18 @@
       call ceedvectorsetarray(x,ceed_mem_host,ceed_use_pointer,arrx,xoffset,err)
       call ceedvectorcreate(ceed,nqpts,qdata,err)
 
-      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
-      call ceedoperatorsetfield(op_setup,'x',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+      call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,bx,&
+     & ceed_vector_none,err)
+      call ceedoperatorsetfield(op_setup,'x',erestrictx,bx,&
+     & ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
-      call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
-      call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & ceed_basis_collocated,qdata,err)
+      call ceedoperatorsetfield(op_mass,'u',erestrictu,bu,&
+     & ceed_vector_active,err)
+      call ceedoperatorsetfield(op_mass,'v',erestrictu,bu,&
+     & ceed_vector_active,err)
 
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
 

--- a/tests/t511-operator-f.f90
+++ b/tests/t511-operator-f.f90
@@ -39,8 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -103,14 +103,14 @@
         indx(i*2*p+12)=16+offset
       enddo
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,d,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,ndofs,d,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p,nelem*p,d,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p,nelem*p,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,ndofs,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,nqpts,1,&
      & erestrictui,err)
 
       call buildmats(qref,qweight,interp,grad)

--- a/tests/t511-operator.c
+++ b/tests/t511-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -53,14 +53,14 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P, nelem*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P, nelem*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, nqpts, 1,
                                     &Erestrictui);
 
 

--- a/tests/t511-operator.c
+++ b/tests/t511-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu, Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
   CeedQFunction qf_setup, qf_mass;
@@ -52,13 +53,15 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P, nelem*P, dim, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P, nelem*P, dim,
+                                    &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, nqpts, 1,
+                                    &Erestrictui);
 
 
   // Bases
@@ -92,19 +95,15 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
   CeedVectorCreate(ceed, nqpts, &qdata);
 
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "x", Erestrictx, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "x", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
 
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE,
-                       bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -39,8 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -123,14 +123,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,ptet,&
      & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,qtet,nqptstet,&
      & 1,erestrictuitet,err)
 
 ! -- Bases
@@ -189,14 +189,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,qhex*qhex,&
      & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -39,6 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -121,15 +123,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,d,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,ptet,nelemtet*ptet,&
-     & d,erestrictxitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+     & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,1,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,qtet,nqptstet,1,&
-     & erestrictuitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+     & 1,erestrictuitet,err)
 
 ! -- Bases
       call buildmats(qref,qweight,interp,grad)
@@ -159,20 +161,20 @@
       call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
-     & ceed_notranspose,bxtet,ceed_vector_none,err)
+     & bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
-     & ceed_notranspose,bxtet,ceed_vector_active,err)
+     & bxtet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
 ! ---- Mass Tet
       call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masstet,err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masstet,'v',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
 
 ! Hex Elements
       do i=0,nelemhex-1
@@ -187,15 +189,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,qhex*qhex,nqptshex,&
-     & 1,erestrictuihex,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+     & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases
       call ceedbasiscreatetensorh1lagrange(ceed,d,d,phex,qhex,ceed_gauss,&
@@ -223,20 +225,20 @@
       call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
-     & ceed_notranspose,bxhex,ceed_vector_none,err)
+     & bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
-     & ceed_notranspose,bxhex,ceed_vector_active,err)
+     & bxhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
 ! ---- Mass Hex
       call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masshex,err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masshex,'v',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
 
 ! Composite Operators
       call ceedcompositeoperatorcreate(ceed,op_setup,err)

--- a/tests/t520-operator.c
+++ b/tests/t520-operator.c
@@ -18,7 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -83,16 +83,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, PTet, nelemTet*PTet,
                                     dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -146,16 +146,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, QHex*QHex, nqptsHex,
                                     1, &ErestrictuiHex);
 
   // -- Bases

--- a/tests/t520-operator.c
+++ b/tests/t520-operator.c
@@ -18,6 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -82,14 +83,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, dim, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, PTet, nelemTet*PTet, dim,
-                                    &ErestrictxiTet);
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictxTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+                                    dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, 1, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictuTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -116,21 +119,21 @@ int main(int argc, char **argv) {
   // ---- Setup Tet
   CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupTet);
-  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, bxTet,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, bxTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- Mass Tet
   CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massTet);
-  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataTet);
-  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_BASIS_COLLOCATED,
+                       qdataTet);
+  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
 
   // Set up Hex Elements
   for (CeedInt i=0; i<nelemHex; i++) {
@@ -143,17 +146,17 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, QHex*QHex, nqptsHex, 1,
-                                    &ErestrictuiHex);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+                                    1, &ErestrictuiHex);
 
   // -- Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, PHex, QHex, CEED_GAUSS,
@@ -174,21 +177,21 @@ int main(int argc, char **argv) {
   // -- Operators
   CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupHex);
-  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, bxHex,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, bxHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
   CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massHex);
-  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataHex);
-  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_BASIS_COLLOCATED,
+                       qdataHex);
+  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
 
   // Set up Composite Operators
   // -- Create

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -39,6 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -122,15 +124,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,d,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,ptet,nelemtet*ptet,&
-     & d,erestrictxitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+     & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,1,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,qtet,nqptstet,1,&
-     & erestrictuitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+     & 1,erestrictuitet,err)
 
 ! -- Bases
       call buildmats(qref,qweight,interp,grad)
@@ -160,20 +162,20 @@
       call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
-     & ceed_notranspose,bxtet,ceed_vector_none,err)
+     & bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
-     & ceed_notranspose,bxtet,ceed_vector_active,err)
+     & bxtet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
 ! ---- Mass Tet
       call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masstet,err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masstet,'v',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
 
 ! Hex Elements
       do i=0,nelemhex-1
@@ -188,15 +190,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,qhex*qhex,nqptshex,&
-     & 1,erestrictuihex,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+     & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases
       call ceedbasiscreatetensorh1lagrange(ceed,d,d,phex,qhex,ceed_gauss,&
@@ -224,20 +226,20 @@
       call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
-     & ceed_notranspose,bxhex,ceed_vector_none,err)
+     & bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
-     & ceed_notranspose,bxhex,ceed_vector_active,err)
+     & bxhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
 ! ---- Mass Hex
       call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masshex,err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masshex,'v',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
 
 ! Composite Operators
       call ceedcompositeoperatorcreate(ceed,op_setup,err)

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -39,8 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -124,14 +124,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,ptet,&
      & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,qtet,nqptstet,&
      & 1,erestrictuitet,err)
 
 ! -- Bases
@@ -190,14 +190,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,qhex*qhex,&
      & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases

--- a/tests/t521-operator.c
+++ b/tests/t521-operator.c
@@ -18,7 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -84,16 +84,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, PTet, nelemTet*PTet,
                                     dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -147,16 +147,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, QHex*QHex, nqptsHex,
                                     1, &ErestrictuiHex);
 
   // -- Bases

--- a/tests/t521-operator.c
+++ b/tests/t521-operator.c
@@ -18,6 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -83,14 +84,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, dim, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, PTet, nelemTet*PTet, dim,
-                                    &ErestrictxiTet);
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictxTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+                                    dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, 1, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictuTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -117,21 +120,21 @@ int main(int argc, char **argv) {
   // ---- Setup Tet
   CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupTet);
-  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, bxTet,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, bxTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- Mass Tet
   CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massTet);
-  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataTet);
-  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_BASIS_COLLOCATED,
+                       qdataTet);
+  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
 
   // Hex Elements
   for (CeedInt i=0; i<nelemHex; i++) {
@@ -144,17 +147,17 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, QHex*QHex, nqptsHex, 1,
-                                    &ErestrictuiHex);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+                                    1, &ErestrictuiHex);
 
   // -- Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, PHex, QHex, CEED_GAUSS,
@@ -175,21 +178,21 @@ int main(int argc, char **argv) {
   // -- Operators
   CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupHex);
-  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, bxHex,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, bxHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
   CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massHex);
-  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataHex);
-  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_BASIS_COLLOCATED,
+                       qdataHex);
+  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
 
   // Composite Operators
   CeedCompositeOperatorCreate(ceed, &op_setup);

--- a/tests/t522-operator-f.f90
+++ b/tests/t522-operator-f.f90
@@ -44,8 +44,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictqditet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictqdihex
       integer bxtet,butet,bxhex,buhex
@@ -129,14 +129,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,ptet,&
      & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,qtet,nqptstet,&
      & d*(d+1)/2,erestrictqditet,err)
 
 ! -- Bases
@@ -196,14 +196,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,qhex*qhex,&
      & nqptshex,d*(d+1)/2,erestrictqdihex,err)
 
 ! -- Bases

--- a/tests/t522-operator-f.f90
+++ b/tests/t522-operator-f.f90
@@ -44,6 +44,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictqditet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictqdihex
       integer bxtet,butet,bxhex,buhex
@@ -127,14 +129,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,d,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,ptet,nelemtet*ptet,&
-     & d,erestrictxitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+     & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,1,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,qtet,nqptstet,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
      & d*(d+1)/2,erestrictqditet,err)
 
 ! -- Bases
@@ -166,20 +168,20 @@
       call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
-     & ceed_notranspose,bxtet,ceed_vector_none,err)
+     & bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
-     & ceed_notranspose,bxtet,ceed_vector_active,err)
+     & bxtet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictqditet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
 ! ---- diff Tet
       call ceedoperatorcreate(ceed,qf_difftet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_difftet,err)
       call ceedoperatorsetfield(op_difftet,'rho',erestrictqditet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_difftet,'u',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_difftet,'v',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
 
 ! Hex Elements
       do i=0,nelemhex-1
@@ -194,15 +196,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,qhex*qhex,nqptshex,&
-     & d*(d+1)/2,erestrictqdihex,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+     & nqptshex,d*(d+1)/2,erestrictqdihex,err)
 
 ! -- Bases
       call ceedbasiscreatetensorh1lagrange(ceed,d,d,phex,qhex,ceed_gauss,&
@@ -231,20 +233,20 @@
       call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
-     & ceed_notranspose,bxhex,ceed_vector_none,err)
+     & bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
-     & ceed_notranspose,bxhex,ceed_vector_active,err)
+     & bxhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictqdihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
 ! ---- diff Hex
       call ceedoperatorcreate(ceed,qf_diffhex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_diffhex,err)
       call ceedoperatorsetfield(op_diffhex,'rho',erestrictqdihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_diffhex,'u',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diffhex,'v',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
 
 ! Composite Operators
       call ceedcompositeoperatorcreate(ceed,op_setup,err)

--- a/tests/t522-operator.c
+++ b/tests/t522-operator.c
@@ -18,6 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictqdiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -82,14 +83,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, dim, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, PTet, nelemTet*PTet, dim,
-                                    &ErestrictxiTet);
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictxTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+                                    dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, 1, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, QTet, nqptsTet,
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictuTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet,
                                     dim*(dim+1)/2, &ErestrictqdiTet);
 
   // -- Bases
@@ -116,21 +119,21 @@ int main(int argc, char **argv) {
   // ---- Setup Tet
   CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupTet);
-  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupTet, "rho", ErestrictqdiTet, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, bxTet,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, bxTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupTet, "rho", ErestrictqdiTet,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- diff Tet
   CeedOperatorCreate(ceed, qf_diffTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_diffTet);
-  CeedOperatorSetField(op_diffTet, "rho", ErestrictqdiTet, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_diffTet, "rho", ErestrictqdiTet,
                        CEED_BASIS_COLLOCATED, qdataTet);
-  CeedOperatorSetField(op_diffTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diffTet, "v", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diffTet, "u", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diffTet, "v", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
 
   // Hex Elements
   for (CeedInt i=0; i<nelemHex; i++) {
@@ -143,16 +146,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, QHex*QHex,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex,
                                     nqptsHex, dim*(dim+1)/2,
                                     &ErestrictqdiHex);
 
@@ -175,21 +178,21 @@ int main(int argc, char **argv) {
   // -- Operators
   CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupHex);
-  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupHex, "rho", ErestrictqdiHex, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, bxHex,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, bxHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupHex, "rho", ErestrictqdiHex,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
   CeedOperatorCreate(ceed, qf_diffHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_diffHex);
-  CeedOperatorSetField(op_diffHex, "rho", ErestrictqdiHex, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_diffHex, "rho", ErestrictqdiHex,
                        CEED_BASIS_COLLOCATED, qdataHex);
-  CeedOperatorSetField(op_diffHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diffHex, "v", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diffHex, "u", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diffHex, "v", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
 
   // Composite Operators
   CeedCompositeOperatorCreate(ceed, &op_setup);

--- a/tests/t522-operator.c
+++ b/tests/t522-operator.c
@@ -18,7 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictqdiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -83,16 +83,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, PTet, nelemTet*PTet,
                                     dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, QTet, nqptsTet,
                                     dim*(dim+1)/2, &ErestrictqdiTet);
 
   // -- Bases
@@ -146,16 +146,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, QHex*QHex,
                                     nqptsHex, dim*(dim+1)/2,
                                     &ErestrictqdiHex);
 

--- a/tests/t523-operator-f.f90
+++ b/tests/t523-operator-f.f90
@@ -43,8 +43,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -116,14 +116,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,ptet,&
      & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,qtet,nqptstet,&
      & 1,erestrictuitet,err)
 
 ! -- Bases
@@ -182,14 +182,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,qhex*qhex,&
      & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases

--- a/tests/t523-operator-f.f90
+++ b/tests/t523-operator-f.f90
@@ -43,6 +43,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -114,15 +116,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,d,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,ptet,nelemtet*ptet,&
-     & d,erestrictxitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+     & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,1,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,qtet,nqptstet,1,&
-     & erestrictuitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+     & 1,erestrictuitet,err)
 
 ! -- Bases
       call buildmats(qref,qweight,interp,grad)
@@ -152,20 +154,20 @@
       call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
-     & ceed_notranspose,bxtet,ceed_vector_none,err)
+     & bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
-     & ceed_notranspose,bxtet,ceed_vector_active,err)
+     & bxtet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
 ! ---- Mass Tet
       call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masstet,err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masstet,'v',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
 
 ! Hex Elements
       do i=0,nelemhex-1
@@ -180,15 +182,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,qhex*qhex,nqptshex,&
-     & 1,erestrictuihex,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+     & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases
       call ceedbasiscreatetensorh1lagrange(ceed,d,d,phex,qhex,ceed_gauss,&
@@ -216,20 +218,20 @@
       call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuphex,err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
-     & ceed_notranspose,bxhex,ceed_vector_none,err)
+     & bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
-     & ceed_notranspose,bxhex,ceed_vector_active,err)
+     & bxhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
 ! ---- Mass Hex
       call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masshex,err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masshex,'v',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
 
 ! Composite Operators
       call ceedcompositeoperatorcreate(ceed,op_setup,err)

--- a/tests/t523-operator.c
+++ b/tests/t523-operator.c
@@ -18,7 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -75,16 +75,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, PTet, nelemTet*PTet,
                                     dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -138,16 +138,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, QHex*QHex, nqptsHex,
                                     1, &ErestrictuiHex);
 
   // -- Bases

--- a/tests/t523-operator.c
+++ b/tests/t523-operator.c
@@ -18,6 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -74,14 +75,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, dim, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, PTet, nelemTet*PTet, dim,
-                                    &ErestrictxiTet);
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictxTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+                                    dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, 1, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictuTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -108,21 +111,21 @@ int main(int argc, char **argv) {
   // ---- Setup Tet
   CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupTet);
-  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, bxTet,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, bxTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- Mass Tet
   CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massTet);
-  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataTet);
-  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_BASIS_COLLOCATED,
+                       qdataTet);
+  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
 
   // Set up Hex Elements
   for (CeedInt i=0; i<nelemHex; i++) {
@@ -135,17 +138,17 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, QHex*QHex, nqptsHex, 1,
-                                    &ErestrictuiHex);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+                                    1, &ErestrictuiHex);
 
   // -- Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, PHex, QHex, CEED_GAUSS,
@@ -166,21 +169,21 @@ int main(int argc, char **argv) {
   // -- Operators
   CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupHex);
-  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, bxHex,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, bxHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
   CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massHex);
-  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataHex);
-  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_BASIS_COLLOCATED,
+                       qdataHex);
+  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
 
   // Set up Composite Operators
   // -- Create

--- a/tests/t524-operator-f.f90
+++ b/tests/t524-operator-f.f90
@@ -39,8 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -124,14 +124,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,ptet,&
      & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemtet,ptet,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemtet,qtet,nqptstet,&
      & 1,erestrictuitet,err)
 
 ! -- Bases
@@ -190,14 +190,14 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelemhex,qhex*qhex,&
      & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases

--- a/tests/t524-operator-f.f90
+++ b/tests/t524-operator-f.f90
@@ -39,6 +39,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictxtet,erestrictutet,erestrictxitet,erestrictuitet,&
 &             erestrictxhex,erestrictuhex,erestrictxihex,erestrictuihex
       integer bxtet,butet,bxhex,buhex
@@ -122,15 +124,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,d,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictxtet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,ptet,nelemtet*ptet,&
-     & d,erestrictxitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,d,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictxtet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,ptet,&
+     & nelemtet*ptet,d,erestrictxitet,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemtet,ptet,ndofs,1,ceed_mem_host,&
-     & ceed_use_pointer,indxtet,erestrictutet,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemtet,qtet,nqptstet,1,&
-     & erestrictuitet,err)
+      call ceedelemrestrictioncreate(ceed,lmode,nelemtet,ptet,ndofs,1,&
+     & ceed_mem_host,ceed_use_pointer,indxtet,erestrictutet,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemtet,qtet,nqptstet,&
+     & 1,erestrictuitet,err)
 
 ! -- Bases
       call buildmats(qref,qweight,interp,grad)
@@ -160,20 +162,20 @@
       call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuptet,err)
       call ceedoperatorsetfield(op_setuptet,'_weight',erestrictxitet,&
-     & ceed_notranspose,bxtet,ceed_vector_none,err)
+     & bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
-     & ceed_notranspose,bxtet,ceed_vector_active,err)
+     & bxtet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuptet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
 ! ---- Mass Tet
       call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masstet,err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
-     & ceed_notranspose,ceed_basis_collocated,qdatatet,err)
+     & ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masstet,'v',erestrictutet,&
-     & ceed_notranspose,butet,ceed_vector_active,err)
+     & butet,ceed_vector_active,err)
 
 ! Hex Elements
       do i=0,nelemhex-1
@@ -188,15 +190,15 @@
       enddo
 
 ! -- Restrictions
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictxhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,phex*phex,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,phex*phex,&
      & nelemhex*phex*phex,d,erestrictxihex,err)
 
-      call ceedelemrestrictioncreate(ceed,nelemhex,phex*phex,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelemhex,phex*phex,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indxhex,erestrictuhex,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelemhex,qhex*qhex,nqptshex,&
-     & 1,erestrictuihex,err)
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelemhex,qhex*qhex,&
+     & nqptshex,1,erestrictuihex,err)
 
 ! -- Bases
       call ceedbasiscreatetensorh1lagrange(ceed,d,d,phex,qhex,ceed_gauss,&
@@ -225,21 +227,21 @@
      & ceed_qfunction_none,op_setuphex,&
      & err)
       call ceedoperatorsetfield(op_setuphex,'_weight',erestrictxihex,&
-     & ceed_notranspose,bxhex,ceed_vector_none,err)
+     & bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
-     & ceed_notranspose,bxhex,ceed_vector_active,err)
+     & bxhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setuphex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
 ! ---- Mass Hex
       call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masshex,&
      & err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
-     & ceed_notranspose,ceed_basis_collocated,qdatahex,err)
+     & ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
       call ceedoperatorsetfield(op_masshex,'v',erestrictuhex,&
-     & ceed_notranspose,buhex,ceed_vector_active,err)
+     & buhex,ceed_vector_active,err)
 
 ! Composite Operators
       call ceedcompositeoperatorcreate(ceed,op_setup,err)

--- a/tests/t524-operator.c
+++ b/tests/t524-operator.c
@@ -18,7 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -84,16 +84,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, PTet, nelemTet*PTet,
                                     dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemTet, PTet, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
                             &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -147,16 +147,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, imode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelemHex, QHex*QHex, nqptsHex,
                                     1, &ErestrictuiHex);
 
   // -- Bases

--- a/tests/t524-operator.c
+++ b/tests/t524-operator.c
@@ -18,6 +18,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction ErestrictxTet, ErestrictuTet,
                       ErestrictxiTet, ErestrictuiTet,
                       ErestrictxHex, ErestrictuHex,
@@ -83,14 +84,16 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, dim, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictxTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, PTet, nelemTet*PTet, dim,
-                                    &ErestrictxiTet);
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, dim,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictxTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, PTet, nelemTet*PTet,
+                                    dim, &ErestrictxiTet);
 
-  CeedElemRestrictionCreate(ceed, nelemTet, PTet, ndofs, 1, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indxTet, &ErestrictuTet);
-  CeedElemRestrictionCreateIdentity(ceed, nelemTet, QTet, nqptsTet, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemTet, PTet, ndofs, 1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indxTet,
+                            &ErestrictuTet);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemTet, QTet, nqptsTet, 1,
                                     &ErestrictuiTet);
 
   // -- Bases
@@ -117,21 +120,21 @@ int main(int argc, char **argv) {
   // ---- Setup Tet
   CeedOperatorCreate(ceed, qf_setupTet, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setupTet);
-  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, CEED_NOTRANSPOSE,
-                       bxTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupTet, "_weight", ErestrictxiTet, bxTet,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupTet, "dx", ErestrictxTet, bxTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupTet, "rho", ErestrictuiTet,
                        CEED_BASIS_COLLOCATED, qdataTet);
   // ---- Mass Tet
   CeedOperatorCreate(ceed, qf_massTet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massTet);
-  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataTet);
-  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, CEED_NOTRANSPOSE,
-                       buTet, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "rho", ErestrictuiTet, CEED_BASIS_COLLOCATED,
+                       qdataTet);
+  CeedOperatorSetField(op_massTet, "u", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massTet, "v", ErestrictuTet, buTet,
+                       CEED_VECTOR_ACTIVE);
 
   // Hex Elements
   for (CeedInt i=0; i<nelemHex; i++) {
@@ -144,17 +147,17 @@ int main(int argc, char **argv) {
   }
 
   // -- Restrictions
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, dim,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, dim,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictxHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, PHex*PHex,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, PHex*PHex,
                                     nelemHex*PHex*PHex, dim, &ErestrictxiHex);
 
-  CeedElemRestrictionCreate(ceed, nelemHex, PHex*PHex, ndofs, 1,
+  CeedElemRestrictionCreate(ceed, lmode, nelemHex, PHex*PHex, ndofs, 1,
                             CEED_MEM_HOST, CEED_USE_POINTER, indxHex,
                             &ErestrictuHex);
-  CeedElemRestrictionCreateIdentity(ceed, nelemHex, QHex*QHex, nqptsHex, 1,
-                                    &ErestrictuiHex);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelemHex, QHex*QHex, nqptsHex,
+                                    1, &ErestrictuiHex);
 
   // -- Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, PHex, QHex, CEED_GAUSS,
@@ -175,21 +178,21 @@ int main(int argc, char **argv) {
   // -- Operators
   CeedOperatorCreate(ceed, qf_setupHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_setupHex);
-  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, CEED_NOTRANSPOSE,
-                       bxHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setupHex, "_weight", ErestrictxiHex, bxHex,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupHex, "dx", ErestrictxHex, bxHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupHex, "rho", ErestrictuiHex,
                        CEED_BASIS_COLLOCATED, qdataHex);
 
   CeedOperatorCreate(ceed, qf_massHex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_massHex);
-  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdataHex);
-  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, CEED_NOTRANSPOSE,
-                       buHex, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "rho", ErestrictuiHex, CEED_BASIS_COLLOCATED,
+                       qdataHex);
+  CeedOperatorSetField(op_massHex, "u", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_massHex, "v", ErestrictuHex, buHex,
+                       CEED_VECTOR_ACTIVE);
 
   // Composite Operators
   CeedCompositeOperatorCreate(ceed, &op_setup);

--- a/tests/t530-operator-f.f90
+++ b/tests/t530-operator-f.f90
@@ -34,6 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictlini
       integer bx,bu
       integer qf_setup,qf_mass
@@ -90,14 +92,14 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
 ! Bases
@@ -127,20 +129,20 @@
       call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 ! -- Mass
       call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_mass,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
+     & ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)

--- a/tests/t530-operator-f.f90
+++ b/tests/t530-operator-f.f90
@@ -34,8 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictlini
       integer bx,bu
       integer qf_setup,qf_mass
@@ -92,14 +92,14 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
 ! Bases

--- a/tests/t530-operator.c
+++ b/tests/t530-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui, Erestrictlini;
   CeedBasis bx, bu;
@@ -48,14 +48,14 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t531-operator-f.f90
+++ b/tests/t531-operator-f.f90
@@ -61,8 +61,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer erestrictqi,erestrictlini
       integer bx,bu
@@ -119,17 +119,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases

--- a/tests/t531-operator-f.f90
+++ b/tests/t531-operator-f.f90
@@ -61,6 +61,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer erestrictqi,erestrictlini
       integer bx,bu
@@ -117,17 +119,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases
@@ -148,11 +150,11 @@
       call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
@@ -169,11 +171,11 @@
       call ceedoperatorcreate(ceed,qf_diff,ceed_qfunction_none,&
      & ceed_qfunction_none,op_diff,err)
       call ceedoperatorsetfield(op_diff,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diff,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
+     & ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_diff,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply original Poisson Operator
       call ceedvectorcreate(ceed,ndofs,u,err)
@@ -209,11 +211,11 @@
       call ceedoperatorcreate(ceed,qf_diff_lin,ceed_qfunction_none,&
      & ceed_qfunction_none,op_diff_lin,err)
       call ceedoperatorsetfield(op_diff_lin,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diff_lin,'qdata',erestrictlini,&
-     & ceed_notranspose,ceed_basis_collocated,a,err)
+     & ceed_basis_collocated,a,err)
       call ceedoperatorsetfield(op_diff_lin,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply linearized Poisson Operator
       call ceedvectorsetvalue(v,0.d0,err)

--- a/tests/t531-operator.c
+++ b/tests/t531-operator.c
@@ -8,6 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi, Erestrictlini;
@@ -47,17 +48,18 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+                                    &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, dim*(dim+1)/2,
-                                    &Erestrictqi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+                                    dim*(dim+1)/2, &Erestrictqi);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
@@ -72,12 +74,10 @@ int main(int argc, char **argv) {
   // Operator - setup
   CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_setup);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
                        CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
@@ -91,12 +91,10 @@ int main(int argc, char **argv) {
   // Operator - apply
   CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_diff);
-  CeedOperatorSetField(op_diff, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_diff, "dv", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_diff, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Apply original Poisson Operator
   CeedVectorCreate(ceed, ndofs, &u);
@@ -128,12 +126,10 @@ int main(int argc, char **argv) {
   // Operator - apply assembled
   CeedOperatorCreate(ceed, qf_diff_lin, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_diff_lin);
-  CeedOperatorSetField(op_diff_lin, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diff_lin, "qdata", Erestrictlini, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_diff_lin, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff_lin, "qdata", Erestrictlini,
                        CEED_BASIS_COLLOCATED, A);
-  CeedOperatorSetField(op_diff_lin, "dv", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff_lin, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Apply new Poisson Operator
   CeedVectorSetValue(v, 0.0);

--- a/tests/t531-operator.c
+++ b/tests/t531-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi, Erestrictlini;
@@ -48,17 +48,17 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts,
                                     dim*(dim+1)/2, &Erestrictqi);
 
   // Bases

--- a/tests/t532-operator-f.f90
+++ b/tests/t532-operator-f.f90
@@ -88,6 +88,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer erestrictqi,erestrictlini
       integer bx,bu
@@ -146,17 +148,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases
@@ -175,11 +177,11 @@
       call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_mass,'qdata',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! QFunction - setup diff
       call ceedqfunctioncreateinterior(ceed,1,setup_diff,&
@@ -194,11 +196,11 @@
       call ceedoperatorcreate(ceed,qf_setup_diff,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_diff,err)
       call ceedoperatorsetfield(op_setup_diff,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_diff,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_diff,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! Apply Setup Operators
       call ceedoperatorapply(op_setup_mass,x,qdata_mass,&
@@ -222,17 +224,17 @@
       call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
      & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_mass,err)
+     & ceed_basis_collocated,qdata_mass,err)
       call ceedoperatorsetfield(op_apply,'qdata_diff',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_diff,err)
+     & ceed_basis_collocated,qdata_diff,err)
       call ceedoperatorsetfield(op_apply,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply Original Operator
       call ceedvectorcreate(ceed,ndofs,u,err)
@@ -273,15 +275,15 @@
       call ceedoperatorcreate(ceed,qf_apply_lin,ceed_qfunction_none,&
      & ceed_qfunction_none,op_apply_lin,err)
       call ceedoperatorsetfield(op_apply_lin,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply_lin,'qdata',erestrictlini,&
-     & ceed_notranspose,ceed_basis_collocated,a,err)
+     & ceed_basis_collocated,a,err)
       call ceedoperatorsetfield(op_apply_lin,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply_lin,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply_lin,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply Linearized QFunction Operator
       call ceedvectorsetvalue(v,0.d0,err)

--- a/tests/t532-operator-f.f90
+++ b/tests/t532-operator-f.f90
@@ -88,8 +88,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer erestrictqi,erestrictlini
       integer bx,bu
@@ -148,17 +148,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases

--- a/tests/t532-operator.c
+++ b/tests/t532-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi, Erestrictlini;
@@ -49,17 +49,17 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts,
                                     dim*(dim+1)/2, &Erestrictqi);
 
   // Bases

--- a/tests/t532-operator.c
+++ b/tests/t532-operator.c
@@ -8,6 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi, Erestrictlini;
@@ -48,17 +49,18 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+                                    &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, dim*(dim+1)/2,
-                                    &Erestrictqi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+                                    dim*(dim+1)/2, &Erestrictqi);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
@@ -74,11 +76,10 @@ int main(int argc, char **argv) {
   // Operator - setup mass
   CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setup_mass);
-  CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup_mass, "qdata", Erestrictui, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_mass, "qdata", Erestrictui,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // QFunction - setup diff
@@ -91,11 +92,10 @@ int main(int argc, char **argv) {
   // Operator - setup diff
   CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setup_diff);
-  CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup_diff, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_diff, "qdata", Erestrictqi,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Apply Setup Operators
@@ -114,18 +114,14 @@ int main(int argc, char **argv) {
   // Operator - apply
   CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_apply);
-  CeedOperatorSetField(op_apply, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_apply, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui,
                        CEED_BASIS_COLLOCATED, qdata_mass);
-  CeedOperatorSetField(op_apply, "qdata_diff", Erestrictqi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_apply, "qdata_diff", Erestrictqi,
                        CEED_BASIS_COLLOCATED, qdata_diff);
-  CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "v", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "dv", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Apply original operator
   CeedVectorCreate(ceed, ndofs, &u);
@@ -161,16 +157,12 @@ int main(int argc, char **argv) {
   // Operator - apply assembled
   CeedOperatorCreate(ceed, qf_apply_lin, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_apply_lin);
-  CeedOperatorSetField(op_apply_lin, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply_lin, "qdata", Erestrictlini, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_apply_lin, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply_lin, "qdata", Erestrictlini,
                        CEED_BASIS_COLLOCATED, A);
-  CeedOperatorSetField(op_apply_lin, "u", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply_lin, "v", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply_lin, "dv", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply_lin, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply_lin, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply_lin, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Apply assembled QFunction operator
   CeedVectorSetValue(v, 0.0);

--- a/tests/t533-operator-f.f90
+++ b/tests/t533-operator-f.f90
@@ -34,6 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -89,14 +91,14 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
 ! Bases
@@ -126,20 +128,20 @@
       call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 ! -- Mass
       call ceedoperatorcreate(ceed,qf_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_mass,err)
       call ceedoperatorsetfield(op_mass,'rho',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
+     & ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_mass,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_mass,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)

--- a/tests/t533-operator-f.f90
+++ b/tests/t533-operator-f.f90
@@ -34,8 +34,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui
       integer bx,bu
       integer qf_setup,qf_mass
@@ -91,14 +91,14 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
 ! Bases

--- a/tests/t533-operator.c
+++ b/tests/t533-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
@@ -49,14 +49,14 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictui);
 
   // Bases

--- a/tests/t533-operator.c
+++ b/tests/t533-operator.c
@@ -8,6 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui;
   CeedBasis bx, bu;
@@ -48,14 +49,15 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+                                    &Erestrictui);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
@@ -75,21 +77,17 @@ int main(int argc, char **argv) {
   // Operators
   CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_setup);
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
                        CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_mass);
-  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_mass, "u", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_mass, "v", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);

--- a/tests/t534-operator-f.f90
+++ b/tests/t534-operator-f.f90
@@ -42,6 +42,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup,qf_diff
@@ -97,17 +99,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases
@@ -128,11 +130,11 @@
       call ceedoperatorcreate(ceed,qf_setup,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup,err)
       call ceedoperatorsetfield(op_setup,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,qdata,ceed_request_immediate,err)
@@ -149,11 +151,11 @@
       call ceedoperatorcreate(ceed,qf_diff,ceed_qfunction_none,&
      & ceed_qfunction_none,op_diff,err)
       call ceedoperatorsetfield(op_diff,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_diff,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,qdata,err)
+     & ceed_basis_collocated,qdata,err)
       call ceedoperatorsetfield(op_diff,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Assemble Diagonal
       call ceedoperatorassemblelineardiagonal(op_diff,a,&

--- a/tests/t534-operator-f.f90
+++ b/tests/t534-operator-f.f90
@@ -42,8 +42,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup,qf_diff
@@ -99,17 +99,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases

--- a/tests/t534-operator.c
+++ b/tests/t534-operator.c
@@ -8,6 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi;
@@ -49,17 +50,18 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+                                    &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q*Q, nqpts, dim*(dim+1)/2,
-                                    &Erestrictqi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+                                    dim*(dim+1)/2, &Erestrictqi);
 
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
@@ -74,12 +76,10 @@ int main(int argc, char **argv) {
   // Operator - setup
   CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_setup);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, bx, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
                        CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup, "_weight", Erestrictxi, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
@@ -93,12 +93,10 @@ int main(int argc, char **argv) {
   // Operator - apply
   CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_diff);
-  CeedOperatorSetField(op_diff, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
-                       CEED_BASIS_COLLOCATED, qdata);
-  CeedOperatorSetField(op_diff, "dv", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_diff, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Assemble diagonal
   CeedOperatorAssembleLinearDiagonal(op_diff, &A, CEED_REQUEST_IMMEDIATE);

--- a/tests/t534-operator.c
+++ b/tests/t534-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi;
@@ -50,17 +50,17 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts,
                                     dim*(dim+1)/2, &Erestrictqi);
 
   // Bases

--- a/tests/t535-operator-f.f90
+++ b/tests/t535-operator-f.f90
@@ -65,6 +65,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup_mass,qf_setup_diff,qf_apply
@@ -121,17 +123,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases
@@ -150,11 +152,11 @@
       call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_mass,'qdata',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! QFunction - setup diff
       call ceedqfunctioncreateinterior(ceed,1,setup_diff,&
@@ -169,11 +171,11 @@
       call ceedoperatorcreate(ceed,qf_setup_diff,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_diff,err)
       call ceedoperatorsetfield(op_setup_diff,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_diff,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_diff,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! Apply Setup Operators
       call ceedoperatorapply(op_setup_mass,x,qdata_mass,&
@@ -197,17 +199,17 @@
       call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
      & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_mass,err)
+     & ceed_basis_collocated,qdata_mass,err)
       call ceedoperatorsetfield(op_apply,'qdata_diff',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_diff,err)
+     & ceed_basis_collocated,qdata_diff,err)
       call ceedoperatorsetfield(op_apply,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Assemble Diagonal
       call ceedoperatorassemblelineardiagonal(op_apply,a,&

--- a/tests/t535-operator-f.f90
+++ b/tests/t535-operator-f.f90
@@ -65,8 +65,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i,j,k
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup_mass,qf_setup_diff,qf_apply
@@ -123,17 +123,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,d,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,d,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,&
      & nelem*p*p,d,erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p*p,ndofs,1,&
      & ceed_mem_host,ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & 1,erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,&
      & d*(d+1)/2,erestrictqi,err)
 
 ! Bases

--- a/tests/t535-operator.c
+++ b/tests/t535-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi;
@@ -51,17 +51,17 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, nelem*P*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, nelem*P*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P*P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts,
                                     dim*(dim+1)/2, &Erestrictqi);
 
   // Bases

--- a/tests/t536-operator-f.f90
+++ b/tests/t536-operator-f.f90
@@ -70,6 +70,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup_mass,qf_setup_diff,qf_apply
@@ -140,17 +142,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,nelem,p,ndofs,d,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,d,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p,nelem*p,d,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p,nelem*p,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,nelem,p,ndofs,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,1,&
      & erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q,nqpts,d*(d+1)/2,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,d*(d+1)/2,&
      & erestrictqi,err)
 
 ! Bases
@@ -173,11 +175,11 @@
       call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_mass,'qdata',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! QFunction - setup diff
       call ceedqfunctioncreateinterior(ceed,1,setup_diff,&
@@ -192,11 +194,11 @@
       call ceedoperatorcreate(ceed,qf_setup_diff,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_diff,err)
       call ceedoperatorsetfield(op_setup_diff,'dx',erestrictx,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_diff,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_diff,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! Apply Setup Operators
       call ceedoperatorapply(op_setup_mass,x,qdata_mass,&
@@ -220,17 +222,17 @@
       call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
      & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'du',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictui,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_mass,err)
+     & ceed_basis_collocated,qdata_mass,err)
       call ceedoperatorsetfield(op_apply,'qdata_diff',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_diff,err)
+     & ceed_basis_collocated,qdata_diff,err)
       call ceedoperatorsetfield(op_apply,'u',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'v',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'dv',erestrictu,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Assemble Diagonal
       call ceedoperatorassemblelineardiagonal(op_apply,a,&

--- a/tests/t536-operator-f.f90
+++ b/tests/t536-operator-f.f90
@@ -70,8 +70,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictx,erestrictu,erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup_mass,qf_setup_diff,qf_apply
@@ -142,17 +142,17 @@
       enddo
 
 ! Restrictions
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,d,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,ndofs,d,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictx,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p,nelem*p,d,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p,nelem*p,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreate(ceed,lmode,nelem,p,ndofs,1,ceed_mem_host,&
+      call ceedelemrestrictioncreate(ceed,imode,nelem,p,ndofs,1,ceed_mem_host,&
      & ceed_use_pointer,indx,erestrictu,err)
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,nqpts,1,&
      & erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q,nqpts,d*(d+1)/2,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q,nqpts,d*(d+1)/2,&
      & erestrictqi,err)
 
 ! Bases

--- a/tests/t536-operator.c
+++ b/tests/t536-operator.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi;
@@ -64,18 +64,18 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P, nelem*P, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P, nelem*P, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, imode, nelem, P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, nqpts, 1,
                                     &Erestrictui);
 
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, nqpts, dim*(dim+1)/2,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q, nqpts, dim*(dim+1)/2,
                                     &Erestrictqi);
 
   // Bases

--- a/tests/t536-operator.c
+++ b/tests/t536-operator.c
@@ -9,6 +9,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
+  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
   CeedElemRestriction Erestrictx, Erestrictu,
                       Erestrictxi, Erestrictui,
                       Erestrictqi;
@@ -63,16 +64,18 @@ int main(int argc, char **argv) {
   }
 
   // Restrictions
-  CeedElemRestrictionCreate(ceed, nelem, P, ndofs, dim, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, dim, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictx);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, P, nelem*P, dim, &Erestrictxi);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P, nelem*P, dim,
+                                    &Erestrictxi);
 
-  CeedElemRestrictionCreate(ceed, nelem, P, ndofs, 1, CEED_MEM_HOST,
+  CeedElemRestrictionCreate(ceed, lmode, nelem, P, ndofs, 1, CEED_MEM_HOST,
                             CEED_USE_POINTER, indx, &Erestrictu);
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, nqpts, 1, &Erestrictui);
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, nqpts, 1,
+                                    &Erestrictui);
 
 
-  CeedElemRestrictionCreateIdentity(ceed, nelem, Q, nqpts, dim*(dim+1)/2,
+  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q, nqpts, dim*(dim+1)/2,
                                     &Erestrictqi);
 
   // Bases
@@ -94,11 +97,10 @@ int main(int argc, char **argv) {
   // Operator - setup mass
   CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setup_mass);
-  CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup_mass, "qdata", Erestrictui, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_mass, "_weight", Erestrictxi, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_mass, "qdata", Erestrictui,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // QFunction - setup diff
@@ -111,11 +113,10 @@ int main(int argc, char **argv) {
   // Operator - setup diff
   CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setup_diff);
-  CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, CEED_NOTRANSPOSE, bx,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, CEED_NOTRANSPOSE,
-                       bx, CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup_diff, "qdata", Erestrictqi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_diff, "_weight", Erestrictxi, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_diff, "qdata", Erestrictqi,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // Apply Setup Operators
@@ -134,18 +135,14 @@ int main(int argc, char **argv) {
   // Operator - apply
   CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_apply);
-  CeedOperatorSetField(op_apply, "du", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_apply, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui,
                        CEED_BASIS_COLLOCATED, qdata_mass);
-  CeedOperatorSetField(op_apply, "qdata_diff", Erestrictqi, CEED_NOTRANSPOSE,
+  CeedOperatorSetField(op_apply, "qdata_diff", Erestrictqi,
                        CEED_BASIS_COLLOCATED, qdata_diff);
-  CeedOperatorSetField(op_apply, "u", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "v", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "dv", Erestrictu, CEED_NOTRANSPOSE, bu,
-                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Assemble diagonal
   CeedOperatorAssembleLinearDiagonal(op_apply, &A, CEED_REQUEST_IMMEDIATE);

--- a/tests/t540-operator-f.f90
+++ b/tests/t540-operator-f.f90
@@ -36,8 +36,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
-      integer lmode
-      parameter(lmode=ceed_notranspose)
+      integer imode
+      parameter(imode=ceed_noninterlaced)
       integer erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup_mass,qf_apply
@@ -77,13 +77,13 @@
       call ceedvectorcreate(ceed,nqpts,qdata_mass,err)
 
 ! Restrictions
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2*2,nelem*2*2,d,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,2*2,nelem*2*2,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,p*p,ndofs,1,&
      & erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,imode,nelem,q*q,nqpts,1,&
      & erestrictqi,err)
 
 ! Bases

--- a/tests/t540-operator-f.f90
+++ b/tests/t540-operator-f.f90
@@ -36,6 +36,8 @@
       include 'ceedf.h'
 
       integer ceed,err,i
+      integer lmode
+      parameter(lmode=ceed_notranspose)
       integer erestrictxi,erestrictui,erestrictqi
       integer bx,bu
       integer qf_setup_mass,qf_apply
@@ -75,13 +77,13 @@
       call ceedvectorcreate(ceed,nqpts,qdata_mass,err)
 
 ! Restrictions
-      call ceedelemrestrictioncreateidentity(ceed,nelem,2*2,nelem*2*2,d,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,2*2,nelem*2*2,d,&
      & erestrictxi,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,p*p,ndofs,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,p*p,ndofs,1,&
      & erestrictui,err)
 
-      call ceedelemrestrictioncreateidentity(ceed,nelem,q*q,nqpts,1,&
+      call ceedelemrestrictioncreateidentity(ceed,lmode,nelem,q*q,nqpts,1,&
      & erestrictqi,err)
 
 ! Bases
@@ -100,11 +102,11 @@
       call ceedoperatorcreate(ceed,qf_setup_mass,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setup_mass,err)
       call ceedoperatorsetfield(op_setup_mass,'dx',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_active,err)
+     & bx,ceed_vector_active,err)
       call ceedoperatorsetfield(op_setup_mass,'_weight',erestrictxi,&
-     & ceed_notranspose,bx,ceed_vector_none,err)
+     & bx,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setup_mass,'qdata',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,ceed_vector_active,err)
+     & ceed_basis_collocated,ceed_vector_active,err)
 
 ! Apply Setup Operators
       call ceedoperatorapply(op_setup_mass,x,qdata_mass,&
@@ -122,11 +124,11 @@
       call ceedoperatorcreate(ceed,qf_apply,ceed_qfunction_none,&
      & ceed_qfunction_none,op_apply,err)
       call ceedoperatorsetfield(op_apply,'u',erestrictui,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
       call ceedoperatorsetfield(op_apply,'qdata_mass',erestrictqi,&
-     & ceed_notranspose,ceed_basis_collocated,qdata_mass,err)
+     & ceed_basis_collocated,qdata_mass,err)
       call ceedoperatorsetfield(op_apply,'v',erestrictui,&
-     & ceed_notranspose,bu,ceed_vector_active,err)
+     & bu,ceed_vector_active,err)
 
 ! Apply original operator
       call ceedvectorcreate(ceed,ndofs,u,err)

--- a/tests/t540-operator.c
+++ b/tests/t540-operator.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   Ceed ceed;
-  CeedTransposeMode lmode = CEED_NOTRANSPOSE;
+  CeedInterlaceMode imode = CEED_NONINTERLACED;
   CeedElemRestriction Erestrictxi, Erestrictui, Erestrictqi;
   CeedBasis bx, bu;
   CeedQFunction qf_setup_mass, qf_apply;
@@ -36,13 +36,13 @@ int main(int argc, char **argv) {
   // Element Setup
 
   // Restrictions
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, 2*2, nelem*2*2, dim,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, 2*2, nelem*2*2, dim,
                                     &Erestrictxi);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, P*P, ndofs, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, P*P, ndofs, 1,
                                     &Erestrictui);
 
-  CeedElemRestrictionCreateIdentity(ceed, lmode, nelem, Q*Q, nqpts, 1,
+  CeedElemRestrictionCreateIdentity(ceed, imode, nelem, Q*Q, nqpts, 1,
                                     &Erestrictqi);
 
   // Bases


### PR DESCRIPTION
***Breaking Change***


This is the first of the two ElemRestriction changes we discussed earlier this week. I made `lmode` a property of the ElemRestriction when created rather than having it as a flag during application.

@YohannDudouit, this will break libCEED+MFEM integration.

@nbeams, this should be fully compatible with #424, provided that I got the changes to the CUDA backends correct. (I need to test) Edit: Testing looks good on my machine