### PR TITLE
CUDA - shared basis needs minimum of 1 elem per block

### DIFF
--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -781,7 +781,9 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
                                         interpargs); CeedChk(ierr);
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
+      // elemsPerBlock must be at least 1
       CeedInt elemsPerBlock = Q1d < 7 ? optElems[Q1d]/ncomp : 1;
+      if (elemsPerBlock == 0) elemsPerBlock = 1;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt sharedMem = ncomp*elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
@@ -818,7 +820,9 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedChk(ierr);
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
+      // elemsPerBlock must be at least 1
       CeedInt elemsPerBlock = Q1d < 7 ? optElems[Q1d]/ncomp : 1;
+      if (elemsPerBlock == 0) elemsPerBlock = 1;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt sharedMem = ncomp*elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);


### PR DESCRIPTION
Closes #462

We were getting a small divide by zero that I've corrected. Now `petsc-area` and `petsc-bpssphere` pass with all backends.