### PR TITLE
Jed/petsc bps avoid redundant zero

### DIFF
--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -311,7 +311,6 @@ int main(int argc, char **argv) {
     ierr = KSPSetTolerances(ksp, 1e-10, PETSC_DEFAULT, PETSC_DEFAULT,
                             PETSC_DEFAULT); CHKERRQ(ierr);
   }
-  ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
   ierr = KSPSetOperators(ksp, matO, matO); CHKERRQ(ierr);
 
   // First run, if benchmarking
@@ -332,6 +331,7 @@ int main(int argc, char **argv) {
       CHKERRQ(ierr);
     }
   }
+  ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
 
   // Timed solve
   ierr = VecZeroEntries(X); CHKERRQ(ierr);

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -288,7 +288,6 @@ static PetscErrorCode MatMult_Mass(Mat A, Vec X, Vec Y) {
                          SCATTER_REVERSE); CHKERRQ(ierr);
   ierr = VecScatterEnd(user->ltog, X, user->Xloc, INSERT_VALUES,
                        SCATTER_REVERSE); CHKERRQ(ierr);
-  ierr = VecZeroEntries(user->Yloc); CHKERRQ(ierr);
 
   // Setup libCEED vectors
   ierr = user->VecGetArrayRead(user->Xloc, (const PetscScalar **)&x);
@@ -335,7 +334,6 @@ static PetscErrorCode MatMult_Diff(Mat A, Vec X, Vec Y) {
   ierr = VecScatterEnd(user->ltog0, X, user->Xloc, INSERT_VALUES,
                        SCATTER_REVERSE);
   CHKERRQ(ierr);
-  ierr = VecZeroEntries(user->Yloc); CHKERRQ(ierr);
 
   // Setup libCEED vectors
   ierr = user->VecGetArrayRead(user->Xloc, (const PetscScalar **)&x);

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -872,7 +872,6 @@ int main(int argc, char **argv) {
     ierr = KSPSetTolerances(ksp, 1e-10, PETSC_DEFAULT, PETSC_DEFAULT,
                             PETSC_DEFAULT); CHKERRQ(ierr);
   }
-  ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
   ierr = KSPSetOperators(ksp, mat, mat); CHKERRQ(ierr);
   // First run, if benchmarking
   if (benchmark_mode) {
@@ -892,6 +891,7 @@ int main(int argc, char **argv) {
       CHKERRQ(ierr);
     }
   }
+  ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
 
   // Timed solve
   ierr = VecZeroEntries(X); CHKERRQ(ierr);

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -738,7 +738,6 @@ static PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, UserO user) {
 
   // Global-to-local
   ierr = DMGlobalToLocal(user->dm, X, INSERT_VALUES, user->Xloc); CHKERRQ(ierr);
-  ierr = VecZeroEntries(user->Yloc); CHKERRQ(ierr);
 
   // Setup libCEED vectors
   ierr = user->VecGetArrayRead(user->Xloc, (const PetscScalar **)&x);
@@ -808,7 +807,6 @@ static PetscErrorCode MatMult_Prolong(Mat A, Vec X, Vec Y) {
   ierr = VecZeroEntries(user->locvecc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dmc, X, INSERT_VALUES, user->locvecc);
   CHKERRQ(ierr);
-  ierr = VecZeroEntries(user->locvecf); CHKERRQ(ierr);
 
   // Setup libCEED vectors
   ierr = user->VecGetArrayRead(user->locvecc, (const PetscScalar **)&c);
@@ -854,7 +852,6 @@ static PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y) {
   ierr = VecZeroEntries(user->locvecf); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dmf, X, INSERT_VALUES, user->locvecf);
   CHKERRQ(ierr);
-  ierr = VecZeroEntries(user->locvecc); CHKERRQ(ierr);
 
   // Multiplicity
   ierr = VecPointwiseMult(user->locvecf, user->locvecf, user->multvec);


### PR DESCRIPTION
New numbers for BP3 with (unstructrured) `bps` on one node of Lassen:
```
  Performance:
    Pointwise Error (max)              : 2.424969e-05
    CG Solve Time                      : 0.653718 (0.653667) sec
    DoFs/Sec in CG                     : 8016.16 (8016.79) million
```
Uses: https://gitlab.com/petsc/petsc/-/merge_requests/2656#note_313507355