### PR TITLE
Fix t412 segfault

### DIFF
--- a/tests/t412-qfunction.c
+++ b/tests/t412-qfunction.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   CeedQFunction qf;
   CeedInt Q = 8, size = 3;
   const CeedScalar *v;
-  CeedScalar u[Q];
+  CeedScalar u[Q*size];
 
   CeedInit(argv[1], &ceed);
 


### PR DESCRIPTION
I noticed I was getting segfaults with all backends on t412-qfunction.c.  It seemed like the problem was from the declared size of the array `u`.  Is this change what was originally intended for the test, or was the loop setting `u` supposed to be changed instead?