### PR TITLE
Rename master branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Contributions to libCEED are encouraged.
 <!---
-Please use a pull request to the appropriate branch ('maint' for
-backward-compatible bug fixes for the last stable release, 'master' for
+Please use a pull request to the appropriate branch ('stable' for
+backward-compatible bug fixes for the last stable release, main' for
 new features and everything else).
 -->
 Please make your commits well-organized and
@@ -41,7 +41,7 @@ email becomes inconsistent (look at `git shortlog -se`), please edit
 When contributors make a major contribution and support it, their names
 are included in the automatically generated user-manual documentation.
 
-Please avoid "merging from upstream" (like merging 'master' into your
+Please avoid "merging from upstream" (like merging 'main' into your
 feature branch) unless there is a specific reason to do so, in which
 case you should explain why in the merge commit.
 [Rationale](https://lwn.net/Articles/328436/) from

--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,12 @@ libCEED: the CEED Library
 
 |build-status| |codecov| |license| |doc| |doxygen| |binder|
 
-.. |build-status| image:: https://travis-ci.com/CEED/libCEED.svg?branch=master
+.. |build-status| image:: https://travis-ci.com/CEED/libCEED.svg?branch=main
     :alt: Build Status
     :scale: 100%
     :target: https://travis-ci.com/CEED/libCEED
 
-.. |codecov| image:: https://codecov.io/gh/CEED/libCEED/branch/master/graphs/badge.svg
+.. |codecov| image:: https://codecov.io/gh/CEED/libCEED/branch/main/graphs/badge.svg
     :alt: Code Coverage
     :scale: 100%
     :target: https://codecov.io/gh/CEED/libCEED/
@@ -31,7 +31,7 @@ libCEED: the CEED Library
 .. |binder| image:: http://mybinder.org/badge_logo.svg
     :alt: Binder
     :scale: 100%
-    :target: https://mybinder.org/v2/gh/CEED/libCEED/master?urlpath=lab/tree/examples/tutorials/tutorial-0-ceed.ipynb
+    :target: https://mybinder.org/v2/gh/CEED/libCEED/main?urlpath=lab/tree/examples/tutorials/tutorial-0-ceed.ipynb
 
 Code for Efficient Extensible Discretization
 --------------------------------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
 trigger:
-- master
+- main
 
 pool:
   vmImage: 'Ubuntu-16.04'

--- a/doc/sphinx/source/libCEEDapi.rst
+++ b/doc/sphinx/source/libCEEDapi.rst
@@ -277,7 +277,7 @@ Our long-term vision is to include a variety of backend implementations in
 libCEED, ranging from reference kernels to highly optimized kernels targeting
 specific devices (e.g. GPUs) or specific polynomial orders. A simple reference
 backend implementation is provided in the file
-`ceed-ref.c <https://github.com/CEED/libCEED/blob/master/backends/ref/ceed-ref.c>`_.
+`ceed-ref.c <https://github.com/CEED/libCEED/blob/main/backends/ref/ceed-ref.c>`_.
 
 On the frontend, the mapping between the decomposition concepts and the code
 implementation is as follows:
@@ -298,7 +298,7 @@ implementation is as follows:
 
 To clarify these concepts and illustrate how they are combined in the API,
 consider the implementation of the action of a simple 1D mass matrix
-(cf. `tests/t500-operator.c <https://github.com/CEED/libCEED/blob/master/tests/t500-operator.c>`_).
+(cf. `tests/t500-operator.c <https://github.com/CEED/libCEED/blob/main/tests/t500-operator.c>`_).
 
 .. literalinclude::  ../../../tests/t500-operator.c
    :language: c
@@ -410,10 +410,9 @@ explicitly store **E-vectors** (inter-element continuity has been subsumed by
 the parallel restriction :math:`\bm{P}`), the element restriction :math:`\bm{G}`
 is the identity and :c:func:`CeedElemRestrictionCreateStrided()` is used instead.
 We plan to support other structured representations of :math:`\bm{G}` which will
-be added according to demand. In the case of non-conforming mesh elements,
-:math:`\bm{G}` needs a more general representation that expresses values at slave
-nodes (which do not appear in **L-vectors**) as linear combinations of the degrees of
-freedom at master nodes.
+be added according to demand.
+There are two common approaches for supporting non-conforming elements: applying the node constraints via :math:`\bm P` so that the **L-vector** can be processed uniformly and applying the constraintsss via :math:`\bm G` so that the **E-vector** is uniform.
+The former can be done with the existing interface while the latter will require a generalization to element restriction that would define field values at constrained nodes as linear combinations of the values at primary nodes.
 
 These operations, :math:`\bm{P}`, :math:`\bm{B}`, and :math:`\bm{D}`,
 are combined with a :ref:`CeedOperator`. As with :ref:`CeedQFunction`\s, operator fields are added
@@ -481,7 +480,7 @@ The available QFunctions are the ones associated with the mass, the Laplacian, a
 the identity operators. To illustrate how the user can declare a :ref:`CeedQFunction`
 via the gallery of available QFunctions, consider the selection of the
 :ref:`CeedQFunction` associated with a simple 1D mass matrix
-(cf. `tests/t410-qfunction.c <https://github.com/CEED/libCEED/blob/master/tests/t410-qfunction.c>`_).
+(cf. `tests/t410-qfunction.c <https://github.com/CEED/libCEED/blob/main/tests/t410-qfunction.c>`_).
 
 .. literalinclude::  ../../../tests/t410-qfunction.c
    :language: c

--- a/doc/sphinx/source/releasenotes.rst
+++ b/doc/sphinx/source/releasenotes.rst
@@ -4,12 +4,12 @@ Changes/Release Notes
 On this page we provide a summary of the main API changes, new features and examples
 for each release of libCEED.
 
-.. _master:
+.. _main:
 
-Current Master
+Current Main
 ----------------------------------------
 
-The current master branch contains bug fixes and interfaces changes.
+The current ``main`` branch contains bug fixes and interfaces changes.
 
 Interface changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ New features
   1-1 correspondence with the C interface, plus some convenience features.  For instance,
   data stored in the :cpp:type:`CeedVector` structure are available without copy as
   :py:class:`numpy.ndarray`.  Short tutorials are provided in
-  `Binder <https://mybinder.org/v2/gh/CEED/libCEED/master?urlpath=lab/tree/examples/tutorials/>`_.
+  `Binder <https://mybinder.org/v2/gh/CEED/libCEED/main?urlpath=lab/tree/examples/tutorials/>`_.
 * Linear QFunctions can be assembled as block-diagonal matrices (per quadrature point,
   :cpp:func:`CeedOperatorAssembleLinearQFunction`) or to evaluate the diagonal
   (:cpp:func:`CeedOperatorAssembleLinearDiagonal`).  These operations are useful for


### PR DESCRIPTION
This may be a small gesture, but it's easy and I haven't seen any names rise to become contenders with `main`.

https://www.zdnet.com/article/github-to-replace-master-with-alternative-term-to-avoid-slavery-references/

If approved, I'll set the default branch here and update codecov and readthedocs. It'll require current developers to do the following once. (Fresh clones will require no extra steps.)

    git fetch
    git branch -m main
    git branch --set-upstream-to=origin/main