### PR TITLE
Refactor Petsc area example

### DIFF
--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -29,15 +29,15 @@
 // Sample runs:
 //   Sequential:
 //
-//     ./area -problem cube -petscspace_degree 3 -dm_refine 2
+//     ./area -problem cube -degree 3 -dm_refine 2
 //
-//     ./area -problem sphere -petscspace_degree 3 -dm_refine 2
+//     ./area -problem sphere -degree 3 -dm_refine 2
 //
 //   In parallel:
 //
-//     mpiexec -n 4 ./area -probelm cube -petscspace_degree 3 -dm_refine 2
+//     mpiexec -n 4 ./area -problem cube -degree 3 -dm_refine 2
 //
-//     mpiexec -n 4 ./area -problem sphere -petscspace_degree 3 -dm_refine 2
+//     mpiexec -n 4 ./area -problem sphere -degree 3 -dm_refine 2
 //
 //   The above example runs use 2 levels of refinement for the mesh.
 //   Use -dm_refine k, for k levels of uniform refinement.
@@ -52,84 +52,11 @@ static const char help[] =
 #include <string.h>
 #include <petscdmplex.h>
 #include <ceed.h>
-#include "qfunctions/area/areacube.h"
-#include "qfunctions/area/areasphere.h"
+#include "setuparea.h"
 
 #ifndef M_PI
 #  define M_PI    3.14159265358979323846
 #endif
