### PR TITLE
CPU Impl of AssemblePointBlockDiagonal

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -206,6 +206,17 @@ static int CeedOperatorAssembleLinearDiagonal_Cuda(CeedOperator op) {
 }
 
 //------------------------------------------------------------------------------
+// Assemble linear point block diagonal not supported
+//------------------------------------------------------------------------------
+static int CeedOperatorAssembleLinearPointBlockDiagonal_Cuda(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1,
+                   "Backend does not implement Operator point block diagonal assembly");
+}
+
+//------------------------------------------------------------------------------
 // Create FDM element inverse not supported
 //------------------------------------------------------------------------------
 static int CeedOperatorCreateFDMElementInverse_Cuda(CeedOperator op) {
@@ -232,6 +243,10 @@ int CeedOperatorCreate_Cuda_gen(CeedOperator op) {
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearDiagonal",
                                 CeedOperatorAssembleLinearDiagonal_Cuda);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op,
+                                "AssembleLinearPointBlockDiagonal",
+                                CeedOperatorAssembleLinearPointBlockDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",
                                 CeedOperatorCreateFDMElementInverse_Cuda);

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -445,6 +445,17 @@ static int CeedOperatorAssembleLinearDiagonal_Cuda(CeedOperator op) {
 }
 
 //------------------------------------------------------------------------------
+// Assemble linear point block diagonal not supported
+//------------------------------------------------------------------------------
+static int CeedOperatorAssembleLinearPointBlockDiagonal_Cuda(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1,
+                   "Backend does not implement Operator point block diagonal assembly");
+}
+
+//------------------------------------------------------------------------------
 // Create FDM element inverse not supported
 //------------------------------------------------------------------------------
 static int CeedOperatorCreateFDMElementInverse_Cuda(CeedOperator op) {
@@ -472,6 +483,10 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearDiagonal",
                                 CeedOperatorAssembleLinearDiagonal_Cuda);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op,
+                                "AssembleLinearPointBlockDiagonal",
+                                CeedOperatorAssembleLinearPointBlockDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",
                                 CeedOperatorCreateFDMElementInverse_Cuda);

--- a/backends/occa/ceed-occa-operator.c
+++ b/backends/occa/ceed-occa-operator.c
@@ -520,6 +520,48 @@ static int CeedOperatorApply_Occa(CeedOperator op,
 }
 
 // *****************************************************************************
+// * Assemble linear QFunction not supported
+// *****************************************************************************
+static int CeedOperatorAssembleLinearQFunction_Occa(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement QFunction assembly");
+}
+
+// *****************************************************************************
+// * Assemble linear diagonal not supported
+// *****************************************************************************
+static int CeedOperatorAssembleLinearDiagonal_Occa(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1,
+                   "Backend does not implement Operator diagonal assembly");
+}
+
+// *****************************************************************************
+// * Assemble linear point block diagonal not supported
+// *****************************************************************************
+static int CeedOperatorAssembleLinearPointBlockDiagonal_Occa(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1,
+                   "Backend does not implement Operator point block diagonal assembly");
+}
+
+// *****************************************************************************
+// * Create FDM element inverse not supported
+// *****************************************************************************
+static int CeedOperatorCreateFDMElementInverse_Occa(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement FDM inverse creation");
+}
+
+// *****************************************************************************
 // * Create an operator
 // *****************************************************************************
 int CeedOperatorCreate_Occa(CeedOperator op) {
@@ -531,6 +573,20 @@ int CeedOperatorCreate_Occa(CeedOperator op) {
   dbg("[CeedOperator][Create]");
   ierr = CeedCalloc(1, &impl); CeedChk(ierr);
   ierr = CeedOperatorSetData(op, (void *)&impl); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearQFunction",
+                                CeedOperatorAssembleLinearQFunction_Occa);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearDiagonal",
+                                CeedOperatorAssembleLinearDiagonal_Occa);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op,
+                                "AssembleLinearPointBlockDiagonal",
+                                CeedOperatorAssembleLinearPointBlockDiagonal_Occa);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",
+                                CeedOperatorCreateFDMElementInverse_Occa);
+  CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                 CeedOperatorApply_Occa); CeedChk(ierr);

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -566,7 +566,7 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   // LCOV_EXCL_STOP
 
   // Create output restriction
