### PR TITLE
PETSc - fix PETSc test parameters for CUDA backends

### DIFF
--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -34,7 +34,7 @@
 //     ./bps -problem bp5 -ceed /omp/occa -degree 3
 //     ./bps -problem bp6 -ceed /ocl/occa -degree 3
 //
-//TESTARGS -ceed {ceed_resource} -test -problem bp5 -degree 3
+//TESTARGS -ceed {ceed_resource} -test -problem bp5 -degree 3 -ksp_max_it_clip 15,15
 
 /// @file
 /// CEED BPs example using PETSc with DMPlex


### PR DESCRIPTION
This fixes the new failures introduced in da9108adaf6ecb2b81aea3a8abf5084549c21a2a
I think this indicates that something strange is going on here. I'm not sure if it's libCEED or PETSc.