### PR TITLE
Small doc fixes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: doc/sphinx/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub

--- a/doc/img/SphereSketch.svg
+++ b/doc/img/SphereSketch.svg
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="69mm"
+   height="72mm"
+   viewBox="0 0 195.59056 204.09449"
+   version="1.2"
+   id="svg188"
+   sodipodi:docname="SphereSketch.svg"
+   inkscape:version="0.92.4 (fd57863, 2020-04-02)">
+  <metadata
+     id="metadata192">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="2132"
+     id="namedview190"
+     showgrid="false"
+     units="mm"
+     inkscape:zoom="5.3077459"
+     inkscape:cx="122.56176"
+     inkscape:cy="100.04247"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg188" />
+  <defs
+     id="defs85">
+    <g
+       id="g71">
+      <symbol
+         overflow="visible"
+         id="glyph0-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d=""
+           id="path29"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph0-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 5.34375,-4 c -0.359375,0.109375 -0.53125,0.4375 -0.53125,0.6875 0,0.21875 0.15625,0.46875 0.484375,0.46875 0.359375,0 0.71875,-0.296875 0.71875,-0.78125 C 6.015625,-4.15625 5.5,-4.5 4.890625,-4.5 4.3125,-4.5 3.953125,-4.078125 3.8125,-3.890625 3.5625,-4.3125 3.015625,-4.5 2.4375,-4.5 c -1.25,0 -1.921875,1.21875 -1.921875,1.546875 0,0.140625 0.140625,0.140625 0.234375,0.140625 0.125,0 0.1875,0 0.234375,-0.125 0.28125,-0.90625 1,-1.203125 1.40625,-1.203125 0.375,0 0.5625,0.171875 0.5625,0.484375 0,0.203125 -0.140625,0.75 -0.234375,1.109375 L 2.375,-1.1875 c -0.140625,0.609375 -0.5,0.90625 -0.84375,0.90625 -0.046875,0 -0.28125,0 -0.46875,-0.140625 0.359375,-0.109375 0.53125,-0.453125 0.53125,-0.6875 0,-0.21875 -0.171875,-0.46875 -0.5,-0.46875 -0.34375,0 -0.71875,0.296875 -0.71875,0.78125 0,0.53125 0.53125,0.875 1.140625,0.875 0.5625,0 0.9375,-0.421875 1.0625,-0.609375 0.25,0.421875 0.8125,0.609375 1.375,0.609375 1.265625,0 1.9375,-1.21875 1.9375,-1.546875 0,-0.140625 -0.15625,-0.140625 -0.234375,-0.140625 -0.125,0 -0.1875,0 -0.234375,0.125 -0.28125,0.90625 -1,1.203125 -1.421875,1.203125 -0.375,0 -0.546875,-0.171875 -0.546875,-0.5 0,-0.203125 0.125,-0.734375 0.21875,-1.109375 0.0625,-0.25 0.296875,-1.1875 0.34375,-1.34375 0.15625,-0.609375 0.5,-0.90625 0.84375,-0.90625 0.0625,0 0.28125,0 0.484375,0.140625 z m 0,0"
+           id="path32"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph0-2"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 5.796875,-3.9375 7.125,-5.234375 l 0.609375,-0.625 c 0.40625,-0.375 0.515625,-0.5 1.5625,-0.515625 0.1875,0 0.203125,-0.25 0.203125,-0.28125 0,-0.0625 -0.046875,-0.1875 -0.203125,-0.1875 -0.34375,0 -0.71875,0.03125 -1.078125,0.03125 -0.296875,0 -1.015625,-0.03125 -1.296875,-0.03125 -0.078125,0 -0.28125,0 -0.28125,0.28125 0,0.1875 0.15625,0.1875 0.25,0.1875 0.296875,0.015625 0.5625,0.09375 0.59375,0.109375 l -1.90625,1.875 L 4.671875,-6.3125 C 4.765625,-6.328125 5.078125,-6.375 5.25,-6.375 c 0.109375,0 0.28125,0 0.28125,-0.28125 0,-0.125 -0.09375,-0.1875 -0.21875,-0.1875 -0.34375,0 -1.171875,0.03125 -1.515625,0.03125 -0.234375,0 -0.453125,0 -0.6875,0 -0.234375,0 -0.46875,-0.03125 -0.703125,-0.03125 -0.078125,0 -0.265625,0 -0.265625,0.28125 0,0.1875 0.125,0.1875 0.40625,0.1875 0.140625,0 0.25,0 0.390625,0.015625 0.140625,0.015625 0.140625,0.03125 0.203125,0.15625 l 1.375,2.875 -2.5,2.46875 c -0.1875,0.171875 -0.390625,0.375 -1.28125,0.390625 -0.171875,0 -0.34375,0 -0.34375,0.296875 C 0.390625,-0.109375 0.4375,0 0.59375,0 0.828125,0 1.4375,-0.03125 1.671875,-0.03125 1.96875,-0.03125 2.6875,0 2.96875,0 3.046875,0 3.25,0 3.25,-0.296875 3.25,-0.46875 3.078125,-0.46875 2.984375,-0.46875 2.796875,-0.46875 2.59375,-0.5 2.40625,-0.5625 l 2.3125,-2.3125 1.140625,2.34375 c -0.015625,0 -0.34375,0.0625 -0.578125,0.0625 -0.109375,0 -0.296875,0 -0.296875,0.296875 C 4.984375,-0.15625 5,0 5.203125,0 c 0.34375,0 1.1875,-0.03125 1.53125,-0.03125 0.21875,0 0.453125,0.015625 0.6875,0.015625 C 7.640625,-0.015625 7.890625,0 8.109375,0 8.1875,0 8.390625,0 8.390625,-0.296875 8.390625,-0.46875 8.234375,-0.46875 8,-0.46875 c -0.140625,0 -0.25,0 -0.390625,-0.015625 C 7.453125,-0.5 7.453125,-0.515625 7.375,-0.640625 Z m 0,0"
+           id="path35"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d=""
+           id="path38"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 3.296875,2.390625 c 0,-0.03125 0,-0.046875 -0.171875,-0.21875 C 1.890625,0.921875 1.5625,-0.96875 1.5625,-2.5 c 0,-1.734375 0.375,-3.46875 1.609375,-4.703125 0.125,-0.125 0.125,-0.140625 0.125,-0.171875 0,-0.078125 -0.03125,-0.109375 -0.09375,-0.109375 -0.109375,0 -1,0.6875 -1.59375,1.953125 -0.5,1.09375 -0.625,2.203125 -0.625,3.03125 0,0.78125 0.109375,1.984375 0.65625,3.125 C 2.25,1.84375 3.09375,2.5 3.203125,2.5 c 0.0625,0 0.09375,-0.03125 0.09375,-0.109375 z m 0,0"
+           id="path41"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph1-2"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 2.875,-2.5 c 0,-0.765625 -0.109375,-1.96875 -0.65625,-3.109375 -0.59375,-1.21875 -1.453125,-1.875 -1.546875,-1.875 -0.0625,0 -0.109375,0.046875 -0.109375,0.109375 0,0.03125 0,0.046875 0.1875,0.234375 0.984375,0.984375 1.546875,2.5625 1.546875,4.640625 0,1.71875 -0.359375,3.46875 -1.59375,4.71875 C 0.5625,2.34375 0.5625,2.359375 0.5625,2.390625 0.5625,2.453125 0.609375,2.5 0.671875,2.5 0.765625,2.5 1.671875,1.8125 2.25,0.546875 2.765625,-0.546875 2.875,-1.65625 2.875,-2.5 Z m 0,0"
+           id="path44"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph2-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d=""
+           id="path47"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph2-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 3.53125,-1.734375 c 0,-0.84375 -0.671875,-1.5 -1.5,-1.5 -0.828125,0 -1.5,0.671875 -1.5,1.484375 0,0.84375 0.6875,1.5 1.5,1.5 0.84375,0 1.5,-0.671875 1.5,-1.484375 z m -1.5,1.140625 C 1.375,-0.59375 0.875,-1.125 0.875,-1.734375 c 0,-0.65625 0.515625,-1.171875 1.15625,-1.171875 0.65625,0 1.15625,0.53125 1.15625,1.15625 0,0.65625 -0.515625,1.15625 -1.15625,1.15625 z m 0,0"
+           id="path50"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph3-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d=""
+           id="path53"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph3-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 0.453125,1.21875 C 0.375,1.5625 0.34375,1.625 -0.09375,1.625 c -0.109375,0 -0.21875,0 -0.21875,0.1875 0,0.078125 0.046875,0.125 0.125,0.125 0.265625,0 0.5625,-0.03125 0.828125,-0.03125 0.34375,0 0.671875,0.03125 1,0.03125 0.046875,0 0.171875,0 0.171875,-0.203125 C 1.8125,1.625 1.71875,1.625 1.578125,1.625 c -0.5,0 -0.5,-0.0625 -0.5,-0.15625 0,-0.125 0.421875,-1.75 0.484375,-2 0.125,0.296875 0.40625,0.640625 0.921875,0.640625 1.15625,0 2.40625,-1.453125 2.40625,-2.921875 0,-0.9375 -0.578125,-1.59375 -1.328125,-1.59375 -0.5,0 -0.984375,0.359375 -1.3125,0.75 -0.09375,-0.546875 -0.53125,-0.75 -0.890625,-0.75 -0.46875,0 -0.65625,0.390625 -0.734375,0.5625 C 0.4375,-3.5 0.3125,-2.90625 0.3125,-2.875 c 0,0.109375 0.09375,0.109375 0.109375,0.109375 0.109375,0 0.109375,-0.015625 0.171875,-0.234375 0.171875,-0.703125 0.375,-1.1875 0.734375,-1.1875 0.171875,0 0.3125,0.078125 0.3125,0.453125 0,0.234375 -0.03125,0.34375 -0.078125,0.515625 z m 1.75,-4.328125 C 2.265625,-3.375 2.546875,-3.65625 2.71875,-3.8125 c 0.359375,-0.296875 0.640625,-0.375 0.8125,-0.375 0.390625,0 0.640625,0.34375 0.640625,0.9375 0,0.59375 -0.328125,1.734375 -0.515625,2.109375 -0.34375,0.703125 -0.8125,1.03125 -1.1875,1.03125 C 1.8125,-0.109375 1.6875,-0.9375 1.6875,-1 c 0,-0.015625 0,-0.03125 0.03125,-0.15625 z m 0,0"
+           id="path56"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph3-2"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 4.5,-4.296875 c 0,-0.046875 -0.03125,-0.09375 -0.09375,-0.09375 -0.109375,0 -0.515625,0.390625 -0.671875,0.6875 C 3.515625,-4.25 3.125,-4.40625 2.796875,-4.40625 c -1.171875,0 -2.390625,1.46875 -2.390625,2.921875 0,0.96875 0.578125,1.59375 1.3125,1.59375 0.421875,0 0.8125,-0.234375 1.171875,-0.59375 -0.09375,0.34375 -0.421875,1.6875 -0.453125,1.78125 -0.078125,0.28125 -0.15625,0.3125 -0.71875,0.328125 -0.125,0 -0.21875,0 -0.21875,0.203125 0,0 0,0.109375 0.125,0.109375 0.3125,0 0.671875,-0.03125 1,-0.03125 0.328125,0 0.6875,0.03125 1.03125,0.03125 0.046875,0 0.171875,0 0.171875,-0.203125 C 3.828125,1.625 3.734375,1.625 3.5625,1.625 3.09375,1.625 3.09375,1.5625 3.09375,1.46875 3.09375,1.390625 3.109375,1.328125 3.125,1.25 Z m -2.75,4.1875 c -0.609375,0 -0.640625,-0.765625 -0.640625,-0.9375 0,-0.484375 0.28125,-1.5625 0.453125,-1.984375 0.3125,-0.734375 0.828125,-1.15625 1.234375,-1.15625 0.65625,0 0.796875,0.8125 0.796875,0.875 0,0.0625 -0.546875,2.25 -0.578125,2.28125 C 2.859375,-0.75 2.296875,-0.109375 1.75,-0.109375 Z m 0,0"
+           id="path59"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph4-0"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d=""
+           id="path62"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph4-1"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="M 3.59375,-2.21875 C 3.59375,-2.984375 3.5,-3.546875 3.1875,-4.03125 2.96875,-4.34375 2.53125,-4.625 1.984375,-4.625 c -1.625,0 -1.625,1.90625 -1.625,2.40625 0,0.5 0,2.359375 1.625,2.359375 1.609375,0 1.609375,-1.859375 1.609375,-2.359375 z M 1.984375,-0.0625 c -0.328125,0 -0.75,-0.1875 -0.890625,-0.75 C 1,-1.21875 1,-1.796875 1,-2.3125 1,-2.828125 1,-3.359375 1.09375,-3.734375 1.25,-4.28125 1.6875,-4.4375 1.984375,-4.4375 c 0.375,0 0.734375,0.234375 0.859375,0.640625 0.109375,0.375 0.125,0.875 0.125,1.484375 0,0.515625 0,1.03125 -0.09375,1.46875 -0.140625,0.640625 -0.609375,0.78125 -0.890625,0.78125 z m 0,0"
+           id="path65"
+           inkscape:connector-curvature="0" />
+      </symbol>
+      <symbol
+         overflow="visible"
+         id="glyph4-2"
+         style="overflow:visible">
+        <path
+           style="stroke:none"
+           d="m 2.328125,-4.4375 c 0,-0.1875 0,-0.1875 -0.203125,-0.1875 -0.453125,0.4375 -1.078125,0.4375 -1.359375,0.4375 v 0.25 c 0.15625,0 0.625,0 1,-0.1875 v 3.546875 c 0,0.234375 0,0.328125 -0.6875,0.328125 H 0.8125 V 0 c 0.125,0 0.984375,-0.03125 1.234375,-0.03125 0.21875,0 1.09375,0.03125 1.25,0.03125 V -0.25 H 3.03125 c -0.703125,0 -0.703125,-0.09375 -0.703125,-0.328125 z m 0,0"
+           id="path68"
+           inkscape:connector-curvature="0" />
+      </symbol>
+    </g>
+    <clipPath
+       id="clip1">
+      <path
+         d="m 12,7 h 92.71484 v 97 H 12 Z m 0,0"
+         id="path73"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       id="clip2">
+      <path
+         d="m 95,92 h 9.71484 v 24.15234 H 95 Z m 0,0"
+         id="path76"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       id="clip3">
+      <path
+         d="m 12,7 h 92.71484 v 97 H 12 Z m 0,0"
+         id="path79"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       id="clip4">
+      <path
+         d="m 95,91 h 9.71484 v 15 H 95 Z m 0,0"
+         id="path82"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+  </defs>
+  <g
+     id="surface3093"
+     transform="matrix(1.8152104,0,0,1.8152104,-0.16240621,-6.5826914)">
+    <g
+       clip-path="url(#clip1)"
+       id="g89"
+       style="clip-rule:nonzero">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+         d="m 0.001875,0.00146875 c 0,46.96484425 -38.074219,85.03906225 -85.042969,85.03906225"
+         transform="matrix(1,0,0,-1,102.92,98.271)"
+         id="path87"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:2.98883, 2.98883;stroke-opacity:1"
+       d="m -85.041094,85.040531 c -5.941406,0 -11.871094,-0.625 -17.679686,-1.859375"
+       transform="matrix(1,0,0,-1,102.92,98.271)"
+       id="path91"
+       inkscape:connector-curvature="0" />
+    <g
+       clip-path="url(#clip2)"
+       id="g95"
+       style="clip-rule:nonzero">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:2.98883, 2.98883;stroke-opacity:1"
+         d="m 0.001875,0.00146875 c 0,-5.94140575 -0.625,-11.87499975 -1.859375,-17.68359375"
+         transform="matrix(1,0,0,-1,102.92,98.271)"
+         id="path93"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       clip-path="url(#clip3)"
+       id="g99"
+       style="clip-rule:nonzero">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+         d="M -85.041094,85.040531 0.001875,0.00146875"
+         transform="matrix(1,0,0,-1,102.92,98.271)"
+         id="path97"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -60.123125,60.122563 7.800781,17.042968"
+       transform="matrix(1,0,0,-1,102.92,98.271)"
+       id="path101"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.31878999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-opacity:1"
+       d="M -1.195432,1.593868 C -1.09746,0.996191 -7.25884e-4,0.0975343 0.30092,2.51455e-5 -5.23286e-4,-0.0994138 -1.097952,-0.995861 -1.196928,-1.59374"
+       transform="matrix(0.41745,-0.91193,-0.91193,-0.41745,50.59706,21.10646)"
+       id="path103"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 52.601562,19.992188 c 0,-0.828126 -0.667968,-1.496094 -1.492187,-1.496094 -0.828125,0 -1.496094,0.667968 -1.496094,1.496094 0,0.824218 0.667969,1.492187 1.496094,1.492187 0.824219,0 1.492187,-0.667969 1.492187,-1.492187 z m 0,0"
+       id="path105"
+       inkscape:connector-curvature="0" />
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g109">
+      <use
+         xlink:href="#glyph0-1"
+         x="47.734001"
+         y="42.056"
+         id="use107"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g113">
+      <use
+         xlink:href="#glyph1-1"
+         x="54.299999"
+         y="42.056"
+         id="use111"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g117">
+      <use
+         xlink:href="#glyph0-2"
+         x="58.174"
+         y="42.056"
+         id="use115"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g121">
+      <use
+         xlink:href="#glyph1-2"
+         x="68.386002"
+         y="42.056"
+         id="use119"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g125">
+      <use
+         xlink:href="#glyph2-1"
+         x="43.327"
+         y="7.5609999"
+         id="use123"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g129">
+      <use
+         xlink:href="#glyph0-1"
+         x="42.084999"
+         y="13.981"
+         id="use127"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g133">
+      <use
+         xlink:href="#glyph1-1"
+         x="48.651001"
+         y="13.981"
+         id="use131"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g137">
+      <use
+         xlink:href="#glyph0-1"
+         x="52.525002"
+         y="13.981"
+         id="use135"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g141">
+      <use
+         xlink:href="#glyph1-2"
+         x="59.091"
+         y="13.981"
+         id="use139"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g145">
+      <use
+         xlink:href="#glyph3-1"
+         x="9.8599997"
+         y="8.7379999"
+         id="use143"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g149">
+      <use
+         xlink:href="#glyph4-1"
+         x="14.872"
+         y="10.233"
+         id="use147"
+         width="100%"
+         height="100%" />
+    </g>
+    <path
+       style="fill:none;stroke:#ff0000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+       d="m -86.634844,83.446781 3.1875,3.1875 m -3.1875,0 3.1875,-3.1875"
+       transform="matrix(1,0,0,-1,102.92,98.271)"
+       id="path151"
+       inkscape:connector-curvature="0" />
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g155">
+      <use
+         xlink:href="#glyph3-2"
+         x="30.360001"
+         y="42.159"
+         id="use153"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g159">
+      <use
+         xlink:href="#glyph4-1"
+         x="34.807999"
+         y="43.653"
+         id="use157"
+         width="100%"
+         height="100%" />
+    </g>
+    <path
+       style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 44.289062,38.148438 c 0,-0.828126 -0.667968,-1.496094 -1.492187,-1.496094 -0.824219,0 -1.496094,0.667968 -1.496094,1.496094 0,0.824218 0.671875,1.492187 1.496094,1.492187 0.824219,0 1.492187,-0.667969 1.492187,-1.492187 z m 0,0"
+       id="path161"
+       inkscape:connector-curvature="0" />
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g165">
+      <use
+         xlink:href="#glyph3-2"
+         x="65.595001"
+         y="77.392998"
+         id="use163"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g169">
+      <use
+         xlink:href="#glyph4-2"
+         x="70.042"
+         y="78.888"
+         id="use167"
+         width="100%"
+         height="100%" />
+    </g>
+    <path
+       style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 79.527344,73.382812 c 0,-0.824218 -0.671875,-1.496093 -1.496094,-1.496093 -0.824219,0 -1.496094,0.671875 -1.496094,1.496093 0,0.824219 0.671875,1.492188 1.496094,1.492188 0.824219,0 1.496094,-0.667969 1.496094,-1.492188 z m 0,0"
+       id="path171"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 97.652344,65.042969 c 0,-0.824219 -0.667969,-1.496094 -1.492188,-1.496094 -0.824218,0 -1.496094,0.671875 -1.496094,1.496094 0,0.824219 0.671876,1.496093 1.496094,1.496093 0.824219,0 1.492188,-0.671874 1.492188,-1.496093 z m 0,0"
+       id="path173"
+       inkscape:connector-curvature="0" />
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g177">
+      <use
+         xlink:href="#glyph3-1"
+         x="90.914001"
+         y="100.443"
+         id="use175"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g181">
+      <use
+         xlink:href="#glyph4-2"
+         x="95.927002"
+         y="101.937"
+         id="use179"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       clip-path="url(#clip4)"
+       id="g185"
+       style="clip-rule:nonzero">
+      <path
+         style="fill:none;stroke:#ff0000;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1"
+         d="m -1.595781,-1.592281 3.191406,3.1875 m -3.191406,0 3.191406,-3.1875"
+         transform="matrix(1,0,0,-1,102.92,98.271)"
+         id="path183"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/doc/sphinx/source/FEMtheory.rst.inc
+++ b/doc/sphinx/source/FEMtheory.rst.inc
@@ -18,7 +18,7 @@ We start by considering the discrete residual :math:`F(u)=0` formulation
 in weak form. We first define the :math:`L^2` inner product between real-valued functions
 
 .. math::