-  CeedInt strides[3] = {1, Q, numactivein *numactiveout*Q};
+  CeedInt strides[3] = {1, Q, numactivein*numactiveout*Q};
   ierr = CeedElemRestrictionCreateStrided(ceedparent, numelements, Q,
                                           numactivein*numactiveout,
                                           numactivein*numactiveout*numelements*Q,
@@ -698,7 +698,7 @@ static int CreateCSRRestriction(CeedElemRestriction rstr,
   ierr = CeedElemRestrictionGetNumComponents(rstr, &ncomp); CeedChk(ierr);
   ierr = CeedElemRestrictionGetElementSize(rstr, &elemsize); CeedChk(ierr);
   ierr = CeedElemRestrictionGetCompStride(rstr, &compstride); CeedChk(ierr);
-  shift = ncomp;  
+  shift = ncomp;
   if (compstride != 1)
     shift *= ncomp;
   ierr = CeedCalloc(nelem*elemsize, &csrOffsets); CeedChk(ierr);
@@ -892,7 +892,7 @@ static int CeedOperatorAssembleDiagonalCore_Ref(CeedOperator op,
                 if (fabs(qfvalue) > maxnorm*1e-12)
                   for (CeedInt n=0; n<nnodes; n++)
                     elemdiagarray[((e*ncomp+compOut)*ncomp+compIn)*nnodes+n] +=
-                        bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
+                      bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
               }
             } else {
               // Diagonal Only
@@ -902,7 +902,7 @@ static int CeedOperatorAssembleDiagonalCore_Ref(CeedOperator op,
               if (fabs(qfvalue) > maxnorm*1e-12)
                 for (CeedInt n=0; n<nnodes; n++)
                   elemdiagarray[(e*ncomp+compOut)*nnodes+n] +=
-                      bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
+                    bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
             }
       }
     }
@@ -1197,7 +1197,8 @@ int CeedOperatorCreate_Ref(CeedOperator op) {
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearDiagonal",
                                 CeedOperatorAssembleLinearDiagonal_Ref);
   CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "AssembleLinearPointBlockDiagonal",
