### PR TITLE
Postprocessing: Add Backend_MemType information

### DIFF
--- a/benchmarks/postprocess-base.py
+++ b/benchmarks/postprocess-base.py
@@ -89,6 +89,8 @@ while True:
          data['case']='scalar' if (('Problem 1' in line) or ('Problem 3' in line)
                                   or ('Problem 5' in line)) else 'vector'
       ## Backend
+      elif 'libCEED Backend MemType' in line:
+         data['backend_memtype']=line.split(':')[1].strip()
       elif 'libCEED Backend' in line:
          data['backend']=line.split(':')[1].strip()
       ## P

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -18,7 +18,7 @@
 #####   Adjustable plot parameters:
 log_y=0               # use log scale on the y-axis?
 x_range=(1e1,4e6)     # plot range for the x-axis; comment out for auto
-y_range=(0,8e7)       # plot range for the y-axis; comment out for auto
+y_range=(0,2e9)       # plot range for the y-axis; comment out for auto
 draw_iter_lines=0     # draw the "iter/s" lines?
 ymin_iter_lines=3e5   # minimal y value for the "iter/s" lines
 ymax_iter_lines=8e8   # maximal y value for the "iter/s" lines

--- a/benchmarks/postprocess-plot.py
+++ b/benchmarks/postprocess-plot.py
@@ -74,12 +74,13 @@ code  = codes[0]
 sel_runs=sel_runs.loc[sel_runs['code'] == code]
 
 ##### Group plots by backend and number of processes
-pl_set=sel_runs[['backend', 'num_procs', 'num_procs_node']]
+pl_set=sel_runs[['backend', 'backend_memtype', 'num_procs', 'num_procs_node']]
 pl_set=pl_set.drop_duplicates()
 
 ##### Plotting
 for index, row in pl_set.iterrows():
    backend=row['backend']
+   backend_memtype=row['backend_memtype']
    num_procs=float(row['num_procs'])
    num_procs_node=float(row['num_procs_node'])
    num_nodes=num_procs/num_procs_node
@@ -156,9 +157,9 @@ for index, row in pl_set.iterrows():
       plot(y/slope2,y,'k-',label='%g iter/s'%(slope2/vdim))
 
    # Plot information
-   title(r'%i node%s $\times$ %i ranks, %s, %s'%(
+   title(r'%i node%s $\times$ %i ranks, %s, %s, %s'%(
          num_nodes,'' if num_nodes==1 else 's',
-         num_procs_node,backend,test_short),fontsize=16)
+         num_procs_node,backend,backend_memtype,test_short),fontsize=16)
    xscale('log') # subsx=[2,4,6,8]
    if log_y:
       yscale('log')
@@ -180,8 +181,8 @@ for index, row in pl_set.iterrows():
    if write_figures: # write .pdf file?
       short_backend=backend.replace('/','')
       test_short_save=test_short.replace(' ','')
-      pdf_file='plot_%s_%s_%s_N%03i_pn%i.pdf'%(
-               code,test_short_save,short_backend,num_nodes,num_procs_node)
+      pdf_file='plot_%s_%s_%s_%s_N%03i_pn%i.pdf'%(
+               code,test_short_save,short_backend,backend_memtype,num_nodes,num_procs_node)
       print('\nsaving figure --> %s'%pdf_file)
       savefig(pdf_file, format='pdf', bbox_inches='tight')
 


### PR DESCRIPTION
This very small PR is needed because after we updated the summary printed in our PETSc BPs, we did not update the parsing of that info in the post processing scripts. Therefore, in the loop over lines, only the last line was read and in the `backend` field only the MemType info was stored.