-   \langle u, v \rangle = \int_\Omega u v d \bm{x},
+   \langle v, u \rangle = \int_\Omega v u d \bm{x},
 
 where :math:`\bm{x} \in \mathbb{R}^d \supset \Omega`.
 

--- a/doc/sphinx/source/FEMtheory.rst.inc
+++ b/doc/sphinx/source/FEMtheory.rst.inc
@@ -18,9 +18,9 @@ We start by considering the discrete residual :math:`F(u)=0` formulation
 in weak form. We first define the :math:`L^2` inner product
 
 .. math::
-   \langle u, v \rangle = \int_\Omega u v d \mathbf{x},
+   \langle u, v \rangle = \int_\Omega u v d \bm{x},
 
-where :math:`d \mathbf{x} \in \mathbb{R}^d \supset \Omega`.
+where :math:`d \bm{x} \in \mathbb{R}^d \supset \Omega`.
 
 We want to find :math:`u` in a suitable space :math:`V_D`,
 such that

--- a/doc/sphinx/source/FEMtheory.rst.inc
+++ b/doc/sphinx/source/FEMtheory.rst.inc
@@ -15,42 +15,42 @@ of computational device types (selectable at run time). We present here the nota
 and the mathematical formulation adopted in libCEED.
 
 We start by considering the discrete residual :math:`F(u)=0` formulation
-in weak form. We first define the :math:`L^2` inner product
+in weak form. We first define the :math:`L^2` inner product between real-valued functions
 
 .. math::
    \langle u, v \rangle = \int_\Omega u v d \bm{x},
 
-where :math:`d \bm{x} \in \mathbb{R}^d \supset \Omega`.
+where :math:`\bm{x} \in \mathbb{R}^d \supset \Omega`.
 
 We want to find :math:`u` in a suitable space :math:`V_D`,
 such that
 
 .. math::
-   \langle v, f(u) \rangle = \int_\Omega v \cdot f_0 (u, \nabla u) + \nabla v : f_1 (u, \nabla u) = 0
+   \langle  \bm v,  \bm f(u) \rangle = \int_\Omega  \bm v \cdot  \bm f_0 (u, \nabla u) + \nabla \bm v :  \bm f_1 (u, \nabla u) = 0
    :label: residual
 
-for all :math:`v` in the corresponding homogeneous space :math:`V_0`, where :math:`f_0`
-and :math:`f_1` contain all possible sources in the problem. We notice here that
-:math:`f_0` represents all terms in :math:numref:`residual` which multiply the test
-function :math:`v` and :math:`f_1` all terms which multiply its gradient :math:`\nabla v`.
-For an n-component problems in :math:`d` dimensions, :math:`f_0 \in \mathbb{R}^n` and
-:math:`f_1 \in \mathbb{R}^{nd}`.
+for all :math:`\bm v` in the corresponding homogeneous space :math:`V_0`, where :math:`\bm f_0`
+and :math:`\bm f_1` contain all possible sources in the problem. We notice here that
+:math:`\bm f_0` represents all terms in :math:numref:`residual` which multiply the (possibly vector-valued) test
+function :math:`\bm v` and :math:`\bm f_1` all terms which multiply its gradient :math:`\nabla \bm v`.
+For an n-component problems in :math:`d` dimensions, :math:`\bm f_0 \in \mathbb{R}^n` and
+:math:`\bm f_1 \in \mathbb{R}^{nd}`.
 
 .. note::
-   The notation :math:`\nabla \bm v \!:\! f_1` represents contraction over both
+   The notation :math:`\nabla \bm v \!:\! \bm f_1` represents contraction over both
    fields and spatial dimensions while a single dot represents contraction in just one,
-   which should be clear from context, e.g., :math:`v \cdot f_0` contracts only over
+   which should be clear from context, e.g., :math:`\bm v \cdot \bm f_0` contracts only over
    fields.
 
 .. note::
    In the code, the function that represents the weak form at quadrature
    points is called the :ref:`CeedQFunction`. In the :ref:`Examples` provided with the
-   library (in the :file:`examples/` directory), we store the term :math:`f_0` directly
-   into `v`, and the term :math:`f_1` directly into `dv` (which stands for
-   :math:`\nabla v`). If equation :math:numref:`residual` only presents a term of the
-   type :math:`f_0`, the :ref:`CeedQFunction` will only have one output argument,
+   library (in the :file:`examples/` directory), we store the term :math:`\bm f_0` directly
+   into `v`, and the term :math:`\bm f_1` directly into `dv` (which stands for
+   :math:`\nabla \bm v`). If equation :math:numref:`residual` only presents a term of the
+   type :math:`\bm f_0`, the :ref:`CeedQFunction` will only have one output argument,
    namely `v`. If equation :math:numref:`residual` also presents a term of the type
-   :math:`f_1`, then the :ref:`CeedQFunction` will have two output arguments, namely,
+   :math:`\bm f_1`, then the :ref:`CeedQFunction` will have two output arguments, namely,
    `v` and `dv`.
 
 