+  ierr = CeedSetBackendFunction(ceed, "Operator", op,
+                                "AssembleLinearPointBlockDiagonal",
                                 CeedOperatorAssembleLinearPointBlockDiagonal_Ref);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -566,7 +566,7 @@ static int CeedOperatorAssembleLinearQFunction_Ref(CeedOperator op,
   // LCOV_EXCL_STOP
 
   // Create output restriction
-  CeedInt strides[3] = {1, Q, numactivein*numactiveout*Q};
+  CeedInt strides[3] = {1, Q, numactivein*numactiveout*Q}; /* *NOPAD* */
   ierr = CeedElemRestrictionCreateStrided(ceedparent, numelements, Q,
                                           numactivein*numactiveout,
                                           numactivein*numactiveout*numelements*Q,

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -804,7 +804,7 @@ static int CeedOperatorAssembleDiagonalCore_Ref(CeedOperator op,
     }
   }
 
-  // Assemble CSR restriction, if needed
+  // Assemble point-block diagonal restriction, if needed
   CeedElemRestriction diagrstr = rstrout;
   if (pointBlock) {
     ierr = CreatePBRestriction(rstrout, &diagrstr); CeedChk(ierr);

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -91,7 +91,7 @@ CEED_EXTERN int CeedElemRestrictionGetOffsets(CeedElemRestriction rstr,
     CeedMemType mtype, const CeedInt **offsets);
 CEED_EXTERN int CeedElemRestrictionRestoreOffsets(CeedElemRestriction rstr,
     const CeedInt **offsets);
-CEED_EXTERN int CeedElemRestrictionGetStridedStatus( CeedElemRestriction rstr,
+CEED_EXTERN int CeedElemRestrictionGetStridedStatus(CeedElemRestriction rstr,
     bool *status);
 CEED_EXTERN int CeedElemRestrictionGetBackendStridesStatus(
   CeedElemRestriction rstr, bool *status);

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -271,6 +271,8 @@ struct CeedOperator_private {
   int (*AssembleLinearQFunction)(CeedOperator, CeedVector *,
                                  CeedElemRestriction *, CeedRequest *);
   int (*AssembleLinearDiagonal)(CeedOperator, CeedVector *, CeedRequest *);
+  int (*AssembleLinearPointBlockDiagonal)(CeedOperator, CeedVector *,
+                                          CeedRequest *);
   int (*CreateFDMElementInverse)(CeedOperator, CeedOperator *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -488,6 +488,8 @@ CEED_EXTERN int CeedOperatorAssembleLinearQFunction(CeedOperator op,
     CeedVector *assembled, CeedElemRestriction *rstr, CeedRequest *request);
 CEED_EXTERN int CeedOperatorAssembleLinearDiagonal(CeedOperator op,
     CeedVector *assembled, CeedRequest *request);
+CEED_EXTERN int CeedOperatorAssembleLinearPointBlockDiagonal(CeedOperator op,
+    CeedVector *assembled, CeedRequest *request);
 CEED_EXTERN int CeedOperatorCreateFDMElementInverse(CeedOperator op,
     CeedOperator *fdminv, CeedRequest *request);
 CEED_EXTERN int CeedOperatorView(CeedOperator op, FILE *stream);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -779,9 +779,12 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
 }
 
 /**
-  @brief Assemble the diagonal of a square linear Operator
+  @brief Assemble the diagonal of a square linear CeedOperator
 
   This returns a CeedVector containing the diagonal of a linear CeedOperator.
+
+  Note: Currently only non-composite CeedOperators with a single field are
+          supported.
 
   @param op             CeedOperator to assemble CeedQFunction
   @param[out] assembled CeedVector to store assembled CeedOperator diagonal
@@ -815,16 +818,21 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
 }
 
 /**
-  @brief Assemble the point block diagonal of a square linear Operator
+  @brief Assemble the point block diagonal of a square linear CeedOperator
 
   This returns a CeedVector containing the point block diagonal of a linear
     CeedOperator.
 
+  Note: Currently only non-composite CeedOperators with a single field are
+          supported.
+
   @param op             CeedOperator to assemble CeedQFunction
   @param[out] assembled CeedVector to store assembled CeedOperator point block
-                          diagonal, provided in CSR format with an
-                          @a ncomp * @a ncomp block at each node. The array has
-                          shape [nodes, component out, component in].
+                          diagonal, provided in row-major form with an
+                          @a ncomp * @a ncomp block at each node. The dimensions
+                          of this vector are derived from the active vector
+                          for the CeedOperator. The array has shape
+                          [nodes, component out, component in].
   @param request        Address of CeedRequest for non-blocking completion, else
                           CEED_REQUEST_IMMEDIATE
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -822,7 +822,9 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
 
   @param op             CeedOperator to assemble CeedQFunction
   @param[out] assembled CeedVector to store assembled CeedOperator point block
-                          diagonal
+                          diagonal, provided in CSR format with an
+                          @a ncomp * @a ncomp block at each node. The array has
+                          shape [nodes, component out, component in].
   @param request        Address of CeedRequest for non-blocking completion, else
                           CEED_REQUEST_IMMEDIATE
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -669,6 +669,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedQFunction, Destroy),
     CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearQFunction),
     CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearDiagonal),
+    CEED_FTABLE_ENTRY(CeedOperator, AssembleLinearPointBlockDiagonal),
     CEED_FTABLE_ENTRY(CeedOperator, CreateFDMElementInverse),
     CEED_FTABLE_ENTRY(CeedOperator, Apply),
     CEED_FTABLE_ENTRY(CeedOperator, ApplyComposite),

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(name="libceed",
       cmdclass={'build_ext': libceed_build_ext},
 
       extras_require={
-          'cuda' : ['numba']
+          'cuda': ['numba']
       },
       )
 

--- a/tests/t533-operator.c
+++ b/tests/t533-operator.c
@@ -1,6 +1,6 @@
 /// @file
-/// Test assembly of mass matrix operator QFunction
-/// \test Test assembly of mass matrix operator QFunction
+/// Test assembly of mass matrix operator diagonal
+/// \test Test assembly of mass matrix operator diagonal
 #include <ceed.h>
 #include <stdlib.h>
 #include <math.h>
@@ -122,6 +122,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP
+  CeedVectorRestoreArrayRead(A, &a);
 
   // Cleanup
   CeedQFunctionDestroy(&qf_setup);

--- a/tests/t535-operator.c
+++ b/tests/t535-operator.c
@@ -155,6 +155,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP
+  CeedVectorRestoreArrayRead(A, &a);
 
   // Cleanup
   CeedQFunctionDestroy(&qf_setup_mass);

--- a/tests/t536-operator.c
+++ b/tests/t536-operator.c
@@ -173,6 +173,7 @@ int main(int argc, char **argv) {
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP
+  CeedVectorRestoreArrayRead(A, &a);
 
   // Cleanup
   CeedQFunctionDestroy(&qf_setup_mass);

--- a/tests/t537-operator.c
+++ b/tests/t537-operator.c
@@ -1,24 +1,24 @@
 /// @file
-/// Test assembly of Poisson operator diagonal
-/// \test Test assembly of Poisson operator diagonal
+/// Test assembly of mass matrix operator point block diagonal
+/// \test Test assembly of mass matrix operator point block diagonal
 #include <ceed.h>
 #include <stdlib.h>
 #include <math.h>
-#include "t534-operator.h"
+#include "t537-operator.h"
 
 int main(int argc, char **argv) {
   Ceed ceed;
   CeedElemRestriction Erestrictx, Erestrictu,
-                      Erestrictui, Erestrictqi;
+                      Erestrictui;
   CeedBasis bx, bu;
-  CeedQFunction qf_setup, qf_diff;
-  CeedOperator op_setup, op_diff;
+  CeedQFunction qf_setup, qf_mass;
+  CeedOperator op_setup, op_mass;
   CeedVector qdata, X, A, U, V;
-  CeedInt nelem = 6, P = 3, Q = 4, dim = 2;
+  CeedInt nelem = 6, P = 3, Q = 4, dim = 2, ncomp = 2;
   CeedInt nx = 3, ny = 2;
   CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q*Q;
   CeedInt indx[nelem*P*P];
-  CeedScalar x[dim*ndofs], assembledTrue[ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ncomp*ncomp*ndofs];
   CeedScalar *u;
   const CeedScalar *a, *v;
 
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
 
   // Qdata Vector
-  CeedVectorCreate(ceed, nqpts*dim*(dim+1)/2, &qdata);
+  CeedVectorCreate(ceed, nqpts, &qdata);
 
   // Element Setup
   for (CeedInt i=0; i<nelem; i++) {
@@ -50,82 +50,83 @@ int main(int argc, char **argv) {
   // Restrictions
   CeedElemRestrictionCreate(ceed, nelem, P*P, dim, ndofs, dim*ndofs,
                             CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
-
-  CeedElemRestrictionCreate(ceed, nelem, P*P, 1, 1, ndofs, CEED_MEM_HOST,
-                            CEED_USE_POINTER, indx, &Erestrictu);
+  CeedElemRestrictionCreate(ceed, nelem, P*P, ncomp, ndofs, ncomp*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictu);
   CeedInt stridesu[3] = {1, Q*Q, Q*Q};
   CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts, stridesu,
                                    &Erestrictui);
 
-  CeedInt stridesqd[3] = {1, Q*Q, Q *Q *dim *(dim+1)/2};
-  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, dim*(dim+1)/2,
-                                   dim*(dim+1)/2*nqpts,
-                                   stridesqd, &Erestrictqi);
-
   // Bases
   CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
-  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P, Q, CEED_GAUSS, &bu);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncomp, P, Q, CEED_GAUSS, &bu);
 
-  // QFunction - setup
+  // QFunctions
   CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
-  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(qf_setup, "_weight", 1, CEED_EVAL_WEIGHT);
-  CeedQFunctionAddOutput(qf_setup, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
 
-  // Operator - setup
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", ncomp, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", ncomp, CEED_EVAL_INTERP);
+
+  // Operators
   CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_setup);
-  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_setup, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
                        CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setup, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
                        CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
 
-  // QFunction - apply
-  CeedQFunctionCreateInterior(ceed, 1, diff, diff_loc, &qf_diff);
-  CeedQFunctionAddInput(qf_diff, "du", dim, CEED_EVAL_GRAD);
-  CeedQFunctionAddInput(qf_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_diff, "dv", dim, CEED_EVAL_GRAD);
-
-  // Operator - apply
-  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
-                     &op_diff);
-  CeedOperatorSetField(op_diff, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
-                       qdata);
-  CeedOperatorSetField(op_diff, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
-
   // Assemble diagonal
-  CeedOperatorAssembleLinearDiagonal(op_diff, &A, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorAssembleLinearPointBlockDiagonal(op_mass, &A,
+                                               CEED_REQUEST_IMMEDIATE);
 
   // Manually assemble diagonal
-  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorCreate(ceed, ncomp*ndofs, &U);
   CeedVectorSetValue(U, 0.0);
-  CeedVectorCreate(ceed, ndofs, &V);
+  CeedVectorCreate(ceed, ncomp*ndofs, &V);
+  for (int i=0; i<ncomp*ncomp*ndofs; i++)
+    assembledTrue[i] = 0.0;
+  CeedInt indOld = -1;
   for (int i=0; i<ndofs; i++) {
-    // Set input
-    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
-    u[i] = 1.0;
-    if (i)
-      u[i-1] = 0.0;
-    CeedVectorRestoreArray(U, &u);
+    for (int j=0; j<ncomp; j++) {
+      // Set input
+      CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+      CeedInt ind = i + j*ndofs;
+      u[ind] = 1.0;
+      if (ind > 0)
+        u[indOld] = 0.0;
+      indOld = ind;
+      CeedVectorRestoreArray(U, &u);
 
-    // Compute diag entry for DoF i
-    CeedOperatorApply(op_diff, U, V, CEED_REQUEST_IMMEDIATE);
+      // Compute effect of DoF i, comp j
+      CeedOperatorApply(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
 
-    // Retrieve entry
-    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
-    assembledTrue[i] = v[i];
-    CeedVectorRestoreArrayRead(V, &v);
+      // Retrieve entry
+      CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+      for (int k = 0; k<ncomp; k++)
+        assembledTrue[i*ncomp*ncomp + k*ncomp + j] += v[i + k*ndofs];
+      CeedVectorRestoreArrayRead(V, &v);
+    }
   }
 
   // Check output
   CeedVectorGetArrayRead(A, CEED_MEM_HOST, &a);
-  for (int i=0; i<ndofs; i++)
-    if (fabs(a[i] - assembledTrue[i]) > 1e-13)
+  for (int i=0; i<ncomp*ncomp*ndofs; i++)
+    if (fabs(a[i] - assembledTrue[i]) > 1e-14)
       // LCOV_EXCL_START
       printf("[%d] Error in assembly: %f != %f\n", i, a[i], assembledTrue[i]);
   // LCOV_EXCL_STOP
@@ -133,13 +134,12 @@ int main(int argc, char **argv) {
 
   // Cleanup
   CeedQFunctionDestroy(&qf_setup);
-  CeedQFunctionDestroy(&qf_diff);
+  CeedQFunctionDestroy(&qf_mass);
   CeedOperatorDestroy(&op_setup);
-  CeedOperatorDestroy(&op_diff);
+  CeedOperatorDestroy(&op_mass);
   CeedElemRestrictionDestroy(&Erestrictu);
   CeedElemRestrictionDestroy(&Erestrictx);
   CeedElemRestrictionDestroy(&Erestrictui);
-  CeedElemRestrictionDestroy(&Erestrictqi);
   CeedBasisDestroy(&bu);
   CeedBasisDestroy(&bx);
   CeedVectorDestroy(&X);

--- a/tests/t537-operator.c
+++ b/tests/t537-operator.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
 
   // Assemble diagonal
   CeedOperatorAssembleLinearPointBlockDiagonal(op_mass, &A,
-                                               CEED_REQUEST_IMMEDIATE);
+      CEED_REQUEST_IMMEDIATE);
 
   // Manually assemble diagonal
   CeedVectorCreate(ceed, ncomp*ndofs, &U);

--- a/tests/t537-operator.h
+++ b/tests/t537-operator.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q,
+                      const CeedScalar *const *in,
+                      CeedScalar *const *out) {
+  const CeedScalar *weight = in[0], *J = in[1];
+  CeedScalar *rho = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    rho[i] = weight[i] * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
+                     CeedScalar *const *out) {
+  const CeedScalar *rho = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    for (CeedInt c=0; c<2; c++)
+      v[i+Q*c] = rho[i] * u[i+Q*(c ? 0 : 1)];
+  }
+  return 0;
+}

--- a/tests/t537-operator.okl
+++ b/tests/t537-operator.okl
@@ -1,0 +1,51 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+// *****************************************************************************
+typedef int CeedInt;
+typedef double CeedScalar;
+// OCCA parser doesn't like __global here
+//typedef __global double gCeedScalar;
+
+// *****************************************************************************
+@kernel void setup(void *ctx, CeedInt Q,
+                   const int *iOf7, const int *oOf7, 
+                   const CeedScalar *in, CeedScalar *out) {
+  for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
+    // OCCA parser can't insert an __global here
+    /*const CeedScalar *weight = in + iOf7[0];
+    const CeedScalar *dxdX = in + iOf7[1];
+    CeedScalar *rho = out + oOf7[0];
+    rho[i] = weight[i] * dxdX[i];*/
+    out[oOf7[0]+i] = in[iOf7[0]+i] * (in[iOf7[1]+i+Q*0]*in[iOf7[1]+i+Q*3] -
+                                      in[iOf7[1]+i+Q*1]*in[iOf7[1]+i+Q*2]);
+  }
+}
+
+// *****************************************************************************
+@kernel void mass(void *ctx, CeedInt Q,
+                  const int *iOf7, const int *oOf7,
+                  const CeedScalar *in, CeedScalar *out) {
+  for (int i=0; i<Q; i++; @tile(TILE_SIZE,@outer,@inner)) {
+    // OCCA parser can't insert an __global here
+    /*const CeedScalar *rho = in + iOf7[0];
+    const CeedScalar *u = in + iOf7[1];
+    CeedScalar *v = out + oOf7[0];
+    v[i] = rho[i] * u[i];*/
+    for (int c=0; c<2; c++)
+      out[oOf7[0]+i+Q*c] = in[iOf7[0]+i] * in[iOf7[1]+i+Q*(c?0:1)];
+  }
+}


### PR DESCRIPTION
Here is the initial framework for `AssemblePointBlockDiagonal()`.

The easiest way to get this to work would be to return a vector, interlaced as the active output for the operator is, with `nfields*nfields*nnodes` elements. I can create the code for that with only minor changes to our current code. We would certainly be able to use such a vector for providing the action of a *local* point block Jacobi in libCEED. I think we have all of the functions we need to invert an arbitrary block.

It's not currently clear to me, however, what the data should look like for a BAIJ in PETSc when we have Dirichlet BCs.