### PR TITLE
Use Released for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,10 +115,9 @@ install:
         && cd occa && git reset --hard 327badb && cd ..
         && make -C occa -j2
         && export OCCA_DIR=$PWD/occa;
-# LIBXSMM v1.16 (need to use releases or specific commits, XSMM develops on master)
+# LIBXSMM v1.16.1 (need to use releases or specific commits, XSMM develops on master)
   - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
-        git clone https://github.com/hfp/libxsmm.git
-        && cd libxsmm && git reset --hard 143409c && cd ..
+        git clone --depth=1 --branch 1.16.1 https://github.com/hfp/libxsmm.git
         && make -C libxsmm -j2
         && export XSMM_DIR=$PWD/libxsmm;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,8 +121,8 @@ install:
         && make -C libxsmm -j2
         && export XSMM_DIR=$PWD/libxsmm;
     fi
-# MFEM
-  - git clone --depth 1 https://github.com/mfem/mfem.git
+# MFEM v4.1
+  - git clone --depth 1 --branch v4.1 https://github.com/mfem/mfem.git
         && make -C mfem -j2 serial CXXFLAGS="-O -std=c++11" MFEM_USE_SIMD=${MFEM_USE_SIMD}
         && export MFEM_DIR=$PWD/mfem
 # Nek5k (pinned before Nek partially updated MPI_Type_extent)

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ install:
         && cd occa && git reset --hard 327badb && cd ..
         && make -C occa -j2
         && export OCCA_DIR=$PWD/occa;
-# LIBXSMM v1.16.1 (need to use releases or specific commits, XSMM develops on master)
+# LIBXSMM v1.16.1
   - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
         git clone --depth=1 --branch 1.16.1 https://github.com/hfp/libxsmm.git
         && make -C libxsmm -j2
@@ -125,9 +125,8 @@ install:
   - git clone --depth 1 --branch v4.1 https://github.com/mfem/mfem.git
         && make -C mfem -j2 serial CXXFLAGS="-O -std=c++11" MFEM_USE_SIMD=${MFEM_USE_SIMD}
         && export MFEM_DIR=$PWD/mfem
-# Nek5k (pinned before Nek partially updated MPI_Type_extent)
-  - git clone https://github.com/Nek5000/Nek5000.git
-        && cd Nek5000 && git reset --hard 6f5c7eb && cd ..
+# Nek5k v19.0
+  - git clone --depth 1 --branch v19.0 https://github.com/Nek5000/Nek5000.git
         && cd Nek5000/tools && ./maketools genbox genmap reatore2 && cd ../..
         && export NEK5K_DIR=$PWD/Nek5000 PATH=$PWD/Nek5000/bin:$PATH MPI=0;
 # PETSc


### PR DESCRIPTION
With XSMM releasing a new version, I went ahead and made this PR to switch Travis to use specific releases of updates. I hope this reduces failures due to other repos