--- a/doc/sphinx/source/FEMtheory.rst.inc
+++ b/doc/sphinx/source/FEMtheory.rst.inc
@@ -37,7 +37,7 @@ For an n-component problems in :math:`d` dimensions, :math:`f_0 \in \mathbb{R}^n
 :math:`f_1 \in \mathbb{R}^{nd}`.
 
 .. note::
-   The notation :math:`\nabla \boldsymbol v \!:\! f_1` represents contraction over both
+   The notation :math:`\nabla \bm v \!:\! f_1` represents contraction over both
    fields and spatial dimensions while a single dot represents contraction in just one,
    which should be clear from context, e.g., :math:`v \cdot f_0` contracts only over
    fields.

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -130,7 +130,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/doc/sphinx/source/libCEEDapi.rst
+++ b/doc/sphinx/source/libCEEDapi.rst
@@ -52,9 +52,9 @@ versions of :math:`\bm{P}`, :math:`\bm{G}` and :math:`\bm{B}`.
 Note that in the case of adaptive mesh refinement (AMR), the restrictions
 :math:`\bm{P}` and :math:`\bm{G}` will involve not just extracting sub-vectors,
 but evaluating values at constrained degrees of freedom through the AMR interpolation.
-There can also be several levels of subdomains (:math:`\bm{P1}`, :math:`\bm{P2}`,
+There can also be several levels of subdomains (:math:`\bm P_1`, :math:`\bm P_2`,
 etc.), and it may be convenient to split :math:`\bm{D}` as the product of several
-operators (:math:`\bm{D1}`, :math:`\bm{D2}`, etc.).
+operators (:math:`\bm D_1`, :math:`\bm D_2`, etc.).
 
 
 Terminology and Notation
@@ -78,7 +78,7 @@ Vector representation/storage categories:
      element containing :math:`i`
 
    - this is an overlapping vector decomposition with overlaps only across
-     different processors - there is no duplication of unknowns on a single
+     different processors---there is no duplication of unknowns on a single
      processor
 
    - the shared dofs/unknowns are the overlapping dofs, i.e. the ones that have
@@ -109,7 +109,7 @@ Vector representation/storage categories:
 
    - in other words, an entry in an **E-vector** is obtained by copying an entry
      from the corresponding **L-vector**, optionally switching the sign of the
-     entry (for :math:`H(\mathrm{div})`- and :math:`H(\mathrm{curl})`-conforming spaces).
+     entry (for :math:`H(\mathrm{div})`---and :math:`H(\mathrm{curl})`-conforming spaces).
 
    .. image:: ../../img/L-vector-AMR.svg
 
@@ -125,13 +125,13 @@ Vector representation/storage categories:
 
 - In many cases it is useful to distinguish two types of vectors:
 
-   - X-vector, or **primal** X-vector, and X'-vector, or **dual** X-vector
+   - **X-vector**, or **primal X-vector**, and **X'-vector**, or **dual X-vector**
 
    - here X can be any of the T, L, E, or Q categories
 
-   - for example, the mass matrix operator maps a **T-vector** to a T'-vector
+   - for example, the mass matrix operator maps a **T-vector** to a **T'-vector**
 
-   - the solutions vector is a **T-vector**, and the RHS vector is a T'-vector
+   - the solutions vector is a **T-vector**, and the RHS vector is a **T'-vector**
 
    - using the parallel prolongation operator, one can map the solution
      **T-vector** to a solution **L-vector**, etc.
@@ -165,8 +165,7 @@ Operator representation/storage/action categories:
 
 - Quadrature-point/partial assembly, **QA** or **PA**:
 
-   - precompute and store :math:`w\det(J)`, or :math:`\det(J)` (in the case of mass
-     matrix) at all quadrature points in all mesh elements
+   - precompute and store :math:`w\det(J)` at all quadrature points in all mesh elements
 
    - the stored data can be viewed as a **Q-vector**.
 
@@ -363,12 +362,6 @@ More general operators, such as those of the form
    \int_\Omega v \cdot f_0 (u, \nabla u) + \nabla v : f_1 (u, \nabla u)
 
 can be expressed.
-
-.. note::
-   The notation :math:`\nabla \bm v \!:\! f_1` represents contraction over both
-   fields and spatial dimensions while a single dot represents contraction in just one,
-   which should be clear from context, e.g., :math:`v \cdot f_0` contracts only over
-   fields.
 
 For fields with derivatives, such as with the basis evaluation mode
 (see :ref:`CeedBasis-Typedefs and Enumerations`) ``CEED_EVAL_GRAD``, the size of the

--- a/doc/sphinx/source/libCEEDapi.rst
+++ b/doc/sphinx/source/libCEEDapi.rst
@@ -84,7 +84,6 @@ Vector representation/storage categories:
    - the shared dofs/unknowns are the overlapping dofs, i.e. the ones that have
      more than one copy, on different processors.
 
-
    .. image:: ../../img/L-vector.svg
 
 - Per element decomposition, **E-vector**:

--- a/doc/sphinx/source/libCEEDapi.rst
+++ b/doc/sphinx/source/libCEEDapi.rst
@@ -35,13 +35,13 @@ mesh elements, and the values at quadrature points, respectively.
 
 We refer to the operators that connect the different types of vectors as:
 
-- Subdomain restriction :math:`\mathbf{P}`
-- Element restriction :math:`\mathbf{G}`
-- Basis (Dofs-to-Qpts) evaluator :math:`\mathbf{B}`
-- Operator at quadrature points :math:`\mathbf{D}`
+- Subdomain restriction :math:`\bm{P}`
+- Element restriction :math:`\bm{G}`
+- Basis (Dofs-to-Qpts) evaluator :math:`\bm{B}`
+- Operator at quadrature points :math:`\bm{D}`
 
 More generally, when the test and trial space differ, they get their own
-versions of :math:`\mathbf{P}`, :math:`\mathbf{G}` and :math:`\mathbf{B}`.
+versions of :math:`\bm{P}`, :math:`\bm{G}` and :math:`\bm{B}`.
 
 .. _fig-operator-decomp:
 
@@ -50,11 +50,11 @@ versions of :math:`\mathbf{P}`, :math:`\mathbf{G}` and :math:`\mathbf{B}`.
    Operator Decomposition
 
 Note that in the case of adaptive mesh refinement (AMR), the restrictions
-:math:`\mathbf{P}` and :math:`\mathbf{G}` will involve not just extracting sub-vectors,
+:math:`\bm{P}` and :math:`\bm{G}` will involve not just extracting sub-vectors,
 but evaluating values at constrained degrees of freedom through the AMR interpolation.
-There can also be several levels of subdomains (:math:`\mathbf{P1}`, :math:`\mathbf{P2}`,
-etc.), and it may be convenient to split :math:`\mathbf{D}` as the product of several
-operators (:math:`\mathbf{D1}`, :math:`\mathbf{D2}`, etc.).
+There can also be several levels of subdomains (:math:`\bm{P1}`, :math:`\bm{P2}`,
+etc.), and it may be convenient to split :math:`\bm{D}` as the product of several
+operators (:math:`\bm{D1}`, :math:`\bm{D2}`, etc.).
 
 
 Terminology and Notation
@@ -149,10 +149,10 @@ Operator representation/storage/action categories:
 
    - CSR matrix on each rank
 
-   - the parallel prolongation operator, :math:`\mathbf{P}`, (and its transpose) should use
+   - the parallel prolongation operator, :math:`\bm{P}`, (and its transpose) should use
      optimized matrix-free action
 
-   - note that :math:`\mathbf{P}` is the operator mapping T-vectors to L-vectors.
+   - note that :math:`\bm{P}` is the operator mapping T-vectors to L-vectors.
 
 - Element matrix assembly, **EA**:
 
@@ -182,62 +182,62 @@ Operator representation/storage/action categories:
 Partial Assembly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since the global operator :math:`\mathbf{A}` is just a series of variational restrictions
-with :math:`\mathbf{B}`, :math:`\mathbf{G}` and :math:`\mathbf{P}`, starting from its
-point-wise kernel :math:`\mathbf{D}`, a "matvec" with :math:`\mathbf{A}` can be
+Since the global operator :math:`\bm{A}` is just a series of variational restrictions
+with :math:`\bm{B}`, :math:`\bm{G}` and :math:`\bm{P}`, starting from its
+point-wise kernel :math:`\bm{D}`, a "matvec" with :math:`\bm{A}` can be
 performed by evaluating and storing some of the innermost variational restriction
 matrices, and applying the rest of the operators "on-the-fly". For example, one can
 compute and store a global matrix on **T-vector** level. Alternatively, one can compute
 and store only the subdomain (**L-vector**) or element (**E-vector**) matrices and
-perform the action of :math:`\mathbf{A}` using matvecs with :math:`\mathbf{P}` or
-:math:`\mathbf{P}` and :math:`\mathbf{G}`. While these options are natural for
+perform the action of :math:`\bm{A}` using matvecs with :math:`\bm{P}` or
+:math:`\bm{P}` and :math:`\bm{G}`. While these options are natural for
 low-order discretizations, they are not a good fit for high-order methods due to
 the amount of FLOPs needed for their evaluation, as well as the memory transfer
 needed for a matvec.
 
 Our focus in libCEED, instead, is on **partial assembly**, where we compute and
-store only :math:`\mathbf{D}` (or portions of it) and evaluate the actions of
-:math:`\mathbf{P}`, :math:`\mathbf{G}` and :math:`\mathbf{B}` on-the-fly.
+store only :math:`\bm{D}` (or portions of it) and evaluate the actions of
+:math:`\bm{P}`, :math:`\bm{G}` and :math:`\bm{B}` on-the-fly.
 Critically for performance, we take advantage of the tensor-product structure of the
 degrees of freedom and quadrature points on *quad* and *hex* elements to perform the
-action of :math:`\mathbf{B}` without storing it as a matrix.
+action of :math:`\bm{B}` without storing it as a matrix.
 
 Implemented properly, the partial assembly algorithm requires optimal amount of
 memory transfers (with respect to the polynomial order) and near-optimal FLOPs
 for operator evaluation. It consists of an operator *setup* phase, that
-evaluates and stores :math:`\mathbf{D}` and an operator *apply* (evaluation) phase that
-computes the action of :math:`\mathbf{A}` on an input vector. When desired, the setup
+evaluates and stores :math:`\bm{D}` and an operator *apply* (evaluation) phase that
+computes the action of :math:`\bm{A}` on an input vector. When desired, the setup
 phase may be done as a side-effect of evaluating a different operator, such as a
 nonlinear residual. The relative costs of the setup and apply phases are
 different depending on the physics being expressed and the representation of
-:math:`\mathbf{D}`.
+:math:`\bm{D}`.
 
 
 Parallel Decomposition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After the application of each of the first three transition operators,
-:math:`\mathbf{P}`, :math:`\mathbf{G}` and :math:`\mathbf{B}`, the operator evaluation
-is decoupled  on their ranges, so :math:`\mathbf{P}`, :math:`\mathbf{G}` and
-:math:`\mathbf{B}` allow us to "zoom-in" to subdomain, element and quadrature point
+:math:`\bm{P}`, :math:`\bm{G}` and :math:`\bm{B}`, the operator evaluation
+is decoupled  on their ranges, so :math:`\bm{P}`, :math:`\bm{G}` and
+:math:`\bm{B}` allow us to "zoom-in" to subdomain, element and quadrature point
 level, ignoring the coupling at higher levels.
 
-Thus, a natural mapping of :math:`\mathbf{A}` on a parallel computer is to split the
+Thus, a natural mapping of :math:`\bm{A}` on a parallel computer is to split the
 **T-vector** over MPI ranks (a non-overlapping decomposition, as is typically
 used for sparse matrices), and then split the rest of the vector types over
 computational devices (CPUs, GPUs, etc.) as indicated by the shaded regions in
 the diagram above.
 
 One of the advantages of the decomposition perspective in these settings is that
-the operators :math:`\mathbf{P}`, :math:`\mathbf{G}`, :math:`\mathbf{B}` and
-:math:`\mathbf{D}` clearly separate the MPI parallelism
-in the operator (:math:`\mathbf{P}`) from the unstructured mesh topology
-(:math:`\mathbf{G}`), the choice of the finite element space/basis (:math:`\mathbf{B}`)
-and the geometry and point-wise physics :math:`\mathbf{D}`. These components also
+the operators :math:`\bm{P}`, :math:`\bm{G}`, :math:`\bm{B}` and
+:math:`\bm{D}` clearly separate the MPI parallelism
+in the operator (:math:`\bm{P}`) from the unstructured mesh topology
+(:math:`\bm{G}`), the choice of the finite element space/basis (:math:`\bm{B}`)
+and the geometry and point-wise physics :math:`\bm{D}`. These components also
 naturally fall in different classes of numerical algorithms -- parallel (multi-device)
-linear algebra for :math:`\mathbf{P}`, sparse (on-device) linear algebra for
-:math:`\mathbf{G}`, dense/structured linear algebra (tensor contractions) for
-:math:`\mathbf{B}` and parallel point-wise evaluations for :math:`\mathbf{D}`.
+linear algebra for :math:`\bm{P}`, sparse (on-device) linear algebra for
+:math:`\bm{G}`, dense/structured linear algebra (tensor contractions) for
+:math:`\bm{B}` and parallel point-wise evaluations for :math:`\bm{D}`.
 
 Currently in libCEED, it is assumed that the host application manages the global
 **T-vectors** and the required communications among devices (which are generally
@@ -252,7 +252,7 @@ ranks (each using a single ``Ceed`` object): 2 ranks using 1 CPU socket each, an
 4 using 1 GPU each. Another choice could be to run 1 MPI rank on the whole node
 and use 5 ``Ceed`` objects: 1 managing all CPU cores on the 2 sockets and 4
 managing 1 GPU each. The communications among the devices, e.g. required for
-applying the action of :math:`\mathbf{P}`, are currently out of scope of libCEED. The
+applying the action of :math:`\bm{P}`, are currently out of scope of libCEED. The
 interface is non-blocking for all operations involving more than O(1) data,
 allowing operations performed on a coprocessor or worker threads to overlap with
 operations on the host.
@@ -288,13 +288,13 @@ implementation is as follows:
   (A backend may choose to operate incrementally without forming explicit **E-** or
   **Q-vectors**.)
 
-- :math:`\mathbf{G}` is represented as variable of type :ref:`CeedElemRestriction`.
+- :math:`\bm{G}` is represented as variable of type :ref:`CeedElemRestriction`.
 
-- :math:`\mathbf{B}` is represented as variable of type :ref:`CeedBasis`.
+- :math:`\bm{B}` is represented as variable of type :ref:`CeedBasis`.
 
-- the action of :math:`\mathbf{D}` is represented as variable of type :ref:`CeedQFunction`.
+- the action of :math:`\bm{D}` is represented as variable of type :ref:`CeedQFunction`.
 
-- the overall operator :math:`\mathbf{G}^T \mathbf{B}^T \mathbf{D} \mathbf{B} \mathbf{G}`
+- the overall operator :math:`\bm{G}^T \bm{B}^T \bm{D} \bm{B} \bm{G}`
   is represented as variable of type
   :ref:`CeedOperator` and its action is accessible through ``CeedOperatorApply()``.
 
@@ -320,9 +320,9 @@ may suffer in case of oversubscription). The resource is used to locate a
 suitable backend which will have discretion over the implementations of all
 objects created with this logical device.
 
-The ``setup`` routine above computes and stores :math:`\mathbf{D}`, in this case a
+The ``setup`` routine above computes and stores :math:`\bm{D}`, in this case a
 scalar value in each quadrature point, while ``mass`` uses these saved values to perform
-the action of :math:`\mathbf{D}`. These functions are turned into the ``CeedQFunction``
+the action of :math:`\bm{D}`. These functions are turned into the ``CeedQFunction``
 variables ``qf_setup`` and ``qf_mass`` in the ``CeedQFunctionCreateInterior()`` calls:
 
 .. literalinclude::  ../../../tests/t500-operator.c
@@ -376,7 +376,7 @@ field needs to reflect both the number of components and the geometric dimension
 A 3-dimensional gradient on four components would therefore mean the field has a size of
 12.
 
-The :math:`\mathbf{B}` operators for the mesh nodes, ``bx``, and the unknown field,
+The :math:`\bm{B}` operators for the mesh nodes, ``bx``, and the unknown field,
 ``bu``, are defined in the calls to the function ``CeedBasisCreateTensorH1Lagrange()``.
 In this example, both the mesh and the unknown field use :math:`H^1` Lagrange finite
 elements of order 1 and 4 respectively (the ``P`` argument represents the number of 1D
@@ -394,7 +394,7 @@ dimension using ``CeedBasisCreateTensorH1()``. Elements that do not have tensor
 product structure, such as symmetric elements on simplices, will be created
 using different constructors.
 
-The :math:`\mathbf{G}` operators for the mesh nodes, ``Erestrictx``, and the unknown field,
+The :math:`\bm{G}` operators for the mesh nodes, ``Erestrictx``, and the unknown field,
 ``Erestrictu``, are specified in the ``CeedElemRestrictionCreate()``. Both of these
 specify directly the dof indices for each element in the ``indx`` and ``indu``
 arrays:
@@ -415,23 +415,23 @@ contexts that involve problem-sized data.
 
 For discontinuous Galerkin and for applications such as Nek5000 that only
 explicitly store **E-vectors** (inter-element continuity has been subsumed by
-the parallel restriction :math:`\mathbf{P}`), the element restriction :math:`\mathbf{G}`
+the parallel restriction :math:`\bm{P}`), the element restriction :math:`\bm{G}`
 is the identity and ``CeedElemRestrictionCreateStrided()`` is used instead.
-We plan to support other structured representations of :math:`\mathbf{G}` which will
+We plan to support other structured representations of :math:`\bm{G}` which will
 be added according to demand. In the case of non-conforming mesh elements,
-:math:`\mathbf{G}` needs a more general representation that expresses values at slave
+:math:`\bm{G}` needs a more general representation that expresses values at slave
 nodes (which do not appear in **L-vectors**) as linear combinations of the degrees of
 freedom at master nodes.
 
-These operations, :math:`\mathbf{P}`, :math:`\mathbf{B}`, and :math:`\mathbf{D}`,
+These operations, :math:`\bm{P}`, :math:`\bm{B}`, and :math:`\bm{D}`,
 are combined with a ``CeedOperator``. As with QFunctions, operator fields are added
-separately with a matching field name, basis (:math:`\mathbf{B}`), element restriction
-(:math:`\mathbf{G}`), and **L-vector**. The flag
+separately with a matching field name, basis (:math:`\bm{B}`), element restriction
+(:math:`\bm{G}`), and **L-vector**. The flag
 ``CEED_VECTOR_ACTIVE`` indicates that the vector corresponding to that field will
 be provided to the operator when ``CeedOperatorApply()`` is called. Otherwise the
 input/output will be read from/written to the specified **L-vector**.
 
-With partial assembly, we first perform a setup stage where :math:`\mathbf{D}` is evaluated
+With partial assembly, we first perform a setup stage where :math:`\bm{D}` is evaluated
 and stored. This is accomplished by the operator ``op_setup`` and its application
 to ``X``, the nodes of the mesh (these are needed to compute Jacobians at
 quadrature points). Note that the corresponding ``CeedOperatorApply()`` has no basis

--- a/doc/sphinx/source/libCEEDapi.rst
+++ b/doc/sphinx/source/libCEEDapi.rst
@@ -365,7 +365,7 @@ More general operators, such as those of the form
 can be expressed.
 
 .. note::
-   The notation :math:`\nabla \boldsymbol v \!:\! f_1` represents contraction over both
+   The notation :math:`\nabla \bm v \!:\! f_1` represents contraction over both
    fields and spatial dimensions while a single dot represents contraction in just one,
    which should be clear from context, e.g., :math:`v \cdot f_0` contracts only over
    fields.

--- a/examples/bps.rst
+++ b/examples/bps.rst
@@ -20,16 +20,16 @@ find :math:`u \in V^p` such that for all :math:`v \in V^p`
 .. math::
    :label: eq-general-weak-form
 
-   \langle u,v \rangle = \langle f,v \rangle ,
+   \langle v,u \rangle = \langle v,f \rangle ,
 
-where :math:`\langle u,v\rangle` and :math:`\langle f,v\rangle` express the continuous
+where :math:`\langle v,u\rangle` and :math:`\langle v,f\rangle` express the continuous
 bilinear and linear forms, respectively, defined on :math:`V^p`, and, for sufficiently
 regular :math:`u`, :math:`v`, and :math:`f`, we have:
 
 .. math::
    \begin{aligned}
-   \langle u,v \rangle &:= \int_{\Omega} \, u \, v \, dV ,\\
-   \langle f,v \rangle &:= \int_{\Omega} \, f \, v \, dV .
+   \langle v,u \rangle &:= \int_{\Omega} \, v \, u \, dV ,\\
+   \langle v,f \rangle &:= \int_{\Omega} \, v \, f \, dV .
    \end{aligned}
 
 Following the standard finite/spectral element approach, we formally
@@ -50,13 +50,13 @@ into :math:numref:`eq-general-weak-form`, we obtain the inner-products
 .. math::
    :label: eq-inner-prods
 
-   \langle u,v \rangle = \bm v^T M \bm u , \qquad  \langle f,v\rangle =  \bm v^T \bm b \,.
+   \langle v,u \rangle = \bm v^T M \bm u , \qquad  \langle v,f\rangle =  \bm v^T \bm b \,.
 
 Here, we have introduced the mass matrix, :math:`M`, and the right-hand side,
 :math:`\bm b`,
 
 .. math::
-   M_{ij} :=  (\phi_i,\phi_j), \;\; \qquad b_{i} :=  \langle f, \phi_i \rangle,
+   M_{ij} :=  (\phi_i,\phi_j), \;\; \qquad b_{i} :=  \langle \phi_i, f \rangle,
 
 each defined for index sets :math:`i,j \; \in \; \{1,\dots,n\}`.
 
@@ -70,22 +70,22 @@ The Laplace's operator used in BP3-BP6 is defined via the following variational
 formulation, i.e., find :math:`u \in V^p` such that for all :math:`v \in V^p`
 
 .. math::
-   a(u,v) = \langle f,v \rangle , \,
+   a(v,u) = \langle v,f \rangle , \,
 
-where now :math:`a (u,v)` expresses the continuous bilinear form defined on
+where now :math:`a (v,u)` expresses the continuous bilinear form defined on
 :math:`V^p` for sufficiently regular :math:`u`, :math:`v`, and :math:`f`, that is:
 
 .. math::
    \begin{aligned}
-   a(u,v) &:= \int_{\Omega}\nabla u \, \cdot \, \nabla v \, dV ,\\
-   \langle f,v \rangle &:= \int_{\Omega} \, f \, v \, dV .
+   a(v,u) &:= \int_{\Omega}\nabla v \, \cdot \, \nabla u \, dV ,\\
+   \langle v,f \rangle &:= \int_{\Omega} \, v \, f \, dV .
    \end{aligned}
 
 After substituting the same formulations provided in :math:numref:`eq-nodal-values`,
 we obtain
 
 .. math::
-   a(u,v) = \bm v^T K \bm u ,
+   a(v,u) = \bm v^T K \bm u ,
 
 in which we have introduced the stiffness (diffusion) matrix, :math:`K`, defined as
 

--- a/examples/bps.rst
+++ b/examples/bps.rst
@@ -28,8 +28,8 @@ regular :math:`u`, :math:`v`, and :math:`f`, we have:
 
 .. math::
    \begin{aligned}
-   \langle v,u \rangle &:= \int_{\Omega} \, v \, u \, dV ,\\
-   \langle v,f \rangle &:= \int_{\Omega} \, v \, f \, dV .
+   \langle u,v \rangle &:= \int_{\Omega} \, u \, v \, dV ,\\
+   \langle f,v \rangle &:= \int_{\Omega} \, f \, v \, dV .
    \end{aligned}
 
 Following the standard finite/spectral element approach, we formally
@@ -50,7 +50,7 @@ into :math:numref:`eq-general-weak-form`, we obtain the inner-products
 .. math::
    :label: eq-inner-prods
 
-   \langle v,u \rangle = \bm v^T M \bm u , \qquad  \langle f,v\rangle =  \bm v^T \bm b \,.
+   \langle u,v \rangle = \bm v^T M \bm u , \qquad  \langle f,v\rangle =  \bm v^T \bm b \,.
 
 Here, we have introduced the mass matrix, :math:`M`, and the right-hand side,
 :math:`\bm b`,
@@ -77,15 +77,15 @@ where now :math:`a (u,v)` expresses the continuous bilinear form defined on
 
 .. math::
    \begin{aligned}
-   a(v,u) &:= \int_{\Omega}\nabla v \, \cdot \, \nabla u \, dV ,\\
-   \langle v,f \rangle &:= \int_{\Omega} \, v \, f \, dV .
+   a(u,v) &:= \int_{\Omega}\nabla u \, \cdot \, \nabla v \, dV ,\\
+   \langle f,v \rangle &:= \int_{\Omega} \, f \, v \, dV .
    \end{aligned}
 
 After substituting the same formulations provided in :math:numref:`eq-nodal-values`,
 we obtain
 
 .. math::
-   a(v,u) = \bm v^T K \bm u ,
+   a(u,v) = \bm v^T K \bm u ,
 
 in which we have introduced the stiffness (diffusion) matrix, :math:`K`, defined as
 

--- a/examples/ceed/index.rst
+++ b/examples/ceed/index.rst
@@ -13,25 +13,25 @@ Ex1-Volume
 
 This example is located in the subdirectory :file:`examples/ceed`. It illustrates a
 simple usage of libCEED to compute the volume of a given body using a matrix-free
-application of the mass operator. Arbitrary mesh and solution orders in 1D, 2D and 3D
+application of the mass operator. Arbitrary mesh and solution orders in 1D, 2D, and 3D
 are supported from the same code.
 
 This example shows how to compute line/surface/volume integrals of a 1D, 2D, or 3D
 domain :math:`\Omega` respectively, by applying the mass operator to a vector of
-:math:`\bm{1}`\s. It computes:
+:math:`1`\s. It computes:
 
 .. math::
-   I = \int_{\Omega} \bm{1} \, dV .
+   I = \int_{\Omega} 1 \, dV .
    :label: eq-ex1-volume
 
 Using the same notation as in :ref:`Theoretical Framework`, we write here the vector
-:math:`u(\bm{x})\equiv \bm{1}` in the Galerkin approximation,
+:math:`u(x)\equiv 1` in the Galerkin approximation,
 and find the volume of :math:`\Omega` as
 
 .. math::
    :label: volume-sum
 
-   \sum_e \int_{\Omega_e} v(x) \cdot \bm{1} \, dV
+   \sum_e \int_{\Omega_e} v(x) 1 \, dV
 
 with :math:`v(x) \in \mathcal{V}_p = \{ v \in H^{1}(\Omega_e) \,|\, v \in P_p(\bm{I}), e=1,\ldots,N_e \}`,
 the test functions.
@@ -44,23 +44,22 @@ Ex2-Surface
 
 This example is located in the subdirectory :file:`examples/ceed`. It computes the
 surface area of a given body using matrix-free application of a diffusion operator.
-Arbitrary mesh and solution orders in 1D, 2D and 3D are supported from the same code.
-
-Similarly to :ref:`Ex1-Volume`, it computes:
+Similar to :ref:`Ex1-Volume`, arbitrary mesh and solution orders in 1D, 2D, and 3D
+are supported from the same code. It computes:
 
 .. math::
-   I = \int_{\partial \Omega} \bm{1} \, dS .
+   I = \int_{\partial \Omega} 1 \, dS ,
    :label: eq-ex2-surface
 
-but this time by applying the divergence theorem using a Laplacian.
+by applying the divergence theorem.
 In particular, we select :math:`u(\bm x) = x_0 + x_1 + x_2`, for which :math:`\nabla u = [1, 1, 1]^T`, and thus :math:`\nabla u \cdot \hat{\bm n} = 1`.
 
 Given Laplace's equation,
 
 .. math::
-   -\nabla \cdot \nabla u = 0, \textrm{ for  } \bm{x} \in \Omega
+   \nabla \cdot \nabla u = 0, \textrm{ for  } \bm{x} \in \Omega
 
-multiply by a test function :math:`v` and integrate by parts to obtain
+let us multiply by a test function :math:`v` and integrate by parts to obtain
 
 .. math::
     \int_\Omega \nabla v \cdot \nabla u \, dV - \int_{\partial \Omega} v \nabla u \cdot \hat{\bm n}\, dS = 0 .
@@ -68,4 +67,4 @@ multiply by a test function :math:`v` and integrate by parts to obtain
 Since we have chosen :math:`u` such that :math:`\nabla u \cdot \hat{\bm n} = 1`, the boundary integrand is :math:`v 1 \equiv v`. Hence, similar to :math:numref:`volume-sum`, we can evaluate the surface integral by applying the volumetric Laplacian as follows
 
 .. math::
-   \int_\Omega \nabla v \cdot \nabla u \, dV \approx \sum_e \int_{\partial \Omega_e} v(x) \cdot \bm{1} \, dS .
+   \int_\Omega \nabla v \cdot \nabla u \, dV \approx \sum_e \int_{\partial \Omega_e} v(x) 1 \, dS .

--- a/examples/ceed/index.rst
+++ b/examples/ceed/index.rst
@@ -18,20 +18,20 @@ are supported from the same code.
 
 This example shows how to compute line/surface/volume integrals of a 1D, 2D, or 3D
 domain :math:`\Omega` respectively, by applying the mass operator to a vector of
-:math:`\mathbf{1}`\s. It computes:
+:math:`\bm{1}`\s. It computes:
 
 .. math::
-   I = \int_{\Omega} \mathbf{1} \, dV .
+   I = \int_{\Omega} \bm{1} \, dV .
    :label: eq-ex1-volume
 
 Using the same notation as in :ref:`Theoretical Framework`, we write here the vector
-:math:`u(\mathbf{x})\equiv \mathbf{1}` in the Galerkin approximation,
+:math:`u(\bm{x})\equiv \bm{1}` in the Galerkin approximation,
 and find the volume of :math:`\Omega` as
 
 .. math::
    :label: volume-sum
 
-   \sum_e \int_{\Omega_e} v(x) \cdot \mathbf{1} \, dV
+   \sum_e \int_{\Omega_e} v(x) \cdot \bm{1} \, dV
 
 with :math:`v(x) \in \mathcal{V}_p = \{ v \in H^{1}(\Omega_e) \,|\, v \in P_p(\bm{I}), e=1,\ldots,N_e \}`,
 the test functions.
@@ -49,7 +49,7 @@ Arbitrary mesh and solution orders in 1D, 2D and 3D are supported from the same 
 Similarly to :ref:`Ex1-Volume`, it computes:
 
 .. math::
-   I = \int_{\partial \Omega} \mathbf{1} \, dS .
+   I = \int_{\partial \Omega} \bm{1} \, dS .
    :label: eq-ex2-surface
 
 but this time by applying the divergence theorem using a Laplacian.
@@ -58,7 +58,7 @@ In particular, we select :math:`u(\bm x) = x_0 + x_1 + x_2`, for which :math:`\n
 Given Laplace's equation,
 
 .. math::