-
-// Auxiliary function to define CEED restrictions from DMPlex data
-static int CreateRestrictionPlex(Ceed ceed, CeedInt P, CeedInt ncomp,
-                                 CeedElemRestriction *Erestrict, DM dm) {
-  PetscInt ierr;
-  PetscInt c, cStart, cEnd, nelem, nnodes, *erestrict, eoffset;
-  PetscSection section;
-  Vec Uloc;
-
-  PetscFunctionBegin;
-
-  // Get Nelem
-  ierr = DMGetSection(dm, &section); CHKERRQ(ierr);
-  ierr = DMPlexGetHeightStratum(dm, 0, &cStart,& cEnd); CHKERRQ(ierr);
-  nelem = cEnd - cStart;
-
-  // Get indices
-  ierr = PetscMalloc1(nelem*P*P, &erestrict); CHKERRQ(ierr);
-  for (c=cStart, eoffset = 0; c<cEnd; c++) {
-    PetscInt numindices, *indices, i;
-    ierr = DMPlexGetClosureIndices(dm, section, section, c, &numindices,
-                                   &indices, NULL); CHKERRQ(ierr);
-    for (i=0; i<numindices; i+=ncomp) {
-      for (PetscInt j=0; j<ncomp; j++) {
-        if (indices[i+j] != indices[i] + (PetscInt)(copysign(j, indices[i])))
-          SETERRQ1(PETSC_COMM_SELF, PETSC_ERR_ARG_INCOMP,
-                   "Cell %D closure indices not interlaced", c);
-      }
-      // NO BC on closed surfaces
-      PetscInt loc = indices[i];
-      erestrict[eoffset++] = loc;
-    }
-    ierr = DMPlexRestoreClosureIndices(dm, section, section, c, &numindices,
-                                       &indices, NULL); CHKERRQ(ierr);
-  }
-
-  // Setup CEED restriction
-  ierr = DMGetLocalVector(dm, &Uloc); CHKERRQ(ierr);
-  ierr = VecGetLocalSize(Uloc, &nnodes); CHKERRQ(ierr);
-
-  ierr = DMRestoreLocalVector(dm, &Uloc); CHKERRQ(ierr);
-  CeedElemRestrictionCreate(ceed, nelem, P*P, ncomp, 1, nnodes,
-                            CEED_MEM_HOST, CEED_COPY_VALUES, erestrict,
-                            Erestrict);
-  ierr = PetscFree(erestrict); CHKERRQ(ierr);
-
-  PetscFunctionReturn(0);
-}
-
-// Utility function taken from petsc/src/dm/impls/plex/examples/tutorials/ex7.c
-static PetscErrorCode ProjectToUnitSphere(DM dm) {
-  Vec            coordinates;
-  PetscScalar   *coords;
-  PetscInt       Nv, v, dim, d;
-  PetscErrorCode ierr;
-
-  PetscFunctionBeginUser;
-  ierr = DMGetCoordinatesLocal(dm, &coordinates); CHKERRQ(ierr);
-  ierr = VecGetLocalSize(coordinates, &Nv); CHKERRQ(ierr);
-  ierr = VecGetBlockSize(coordinates, &dim); CHKERRQ(ierr);
-  Nv  /= dim;
-  ierr = VecGetArray(coordinates, &coords); CHKERRQ(ierr);
-  for (v = 0; v < Nv; ++v) {
-    PetscReal r = 0.0;
-
-    for (d = 0; d < dim; ++d) r += PetscSqr(PetscRealPart(coords[v*dim+d]));
-    r = PetscSqrtReal(r);
-    for (d = 0; d < dim; ++d) coords[v*dim+d] /= r;
-  }
-  ierr = VecRestoreArray(coordinates, &coords); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
-}
 
 int main(int argc, char **argv) {
   PetscInt ierr;
@@ -143,37 +70,29 @@ int main(int argc, char **argv) {
            topodim = 2, // topological dimension of manifold
            degree  = 3; // default degree for finite element bases
   PetscBool read_mesh = PETSC_FALSE,
-            test_mode = PETSC_FALSE;
-  PetscSpace sp;
-  PetscFE fe;
-  Vec X, Xloc, V, Vloc;
-  DM  dm, dmcoord;
+            test_mode = PETSC_FALSE,
+            simplex = PETSC_FALSE;
+  Vec U, Uloc, V, Vloc;
+  DM  dm;
+  User user;
   Ceed ceed;
-  CeedInt P, Q;
-  CeedOperator op_setupgeo, op_apply;
-  CeedQFunction qf_setupgeo, qf_apply;
-  CeedBasis basisx, basisu;
-  CeedElemRestriction Erestrictx, Erestrictu, Erestrictqdi;
-  PetscFunctionList geomfactorlist = NULL;
-  char problemtype[PETSC_MAX_PATH_LEN] = "sphere";
+  CeedData ceeddata;
+  problemType problemChoice;
 
   ierr = PetscInitialize(&argc, &argv, NULL, help);
   if (ierr) return ierr;
   comm = PETSC_COMM_WORLD;
 
-  // Set up problem type command line option
-  ierr = PetscFunctionListAdd(&geomfactorlist, "cube", &SetupMassGeoCube);
-  CHKERRQ(ierr);
-  ierr = PetscFunctionListAdd(&geomfactorlist, "sphere", &SetupMassGeoSphere);
-  CHKERRQ(ierr);
-
   // Read command line options
   ierr = PetscOptionsBegin(comm, NULL, "CEED surface area problem with PETSc",
                            NULL);
   CHKERRQ(ierr);
-  ierr = PetscOptionsFList("-problem", "Problem to solve", NULL, geomfactorlist,
-                           problemtype, problemtype, sizeof problemtype, NULL);
-  CHKERRQ(ierr);
+  problemChoice = SPHERE;
+  ierr = PetscOptionsEnum("-problem",
+                          "Problem to solve", NULL,
+                          problemTypes, (PetscEnum)problemChoice,
+                          (PetscEnum *)&problemChoice,
+                          NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-qextra", "Number of extra quadrature points",
                          NULL, qextra, &qextra, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsString("-ceed", "CEED resource specifier",
@@ -185,34 +104,23 @@ int main(int argc, char **argv) {
   ierr = PetscOptionsString("-mesh", "Read mesh from file", NULL,
                             filename, filename, sizeof(filename), &read_mesh);
   CHKERRQ(ierr);
+  ierr = PetscOptionsBool("-simplex", "Use simplices, or tensor product cells",
+                          NULL, simplex, &simplex, NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsInt("-degree", "Polynomial degree of tensor product basis",
+                         NULL, degree, &degree, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
-
-  // Setup function pointer for geometric factors
-  int (*geomfp)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
-                CeedScalar *const *out);
-  ierr = PetscFunctionListFind(geomfactorlist, problemtype,
-                               (void(* *)(void))&geomfp); CHKERRQ(ierr);
-  const char *str;
-  if (geomfp == SetupMassGeoCube)
-    str = SetupMassGeoCube_loc;
-  else if (geomfp == SetupMassGeoSphere)
-    str = SetupMassGeoSphere_loc;
-  else {
-    SETERRQ(comm, PETSC_ERR_USER, "Function not found in the list");
-    return PETSC_ERR_USER;
-  }
 
   // Setup DM
   if (read_mesh) {
     ierr = DMPlexCreateFromFile(PETSC_COMM_WORLD, filename, PETSC_TRUE, &dm);
     CHKERRQ(ierr);
   } else {
-    // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box.
-    PetscBool simplex = PETSC_FALSE;
+    // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box
     ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topodim, simplex, &dm);
     CHKERRQ(ierr);
     // Set the object name
-    ierr = PetscObjectSetName((PetscObject)dm, problemtype); CHKERRQ(ierr);
+    ierr = PetscObjectSetName((PetscObject)dm, problemTypes[problemChoice]);
+    CHKERRQ(ierr);
     // Distribute mesh over processes
     {
       DM dmDist = NULL;
@@ -229,47 +137,36 @@ int main(int argc, char **argv) {
     // Refine DMPlex with uniform refinement using runtime option -dm_refine
     ierr = DMPlexSetRefinementUniform(dm, PETSC_TRUE); CHKERRQ(ierr);
     ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
-    if (!strcmp(problemtype, "sphere"))
+    if (problemChoice == SPHERE) {
       ierr = ProjectToUnitSphere(dm); CHKERRQ(ierr);
+    }
     // View DMPlex via runtime option
     ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
   }
 
-  // Create FE
-  ierr = PetscFECreateDefault(PETSC_COMM_SELF, topodim, ncompu, PETSC_FALSE, NULL,
-                              PETSC_DETERMINE, &fe);
-  CHKERRQ(ierr);
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
-  ierr = DMAddField(dm, NULL, (PetscObject)fe); CHKERRQ(ierr);
-  ierr = DMCreateDS(dm); CHKERRQ(ierr);
-  ierr = DMPlexSetClosurePermutationTensor(dm, PETSC_DETERMINE, NULL);
-  CHKERRQ(ierr);
-
-  // Get basis space degree
-  ierr = PetscFEGetBasisSpace(fe, &sp); CHKERRQ(ierr);
-  ierr = PetscSpaceGetDegree(sp, &degree, NULL); CHKERRQ(ierr);
-  ierr = PetscFEDestroy(&fe); CHKERRQ(ierr);
-  if (degree < 1) SETERRQ1(PETSC_COMM_WORLD, PETSC_ERR_ARG_OUTOFRANGE,
-                             "-petscspace_degree %D must be at least 1", degree);
+  // Create DM
+  ierr = SetupDMByDegree(dm, degree, ncompu, topodim); CHKERRQ(ierr);
 
   // Create vectors
-  ierr = DMCreateGlobalVector(dm, &X); CHKERRQ(ierr);
-  ierr = VecGetLocalSize(X, &lsize); CHKERRQ(ierr);
-  ierr = VecGetSize(X, &gsize); CHKERRQ(ierr);
-  ierr = DMCreateLocalVector(dm, &Xloc); CHKERRQ(ierr);
-  ierr = VecGetSize(Xloc, &xlsize); CHKERRQ(ierr);
-  ierr = VecDuplicate(X, &V); CHKERRQ(ierr);
-  ierr = VecDuplicate(Xloc, &Vloc); CHKERRQ(ierr);
+  ierr = DMCreateGlobalVector(dm, &U); CHKERRQ(ierr);
+  ierr = VecGetLocalSize(U, &lsize); CHKERRQ(ierr);
+  ierr = VecGetSize(U, &gsize); CHKERRQ(ierr);
+  ierr = DMCreateLocalVector(dm, &Uloc); CHKERRQ(ierr);
+  ierr = VecGetSize(Uloc, &xlsize); CHKERRQ(ierr);
+  ierr = VecDuplicate(U, &V); CHKERRQ(ierr);
+  ierr = VecDuplicate(Uloc, &Vloc); CHKERRQ(ierr);
+
+  // Setup user structure
+  ierr = PetscMalloc1(1, &user); CHKERRQ(ierr);
 
   // Set up libCEED
   CeedInit(ceedresource, &ceed);
 
   // Print summary
-  P = degree + 1;
-  Q = P + qextra;
-  const char *usedresource;
-  CeedGetResource(ceed, &usedresource);
   if (!test_mode) {
+    PetscInt P = degree + 1, Q = P + qextra;
+    const char *usedresource;
+    CeedGetResource(ceed, &usedresource);
     ierr = PetscPrintf(comm,
                        "\n-- libCEED + PETSc Surface Area of a Manifold --\n"
                        "  libCEED:\n"
@@ -278,98 +175,23 @@ int main(int argc, char **argv) {
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
                        "    Global nodes                       : %D\n"
-                       "    DoF per node                       : %D\n",
-                       usedresource, P, Q,  gsize/ncompu, ncompu);
+                       "    DoF per node                       : %D\n"
+                       "    Global DoFs                        : %D\n",
+                       usedresource, P, Q,  gsize/ncompu, ncompu, gsize);
     CHKERRQ(ierr);
   }
 
-  // Setup libCEED's objects:
-  // Create bases
-  CeedBasisCreateTensorH1Lagrange(ceed, topodim, ncompu, P, Q,
-                                  CEED_GAUSS, &basisu);
-  CeedBasisCreateTensorH1Lagrange(ceed, topodim, ncompx, 2, Q,
-                                  CEED_GAUSS, &basisx);
+  // Setup libCEED's objects and apply setup operator
+  ierr = PetscMalloc1(1, &ceeddata); CHKERRQ(ierr);
+  ierr = SetupLibceedByDegree(dm, ceed, degree, topodim, qextra,
+                              ncompx, ncompu, xlsize, problemChoice,
+                              ceeddata); CHKERRQ(ierr);
 
-  // CEED restrictions
-  ierr = DMGetCoordinateDM(dm, &dmcoord); CHKERRQ(ierr);
-  ierr = DMPlexSetClosurePermutationTensor(dmcoord, PETSC_DETERMINE, NULL);
-  CHKERRQ(ierr);
-
-  ierr = CreateRestrictionPlex(ceed, 2, ncompx, &Erestrictx, dmcoord);
-  CHKERRQ(ierr);
-  ierr = CreateRestrictionPlex(ceed, P, ncompu, &Erestrictu, dm); CHKERRQ(ierr);
-
-  CeedInt cStart, cEnd;
-  ierr = DMPlexGetHeightStratum(dm, 0, &cStart, &cEnd); CHKERRQ(ierr);
-  const CeedInt nelem = cEnd - cStart;
-
-  // CEED strided restrictions
-  const CeedInt qdatasize = 1;
-  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, qdatasize,
-                                   qdatasize*nelem*Q*Q,
-                                   CEED_STRIDES_BACKEND, &Erestrictqdi);
-
-  // Element coordinates
-  Vec coords;
-  const PetscScalar *coordArray;
-  PetscSection section;
-  ierr = DMGetCoordinatesLocal(dm, &coords); CHKERRQ(ierr);
-  ierr = VecGetArrayRead(coords, &coordArray); CHKERRQ(ierr);
-  ierr = DMGetSection(dmcoord, &section); CHKERRQ(ierr);
-
-  CeedVector xcoord;
-  CeedElemRestrictionCreateVector(Erestrictx, &xcoord, NULL);
-  CeedVectorSetArray(xcoord, CEED_MEM_HOST, CEED_COPY_VALUES,
-                     (PetscScalar *)coordArray);
-  ierr = VecRestoreArrayRead(coords, &coordArray);
-
-  // Create the vectors that will be needed in setup and apply
-  CeedVector uceed, vceed, qdata;
-  CeedInt nqpts;
-  CeedBasisGetNumQuadraturePoints(basisu, &nqpts);
-  CeedVectorCreate(ceed, qdatasize*nelem*nqpts, &qdata);
-  CeedVectorCreate(ceed, xlsize, &uceed);
-  CeedVectorCreate(ceed, xlsize, &vceed);
-
-  // Create the Q-function that builds the operator for the geomteric factors
-  //   (i.e., the quadrature data)
-  CeedQFunctionCreateInterior(ceed, 1, geomfp, str, &qf_setupgeo);
-  CeedQFunctionAddInput(qf_setupgeo, "x", ncompx, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(qf_setupgeo, "dx", ncompx*topodim, CEED_EVAL_GRAD);
-  CeedQFunctionAddInput(qf_setupgeo, "weight", 1, CEED_EVAL_WEIGHT);
-  CeedQFunctionAddOutput(qf_setupgeo, "qdata", qdatasize, CEED_EVAL_NONE);
-
-  // Set up the mass operator
-  CeedQFunctionCreateInterior(ceed, 1, Mass, Mass_loc, &qf_apply);
-  CeedQFunctionAddInput(qf_apply, "u", ncompu, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(qf_apply, "qdata", qdatasize, CEED_EVAL_NONE);
-  CeedQFunctionAddOutput(qf_apply, "v", ncompu, CEED_EVAL_INTERP);
-
-  // Create the operator that builds the quadrature data for the operator
-  CeedOperatorCreate(ceed, qf_setupgeo, NULL, NULL, &op_setupgeo);
-  CeedOperatorSetField(op_setupgeo, "x", Erestrictx, basisx,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, basisx,
-                       CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_setupgeo, "weight", CEED_ELEMRESTRICTION_NONE, basisx,
-                       CEED_VECTOR_NONE);
-  CeedOperatorSetField(op_setupgeo, "qdata", Erestrictqdi,
-                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-
-  // Create the mass operator
-  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
-  CeedOperatorSetField(op_apply, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_BASIS_COLLOCATED,
-                       qdata);
-  CeedOperatorSetField(op_apply, "v", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
-
-  // Compute the quadrature data for the mass operator
-  CeedOperatorApply(op_setupgeo, xcoord, qdata, CEED_REQUEST_IMMEDIATE);
-
+  // Setup output vector
   PetscScalar *v;
   ierr = VecZeroEntries(Vloc); CHKERRQ(ierr);
   ierr = VecGetArray(Vloc, &v);
-  CeedVectorSetArray(vceed, CEED_MEM_HOST, CEED_USE_POINTER, v);
+  CeedVectorSetArray(ceeddata->vceed, CEED_MEM_HOST, CEED_USE_POINTER, v);
 
   // Compute the mesh volume using the mass operator: area = 1^T \cdot M \cdot 1
   if (!test_mode) {
@@ -379,11 +201,12 @@ int main(int argc, char **argv) {
   }
 
   // Initialize u with ones
-  CeedVectorSetValue(uceed, 1.0);
+  CeedVectorSetValue(ceeddata->uceed, 1.0);
 
   // Apply the mass operator: 'u' -> 'v'
-  CeedOperatorApply(op_apply, uceed, vceed, CEED_REQUEST_IMMEDIATE);
-  CeedVectorSyncArray(vceed, CEED_MEM_HOST);
+  CeedOperatorApply(ceeddata->op_apply, ceeddata->uceed, ceeddata->vceed,
+                    CEED_REQUEST_IMMEDIATE);
+  CeedVectorSyncArray(ceeddata->vceed, CEED_MEM_HOST);
 
   // Gather output vector
   ierr = VecRestoreArray(Vloc, &v); CHKERRQ(ierr);
@@ -397,7 +220,7 @@ int main(int argc, char **argv) {
 
   // Compute the exact surface area and print the result
   CeedScalar exact_surfarea = 4 * M_PI;
-  if (!strcmp(problemtype, "cube")) {
+  if (problemChoice == CUBE) {
     PetscScalar l = 1.0/PetscSqrtReal(3.0); // half edge of the cube
     exact_surfarea = 6 * (2*l) * (2*l);
   }
@@ -411,27 +234,13 @@ int main(int argc, char **argv) {
                        fabs(area - exact_surfarea)); CHKERRQ(ierr);
   }
 
-  // PETSc cleanup
+  // Cleanup
   ierr = DMDestroy(&dm); CHKERRQ(ierr);
-  ierr = VecDestroy(&X); CHKERRQ(ierr);
-  ierr = VecDestroy(&Xloc); CHKERRQ(ierr);
+  ierr = VecDestroy(&U); CHKERRQ(ierr);
+  ierr = VecDestroy(&Uloc); CHKERRQ(ierr);
   ierr = VecDestroy(&V); CHKERRQ(ierr);
   ierr = VecDestroy(&Vloc); CHKERRQ(ierr);
-
-  // libCEED cleanup
-  CeedQFunctionDestroy(&qf_setupgeo);
-  CeedOperatorDestroy(&op_setupgeo);
-  CeedVectorDestroy(&xcoord);
-  CeedVectorDestroy(&uceed);
-  CeedVectorDestroy(&vceed);
-  CeedVectorDestroy(&qdata);
-  CeedBasisDestroy(&basisx);
-  CeedBasisDestroy(&basisu);
-  CeedElemRestrictionDestroy(&Erestrictu);
-  CeedElemRestrictionDestroy(&Erestrictx);
-  CeedElemRestrictionDestroy(&Erestrictqdi);
-  CeedQFunctionDestroy(&qf_apply);
-  CeedOperatorDestroy(&op_apply);
+  ierr = CeedDataDestroy(ceeddata); CHKERRQ(ierr);
   CeedDestroy(&ceed);
   return PetscFinalize();
 }

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -122,8 +122,7 @@ int main(int argc, char **argv) {
     ierr = DMPlexCreateFromFile(PETSC_COMM_WORLD, filename, PETSC_TRUE, &dm);
     CHKERRQ(ierr);
   } else {
-    // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box.
-    PetscBool simplex = PETSC_FALSE;
+    // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box
     ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topodim, simplex, &dm);
     CHKERRQ(ierr);
     // Set the object name
@@ -150,8 +149,7 @@ int main(int argc, char **argv) {
   }
 
   // Create DM
-  ierr = SetupDMByDegree(dm, degree, ncompu, topodim);
-  CHKERRQ(ierr);
+  ierr = SetupDMByDegree(dm, degree, ncompu, topodim); CHKERRQ(ierr);
 
   // Create vectors
   ierr = DMCreateGlobalVector(dm, &X); CHKERRQ(ierr);
@@ -166,8 +164,7 @@ int main(int argc, char **argv) {
   ierr = MatCreateShell(comm, lsize, lsize, gsize, gsize,
                         userO, &matO); CHKERRQ(ierr);
   ierr = MatShellSetOperation(matO, MATOP_MULT,
-                              (void(*)(void))MatMult_Ceed);
-  CHKERRQ(ierr);
+                              (void(*)(void))MatMult_Ceed); CHKERRQ(ierr);
 
   // Set up libCEED
   CeedInit(ceedresource, &ceed);
@@ -234,8 +231,6 @@ int main(int argc, char **argv) {
   userO->yceed = ceeddata->yceed;
   userO->op = ceeddata->op_apply;
   userO->ceed = ceed;
-  userO->topodim = topodim;
-  userO->simplex = simplex;
 
   // Setup solver
   ierr = KSPCreate(comm, &ksp); CHKERRQ(ierr);

--- a/examples/petsc/setuparea.h
+++ b/examples/petsc/setuparea.h
@@ -1,0 +1,426 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#ifndef setuparea_h
+#define setuparea_h
+
+#include <stdbool.h>
+#include <string.h>
+#include <petsc.h>
+#include <petscdmplex.h>
+#include <petscfe.h>
+#include <ceed.h>
+#include "qfunctions/area/areacube.h"
+#include "qfunctions/area/areasphere.h"
+
+// -----------------------------------------------------------------------------
+// PETSc Operator Structs
+// -----------------------------------------------------------------------------
+
+// Data for PETSc
+typedef struct User_ *User;
+struct User_ {
+  MPI_Comm comm;
+  DM dm;
+  Vec Xloc, Yloc, diag;
+  CeedVector xceed, yceed;
+  CeedOperator op;
+  Ceed ceed;
+};
+
+// -----------------------------------------------------------------------------
+// libCEED Data Struct
+// -----------------------------------------------------------------------------
+
+// libCEED data struct for level
+typedef struct CeedData_ *CeedData;
+struct CeedData_ {
+  Ceed ceed;
+  CeedBasis basisx, basisu;
+  CeedElemRestriction Erestrictx, Erestrictu, Erestrictqdi;
+  CeedQFunction qf_apply;
+  CeedOperator op_apply, op_restrict, op_interp;
+  CeedVector qdata, uceed, vceed;
+};
+
+// -----------------------------------------------------------------------------
+// Problem Option Data
+// -----------------------------------------------------------------------------
+
+// Problem options
+typedef enum {
+  CUBE = 0, SPHERE = 1
+} problemType;
+static const char *const problemTypes[] = {"cube", "sphere",
+                                           "problemType", "AREA", NULL
+                                          };
+
+// Problem specific data
+typedef struct {
+  CeedInt ncompu, ncompx, qdatasize, qextra, topodim;
+  CeedQFunctionUser setupgeo, apply;
+  const char *setupgeofname, *applyfname;
+  CeedEvalMode inmode, outmode;
+  CeedQuadMode qmode;
+} problemData;
+
+static problemData problemOptions[6] = {
+  [CUBE] = {
+    .ncompx = 3,
+    .ncompu = 1,
+    .topodim = 2,
+    .qdatasize = 1,
+    .qextra = 1,
+    .setupgeo = SetupMassGeoCube,
+    .apply = Mass,
+    .setupgeofname = SetupMassGeoCube_loc,
+    .applyfname = Mass_loc,
+    .inmode = CEED_EVAL_INTERP,
+    .outmode = CEED_EVAL_INTERP,
+    .qmode = CEED_GAUSS
+  },
+  [SPHERE] = {
+    .ncompx = 3,
+    .ncompu = 1,
+    .topodim = 2,
+    .qdatasize = 1,
+    .qextra = 1,
+    .setupgeo = SetupMassGeoSphere,
+    .apply = Mass,
+    .setupgeofname = SetupMassGeoSphere_loc,
+    .applyfname = Mass_loc,
+    .inmode = CEED_EVAL_INTERP,
+    .outmode = CEED_EVAL_INTERP,
+    .qmode = CEED_GAUSS
+  }
+};
+
+// -----------------------------------------------------------------------------
+// PETSc sphere auxiliary functions
+// -----------------------------------------------------------------------------
+
+// Utility function taken from petsc/src/dm/impls/plex/examples/tutorials/ex7.c
+static PetscErrorCode ProjectToUnitSphere(DM dm) {
+  Vec            coordinates;
+  PetscScalar   *coords;
+  PetscInt       Nv, v, dim, d;
+  PetscErrorCode ierr;
+
+  PetscFunctionBeginUser;
+  ierr = DMGetCoordinatesLocal(dm, &coordinates); CHKERRQ(ierr);
+  ierr = VecGetLocalSize(coordinates, &Nv); CHKERRQ(ierr);
+  ierr = VecGetBlockSize(coordinates, &dim); CHKERRQ(ierr);
+  Nv  /= dim;
+  ierr = VecGetArray(coordinates, &coords); CHKERRQ(ierr);
+  for (v = 0; v < Nv; ++v) {
+    PetscReal r = 0.0;
+
+    for (d = 0; d < dim; ++d) r += PetscSqr(PetscRealPart(coords[v*dim+d]));
+    r = PetscSqrtReal(r);
+    for (d = 0; d < dim; ++d) coords[v*dim+d] /= r;
+  }
+  ierr = VecRestoreArray(coordinates, &coords); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+// -----------------------------------------------------------------------------
+// PETSc Finite Element space setup
+// -----------------------------------------------------------------------------
+
+// Create FE by degree
+static int PetscFECreateByDegree(DM dm, PetscInt dim, PetscInt Nc,
+                                 PetscBool isSimplex, const char prefix[],
+                                 PetscInt order, PetscFE *fem) {
+  PetscQuadrature q, fq;
+  DM              K;
+  PetscSpace      P;
+  PetscDualSpace  Q;
+  PetscInt        quadPointsPerEdge;
+  PetscBool       tensor = isSimplex ? PETSC_FALSE : PETSC_TRUE;
+  PetscErrorCode  ierr;
+
+  PetscFunctionBeginUser;
+  /* Create space */
+  ierr = PetscSpaceCreate(PetscObjectComm((PetscObject) dm), &P); CHKERRQ(ierr);
+  ierr = PetscObjectSetOptionsPrefix((PetscObject) P, prefix); CHKERRQ(ierr);
+  ierr = PetscSpacePolynomialSetTensor(P, tensor); CHKERRQ(ierr);
+  ierr = PetscSpaceSetFromOptions(P); CHKERRQ(ierr);
+  ierr = PetscSpaceSetNumComponents(P, Nc); CHKERRQ(ierr);
+  ierr = PetscSpaceSetNumVariables(P, dim); CHKERRQ(ierr);
+  ierr = PetscSpaceSetDegree(P, order, order); CHKERRQ(ierr);
+  ierr = PetscSpaceSetUp(P); CHKERRQ(ierr);
+  ierr = PetscSpacePolynomialGetTensor(P, &tensor); CHKERRQ(ierr);
+  /* Create dual space */
+  ierr = PetscDualSpaceCreate(PetscObjectComm((PetscObject) dm), &Q);
+  CHKERRQ(ierr);
+  ierr = PetscDualSpaceSetType(Q,PETSCDUALSPACELAGRANGE); CHKERRQ(ierr);
+  ierr = PetscObjectSetOptionsPrefix((PetscObject) Q, prefix); CHKERRQ(ierr);
+  ierr = PetscDualSpaceCreateReferenceCell(Q, dim, isSimplex, &K); CHKERRQ(ierr);
+  ierr = PetscDualSpaceSetDM(Q, K); CHKERRQ(ierr);
+  ierr = DMDestroy(&K); CHKERRQ(ierr);
+  ierr = PetscDualSpaceSetNumComponents(Q, Nc); CHKERRQ(ierr);
+  ierr = PetscDualSpaceSetOrder(Q, order); CHKERRQ(ierr);
+  ierr = PetscDualSpaceLagrangeSetTensor(Q, tensor); CHKERRQ(ierr);
+  ierr = PetscDualSpaceSetFromOptions(Q); CHKERRQ(ierr);
+  ierr = PetscDualSpaceSetUp(Q); CHKERRQ(ierr);
+  /* Create element */
+  ierr = PetscFECreate(PetscObjectComm((PetscObject) dm), fem); CHKERRQ(ierr);
+  ierr = PetscObjectSetOptionsPrefix((PetscObject) *fem, prefix); CHKERRQ(ierr);
+  ierr = PetscFESetFromOptions(*fem); CHKERRQ(ierr);
+  ierr = PetscFESetBasisSpace(*fem, P); CHKERRQ(ierr);
+  ierr = PetscFESetDualSpace(*fem, Q); CHKERRQ(ierr);
+  ierr = PetscFESetNumComponents(*fem, Nc); CHKERRQ(ierr);
+  ierr = PetscFESetUp(*fem); CHKERRQ(ierr);
+  ierr = PetscSpaceDestroy(&P); CHKERRQ(ierr);
+  ierr = PetscDualSpaceDestroy(&Q); CHKERRQ(ierr);
+  /* Create quadrature */
+  quadPointsPerEdge = PetscMax(order + 1,1);
+  if (isSimplex) {
+    ierr = PetscDTStroudConicalQuadrature(dim,   1, quadPointsPerEdge, -1.0, 1.0,
+                                          &q); CHKERRQ(ierr);
+    ierr = PetscDTStroudConicalQuadrature(dim-1, 1, quadPointsPerEdge, -1.0, 1.0,
+                                          &fq); CHKERRQ(ierr);
+  } else {
+    ierr = PetscDTGaussTensorQuadrature(dim,   1, quadPointsPerEdge, -1.0, 1.0,
+                                        &q); CHKERRQ(ierr);
+    ierr = PetscDTGaussTensorQuadrature(dim-1, 1, quadPointsPerEdge, -1.0, 1.0,
+                                        &fq); CHKERRQ(ierr);
+  }
+  ierr = PetscFESetQuadrature(*fem, q); CHKERRQ(ierr);
+  ierr = PetscFESetFaceQuadrature(*fem, fq); CHKERRQ(ierr);
+  ierr = PetscQuadratureDestroy(&q); CHKERRQ(ierr);
+  ierr = PetscQuadratureDestroy(&fq); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+}
+
+// -----------------------------------------------------------------------------
+// PETSc Setup for Level
+// -----------------------------------------------------------------------------
+
+// This function sets up a DM for a given degree
+static int SetupDMByDegree(DM dm, PetscInt degree, PetscInt ncompu,
+                           PetscInt dim) {
+  PetscInt ierr;
+  PetscFE fe;
+
+  PetscFunctionBeginUser;
+
+  // Setup FE
+  ierr = PetscFECreateByDegree(dm, dim, ncompu, PETSC_FALSE, NULL, degree, &fe);
+  CHKERRQ(ierr);
+  ierr = DMAddField(dm, NULL, (PetscObject)fe); CHKERRQ(ierr);
+
+  // Setup DM
+  ierr = DMCreateDS(dm); CHKERRQ(ierr);
+  ierr = DMPlexSetClosurePermutationTensor(dm, PETSC_DETERMINE, NULL);
+  CHKERRQ(ierr);
+  ierr = PetscFEDestroy(&fe); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+}
+
+// -----------------------------------------------------------------------------
+// libCEED Setup for Level
+// -----------------------------------------------------------------------------
+
+// Destroy libCEED operator objects
+static PetscErrorCode CeedDataDestroy(CeedData data) {
+  PetscInt ierr;
+
+  CeedVectorDestroy(&data->qdata);
+  CeedVectorDestroy(&data->uceed);
+  CeedVectorDestroy(&data->vceed);
+  CeedBasisDestroy(&data->basisx);
+  CeedBasisDestroy(&data->basisu);
+  CeedElemRestrictionDestroy(&data->Erestrictu);
+  CeedElemRestrictionDestroy(&data->Erestrictx);
+  CeedElemRestrictionDestroy(&data->Erestrictqdi);
+  CeedQFunctionDestroy(&data->qf_apply);
+  CeedOperatorDestroy(&data->op_apply);
+  ierr = PetscFree(data); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+}
+
+// Auxiliary function to define CEED restrictions from DMPlex data
+static int CreateRestrictionPlex(Ceed ceed, CeedInt P, CeedInt ncomp,
+                                 CeedElemRestriction *Erestrict, DM dm) {
+  PetscInt ierr;
+  PetscInt c, cStart, cEnd, nelem, nnodes, *erestrict, eoffset;
+  PetscSection section;
+  Vec Uloc;
+
+  PetscFunctionBegin;
+
+  // Get Nelem
+  ierr = DMGetSection(dm, &section); CHKERRQ(ierr);
+  ierr = DMPlexGetHeightStratum(dm, 0, &cStart,& cEnd); CHKERRQ(ierr);
+  nelem = cEnd - cStart;
+
+  // Get indices
+  ierr = PetscMalloc1(nelem*P*P, &erestrict); CHKERRQ(ierr);
+  for (c=cStart, eoffset = 0; c<cEnd; c++) {
+    PetscInt numindices, *indices, i;
+    ierr = DMPlexGetClosureIndices(dm, section, section, c, &numindices,
+                                   &indices, NULL); CHKERRQ(ierr);
+    for (i=0; i<numindices; i+=ncomp) {
+      for (PetscInt j=0; j<ncomp; j++) {
+        if (indices[i+j] != indices[i] + (PetscInt)(copysign(j, indices[i])))
+          SETERRQ1(PETSC_COMM_SELF, PETSC_ERR_ARG_INCOMP,
+                   "Cell %D closure indices not interlaced", c);
+      }
+      // NO BC on closed surfaces
+      PetscInt loc = indices[i];
+      erestrict[eoffset++] = loc;
+    }
+    ierr = DMPlexRestoreClosureIndices(dm, section, section, c, &numindices,
+                                       &indices, NULL); CHKERRQ(ierr);
+  }
+
+  // Setup CEED restriction
+  ierr = DMGetLocalVector(dm, &Uloc); CHKERRQ(ierr);
+  ierr = VecGetLocalSize(Uloc, &nnodes); CHKERRQ(ierr);
+
+  ierr = DMRestoreLocalVector(dm, &Uloc); CHKERRQ(ierr);
+  CeedElemRestrictionCreate(ceed, nelem, P*P, ncomp, 1, nnodes,
+                            CEED_MEM_HOST, CEED_COPY_VALUES, erestrict,
+                            Erestrict);
+  ierr = PetscFree(erestrict); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+}
+
+// Set up libCEED for a given degree
+static int SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree,
+                                CeedInt topodim, CeedInt qextra,
+                                PetscInt ncompx, PetscInt ncompu,
+                                PetscInt xlsize, problemType problemChoice,
+                                CeedData data) {
+  int ierr;
+  DM dmcoord;
+  Vec coords;
+  const PetscScalar *coordArray;
+  CeedBasis basisx, basisu;
+  CeedElemRestriction Erestrictx, Erestrictu, Erestrictqdi;
+  CeedQFunction qf_setupgeo, qf_apply;
+  CeedOperator op_setupgeo, op_apply;
+  CeedVector xcoord, qdata, uceed, vceed;
+  CeedInt P, Q, cStart, cEnd, nelem,
+          qdatasize = problemOptions[problemChoice].qdatasize;
+
+  // CEED bases
+  P = degree + 1;
+  Q = P + qextra;
+  CeedBasisCreateTensorH1Lagrange(ceed, topodim, ncompu, P, Q,
+                                  problemOptions[problemChoice].qmode, &basisu);
+  CeedBasisCreateTensorH1Lagrange(ceed, topodim, ncompx, 2, Q,
+                                  problemOptions[problemChoice].qmode, &basisx);
+
+  // CEED restrictions
+  ierr = DMGetCoordinateDM(dm, &dmcoord); CHKERRQ(ierr);
+  ierr = DMPlexSetClosurePermutationTensor(dmcoord, PETSC_DETERMINE, NULL);
+  CHKERRQ(ierr);
+
+  ierr = CreateRestrictionPlex(ceed, 2, ncompx, &Erestrictx, dmcoord);
+  CHKERRQ(ierr);
+  ierr = CreateRestrictionPlex(ceed, P, ncompu, &Erestrictu, dm); CHKERRQ(ierr);
+
+  ierr = DMPlexGetHeightStratum(dm, 0, &cStart, &cEnd); CHKERRQ(ierr);
+  nelem = cEnd - cStart;
+
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, qdatasize,
+                                   qdatasize*nelem*Q*Q,
+                                   CEED_STRIDES_BACKEND, &Erestrictqdi);
+
+  // Element coordinates
+  ierr = DMGetCoordinatesLocal(dm, &coords); CHKERRQ(ierr);
+  ierr = VecGetArrayRead(coords, &coordArray); CHKERRQ(ierr);
+
+  CeedElemRestrictionCreateVector(Erestrictx, &xcoord, NULL);
+  CeedVectorSetArray(xcoord, CEED_MEM_HOST, CEED_COPY_VALUES,
+                     (PetscScalar *)coordArray);
+  ierr = VecRestoreArrayRead(coords, &coordArray);
+
+  // Create the vectors that will be needed in setup and apply
+  CeedInt nqpts;
+  CeedBasisGetNumQuadraturePoints(basisu, &nqpts);
+  CeedVectorCreate(ceed, qdatasize*nelem*nqpts, &qdata);
+  CeedVectorCreate(ceed, xlsize, &uceed);
+  CeedVectorCreate(ceed, xlsize, &vceed);
+
+  // Create the Q-function that builds the operator (i.e. computes its
+  // quadrature data) and set its context data
+  CeedQFunctionCreateInterior(ceed, 1, problemOptions[problemChoice].setupgeo,
+                              problemOptions[problemChoice].setupgeofname,
+                              &qf_setupgeo);
+  CeedQFunctionAddInput(qf_setupgeo, "x", ncompx, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_setupgeo, "dx", ncompx*topodim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setupgeo, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_setupgeo, "qdata", qdatasize, CEED_EVAL_NONE);
+
+  // Set up the mass operator
+  CeedQFunctionCreateInterior(ceed, 1, problemOptions[problemChoice].apply,
+                              problemOptions[problemChoice].applyfname,
+                              &qf_apply);
+  CeedQFunctionAddInput(qf_apply, "u", ncompu,
+                        problemOptions[problemChoice].inmode);
+  CeedQFunctionAddInput(qf_apply, "qdata", qdatasize, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_apply, "v", ncompu,
+                         problemOptions[problemChoice].outmode);
+
+  // Create the operator that builds the quadrature data for the operator
+  CeedOperatorCreate(ceed, qf_setupgeo, NULL, NULL, &op_setupgeo);
+  CeedOperatorSetField(op_setupgeo, "x", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupgeo, "dx", Erestrictx, basisx,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupgeo, "weight", CEED_ELEMRESTRICTION_NONE, basisx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupgeo, "qdata", Erestrictqdi,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // Create the mass or diff operator
+  CeedOperatorCreate(ceed, qf_apply, NULL, NULL, &op_apply);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata", Erestrictqdi, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, basisu, CEED_VECTOR_ACTIVE);
+
+  // Setup qdata
+  CeedOperatorApply(op_setupgeo, xcoord, qdata, CEED_REQUEST_IMMEDIATE);
+
+  // Cleanup
+  CeedQFunctionDestroy(&qf_setupgeo);
+  CeedOperatorDestroy(&op_setupgeo);
+  CeedVectorDestroy(&xcoord);
+
+  // Save libCEED data
+  data->basisx = basisx;
+  data->basisu = basisu;
+  data->Erestrictx = Erestrictx;
+  data->Erestrictu = Erestrictu;
+  data->Erestrictqdi = Erestrictqdi;
+  data->qf_apply = qf_apply;
+  data->op_apply = op_apply;
+  data->qdata = qdata;
+  data->uceed = uceed;
+  data->vceed = vceed;
+
+  PetscFunctionReturn(0);
+}
+
+#endif // setuparea_h

--- a/examples/petsc/setupsphere.h
+++ b/examples/petsc/setupsphere.h
@@ -38,11 +38,8 @@ typedef struct UserO_ *UserO;
 struct UserO_ {
   MPI_Comm comm;
   DM dm;
-  PetscInt topodim; /* Topological problem dimension */ // TO DO: check if necessary
-  PetscBool simplex; /* Mesh with simplices */ // TO DO: check if necessary
   Vec Xloc, Yloc, diag;
   CeedVector xceed, yceed;
-//  CeedVector qdata;
   CeedOperator op;
   Ceed ceed;
 };


### PR DESCRIPTION
This PR refactors the `area` example to make it consistent with the other PETSc examples.

Major usage change:
* It now accepts the command line option `-degree`, as all other PETSc examples, instead of `-petscspace_degree`

Bug fixes:
* It eliminates a double call to `DMSetFromOptions()` which was causing an erroneous double refinement of the mesh