### PR TITLE
Jed/breathe 4.17

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2174,7 +2174,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = restrict=
+PREDEFINED             =
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=3.0
-breathe>=4.15
+breathe>=4.17
 recommonmark
 sphinx_rtd_theme
 sphinxcontrib-bibtex

--- a/doc/sphinx/source/api/CeedElemRestriction.rst
+++ b/doc/sphinx/source/api/CeedElemRestriction.rst
@@ -14,9 +14,3 @@ Expressing element decomposition and degrees of freedom over a mesh
    :path: ../../../../xml
    :content-only:
    :members:
-
-Typedefs and Enumerations
--------------------------------------------------------------------
-
-.. doxygenenum:: CeedInterlaceMode
-   :project: libCEED

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -262,7 +262,7 @@ sys.path.append(breathe.__path__)
 breathe_projects = {"libCEED": "../../../xml"}
 breathe_default_project = "libCEED"
 breathe_build_directory = "../build/breathe"
-#breathe_domain_by_extension = {"c": "c", "h": "c", "cpp": "cpp", "hpp": "cpp"}
+breathe_domain_by_extension = {"c": "c", "h": "c", "cpp": "cpp", "hpp": "cpp"}
 
 # Run Doxygen if building on Read The Docs
 rootdir = os.path.join(os.path.dirname(__file__),

--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -21,5 +21,4 @@ Indices and tables
 ========================================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/include/ceedf.h
+++ b/include/ceedf.h
@@ -74,16 +74,6 @@
       parameter(ceed_norm_max    = 2 )
 
 !-----------------------------------------------------------------------
-! CeedInterlaceMode
-!-----------------------------------------------------------------------
-
-      integer ceed_noninterlaced
-      parameter(ceed_noninterlaced = 0)
-
-      integer ceed_interlaced
-      parameter(ceed_interlaced = 1)
-
-!-----------------------------------------------------------------------
 ! Ceed Strides Constant
 !-----------------------------------------------------------------------
 

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -117,9 +117,9 @@ static int CeedHouseholderApplyQ(CeedScalar *A, const CeedScalar *Q,
   @param[in,out] A  Row major matrix to apply Givens rotation to, in place
   @param c          Cosine factor
   @param s          Sine factor
-  @param tmode      CEED_NOTRANSPOSE to rotate the basis counter-clockwise,
+  @param tmode      @ref CEED_NOTRANSPOSE to rotate the basis counter-clockwise,
                     which has the effect of rotating columns of A clockwise;
-                    CEED_TRANSPOSE for the opposite rotation
+                    @ref CEED_TRANSPOSE for the opposite rotation
   @param i          First row/column to apply rotation
   @param k          Second row/column to apply rotation
   @param m          Number of rows in A
@@ -642,7 +642,7 @@ int CeedBasisView(CeedBasis basis, FILE *stream) {
   @param basis   CeedBasis to evaluate
   @param nelem   The number of elements to apply the basis evaluation to;
                    the backend will specify the ordering in
-                   ElemRestrictionCreateBlocked
+                   CeedElemRestrictionCreateBlocked()
   @param tmode   \ref CEED_NOTRANSPOSE to evaluate from nodes to quadrature
                    points, \ref CEED_TRANSPOSE to apply the transpose, mapping
                    from quadrature points to nodes

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -230,7 +230,7 @@ static struct CeedElemRestriction_private ceed_elemrestriction_none;
 /// Indicate that the stride is determined by the backend
 const CeedInt CEED_STRIDES_BACKEND[3] = {};
 
-/// Indicate that no ElemRestriction is provided by the user
+/// Indicate that no CeedElemRestriction is provided by the user
 const CeedElemRestriction CEED_ELEMRESTRICTION_NONE =
   &ceed_elemrestriction_none;
 
@@ -544,11 +544,11 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *lvec,
 
   @param rstr    CeedElemRestriction
   @param tmode   Apply restriction or transpose
-  @param u       Input vector (of size @a lsize when tmode=CEED_NOTRANSPOSE)
+  @param u       Input vector (of size @a lsize when tmode=@ref CEED_NOTRANSPOSE)
   @param ru      Output vector (of shape [@a nelem * @a elemsize] when
-                   tmode=CEED_NOTRANSPOSE). Ordering of the e-vector is decided
+                   tmode=@ref CEED_NOTRANSPOSE). Ordering of the e-vector is decided
                    by the backend.
-  @param request Request or CEED_REQUEST_IMMEDIATE
+  @param request Request or @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -590,11 +590,11 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode tmode,
                    elements [0 : blksize] and block=3 will handle elements
                    [3*blksize : 4*blksize]
   @param tmode   Apply restriction or transpose
-  @param u       Input vector (of size @a lsize when tmode=CEED_NOTRANSPOSE)
+  @param u       Input vector (of size @a lsize when tmode=@ref CEED_NOTRANSPOSE)
   @param ru      Output vector (of shape [@a blksize * @a elemsize] when
-                   tmode=CEED_NOTRANSPOSE). Ordering of the e-vector is decided
+                   tmode=@ref CEED_NOTRANSPOSE). Ordering of the e-vector is decided
                    by the backend.
-  @param request Request or CEED_REQUEST_IMMEDIATE
+  @param request Request or @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -499,9 +499,9 @@ int CeedOperatorFieldGetVector(CeedOperatorField opfield, CeedVector *vec) {
   @param ceed    A Ceed object where the CeedOperator will be created
   @param qf      QFunction defining the action of the operator at quadrature points
   @param dqf     QFunction defining the action of the Jacobian of @a qf (or
-                   CEED_QFUNCTION_NONE)
+                   @ref CEED_QFUNCTION_NONE)
   @param dqfT    QFunction defining the action of the transpose of the Jacobian
-                   of @a qf (or CEED_QFUNCTION_NONE)
+                   of @a qf (or @ref CEED_QFUNCTION_NONE)
   @param[out] op Address of the variable where the newly created
                      CeedOperator will be stored
 
@@ -601,11 +601,11 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
   @param fieldname  Name of the field (to be matched with the name used by
                       CeedQFunction)
   @param r          CeedElemRestriction
-  @param b          CeedBasis in which the field resides or CEED_BASIS_COLLOCATED
+  @param b          CeedBasis in which the field resides or @ref CEED_BASIS_COLLOCATED
                       if collocated with quadrature points
-  @param v          CeedVector to be used by CeedOperator or CEED_VECTOR_ACTIVE
-                      if field is active or CEED_VECTOR_NONE if using
-                      CEED_EVAL_WEIGHT in the QFunction
+  @param v          CeedVector to be used by CeedOperator or @ref CEED_VECTOR_ACTIVE
+                      if field is active or @ref CEED_VECTOR_NONE if using
+                      @ref CEED_EVAL_WEIGHT in the QFunction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -737,7 +737,7 @@ int CeedCompositeOperatorAddSub(CeedOperator compositeop, CeedOperator subop) {
     and contains column-major matrices representing the action of the
     CeedQFunction for a corresponding quadrature point on an element. Inputs and
     outputs are in the order provided by the user when adding CeedOperator fields.
-    For example, a QFunction with inputs 'u' and 'gradu' and outputs 'gradv' and
+    For example, a CeedQFunction with inputs 'u' and 'gradu' and outputs 'gradv' and
     'v', provided in that order, would result in an assembled QFunction that
     consists of (1 + dim) x (dim + 1) matrices at each quadrature point acting
     on the input [u, du_0, du_1] and producing the output [dv_0, dv_1, v].
@@ -748,7 +748,7 @@ int CeedCompositeOperatorAddSub(CeedOperator compositeop, CeedOperator subop) {
   @param[out] rstr      CeedElemRestriction for CeedVector containing assembled
                           CeedQFunction
   @param request        Address of CeedRequest for non-blocking completion, else
-                          CEED_REQUEST_IMMEDIATE
+                          @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -786,7 +786,7 @@ int CeedOperatorAssembleLinearQFunction(CeedOperator op, CeedVector *assembled,
   @param op             CeedOperator to assemble CeedQFunction
   @param[out] assembled CeedVector to store assembled CeedOperator diagonal
   @param request        Address of CeedRequest for non-blocking completion, else
-                          CEED_REQUEST_IMMEDIATE
+                          @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -831,7 +831,7 @@ int CeedOperatorAssembleLinearDiagonal(CeedOperator op, CeedVector *assembled,
   @param[out] fdminv    CeedOperator to apply the action of a FDM based inverse
                           for each element
   @param request        Address of CeedRequest for non-blocking completion, else
-                          CEED_REQUEST_IMMEDIATE
+                          @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -896,13 +896,13 @@ int CeedOperatorView(CeedOperator op, FILE *stream) {
   CeedOperatorSetField().
 
   @param op        CeedOperator to apply
-  @param[in] in    CeedVector containing input state or CEED_VECTOR_NONE if
+  @param[in] in    CeedVector containing input state or @ref CEED_VECTOR_NONE if
                   there are no active inputs
   @param[out] out  CeedVector to store result of applying operator (must be
-                     distinct from @a in) or CEED_VECTOR_NONE if there are no
+                     distinct from @a in) or @ref CEED_VECTOR_NONE if there are no
                      active outputs
   @param request   Address of CeedRequest for non-blocking completion, else
-                     CEED_REQUEST_IMMEDIATE
+                     @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -978,7 +978,7 @@ int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out,
   @param[out] out  CeedVector to sum in result of applying operator (must be
                      distinct from @a in) or NULL if there are no active outputs
   @param request   Address of CeedRequest for non-blocking completion, else
-                     CEED_REQUEST_IMMEDIATE
+                     @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -86,8 +86,8 @@ int CeedQFunctionRegister(const char *name, const char *source,
 
   @param f          CeedQFunctionField
   @param fieldname  Name of QFunction field
-  @param size       Size of QFunction field, (ncomp * dim) for CEED_EVAL_GRAD or
-                      (ncomp * 1) for CEED_EVAL_NONE, CEED_EVAL_INTERP, and CEED_EVAL_WEIGHT
+  @param size       Size of QFunction field, (ncomp * dim) for @ref CEED_EVAL_GRAD or
+                      (ncomp * 1) for @ref CEED_EVAL_NONE, @ref CEED_EVAL_INTERP, and @ref CEED_EVAL_WEIGHT
   @param emode      \ref CEED_EVAL_NONE to use values directly,
                       \ref CEED_EVAL_INTERP to use interpolated values,
                       \ref CEED_EVAL_GRAD to use gradients,
@@ -590,8 +590,8 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode inmode,
 
   @param qf         CeedQFunction
   @param fieldname  Name of QFunction field
-  @param size       Size of QFunction field, (ncomp * dim) for CEED_EVAL_GRAD or
-                      (ncomp * 1) for CEED_EVAL_NONE and CEED_EVAL_INTERP
+  @param size       Size of QFunction field, (ncomp * dim) for @ref CEED_EVAL_GRAD or
+                      (ncomp * 1) for @ref CEED_EVAL_NONE and @ref CEED_EVAL_INTERP
   @param emode      \ref CEED_EVAL_NONE to use values directly,
                       \ref CEED_EVAL_INTERP to use interpolated values,
                       \ref CEED_EVAL_GRAD to use gradients.
@@ -614,8 +614,8 @@ int CeedQFunctionAddInput(CeedQFunction qf, const char *fieldname, CeedInt size,
 
   @param qf         CeedQFunction
   @param fieldname  Name of QFunction field
-  @param size       Size of QFunction field, (ncomp * dim) for CEED_EVAL_GRAD or
-                      (ncomp * 1) for CEED_EVAL_NONE and CEED_EVAL_INTERP
+  @param size       Size of QFunction field, (ncomp * dim) for @ref CEED_EVAL_GRAD or
+                      (ncomp * 1) for @ref CEED_EVAL_NONE and @ref CEED_EVAL_INTERP
   @param emode      \ref CEED_EVAL_NONE to use values directly,
                       \ref CEED_EVAL_INTERP to use interpolated values,
                       \ref CEED_EVAL_GRAD to use gradients.

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -33,7 +33,7 @@ static struct CeedVector_private ceed_vector_none;
 ///   CeedOperatorApply().
 const CeedVector CEED_VECTOR_ACTIVE = &ceed_vector_active;
 
-/// Indicate that no vector is applicable (i.e., for CEED_EVAL_WEIGHTS).
+/// Indicate that no vector is applicable (i.e., for @ref CEED_EVAL_WEIGHTS).
 const CeedVector CEED_VECTOR_NONE = &ceed_vector_none;
 
 /// @}
@@ -171,7 +171,7 @@ int CeedVectorCreate(Ceed ceed, CeedInt length, CeedVector *vec) {
   @param vec   CeedVector
   @param mtype Memory type of the array being passed
   @param cmode Copy mode for the array
-  @param array Array to be used, or NULL with CEED_COPY_VALUES to have the
+  @param array Array to be used, or NULL with @ref CEED_COPY_VALUES to have the
                  library allocate
 
   @return An error code: 0 - success, otherwise - failure
@@ -394,7 +394,7 @@ int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
           of a parallel vector or a CeedVector with duplicated or hanging nodes.
 
   @param vec           CeedVector to retrieve maximum value
-  @param type          Norm type CEED_NORM_1, CEED_NORM_2, or CEED_NORM_MAX
+  @param type          Norm type @ref CEED_NORM_1, @ref CEED_NORM_2, or @ref CEED_NORM_MAX
   @param[out] norm     Variable to store norm value
 
   @return An error code: 0 - success, otherwise - failure

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -88,7 +88,7 @@ CeedRequest *const CEED_REQUEST_IMMEDIATE = &ceed_request_immediate;
   `op2` until `op1` has completed.
 
   @todo The current implementation is overly strict, offering equivalent
-  semantics to CEED_REQUEST_IMMEDIATE.
+  semantics to @ref CEED_REQUEST_IMMEDIATE.
 
   @sa CEED_REQUEST_IMMEDIATE
  */


### PR DESCRIPTION
This upgrades breathe and switches to C domain, because libCEED is a C interface. It also avoids needing the `restrict` hack (though we took `restrict` out of the public interface).

Rendered: https://libceed.readthedocs.io/en/jed-breathe-4.17/

Cc: https://github.com/michaeljones/breathe/issues/477#issuecomment-622525692