-   -\nabla \cdot \nabla u = 0, \textrm{ for  } \mathbf{x} \in \Omega
+   -\nabla \cdot \nabla u = 0, \textrm{ for  } \bm{x} \in \Omega
 
 multiply by a test function :math:`v` and integrate by parts to obtain
 
@@ -68,4 +68,4 @@ multiply by a test function :math:`v` and integrate by parts to obtain
 Since we have chosen :math:`u` such that :math:`\nabla u \cdot \hat{\bm n} = 1`, the boundary integrand is :math:`v 1 \equiv v`. Hence, similar to :math:numref:`volume-sum`, we can evaluate the surface integral by applying the volumetric Laplacian as follows
 
 .. math::
-   \int_\Omega \nabla v \cdot \nabla u \, dV \approx \sum_e \int_{\partial \Omega_e} v(x) \cdot \mathbf{1} \, dS .
+   \int_\Omega \nabla v \cdot \nabla u \, dV \approx \sum_e \int_{\partial \Omega_e} v(x) \cdot \bm{1} \, dS .

--- a/examples/ceed/index.rst
+++ b/examples/ceed/index.rst
@@ -33,7 +33,7 @@ and find the volume of :math:`\Omega` as
 
    \sum_e \int_{\Omega_e} v(x) \cdot \mathbf{1} \, dV
 
-with :math:`v(x) \in \mathcal{V}_p = \{ v \in H^{1}(\Omega_e) \,|\, v \in P_p(\boldsymbol{I}), e=1,\ldots,N_e \}`,
+with :math:`v(x) \in \mathcal{V}_p = \{ v \in H^{1}(\Omega_e) \,|\, v \in P_p(\bm{I}), e=1,\ldots,N_e \}`,
 the test functions.
 
 

--- a/examples/ceed/index.rst
+++ b/examples/ceed/index.rst
@@ -29,6 +29,8 @@ Using the same notation as in :ref:`Theoretical Framework`, we write here the ve
 and find the volume of :math:`\Omega` as
 
 .. math::
+   :label: volume-sum
+
    \sum_e \int_{\Omega_e} v(x) \cdot \mathbf{1} \, dV
 
 with :math:`v(x) \in \mathcal{V}_p = \{ v \in H^{1}(\Omega_e) \,|\, v \in P_p(\boldsymbol{I}), e=1,\ldots,N_e \}`,
@@ -63,4 +65,7 @@ multiply by a test function :math:`v` and integrate by parts to obtain
 .. math::
     \int_\Omega \nabla v \cdot \nabla u \, dV - \int_{\partial \Omega} v \nabla u \cdot \hat{\bm n}\, dS = 0 .
 
-Since we have chosen :math:`u` such that the boundary integrand is :math:`v 1`, we may evaluate the surface integral by applying the volumetric Laplacian and summing the result.
+Since we have chosen :math:`u` such that :math:`\nabla u \cdot \hat{\bm n} = 1`, the boundary integrand is :math:`v 1 \equiv v`. Hence, similar to :math:numref:`volume-sum`, we can evaluate the surface integral by applying the volumetric Laplacian as follows
+
+.. math::
+   \int_\Omega \nabla v \cdot \nabla u \, dV \approx \sum_e \int_{\partial \Omega_e} v(x) \cdot \mathbf{1} \, dS .

--- a/examples/fluids/index.rst
+++ b/examples/fluids/index.rst
@@ -18,26 +18,26 @@ follows. The compressible Navier-Stokes equations in conservative form are
    :label: eq-ns
 
    \begin{aligned}
-   \frac{\partial \rho}{\partial t} + \nabla \cdot \boldsymbol{U} &= 0 \\
-   \frac{\partial \boldsymbol{U}}{\partial t} + \nabla \cdot \left( \frac{\boldsymbol{U} \otimes \boldsymbol{U}}{\rho} + P \mathbf{I}_3 -\boldsymbol\sigma \right) + \rho g \boldsymbol{\hat k} &= 0 \\
-   \frac{\partial E}{\partial t} + \nabla \cdot \left( \frac{(E + P)\boldsymbol{U}}{\rho} -\boldsymbol{u} \cdot \boldsymbol{\sigma} - k \nabla T \right) &= 0 \, , \\
+   \frac{\partial \rho}{\partial t} + \nabla \cdot \bm{U} &= 0 \\
+   \frac{\partial \bm{U}}{\partial t} + \nabla \cdot \left( \frac{\bm{U} \otimes \bm{U}}{\rho} + P \mathbf{I}_3 -\bm\sigma \right) + \rho g \bm{\hat k} &= 0 \\
+   \frac{\partial E}{\partial t} + \nabla \cdot \left( \frac{(E + P)\bm{U}}{\rho} -\bm{u} \cdot \bm{\sigma} - k \nabla T \right) &= 0 \, , \\
    \end{aligned}
 
-where :math:`\boldsymbol{\sigma} = \mu(\nabla \boldsymbol{u} + (\nabla \boldsymbol{u})^T + \lambda (\nabla \cdot \boldsymbol{u})\mathbf{I}_3)`
+where :math:`\bm{\sigma} = \mu(\nabla \bm{u} + (\nabla \bm{u})^T + \lambda (\nabla \cdot \bm{u})\mathbf{I}_3)`
 is the Cauchy (symmetric) stress tensor, with :math:`\mu` the dynamic viscosity
 coefficient, and :math:`\lambda = - 2/3` the Stokes hypothesis constant. In equations
 :math:numref:`eq-ns`, :math:`\rho` represents the volume mass density, :math:`U` the
-momentum density (defined as :math:`\boldsymbol{U}=\rho \boldsymbol{u}`, where
-:math:`\boldsymbol{u}` is the vector velocity field), :math:`E` the total energy
+momentum density (defined as :math:`\bm{U}=\rho \bm{u}`, where
+:math:`\bm{u}` is the vector velocity field), :math:`E` the total energy
 density (defined as :math:`E = \rho e`, where :math:`e` is the total energy),
 :math:`\mathbf{I}_3` represents the :math:`3 \times 3` identity matrix, :math:`g`
-the gravitational acceleration constant, :math:`\boldsymbol{\hat{k}}` the unit vector
+the gravitational acceleration constant, :math:`\bm{\hat{k}}` the unit vector
 in the :math:`z` direction, :math:`k` the thermal conductivity constant, :math:`T`
 represents the temperature, and :math:`P` the pressure, given by the following equation
 of state
 
 .. math::
-   P = \left( {c_p}/{c_v} -1\right) \left( E - {\boldsymbol{U}\cdot\boldsymbol{U}}/{(2 \rho)} - \rho g z \right) \, ,
+   P = \left( {c_p}/{c_v} -1\right) \left( E - {\bm{U}\cdot\bm{U}}/{(2 \rho)} - \rho g z \right) \, ,
    :label: eq-state
 
 where :math:`c_p` is the specific heat at constant pressure and :math:`c_v` is the
@@ -49,15 +49,15 @@ The system :math:numref:`eq-ns` can be rewritten in vector form
 .. math::
    :label: eq-vector-ns
 
-   \frac{\partial \boldsymbol{q}}{\partial t} + \nabla \cdot \boldsymbol{F}(\boldsymbol{q}) -S(\boldsymbol{q}) = 0 \, ,
+   \frac{\partial \bm{q}}{\partial t} + \nabla \cdot \bm{F}(\bm{q}) -S(\bm{q}) = 0 \, ,
 
 for the state variables 5-dimensional vector
 
 .. math::
