### PR TITLE
make: fix CC_VENDOR identification on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 # export LSAN_OPTIONS=suppressions=.asanignore
 AFLAGS = -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
-CC_VENDOR := $(firstword $(filter gcc clang icc XL,$(shell $(CC) --version)))
+CC_VENDOR := $(patsubst gcc%,gcc,$(firstword $(filter gcc clang icc XL,$(shell $(CC) --version))))
 FC_VENDOR := $(firstword $(filter GNU ifort XL,$(shell $(FC) --version 2>&1 || $(FC) -qversion)))
 
 # Default extra flags by vendor


### PR DESCRIPTION
ubuntu$ gcc --version
gcc-9 (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

versus

arch$ gcc --version
gcc (Arch Linux 9.3.0-1) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.