### PR TITLE
Docs - pin python package markdown at 3.2.1

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,5 +1,6 @@
 sphinx>=3.0
 breathe>=4.17
+markdown==3.2.1
 recommonmark
 sphinx_rtd_theme
 sphinxcontrib-bibtex


### PR DESCRIPTION
@jedbrown, can you verify that this fixes the issue on readthedocs? Locally, I have v3.0.1, so I believe that you're correct and this is the problem.