-    \boldsymbol{q} =
+    \bm{q} =
            \begin{pmatrix}
                \rho \\
-               \boldsymbol{U} \equiv \rho \mathbf{ u }\\
+               \bm{U} \equiv \rho \mathbf{ u }\\
                E \equiv \rho e
            \end{pmatrix}
            \begin{array}{l}
@@ -71,16 +71,16 @@ where the flux and the source terms, respectively, are given by
 .. math::
 
     \begin{aligned}
-    \boldsymbol{F}(\boldsymbol{q}) &=
+    \bm{F}(\bm{q}) &=
     \begin{pmatrix}
-        \boldsymbol{U}\\
-        {(\boldsymbol{U} \otimes \boldsymbol{U})}/{\rho} + P \mathbf{I}_3 -  \boldsymbol{\sigma} \\
-        {(E + P)\boldsymbol{U}}/{\rho} - \boldsymbol{u}  \cdot \boldsymbol{\sigma} - k \nabla T
+        \bm{U}\\
+        {(\bm{U} \otimes \bm{U})}/{\rho} + P \mathbf{I}_3 -  \bm{\sigma} \\
+        {(E + P)\bm{U}}/{\rho} - \bm{u}  \cdot \bm{\sigma} - k \nabla T
     \end{pmatrix} ,\\
-    S(\boldsymbol{q}) &=
+    S(\bm{q}) &=
     - \begin{pmatrix}
         0\\
-        \rho g \boldsymbol{\hat{k}}\\
+        \rho g \bm{\hat{k}}\\
         0
     \end{pmatrix}.
     \end{aligned}
@@ -88,10 +88,10 @@ where the flux and the source terms, respectively, are given by
 Let the discrete solution be
 
 .. math::
-   \boldsymbol{q}_N (\boldsymbol{x},t)^{(e)} = \sum_{k=1}^{P}\psi_k (\boldsymbol{x})\boldsymbol{q}_k^{(e)}
+   \bm{q}_N (\bm{x},t)^{(e)} = \sum_{k=1}^{P}\psi_k (\bm{x})\bm{q}_k^{(e)}
 
 with :math:`P=p+1` the number of nodes in the element :math:`e`. We use tensor-product
-bases :math:`\psi_{kji} = h_i(X_1)h_j(X_2)h_k(X_3)`.
+bases :math:`\psi_{kji} = h_i(X_0)h_j(X_1)h_k(X_2)`.
 
 For the time discretization, we use two types of time stepping schemes.
 
@@ -102,24 +102,24 @@ For the time discretization, we use two types of time stepping schemes.
     scheme available in PETSc can be chosen at runtime)
 
     .. math::
-       \boldsymbol{q}_N^{n+1} = \boldsymbol{q}_N^n + \Delta t \sum_{i=1}^{s} b_i k_i \, ,
+       \bm{q}_N^{n+1} = \bm{q}_N^n + \Delta t \sum_{i=1}^{s} b_i k_i \, ,
 
     where
 
     .. math::
 
        \begin{aligned}
-          k_1 &= f(t^n, \boldsymbol{q}_N^n)\\
-          k_2 &= f(t^n + c_2 \Delta t, \boldsymbol{q}_N^n + \Delta t (a_{21} k_1))\\
-          k_3 &= f(t^n + c_3 \Delta t, \boldsymbol{q}_N^n + \Delta t (a_{31} k_1 + a_{32} k_2))\\
+          k_1 &= f(t^n, \bm{q}_N^n)\\
+          k_2 &= f(t^n + c_2 \Delta t, \bm{q}_N^n + \Delta t (a_{21} k_1))\\
+          k_3 &= f(t^n + c_3 \Delta t, \bm{q}_N^n + \Delta t (a_{31} k_1 + a_{32} k_2))\\
           \vdots&\\
-          k_i &= f\left(t^n + c_i \Delta t, \boldsymbol{q}_N^n + \Delta t \sum_{j=1}^s a_{ij} k_j \right)\\
+          k_i &= f\left(t^n + c_i \Delta t, \bm{q}_N^n + \Delta t \sum_{j=1}^s a_{ij} k_j \right)\\
        \end{aligned}
 
     and with
 
     .. math::
-       f(t^n, \boldsymbol{q}_N^n) = - [\nabla \cdot \boldsymbol{F}(\boldsymbol{q}_N)]^n + [S(\boldsymbol{q}_N)]^n \, .
+       f(t^n, \bm{q}_N^n) = - [\nabla \cdot \bm{F}(\bm{q}_N)]^n + [S(\bm{q}_N)]^n \, .
 
 - Implicit time-stepping method
 
@@ -131,12 +131,12 @@ For the time discretization, we use two types of time stepping schemes.
     .. math::
        :label: eq-ts-implicit-ns
 
-       \bm f(\bm q_N) \equiv \bm g(t^{n+1}, \boldsymbol{q}_N, \boldsymbol{\dot{q}}_N) = 0 \, ,
+       \bm f(\bm q_N) \equiv \bm g(t^{n+1}, \bm{q}_N, \bm{\dot{q}}_N) = 0 \, ,
 
     where the time derivative :math:`\bm{\dot q}_N` is defined by
 
     .. math::
-      \boldsymbol{\dot{q}}_N(\bm q_N) = \alpha \bm q_N + \bm z_N
+      \bm{\dot{q}}_N(\bm q_N) = \alpha \bm q_N + \bm z_N
 
     in terms of :math:`\bm z_N` from prior state and :math:`\alpha > 0`,
     both of which depend on the specific time integration scheme (backward difference
@@ -163,13 +163,13 @@ For the time discretization, we use two types of time stepping schemes.
     with the convergence rate of Krylov methods using weak preconditioners.
 
 To obtain a finite element discretization, we first multiply the strong form
-:math:numref:`eq-vector-ns` by a test function :math:`\boldsymbol v \in H^1(\Omega)`
+:math:numref:`eq-vector-ns` by a test function :math:`\bm v \in H^1(\Omega)`
 and integrate,
 
 .. math::
-   \int_{\Omega} \boldsymbol v \cdot \left(\frac{\partial \boldsymbol{q}_N}{\partial t} + \nabla \cdot \boldsymbol{F}(\boldsymbol{q}_N) - \mathbf{S}(\boldsymbol{q}_N) \right) \,dV = 0 \, , \; \forall \boldsymbol v \in \mathcal{V}_p\,,
+   \int_{\Omega} \bm v \cdot \left(\frac{\partial \bm{q}_N}{\partial t} + \nabla \cdot \bm{F}(\bm{q}_N) - \mathbf{S}(\bm{q}_N) \right) \,dV = 0 \, , \; \forall \bm v \in \mathcal{V}_p\,,
 
-with :math:`\mathcal{V}_p = \{ \boldsymbol v(\mathbf x) \in H^{1}(\Omega_e) \,|\, \boldsymbol v(\mathbf x_e(\mathbf X)) \in P_p(\boldsymbol{I}), e=1,\ldots,N_e \}`
+with :math:`\mathcal{V}_p = \{ \bm v(\mathbf x) \in H^{1}(\Omega_e) \,|\, \bm v(\mathbf x_e(\mathbf X)) \in P_p(\bm{I}), e=1,\ldots,N_e \}`
 a mapped space of polynomials containing at least polynomials of degree :math:`p`
 (with or without the higher mixed terms that appear in tensor product spaces).
 
@@ -179,17 +179,17 @@ Integrating by parts on the divergence term, we arrive at the weak form,
    :label: eq-weak-vector-ns
 
    \begin{aligned}
-   \int_{\Omega} \boldsymbol v \cdot \left( \frac{\partial \boldsymbol{q}_N}{\partial t} - \mathbf{S}(\boldsymbol{q}_N) \right)  \,dV
-   - \int_{\Omega} \nabla \boldsymbol v \!:\! \boldsymbol{F}(\boldsymbol{q}_N)\,dV & \\
-   + \int_{\partial \Omega} \boldsymbol v \cdot \boldsymbol{F}(\boldsymbol q_N) \cdot \widehat{\mathbf{n}} \,dS
-     &= 0 \, , \; \forall \boldsymbol v \in \mathcal{V}_p \,,
+   \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \mathbf{S}(\bm{q}_N) \right)  \,dV
+   - \int_{\Omega} \nabla \bm v \!:\! \bm{F}(\bm{q}_N)\,dV & \\
+   + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm q_N) \cdot \widehat{\mathbf{n}} \,dS
+     &= 0 \, , \; \forall \bm v \in \mathcal{V}_p \,,
    \end{aligned}
 
-where :math:`\boldsymbol{F}(\boldsymbol q_N) \cdot \widehat{\mathbf{n}}` is typically
+where :math:`\bm{F}(\bm q_N) \cdot \widehat{\mathbf{n}}` is typically
 replaced with a boundary condition.
 
 .. note::
-  The notation :math:`\nabla \boldsymbol v \!:\! \boldsymbol F` represents contraction over both fields and spatial dimensions while a single dot represents contraction in just one, which should be clear from context, e.g., :math:`\boldsymbol v \cdot \boldsymbol S` contracts over fields while :math:`\boldsymbol F \cdot \widehat{\mathbf n}` contracts over spatial dimensions.
+  The notation :math:`\nabla \bm v \!:\! \bm F` represents contraction over both fields and spatial dimensions while a single dot represents contraction in just one, which should be clear from context, e.g., :math:`\bm v \cdot \bm S` contracts over fields while :math:`\bm F \cdot \widehat{\mathbf n}` contracts over spatial dimensions.
 
 We solve :math:numref:`eq-weak-vector-ns` using a Galerkin discretization (default)
 or a stabilized method, as is necessary for most real-world flows.
@@ -211,12 +211,12 @@ for continuous finite element discretization of compressible flows.
        :label: eq-weak-vector-ns-supg
 
        \begin{aligned}
-       \int_{\Omega} \boldsymbol v \cdot \left( \frac{\partial \boldsymbol{q}_N}{\partial t} - \mathbf{S}(\boldsymbol{q}_N) \right)  \,dV
-       - \int_{\Omega} \nabla \boldsymbol v \!:\! \boldsymbol{F}(\boldsymbol{q}_N)\,dV & \\
-       + \int_{\partial \Omega} \boldsymbol v \cdot \boldsymbol{F}(\boldsymbol{q}_N) \cdot \widehat{\mathbf{n}} \,dS & \\
-       + \int_{\Omega} \boldsymbol{P}(\boldsymbol v)^T \, \left( \frac{\partial \boldsymbol{q}_N}{\partial t} \, + \,
-       \nabla \cdot \boldsymbol{F} \, (\boldsymbol{q}_N) - \mathbf{S}(\boldsymbol{q}_N) \right) \,dV &= 0
-       \, , \; \forall \boldsymbol v \in \mathcal{V}_p
+       \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \mathbf{S}(\bm{q}_N) \right)  \,dV
+       - \int_{\Omega} \nabla \bm v \!:\! \bm{F}(\bm{q}_N)\,dV & \\
+       + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm{q}_N) \cdot \widehat{\mathbf{n}} \,dS & \\
+       + \int_{\Omega} \bm{P}(\bm v)^T \, \left( \frac{\partial \bm{q}_N}{\partial t} \, + \,
+       \nabla \cdot \bm{F} \, (\bm{q}_N) - \mathbf{S}(\bm{q}_N) \right) \,dV &= 0
+       \, , \; \forall \bm v \in \mathcal{V}_p
        \end{aligned}
 
     This stabilization technique can be selected using the option ``-stab supg``.
@@ -232,26 +232,26 @@ for continuous finite element discretization of compressible flows.
        :label: eq-weak-vector-ns-su
 
        \begin{aligned}
-       \int_{\Omega} \boldsymbol v \cdot \left( \frac{\partial \boldsymbol{q}_N}{\partial t} - \mathbf{S}(\boldsymbol{q}_N) \right)  \,dV
-       - \int_{\Omega} \nabla \boldsymbol v \!:\! \boldsymbol{F}(\boldsymbol{q}_N)\,dV & \\
-       + \int_{\partial \Omega} \boldsymbol v \cdot \boldsymbol{F}(\boldsymbol{q}_N) \cdot \widehat{\mathbf{n}} \,dS & \\
-       + \int_{\Omega} \boldsymbol{P}(\boldsymbol v)^T \, \nabla \cdot \boldsymbol{F} \, (\boldsymbol{q}_N) \,dV
-       & = 0 \, , \; \forall \boldsymbol v \in \mathcal{V}_p
+       \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \mathbf{S}(\bm{q}_N) \right)  \,dV
+       - \int_{\Omega} \nabla \bm v \!:\! \bm{F}(\bm{q}_N)\,dV & \\
+       + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm{q}_N) \cdot \widehat{\mathbf{n}} \,dS & \\
+       + \int_{\Omega} \bm{P}(\bm v)^T \, \nabla \cdot \bm{F} \, (\bm{q}_N) \,dV
+       & = 0 \, , \; \forall \bm v \in \mathcal{V}_p
        \end{aligned}
 
     This stabilization technique can be selected using the option ``-stab su``.
 
 
 In both :math:numref:`eq-weak-vector-ns-su` and :math:numref:`eq-weak-vector-ns-supg`,
-:math:`\boldsymbol{P} \,` is called the *perturbation to the test-function space*,
+:math:`\bm{P} \,` is called the *perturbation to the test-function space*,
 since it modifies the original Galerkin method into *SUPG* or *SU* schemes. It is defined
 as
 
 .. math::
-   \boldsymbol{P}(\boldsymbol v) \equiv \left(\boldsymbol{\tau} \cdot \frac{\partial \boldsymbol{F} \, (\boldsymbol{q}_N)}{\partial
-   \boldsymbol{q}_N} \right)^T \, \nabla \boldsymbol v\,,
+   \bm{P}(\bm v) \equiv \left(\bm{\tau} \cdot \frac{\partial \bm{F} \, (\bm{q}_N)}{\partial
+   \bm{q}_N} \right)^T \, \nabla \bm v\,,
 
-where parameter :math:`\boldsymbol{\tau} \in \mathbb R^{3\times 3}` is an intrinsic time/space scale matrix.
+where parameter :math:`\bm{\tau} \in \mathbb R^{3\times 3}` is an intrinsic time/space scale matrix.
 
 Currently, this demo provides two types of problems/physical models that can be selected
 at run time via the option ``-problem``. One is the problem of transport of energy in a
@@ -268,13 +268,13 @@ A simplified version of system :math:numref:`eq-ns`, only accounting for the tra
 of total energy, is given by
 
 .. math::
-   \frac{\partial E}{\partial t} + \nabla \cdot (\boldsymbol{u} E ) = 0 \, ,
+   \frac{\partial E}{\partial t} + \nabla \cdot (\bm{u} E ) = 0 \, ,
    :label: eq-advection
 
-with :math:`\boldsymbol{u}` the vector velocity field. In this particular test case, a
+with :math:`\bm{u}` the vector velocity field. In this particular test case, a
 blob of total energy (defined by a characteristic radius :math:`r_c`) is transported by
 a uniform circular velocity field. We have solved :math:numref:`eq-advection` with
-no-slip and non-penetration boundary conditions for :math:`\boldsymbol{u}`, and no-flux
+no-slip and non-penetration boundary conditions for :math:`\bm{u}`, and no-flux
 for :math:`E`. This problem can be run with::
 
    ./navierstokes -problem advection
@@ -289,17 +289,17 @@ For this test problem (from :cite:`straka1993numerical`), we solve the full
 Navier-Stokes equations :math:numref:`eq-ns`, for which a cold air bubble
 (of radius :math:`r_c`) drops by convection in a neutrally stratified atmosphere.
 Its initial condition is defined in terms of the Exner pressure,
-:math:`\pi(\boldsymbol{x},t)`, and potential temperature,
-:math:`\theta(\boldsymbol{x},t)`, that relate to the state variables via
+:math:`\pi(\bm{x},t)`, and potential temperature,
+:math:`\theta(\bm{x},t)`, that relate to the state variables via
 
 .. math::
    \begin{aligned}
