### PR TITLE
PETSc - add DoF/node output in PETSc examples

### DIFF
--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -276,8 +276,9 @@ int main(int argc, char **argv) {
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
-                       "    Global nodes                       : %D\n",
-                       usedresource, P, Q,  gsize/ncompu);
+                       "    Global nodes                       : %D\n"
+                       "    DoF per node                       : %D\n",
+                       usedresource, P, Q,  gsize/ncompu, ncompu);
     CHKERRQ(ierr);
   }
 

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -174,9 +174,10 @@ int main(int argc, char **argv) {
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
                        "    Global nodes                       : %D\n"
-                       "    Owned nodes                        : %D\n",
+                       "    Owned nodes                        : %D\n"
+                       "    DoF per node                       : %D\n",
                        bpChoice+1, usedresource, P, Q, gsize/ncompu,
-                       lsize/ncompu); CHKERRQ(ierr);
+                       lsize/ncompu, ncompu); CHKERRQ(ierr);
   }
 
   // Create RHS vector

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -498,11 +498,12 @@ int main(int argc, char **argv) {
                        "    Global nodes                       : %D\n"
                        "    Process Decomposition              : %D %D %D\n"
                        "    Local Elements                     : %D = %D %D %D\n"
-                       "    Owned nodes                        : %D = %D %D %D\n",
+                       "    Owned nodes                        : %D = %D %D %D\n"
+                       "    DoF per node                       : %D\n",
                        bpChoice+1, usedresource, P, Q,  gsize/ncompu, p[0],
                        p[1], p[2], localelem, melem[0], melem[1], melem[2],
                        mnodes[0]*mnodes[1]*mnodes[2], mnodes[0], mnodes[1],
-                       mnodes[2]); CHKERRQ(ierr);
+                       mnodes[2], ncompu); CHKERRQ(ierr);
   }
 
   {

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -236,11 +236,12 @@ int main(int argc, char **argv) {
                        "    Number of 1D Quadrature Points (q) : %d\n"
                        "    Global Nodes                       : %D\n"
                        "    Owned Nodes                        : %D\n"
+                       "    DoF per node                       : %D\n"
                        "  Multigrid:\n"
                        "    Number of Levels                   : %d\n",
                        bpChoice+1, usedresource, P, Q,
                        gsize[numlevels-1]/ncompu, lsize[numlevels-1]/ncompu,
-                       numlevels); CHKERRQ(ierr);
+                       ncompu, numlevels); CHKERRQ(ierr);
   }
 
   // Create RHS vector


### PR DESCRIPTION
I added a field for `DoF per Node` for our PETSc examples to make the output clearer for folks that aren't as familiar with our BPs.