### PR TITLE
XSMM - use v1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,10 +115,10 @@ install:
         && cd occa && git reset --hard 327badb && cd ..
         && make -C occa -j2
         && export OCCA_DIR=$PWD/occa;
-# LIBXSMM v1.15 (need to use specific commit, XSMM develops on master)
+# LIBXSMM v1.16 (need to use specific commit, XSMM develops on master)
   - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
         git clone https://github.com/hfp/libxsmm.git
-        && cd libxsmm && git reset --hard 724205c && cd ..
+        && cd libxsmm && git reset --hard 6d6a0f6 && cd ..
         && make -C libxsmm -j2
         && export XSMM_DIR=$PWD/libxsmm;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,10 +115,10 @@ install:
         && cd occa && git reset --hard 327badb && cd ..
         && make -C occa -j2
         && export OCCA_DIR=$PWD/occa;
-# LIBXSMM v1.16 (need to use specific commit, XSMM develops on master)
+# LIBXSMM v1.16 (need to use releases, XSMM develops on master)
   - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
-        git clone https://github.com/hfp/libxsmm.git
-        && cd libxsmm && git reset --hard 6d6a0f6 && cd ..
+        git clone --depth=1 https://github.com/hfp/libxsmm.git
+        && cd libxsmm && git checkout -f tags/1.16 && cd ..
         && make -C libxsmm -j2
         && export XSMM_DIR=$PWD/libxsmm;
     fi

--- a/backends/xsmm/ceed-xsmm-tensor.c
+++ b/backends/xsmm/ceed-xsmm-tensor.c
@@ -104,8 +104,8 @@ int CeedTensorContractCreate_Xsmm(CeedBasis basis,
   impl->lookup = kh_init(m32);
 
   // Set up pointers to kernels
-  ierr = CeedBasisIsTensor(basis, &impl->tensorbasis); CeedChk(ierr);
-  if (impl->tensorbasis) {
+  ierr = CeedBasisIsTensor(basis, &impl->isTensor); CeedChk(ierr);
+  if (impl->isTensor) {
     ierr = CeedBasisGetNumNodes1D(basis, &impl->P); CeedChk(ierr);
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &impl->Q); CeedChk(ierr);
     ierr = CeedBasisGetDimension(basis, &impl->dim); CeedChk(ierr);

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -20,11 +20,16 @@
 #include <string.h>
 #include <math.h>
 
+// LIBXSMM chose to redefine _Bool. This undoes that choice.
+#ifdef _Bool
+#undef _Bool
+#endif
+
 // Instantiate khash structs and methods
 CeedHashIJKLMInit(m32, libxsmm_dmmfunction)
 
 typedef struct {
-  bool tensorbasis;
+  bool isTensor;
   CeedInt P, Q, dim;
   khash_t(m32) *lookup;
 } CeedTensorContract_Xsmm;


### PR DESCRIPTION
This updates our CI to the latest LIBXSMM release and fixes the warnings generated by LIBXSMM's macro to refefine `_Bool` to `int`.