-   \rho &= \frac{P_0}{( c_p - c_v)\theta(\boldsymbol{x},t)} \pi(\boldsymbol{x},t)^{\frac{c_v}{ c_p - c_v}} \, , \\
-   e &= c_v \theta(\boldsymbol{x},t) \pi(\boldsymbol{x},t) + \boldsymbol{u}\cdot \boldsymbol{u} /2 + g z \, ,
+   \rho &= \frac{P_0}{( c_p - c_v)\theta(\bm{x},t)} \pi(\bm{x},t)^{\frac{c_v}{ c_p - c_v}} \, , \\
+   e &= c_v \theta(\bm{x},t) \pi(\bm{x},t) + \bm{u}\cdot \bm{u} /2 + g z \, ,
    \end{aligned}
 
 where :math:`P_0` is the atmospheric pressure. For this problem, we have used no-slip
-and non-penetration boundary conditions for :math:`\boldsymbol{u}`, and no-flux
+and non-penetration boundary conditions for :math:`\bm{u}`, and no-flux
 for mass and energy densities. This problem can be run with::
 
    ./navierstokes -problem density_current

--- a/examples/fluids/index.rst
+++ b/examples/fluids/index.rst
@@ -11,7 +11,7 @@ PETSc). Moreover, the Navier-Stokes example has been developed using PETSc, so t
 pointwise physics (defined at quadrature points) is separated from the parallelization
 and meshing concerns.
 
-The mathematical formulation (from :cite:`giraldoetal2010`, cfr. SE3) is given in what
+The mathematical formulation (from :cite:`giraldoetal2010`, cf. SE3) is given in what
 follows. The compressible Navier-Stokes equations in conservative form are
 
 .. math::

--- a/examples/fluids/index.rst
+++ b/examples/fluids/index.rst
@@ -19,18 +19,18 @@ follows. The compressible Navier-Stokes equations in conservative form are
 
    \begin{aligned}
    \frac{\partial \rho}{\partial t} + \nabla \cdot \bm{U} &= 0 \\
-   \frac{\partial \bm{U}}{\partial t} + \nabla \cdot \left( \frac{\bm{U} \otimes \bm{U}}{\rho} + P \mathbf{I}_3 -\bm\sigma \right) + \rho g \bm{\hat k} &= 0 \\
+   \frac{\partial \bm{U}}{\partial t} + \nabla \cdot \left( \frac{\bm{U} \otimes \bm{U}}{\rho} + P \bm{I}_3 -\bm\sigma \right) + \rho g \bm{\hat k} &= 0 \\
    \frac{\partial E}{\partial t} + \nabla \cdot \left( \frac{(E + P)\bm{U}}{\rho} -\bm{u} \cdot \bm{\sigma} - k \nabla T \right) &= 0 \, , \\
    \end{aligned}
 
-where :math:`\bm{\sigma} = \mu(\nabla \bm{u} + (\nabla \bm{u})^T + \lambda (\nabla \cdot \bm{u})\mathbf{I}_3)`
+where :math:`\bm{\sigma} = \mu(\nabla \bm{u} + (\nabla \bm{u})^T + \lambda (\nabla \cdot \bm{u})\bm{I}_3)`
 is the Cauchy (symmetric) stress tensor, with :math:`\mu` the dynamic viscosity
 coefficient, and :math:`\lambda = - 2/3` the Stokes hypothesis constant. In equations
 :math:numref:`eq-ns`, :math:`\rho` represents the volume mass density, :math:`U` the
 momentum density (defined as :math:`\bm{U}=\rho \bm{u}`, where
 :math:`\bm{u}` is the vector velocity field), :math:`E` the total energy
 density (defined as :math:`E = \rho e`, where :math:`e` is the total energy),
-:math:`\mathbf{I}_3` represents the :math:`3 \times 3` identity matrix, :math:`g`
+:math:`\bm{I}_3` represents the :math:`3 \times 3` identity matrix, :math:`g`
 the gravitational acceleration constant, :math:`\bm{\hat{k}}` the unit vector
 in the :math:`z` direction, :math:`k` the thermal conductivity constant, :math:`T`
 represents the temperature, and :math:`P` the pressure, given by the following equation
@@ -57,7 +57,7 @@ for the state variables 5-dimensional vector
     \bm{q} =
            \begin{pmatrix}
                \rho \\
-               \bm{U} \equiv \rho \mathbf{ u }\\
+               \bm{U} \equiv \rho \bm{ u }\\
                E \equiv \rho e
            \end{pmatrix}
            \begin{array}{l}
@@ -74,7 +74,7 @@ where the flux and the source terms, respectively, are given by
     \bm{F}(\bm{q}) &=
     \begin{pmatrix}
         \bm{U}\\
-        {(\bm{U} \otimes \bm{U})}/{\rho} + P \mathbf{I}_3 -  \bm{\sigma} \\
+        {(\bm{U} \otimes \bm{U})}/{\rho} + P \bm{I}_3 -  \bm{\sigma} \\
         {(E + P)\bm{U}}/{\rho} - \bm{u}  \cdot \bm{\sigma} - k \nabla T
     \end{pmatrix} ,\\
     S(\bm{q}) &=
@@ -167,9 +167,9 @@ To obtain a finite element discretization, we first multiply the strong form
 and integrate,
 
 .. math::
-   \int_{\Omega} \bm v \cdot \left(\frac{\partial \bm{q}_N}{\partial t} + \nabla \cdot \bm{F}(\bm{q}_N) - \mathbf{S}(\bm{q}_N) \right) \,dV = 0 \, , \; \forall \bm v \in \mathcal{V}_p\,,
+   \int_{\Omega} \bm v \cdot \left(\frac{\partial \bm{q}_N}{\partial t} + \nabla \cdot \bm{F}(\bm{q}_N) - \bm{S}(\bm{q}_N) \right) \,dV = 0 \, , \; \forall \bm v \in \mathcal{V}_p\,,
 
-with :math:`\mathcal{V}_p = \{ \bm v(\mathbf x) \in H^{1}(\Omega_e) \,|\, \bm v(\mathbf x_e(\mathbf X)) \in P_p(\bm{I}), e=1,\ldots,N_e \}`
+with :math:`\mathcal{V}_p = \{ \bm v(\bm x) \in H^{1}(\Omega_e) \,|\, \bm v(\bm x_e(\bm X)) \in P_p(\bm{I}), e=1,\ldots,N_e \}`
 a mapped space of polynomials containing at least polynomials of degree :math:`p`
 (with or without the higher mixed terms that appear in tensor product spaces).
 
@@ -179,17 +179,17 @@ Integrating by parts on the divergence term, we arrive at the weak form,
    :label: eq-weak-vector-ns
 
    \begin{aligned}
-   \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \mathbf{S}(\bm{q}_N) \right)  \,dV
+   \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \bm{S}(\bm{q}_N) \right)  \,dV
    - \int_{\Omega} \nabla \bm v \!:\! \bm{F}(\bm{q}_N)\,dV & \\
-   + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm q_N) \cdot \widehat{\mathbf{n}} \,dS
+   + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm q_N) \cdot \widehat{\bm{n}} \,dS
      &= 0 \, , \; \forall \bm v \in \mathcal{V}_p \,,
    \end{aligned}
 
-where :math:`\bm{F}(\bm q_N) \cdot \widehat{\mathbf{n}}` is typically
+where :math:`\bm{F}(\bm q_N) \cdot \widehat{\bm{n}}` is typically
 replaced with a boundary condition.
 
 .. note::
-  The notation :math:`\nabla \bm v \!:\! \bm F` represents contraction over both fields and spatial dimensions while a single dot represents contraction in just one, which should be clear from context, e.g., :math:`\bm v \cdot \bm S` contracts over fields while :math:`\bm F \cdot \widehat{\mathbf n}` contracts over spatial dimensions.
+  The notation :math:`\nabla \bm v \!:\! \bm F` represents contraction over both fields and spatial dimensions while a single dot represents contraction in just one, which should be clear from context, e.g., :math:`\bm v \cdot \bm S` contracts over fields while :math:`\bm F \cdot \widehat{\bm n}` contracts over spatial dimensions.
 
 We solve :math:numref:`eq-weak-vector-ns` using a Galerkin discretization (default)
 or a stabilized method, as is necessary for most real-world flows.
@@ -211,11 +211,11 @@ for continuous finite element discretization of compressible flows.
        :label: eq-weak-vector-ns-supg
 
        \begin{aligned}
-       \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \mathbf{S}(\bm{q}_N) \right)  \,dV
+       \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \bm{S}(\bm{q}_N) \right)  \,dV
        - \int_{\Omega} \nabla \bm v \!:\! \bm{F}(\bm{q}_N)\,dV & \\
-       + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm{q}_N) \cdot \widehat{\mathbf{n}} \,dS & \\
+       + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm{q}_N) \cdot \widehat{\bm{n}} \,dS & \\
        + \int_{\Omega} \bm{P}(\bm v)^T \, \left( \frac{\partial \bm{q}_N}{\partial t} \, + \,
-       \nabla \cdot \bm{F} \, (\bm{q}_N) - \mathbf{S}(\bm{q}_N) \right) \,dV &= 0
+       \nabla \cdot \bm{F} \, (\bm{q}_N) - \bm{S}(\bm{q}_N) \right) \,dV &= 0
        \, , \; \forall \bm v \in \mathcal{V}_p
        \end{aligned}
 
@@ -232,9 +232,9 @@ for continuous finite element discretization of compressible flows.
        :label: eq-weak-vector-ns-su
 
        \begin{aligned}
-       \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \mathbf{S}(\bm{q}_N) \right)  \,dV
+       \int_{\Omega} \bm v \cdot \left( \frac{\partial \bm{q}_N}{\partial t} - \bm{S}(\bm{q}_N) \right)  \,dV
        - \int_{\Omega} \nabla \bm v \!:\! \bm{F}(\bm{q}_N)\,dV & \\
-       + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm{q}_N) \cdot \widehat{\mathbf{n}} \,dS & \\
+       + \int_{\partial \Omega} \bm v \cdot \bm{F}(\bm{q}_N) \cdot \widehat{\bm{n}} \,dS & \\
        + \int_{\Omega} \bm{P}(\bm v)^T \, \nabla \cdot \bm{F} \, (\bm{q}_N) \,dV
        & = 0 \, , \; \forall \bm v \in \mathcal{V}_p
        \end{aligned}

--- a/examples/notation.rst
+++ b/examples/notation.rst
@@ -15,7 +15,8 @@ typically) by letting :math:`\Omega = \bigcup_{e=1}^{N_e}\Omega_e`, with :math:`
 disjoint elements. For most examples we use unstructured meshes for which the elements
 are hexahedra (although this is not a requirement in libCEED).
 
-The physical coordinates are denoted by :math:`\mathbf{x}=(x,y,z)\in\Omega_e`,
+The physical coordinates are denoted by
+:math:`\mathbf{x}=(x,y,z) \equiv (x_0,x_1,x_2) \in\Omega_e`,
 while the reference coordinates are represented as
-:math:`\boldsymbol{X}=(X,Y,Z) \equiv (X_1,X_2,X_3) \in\mathbf{I}=[-1,1]^3`
+:math:`\boldsymbol{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in\mathbf{I}=[-1,1]^3`
 (for :math:`d=3`).

--- a/examples/notation.rst
+++ b/examples/notation.rst
@@ -18,5 +18,5 @@ are hexahedra (although this is not a requirement in libCEED).
 The physical coordinates are denoted by
 :math:`\mathbf{x}=(x,y,z) \equiv (x_0,x_1,x_2) \in\Omega_e`,
 while the reference coordinates are represented as
-:math:`\boldsymbol{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in\mathbf{I}=[-1,1]^3`
+:math:`\bm{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in\mathbf{I}=[-1,1]^3`
 (for :math:`d=3`).

--- a/examples/notation.rst
+++ b/examples/notation.rst
@@ -16,7 +16,7 @@ disjoint elements. For most examples we use unstructured meshes for which the el
 are hexahedra (although this is not a requirement in libCEED).
 
 The physical coordinates are denoted by
-:math:`\mathbf{x}=(x,y,z) \equiv (x_0,x_1,x_2) \in\Omega_e`,
+:math:`\bm{x}=(x,y,z) \equiv (x_0,x_1,x_2) \in\Omega_e`,
 while the reference coordinates are represented as
-:math:`\bm{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in\mathbf{I}=[-1,1]^3`
+:math:`\bm{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in\bm{I}=[-1,1]^3`
 (for :math:`d=3`).

--- a/examples/notation.rst
+++ b/examples/notation.rst
@@ -18,5 +18,5 @@ are hexahedra (although this is not a requirement in libCEED).
 The physical coordinates are denoted by
 :math:`\bm{x}=(x,y,z) \equiv (x_0,x_1,x_2) \in\Omega_e`,
 while the reference coordinates are represented as
-:math:`\bm{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in\bm{I}=[-1,1]^3`
+:math:`\bm{X}=(X,Y,Z) \equiv (X_0,X_1,X_2) \in \textrm{I}=[-1,1]^3`
 (for :math:`d=3`).

--- a/examples/petsc/index.rst
+++ b/examples/petsc/index.rst
@@ -80,17 +80,21 @@ reference element, via the chain rule
 with Jacobian determinant given by
 
 .. math::
-   \left| J \right| = \left| col_1\left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right) \times col_2 \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right)\right| .
    :label: eq-jacobian-sphere
+
+   \left| J \right| = \left| col_1\left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right) \times col_2 \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right)\right| .
 
 .. _fig-sphere-coords:
 
 .. figure:: ../../../../img/SphereSketch.svg
 
-   Sketch of coordinates mapping between a 1D linear element and a circle.
-   Two quadrature points, :math:`q_0` and :math:`q_1`, with physical coordinates
-   denoted by :math:`\bm x(\bm X)`, are mapped to their corresponding radial
-   projections on the circle, which have coordinates :math:`\overset{\circ}{\bm{x}}(\bm x)`.
+   Sketch of coordinates mapping between a 1D linear element and a circle. In the
+   case of a linear element the two nodes, :math:`p_0` and :math:`p_1`, marked
+   by red crosses, coincide with the endpoints of the element.
+   Two quadrature points, :math:`q_0` and :math:`q_1`, marked by blue dots, with
+   physical coordinates denoted by :math:`\bm x(\bm X)`, are mapped to their
+   corresponding radial projections on the circle, which have coordinates
+   :math:`\overset{\circ}{\bm{x}}(\bm x)`.
 
 We note that in equation :math:numref:`eq-coordinate-transforms-sphere`, the right-most
 Jacobian matrix :math:`{\partial\bm{x}}/{\partial \bm{X}}_{(3\times2)}` is

--- a/examples/petsc/index.rst
+++ b/examples/petsc/index.rst
@@ -11,9 +11,9 @@ demonstrates a simple usage of libCEED with PETSc to calculate
 the surface area of a closed surface. The code uses higher level
 communication protocols for mesh handling in PETSc's DMPlex. This example has the
 same mathematical formulation as :ref:`Ex1-Volume`, with the exception that the
-physical coordinates for this problem are :math:`\mathbf{x}=(x,y,z)\in \mathbb{R}^3`,
+physical coordinates for this problem are :math:`\bm{x}=(x,y,z)\in \mathbb{R}^3`,
 while the coordinates of the reference element are
-:math:`\bm{X}=(X,Y) \equiv (X_1,X_2) \in\mathbf{I}=[-1,1]^2`.
+:math:`\bm{X}=(X,Y) \equiv (X_1,X_2) \in\bm{I}=[-1,1]^2`.
 
 
 .. _example-petsc-area-cube:
@@ -28,29 +28,29 @@ This is one of the test cases of the computation of the :ref:`example-petsc-area
 
 This example uses the following coordinate transformations for the computation of the
 geometric factors: from the physical coordinates on the cube, denoted by
-:math:`\bar{\mathbf{x}}=(\bar{x},\bar{y},\bar{z})`,
+:math:`\bar{\bm{x}}=(\bar{x},\bar{y},\bar{z})`,
 and physical coordinates on the discrete surface, denoted by
-:math:`\mathbf{{x}}=(x,y)`, to :math:`\mathbf{X}=(X,Y) \in\mathbf{I}=[-1,1]^2` on the
+:math:`\bm{{x}}=(x,y)`, to :math:`\bm{X}=(X,Y) \in\bm{I}=[-1,1]^2` on the
 reference element, via the chain rule
 
 .. math::
-   \frac{\partial \mathbf{x}}{\partial \mathbf{X}}_{(2\times2)} = \frac{\partial {\mathbf{x}}}{\partial \bar{\mathbf{x}}}_{(2\times3)} \frac{\partial \bar{\mathbf{x}}}{\partial \mathbf{X}}_{(3\times2)},
+   \frac{\partial \bm{x}}{\partial \bm{X}}_{(2\times2)} = \frac{\partial {\bm{x}}}{\partial \bar{\bm{x}}}_{(2\times3)} \frac{\partial \bar{\bm{x}}}{\partial \bm{X}}_{(3\times2)},
    :label: eq-coordinate-transforms-cube
 
 with Jacobian determinant given by
 
 .. math::
-   \left| J \right| = \left\|col_1\left(\frac{\partial \bar{\mathbf{x}}}{\partial \mathbf{X}}\right)\right\| \left\|col_2 \left(\frac{\partial \bar{\mathbf{x}}}{\partial \mathbf{X}}\right) \right\|
+   \left| J \right| = \left\|col_1\left(\frac{\partial \bar{\bm{x}}}{\partial \bm{X}}\right)\right\| \left\|col_2 \left(\frac{\partial \bar{\bm{x}}}{\partial \bm{X}}\right) \right\|
    :label: eq-jacobian-cube
 
 We note that in equation :math:numref:`eq-coordinate-transforms-cube`, the right-most
-Jacobian matrix :math:`{\partial\bar{\mathbf{x}}}/{\partial \mathbf{X}}_{(3\times2)}` is
+Jacobian matrix :math:`{\partial\bar{\bm{x}}}/{\partial \bm{X}}_{(3\times2)}` is
 provided by the library, while
-:math:`{\partial{\mathbf{x}}}/{\partial \bar{ \mathbf{x}}}_{(2\times3)}` is
+:math:`{\partial{\bm{x}}}/{\partial \bar{ \bm{x}}}_{(2\times3)}` is
 provided by the user as
 
 .. math::
-   \left[ col_1\left(\frac{\partial\bar{\mathbf{x}}}{\partial \mathbf{X}}\right) / \left\| col_1\left(\frac{\partial\bar{\mathbf{x}}}{\partial \mathbf{X}}\right)\right\| , col_2\left(\frac{\partial\bar{\mathbf{x}}}{\partial \mathbf{X}}\right) / \left\| col_2\left(\frac{\partial\bar{\mathbf{x}}}{\partial \mathbf{X}}\right)\right\| \right]^T_{(2\times 3)}.
+   \left[ col_1\left(\frac{\partial\bar{\bm{x}}}{\partial \bm{X}}\right) / \left\| col_1\left(\frac{\partial\bar{\bm{x}}}{\partial \bm{X}}\right)\right\| , col_2\left(\frac{\partial\bar{\bm{x}}}{\partial \bm{X}}\right) / \left\| col_2\left(\frac{\partial\bar{\bm{x}}}{\partial \bm{X}}\right)\right\| \right]^T_{(2\times 3)}.
 
 
 .. _example-petsc-area-sphere:
@@ -67,35 +67,35 @@ This problem can be run with::
 
 This example uses the following coordinate transformations for the computation of the
 geometric factors: from the physical coordinates on the sphere, denoted by
-:math:`\overset{\circ}{\mathbf{x}}=(\overset{\circ}{x},\overset{\circ}{y},\overset{\circ}{z})`,
+:math:`\overset{\circ}{\bm{x}}=(\overset{\circ}{x},\overset{\circ}{y},\overset{\circ}{z})`,
 and physical coordinates on the discrete surface, denoted by
-:math:`\mathbf{{x}}=(x,y,z)`, to :math:`\mathbf{X}=(X,Y) \in\mathbf{I}=[-1,1]^2` on the
+:math:`\bm{{x}}=(x,y,z)`, to :math:`\bm{X}=(X,Y) \in\bm{I}=[-1,1]^2` on the
 reference element, via the chain rule
 
 .. math::
-   \frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}_{(3\times2)} = \frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{x}}_{(3\times3)} \frac{\partial\mathbf{x}}{\partial \mathbf{X}}_{(3\times2)} ,
+   \frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}_{(3\times2)} = \frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{x}}_{(3\times3)} \frac{\partial\bm{x}}{\partial \bm{X}}_{(3\times2)} ,
    :label: eq-coordinate-transforms-sphere
 
 with Jacobian determinant given by
 
 .. math::
-   \left| J \right| = \left| col_1\left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}\right) \times col_2 \left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}\right)\right| .
+   \left| J \right| = \left| col_1\left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right) \times col_2 \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right)\right| .
    :label: eq-jacobian-sphere
 
 We note that in equation :math:numref:`eq-coordinate-transforms-sphere`, the right-most
-Jacobian matrix :math:`{\partial\mathbf{x}}/{\partial \mathbf{X}}_{(3\times2)}` is
+Jacobian matrix :math:`{\partial\bm{x}}/{\partial \bm{X}}_{(3\times2)}` is
 provided by the library, while
-:math:`{\partial \overset{\circ}{\mathbf{x}}}/{\partial \mathbf{x}}_{(3\times3)}` is
+:math:`{\partial \overset{\circ}{\bm{x}}}/{\partial \bm{x}}_{(3\times3)}` is
 provided by the user with analytical derivatives.
 In particular, for a sphere of radius 1, we have
 
 .. math::
-   \overset{\circ}{\mathbf x}(\mathbf x) = \frac{1}{\lVert \mathbf x \rVert} \mathbf x_{(3\times 1)}
+   \overset{\circ}{\bm x}(\bm x) = \frac{1}{\lVert \bm x \rVert} \bm x_{(3\times 1)}
 
 and thus
 
 .. math::
-   \frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{x}} = \frac{1}{\lVert \mathbf x \rVert} \mathbf I_{(3\times 3)} - \frac{1}{\lVert \mathbf x \rVert^3} (\mathbf x \mathbf x^T)_{(3\times 3)} .
+   \frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{x}} = \frac{1}{\lVert \bm x \rVert} \bm I_{(3\times 3)} - \frac{1}{\lVert \bm x \rVert^3} (\bm x \bm x^T)_{(3\times 3)} .
 
 
 .. _example-petsc-bps:
@@ -120,43 +120,43 @@ coordinate transformations and the corresponding Jacobian determinant,
 equation :math:numref:`eq-jacobian-sphere`, are the same as in the
 :ref:`example-petsc-area-sphere` example. For the Poisson's problem, BP3-BP6, on the
 cubed-sphere, in addition to equation :math:numref:`eq-jacobian-sphere`, the
-pseudo-inverse of :math:`\partial \overset{\circ}{\mathbf{x}} / \partial \mathbf{X}`
+pseudo-inverse of :math:`\partial \overset{\circ}{\bm{x}} / \partial \bm{X}`
 is used to derive the contravariant metric tensor. We begin by expressing the
 Moore-Penrose (left) pseudo-inverse:
 
 .. math::
-   \frac{\partial \mathbf{X}}{\partial \overset{\circ}{\mathbf{x}}}_{(2\times 3)} \equiv \left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}\right)_{(2\times 3)}^{+} =  \left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}_{(2\times3)}^T \frac{\partial\overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}_{(3\times2)} \right)^{-1} \frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}_{(2\times3)}^T .
+   \frac{\partial \bm{X}}{\partial \overset{\circ}{\bm{x}}}_{(2\times 3)} \equiv \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right)_{(2\times 3)}^{+} =  \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}_{(2\times3)}^T \frac{\partial\overset{\circ}{\bm{x}}}{\partial \bm{X}}_{(3\times2)} \right)^{-1} \frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}_{(2\times3)}^T .
    :label: eq-dxcircdX-pseudo-inv
 
-This enables computation of gradients of an arbitrary function :math:`u(\overset{\circ}{\mathbf x})` in the embedding space as
+This enables computation of gradients of an arbitrary function :math:`u(\overset{\circ}{\bm x})` in the embedding space as
 
 .. math::
-   \frac{\partial u}{\partial \overset{\circ}{\mathbf x}}_{(1\times 3)} = \frac{\partial u}{\partial \mathbf X}_{(1\times 2)} \frac{\partial \mathbf X}{\partial \overset{\circ}{\mathbf x}}_{(2\times 3)}
+   \frac{\partial u}{\partial \overset{\circ}{\bm x}}_{(1\times 3)} = \frac{\partial u}{\partial \bm X}_{(1\times 2)} \frac{\partial \bm X}{\partial \overset{\circ}{\bm x}}_{(2\times 3)}
 
 and thus the weak Laplacian may be expressed as
 
 .. math::
    :label: eq-weak-laplace-sphere
 
-   \int_{\Omega} \frac{\partial v}{\partial \overset\circ{\mathbf x}} \left( \frac{\partial u}{\partial \overset\circ{\mathbf x}} \right)^T \, dS
-       = \int_{\Omega} \frac{\partial v}{\partial \mathbf X} \underbrace{\frac{\partial \mathbf X}{\partial \overset\circ{\mathbf x}} \left( \frac{\partial \mathbf X}{\partial \overset\circ{\mathbf x}} \right)^T}_{\mathbf g_{(2\times 2)}}  \left(\frac{\partial u}{\partial \mathbf X} \right)^T \, dS
+   \int_{\Omega} \frac{\partial v}{\partial \overset\circ{\bm x}} \left( \frac{\partial u}{\partial \overset\circ{\bm x}} \right)^T \, dS
+       = \int_{\Omega} \frac{\partial v}{\partial \bm X} \underbrace{\frac{\partial \bm X}{\partial \overset\circ{\bm x}} \left( \frac{\partial \bm X}{\partial \overset\circ{\bm x}} \right)^T}_{\bm g_{(2\times 2)}}  \left(\frac{\partial u}{\partial \bm X} \right)^T \, dS
 
-where we have identified the :math:`2\times 2` contravariant metric tensor :math:`\mathbf g` (sometimes written :math:`\mathbf g^{ij}`), and where now :math:`\Omega` represents the surface of the sphere,
+where we have identified the :math:`2\times 2` contravariant metric tensor :math:`\bm g` (sometimes written :math:`\bm g^{ij}`), and where now :math:`\Omega` represents the surface of the sphere,
 which is a two-dimensional closed surface embedded in the three-dimensional Euclidean space
 :math:`\mathbb{R}^3`. This expression can be simplified to avoid the explicit
 Moore-Penrose pseudo-inverse,
 
 .. math::
-   \mathbf g = \left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}^T \frac{\partial\overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}} \right)^{-1}_{(2\times 2)} \frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}_{(2\times3)}^T
-   \frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}_{(3\times2)} \left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}^T \frac{\partial\overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}} \right)^{-T}_{(2\times 2)}
-   = \left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}^T \frac{\partial\overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}} \right)^{-1}_{(2\times 2)}
+   \bm g = \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}^T \frac{\partial\overset{\circ}{\bm{x}}}{\partial \bm{X}} \right)^{-1}_{(2\times 2)} \frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}_{(2\times3)}^T
+   \frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}_{(3\times2)} \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}^T \frac{\partial\overset{\circ}{\bm{x}}}{\partial \bm{X}} \right)^{-T}_{(2\times 2)}
+   = \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}^T \frac{\partial\overset{\circ}{\bm{x}}}{\partial \bm{X}} \right)^{-1}_{(2\times 2)}
 
 where we have dropped the transpose due to symmetry.
 This allows us to simplify :math:numref:`eq-weak-laplace-sphere` as
 
 .. math::
-   \int_{\Omega} \frac{\partial v}{\partial \overset\circ{\mathbf x}} \left( \frac{\partial u}{\partial \overset\circ{\mathbf x}} \right)^T \, dS
-       = \int_{\Omega} \frac{\partial v}{\partial \mathbf X} \underbrace{\left(\frac{\partial \overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}}^T \frac{\partial\overset{\circ}{\mathbf{x}}}{\partial \mathbf{X}} \right)^{-1}}_{\mathbf g_{(2\times 2)}}  \left(\frac{\partial u}{\partial \mathbf X} \right)^T \, dS ,
+   \int_{\Omega} \frac{\partial v}{\partial \overset\circ{\bm x}} \left( \frac{\partial u}{\partial \overset\circ{\bm x}} \right)^T \, dS
+       = \int_{\Omega} \frac{\partial v}{\partial \bm X} \underbrace{\left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}^T \frac{\partial\overset{\circ}{\bm{x}}}{\partial \bm{X}} \right)^{-1}}_{\bm g_{(2\times 2)}}  \left(\frac{\partial u}{\partial \bm X} \right)^T \, dS ,
 
 which is the form implemented in ``qfunctions/bps/bp3sphere.h``.
 
@@ -177,9 +177,9 @@ are implemented in libCEED.
 
 The Poisson operator can be specified with the decomposition given by the equation in
 figure :ref:`fig-operator-decomp`, and the restriction and prolongation operators given
-by interpolation basis operations, :math:`\mathbf{B}`, and :math:`\mathbf{B}^T`,
+by interpolation basis operations, :math:`\bm{B}`, and :math:`\bm{B}^T`,
 respectively, act on the different grid levels with corresponding element restrictions,
-:math:`\mathbf{G}`. These three operations can be exploited by existing matrix-free
+:math:`\bm{G}`. These three operations can be exploited by existing matrix-free
 multigrid software and smoothers. Preconditioning based on the libCEED finite element
 operator decomposition is an ongoing area of research.
 

--- a/examples/petsc/index.rst
+++ b/examples/petsc/index.rst
@@ -13,7 +13,7 @@ communication protocols for mesh handling in PETSc's DMPlex. This example has th
 same mathematical formulation as :ref:`Ex1-Volume`, with the exception that the
 physical coordinates for this problem are :math:`\bm{x}=(x,y,z)\in \mathbb{R}^3`,
 while the coordinates of the reference element are
-:math:`\bm{X}=(X,Y) \equiv (X_1,X_2) \in\bm{I}=[-1,1]^2`.
+:math:`\bm{X}=(X,Y) \equiv (X_0,X_1) \in \textrm{I} =[-1,1]^2`.
 
 
 .. _example-petsc-area-cube:
@@ -30,7 +30,7 @@ This example uses the following coordinate transformations for the computation o
 geometric factors: from the physical coordinates on the cube, denoted by
 :math:`\bar{\bm{x}}=(\bar{x},\bar{y},\bar{z})`,
 and physical coordinates on the discrete surface, denoted by
-:math:`\bm{{x}}=(x,y)`, to :math:`\bm{X}=(X,Y) \in\bm{I}=[-1,1]^2` on the
+:math:`\bm{{x}}=(x,y)`, to :math:`\bm{X}=(X,Y) \in \textrm{I}` on the
 reference element, via the chain rule
 
 .. math::
@@ -69,7 +69,7 @@ This example uses the following coordinate transformations for the computation o
 geometric factors: from the physical coordinates on the sphere, denoted by
 :math:`\overset{\circ}{\bm{x}}=(\overset{\circ}{x},\overset{\circ}{y},\overset{\circ}{z})`,
 and physical coordinates on the discrete surface, denoted by
-:math:`\bm{{x}}=(x,y,z)`, to :math:`\bm{X}=(X,Y) \in\bm{I}=[-1,1]^2` on the
+:math:`\bm{{x}}=(x,y,z)`, to :math:`\bm{X}=(X,Y) \in \textrm{I}` on the
 reference element, via the chain rule
 
 .. math::

--- a/examples/petsc/index.rst
+++ b/examples/petsc/index.rst
@@ -69,7 +69,8 @@ This example uses the following coordinate transformations for the computation o
 geometric factors: from the physical coordinates on the sphere, denoted by
 :math:`\overset{\circ}{\bm{x}}=(\overset{\circ}{x},\overset{\circ}{y},\overset{\circ}{z})`,
 and physical coordinates on the discrete surface, denoted by
-:math:`\bm{{x}}=(x,y,z)`, to :math:`\bm{X}=(X,Y) \in \textrm{I}` on the
+:math:`\bm{{x}}=(x,y,z)` (depicted, for simplicity, as coordinates on a circle and 1D linear
+element in figure :numref:`fig-sphere-coords`), to :math:`\bm{X}=(X,Y) \in \textrm{I}` on the
 reference element, via the chain rule
 
 .. math::
@@ -81,6 +82,15 @@ with Jacobian determinant given by
 .. math::
    \left| J \right| = \left| col_1\left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right) \times col_2 \left(\frac{\partial \overset{\circ}{\bm{x}}}{\partial \bm{X}}\right)\right| .
    :label: eq-jacobian-sphere
+
+.. _fig-sphere-coords:
+
+.. figure:: ../../../../img/SphereSketch.svg
+
+   Sketch of coordinates mapping between a 1D linear element and a circle.
+   Two quadrature points, :math:`q_0` and :math:`q_1`, with physical coordinates
+   denoted by :math:`\bm x(\bm X)`, are mapped to their corresponding radial
+   projections on the circle, which have coordinates :math:`\overset{\circ}{\bm{x}}(\bm x)`.
 
 We note that in equation :math:numref:`eq-coordinate-transforms-sphere`, the right-most
 Jacobian matrix :math:`{\partial\bm{x}}/{\partial \bm{X}}_{(3\times2)}` is

--- a/examples/petsc/index.rst
+++ b/examples/petsc/index.rst
@@ -13,7 +13,7 @@ communication protocols for mesh handling in PETSc's DMPlex. This example has th
 same mathematical formulation as :ref:`Ex1-Volume`, with the exception that the
 physical coordinates for this problem are :math:`\mathbf{x}=(x,y,z)\in \mathbb{R}^3`,
 while the coordinates of the reference element are
-:math:`\boldsymbol{X}=(X,Y) \equiv (X_1,X_2) \in\mathbf{I}=[-1,1]^2`.
+:math:`\bm{X}=(X,Y) \equiv (X_1,X_2) \in\mathbf{I}=[-1,1]^2`.
 
 
 .. _example-petsc-area-cube:

--- a/examples/petsc/index.rst
+++ b/examples/petsc/index.rst
@@ -135,7 +135,8 @@ equation :math:numref:`eq-jacobian-sphere`, are the same as in the
 :ref:`example-petsc-area-sphere` example. For the Poisson's problem, BP3-BP6, on the
 cubed-sphere, in addition to equation :math:numref:`eq-jacobian-sphere`, the
 pseudo-inverse of :math:`\partial \overset{\circ}{\bm{x}} / \partial \bm{X}`
-is used to derive the contravariant metric tensor. We begin by expressing the
+is used to derive the contravariant metric tensor (please see figure
+:numref:`fig-sphere-coords` for a reference of the notation used). We begin by expressing the
 Moore-Penrose (left) pseudo-inverse:
 
 .. math::

--- a/examples/solids/README.rst
+++ b/examples/solids/README.rst
@@ -67,7 +67,7 @@ With the sidesets defined in the figure, we provide here an example of a minimal
 
 In this example, we set the left boundary, face set :math:`999`, to zero displacement and the right boundary, face set :math:`998`, to displace by the default value of :math:`-1.0` in the :math:`y` direction.
 
-These command line options are the minimum requirements for the mini-app, but additional options may also be set.
+The command line options just shown are the minimum requirements to run the mini-app, but additional options may also be set as follows
 
 .. list-table:: Additional Runtime Options
    :header-rows: 1

--- a/examples/solids/index.rst
+++ b/examples/solids/index.rst
@@ -51,34 +51,34 @@ The strong form of the static balance of linear momentum at small strain for the
 .. math::
    :label: lin-elas
 
-   \nabla \cdot \boldsymbol{\sigma} + \boldsymbol{g} = \boldsymbol{0}
+   \nabla \cdot \bm{\sigma} + \bm{g} = \bm{0}
 
-where :math:`\boldsymbol{\sigma}` and :math:`\boldsymbol{g}` are stress and forcing functions, respectively.
+where :math:`\bm{\sigma}` and :math:`\bm{g}` are stress and forcing functions, respectively.
 We multiply :math:numref:`lin-elas` by a test function :math:`\bm v` and integrate the divergence term by parts to arrive at the weak form: find :math:`\bm u \in \mathcal V \subset H^1(\Omega)` such that
 
 .. math::
    :label: lin-elas-weak
 
-   \int_{\Omega}{ \nabla \boldsymbol{v} \colon \boldsymbol{\sigma}} \, dV
-   - \int_{\partial \Omega}{\boldsymbol{v} \cdot \left(\boldsymbol{\sigma} \cdot \hat{\boldsymbol{n}}\right)} \, dS
-   - \int_{\Omega}{\boldsymbol{v} \cdot \boldsymbol{g}} \, dV
+   \int_{\Omega}{ \nabla \bm{v} \colon \bm{\sigma}} \, dV
+   - \int_{\partial \Omega}{\bm{v} \cdot \left(\bm{\sigma} \cdot \hat{\bm{n}}\right)} \, dS
+   - \int_{\Omega}{\bm{v} \cdot \bm{g}} \, dV
    = 0, \quad \forall \bm v \in \mathcal V,
 
-where :math:`\boldsymbol{\sigma} \cdot \hat{\boldsymbol{n}}|_{\partial \Omega}` is replaced by an applied force/traction boundary condition.
+where :math:`\bm{\sigma} \cdot \hat{\bm{n}}|_{\partial \Omega}` is replaced by an applied force/traction boundary condition.
 
 The constitutive law (stress-strain relationship) is given by:
 
 .. math::
    :label: linear-stress-strain
 
-   \boldsymbol{\sigma} = \mathsf{C} \!:\! \boldsymbol{\epsilon},
+   \bm{\sigma} = \mathsf{C} \!:\! \bm{\epsilon},
 
 where 
 
 .. math::
    :label: small-strain
 
-   \boldsymbol{\epsilon} = \dfrac{1}{2}\left(\nabla \boldsymbol{u} + \nabla \boldsymbol{u}^T \right)
+   \bm{\epsilon} = \dfrac{1}{2}\left(\nabla \bm{u} + \nabla \bm{u}^T \right)
 
 is the symmetric (small/infinitesimal) strain tensor and the colon represents a double contraction (over both indices of :math:`\bm \epsilon`).
 For notational convenience, we express the symmetric second order tensors :math:`\bm \sigma` and :math:`\bm \epsilon` as vectors of length 6 using the `Voigt notation <https://en.wikipedia.org/wiki/Voigt_notation>`_.
@@ -144,9 +144,9 @@ However, the constitutive law differs and is given as follows:
 .. math::
    :label: eq-neo-hookean-small-strain
    
-   \boldsymbol{\sigma} = \lambda \log(1 + \operatorname{trace} \bm\epsilon) \boldsymbol{I}_3 + 2\mu \boldsymbol{\epsilon}
+   \bm{\sigma} = \lambda \log(1 + \operatorname{trace} \bm\epsilon) \bm{I}_3 + 2\mu \bm{\epsilon}
 
-where :math:`\boldsymbol{\epsilon}` is defined as in :math:numref:`small-strain`.
+where :math:`\bm{\epsilon}` is defined as in :math:numref:`small-strain`.
 
 
 Newton linearization
@@ -157,34 +157,34 @@ To derive the Newton linearization, we begin by expressing the derivative,
 
 .. math::
 
-   \diff \boldsymbol{\sigma} = \dfrac{\partial \boldsymbol{\sigma}}{\partial \boldsymbol{\epsilon}} \colon \diff \boldsymbol{\epsilon}
+   \diff \bm{\sigma} = \dfrac{\partial \bm{\sigma}}{\partial \bm{\epsilon}} \colon \diff \bm{\epsilon}
 
 where
 
 .. math::
 
-   \diff \boldsymbol{\epsilon} = \dfrac{1}{2}\left( \nabla \diff \boldsymbol{u} + \nabla \diff \boldsymbol{u}^T \right)
+   \diff \bm{\epsilon} = \dfrac{1}{2}\left( \nabla \diff \bm{u} + \nabla \diff \bm{u}^T \right)
 
 and 
 
 .. math::
 
-   \diff \nabla \boldsymbol{u} = \nabla \diff \boldsymbol{u} .
+   \diff \nabla \bm{u} = \nabla \diff \bm{u} .
 
 Therefore,
 
 .. math::
    :label: derss
 
-   \diff \boldsymbol{\sigma}  = \bar{\lambda} \cdot \operatorname{trace} \diff \boldsymbol{\epsilon} \cdot \boldsymbol{I}_3 + 2\mu \diff \boldsymbol{\epsilon}
+   \diff \bm{\sigma}  = \bar{\lambda} \cdot \operatorname{trace} \diff \bm{\epsilon} \cdot \bm{I}_3 + 2\mu \diff \bm{\epsilon}
 
 where we have introduced the symbol
 
 .. math::
 
-   \bar{\lambda} = \dfrac{\lambda}{1 + \boldsymbol{\epsilon}_v }
+   \bar{\lambda} = \dfrac{\lambda}{1 + \bm{\epsilon}_v }
 
-where volumetric strain is given by :math:`\boldsymbol{\epsilon}_v = \sum_i \boldsymbol{\epsilon}_{ii}`.
+where volumetric strain is given by :math:`\bm{\epsilon}_v = \sum_i \bm{\epsilon}_{ii}`.
 
 Equation :math:numref:`derss` can be written in Voigt matrix notation as follows:
 
@@ -232,21 +232,21 @@ The strong form of the static balance of linear-momentum at *finite strain* (tot
 .. math::
    :label: sblFinS
 
-   - \nabla_X \cdot \boldsymbol{P} - \rho_0 \boldsymbol{g} = \boldsymbol{0}
+   - \nabla_X \cdot \bm{P} - \rho_0 \bm{g} = \bm{0}
  
 where the :math:`_X` in :math:`\nabla_X` indicates that the gradient is calculated with respect to the reference configuration in the finite strain regime.
-:math:`\boldsymbol{P}` and :math:`\boldsymbol{g}` are the *first Piola-Kirchhoff stress* tensor and the prescribed forcing function, respectively.
+:math:`\bm{P}` and :math:`\bm{g}` are the *first Piola-Kirchhoff stress* tensor and the prescribed forcing function, respectively.
 :math:`\rho_0` is known as the *reference* mass density.
 The tensor :math:`\bm P` is not symmetric, living in the current configuration on the left and the reference configuration on the right.
 
-:math:`\boldsymbol{P}` can be decomposed as
+:math:`\bm{P}` can be decomposed as
 
 .. math::
    :label: 1st2nd
    
-   \boldsymbol{P} = \boldsymbol{F} \, \boldsymbol{S},
+   \bm{P} = \bm{F} \, \bm{S},
 
-where :math:`\bm S` is the *second Piola-Kirchhoff stress* tensor, a symmetric tensor defined entirely in the reference configuration, and :math:`\boldsymbol{F} = \bm I_3 + \nabla_X \bm u` is the deformation gradient.
+where :math:`\bm S` is the *second Piola-Kirchhoff stress* tensor, a symmetric tensor defined entirely in the reference configuration, and :math:`\bm{F} = \bm I_3 + \nabla_X \bm u` is the deformation gradient.
 Different constitutive models can define :math:`\bm S`.
 
 
@@ -367,12 +367,12 @@ find :math:`\bm u \in \mathcal V \subset H^1(\Omega_0)` such that
 .. math::
    :label: hyperelastic-weak-form
 
-    \int_{\Omega_0}{\nabla_X \boldsymbol{v} \colon \boldsymbol{P}} \, dV
-    - \int_{\Omega_0}{\boldsymbol{v} \cdot \rho_0 \boldsymbol{g}} \, dV
-    - \int_{\partial \Omega_0}{\boldsymbol{v} \cdot (\boldsymbol{P} \cdot \hat{\boldsymbol{N}})} \, dS
+    \int_{\Omega_0}{\nabla_X \bm{v} \colon \bm{P}} \, dV
+    - \int_{\Omega_0}{\bm{v} \cdot \rho_0 \bm{g}} \, dV
+    - \int_{\partial \Omega_0}{\bm{v} \cdot (\bm{P} \cdot \hat{\bm{N}})} \, dS
     = 0, \quad \forall \bm v \in \mathcal V,
     
-where :math:`\boldsymbol{P} \cdot \hat{\boldsymbol{N}}|_{\partial\Omega}` is replaced by any prescribed force/traction boundary conditions written in terms of the reference configuration.
+where :math:`\bm{P} \cdot \hat{\bm{N}}|_{\partial\Omega}` is replaced by any prescribed force/traction boundary conditions written in terms of the reference configuration.
 This equation contains material/constitutive nonlinearities in defining :math:`\bm S(\bm E)`, as well as geometric nonlinearities through :math:`\bm P = \bm F\, \bm S`, :math:`\bm E(\bm F)`, and the body force :math:`\bm g`, which must be pulled back from the current configuration to the reference configuration.
 Discretization of :math:numref:`hyperelastic-weak-form` produces a finite-dimensional system of nonlinear algebraic equations, which we solve using Newton-Raphson methods.
 One attractive feature of Galerkin discretization is that we can arrive at the same linear system by discretizing the Newton linearization of the continuous form; that is, discretization and differentiation (Newton linearization) commute.

--- a/examples/solids/index.rst
+++ b/examples/solids/index.rst
@@ -64,7 +64,7 @@ We multiply :math:numref:`lin-elas` by a test function :math:`\bm v` and integra
    - \int_{\Omega}{\bm{v} \cdot \bm{g}} \, dV
    = 0, \quad \forall \bm v \in \mathcal V,
 
-where :math:`\bm{\sigma} \cdot \hat{\bm{n}}|_{\partial \Omega}` is replaced by an applied force/traction boundary condition.
+where :math:`\bm{\sigma} \cdot \hat{\bm{n}}|_{\partial \Omega}` is replaced by an applied force/traction boundary condition written in terms of the reference configuration.
 
 The constitutive law (stress-strain relationship) is given by:
 
@@ -182,9 +182,9 @@ where we have introduced the symbol
 
 .. math::
 
-   \bar{\lambda} = \dfrac{\lambda}{1 + \bm{\epsilon}_v }
+   \bar{\lambda} = \dfrac{\lambda}{1 + \epsilon_v }
 
-where volumetric strain is given by :math:`\bm{\epsilon}_v = \sum_i \bm{\epsilon}_{ii}`.
+where volumetric strain is given by :math:`\epsilon_v = \sum_i \epsilon_{ii}`.
 
 Equation :math:numref:`derss` can be written in Voigt matrix notation as follows:
 
@@ -372,10 +372,11 @@ find :math:`\bm u \in \mathcal V \subset H^1(\Omega_0)` such that
     - \int_{\partial \Omega_0}{\bm{v} \cdot (\bm{P} \cdot \hat{\bm{N}})} \, dS
     = 0, \quad \forall \bm v \in \mathcal V,
     
-where :math:`\bm{P} \cdot \hat{\bm{N}}|_{\partial\Omega}` is replaced by any prescribed force/traction boundary conditions written in terms of the reference configuration.
+where :math:`\bm{P} \cdot \hat{\bm{N}}|_{\partial\Omega}` is replaced by any prescribed force/traction boundary condition written in terms of the reference configuration.
 This equation contains material/constitutive nonlinearities in defining :math:`\bm S(\bm E)`, as well as geometric nonlinearities through :math:`\bm P = \bm F\, \bm S`, :math:`\bm E(\bm F)`, and the body force :math:`\bm g`, which must be pulled back from the current configuration to the reference configuration.
 Discretization of :math:numref:`hyperelastic-weak-form` produces a finite-dimensional system of nonlinear algebraic equations, which we solve using Newton-Raphson methods.
 One attractive feature of Galerkin discretization is that we can arrive at the same linear system by discretizing the Newton linearization of the continuous form; that is, discretization and differentiation (Newton linearization) commute.
+
 
 Newton linearization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -392,7 +393,7 @@ where
 .. math::
    \diff \bm E = \frac{\partial \bm E}{\partial \bm F} \!:\! \diff \bm F = \frac 1 2 \Big( \diff \bm F^T \bm F + \bm F^T \diff \bm F \Big).
 
-The quantity :math:`\frac{\partial \bm S}{\partial \bm E}` is known as the incremental elasticity tensor, and is analogous to the linear elasticity tensor :math:`\mathsf C` of :math:numref:`linear-elasticity-tensor`.
+The quantity :math:`{\partial \bm S} / {\partial \bm E}` is known as the incremental elasticity tensor, and is analogous to the linear elasticity tensor :math:`\mathsf C` of :math:numref:`linear-elasticity-tensor`.
 We now evaluate :math:`\diff \bm S` for the Neo-Hookean model :math:numref:`neo-hookean-stress`,
 
 .. math::


### PR DESCRIPTION
In `examples/notation.rst`: A small shift in notation. This is needed since in the new description of [Ex2-surface](https://libceed.readthedocs.io/en/latest/examples/ceed/index.html) coordinate indices starting from 0 have been used