### PR TITLE
Fortran - guard double calls to ceed*destroy in Fortran interface

### DIFF
--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -102,7 +102,7 @@ void fCeedView(int *ceed, int *err) {
 
 #define fCeedDestroy FORTRAN_NAME(ceeddestroy,CEEDDESTROY)
 void fCeedDestroy(int *ceed, int *err) {
-  if (Ceed_n == 0) return;
+  if (Ceed_n == 0 || !Ceed_dict[*ceed]) return;
   *err = CeedDestroy(&Ceed_dict[*ceed]);
 
   if (*err == 0) {
@@ -211,7 +211,7 @@ void fCeedVectorView(int *vec, int *err) {
 
 #define fCeedVectorDestroy FORTRAN_NAME(ceedvectordestroy,CEEDVECTORDESTROY)
 void fCeedVectorDestroy(int *vec, int *err) {
-  if (CeedVector_n == 0) return;
+  if (CeedVector_n == 0 || !CeedVector_dict[*vec]) return;
   *err = CeedVectorDestroy(&CeedVector_dict[*vec]);
 
   if (*err == 0) {
@@ -433,7 +433,7 @@ void fCeedRequestWait(int *rqst, int *err) {
 #define fCeedElemRestrictionDestroy \
     FORTRAN_NAME(ceedelemrestrictiondestroy,CEEDELEMRESTRICTIONDESTROY)
 void fCeedElemRestrictionDestroy(int *elem, int *err) {
-  if (CeedElemRestriction_n == 0) return;
+  if (CeedElemRestriction_n == 0 || !CeedElemRestriction_dict[*elem]) return;
   *err = CeedElemRestrictionDestroy(&CeedElemRestriction_dict[*elem]);
 
   if (*err == 0) {
@@ -573,7 +573,7 @@ void fCeedBasisGetNumQuadraturePoints(int *basis, int *Q, int *err) {
 
 #define fCeedBasisDestroy FORTRAN_NAME(ceedbasisdestroy,CEEDBASISDESTROY)
 void fCeedBasisDestroy(int *basis, int *err) {
-  if (CeedBasis_n == 0) return;
+  if (CeedBasis_n == 0 || ! CeedBasis_dict[*basis]) return;
   *err = CeedBasisDestroy(&CeedBasis_dict[*basis]);
 
   if (*err == 0) {
@@ -806,7 +806,7 @@ void fCeedQFunctionApply(int *qf, int *Q,
 #define fCeedQFunctionDestroy \
     FORTRAN_NAME(ceedqfunctiondestroy,CEEDQFUNCTIONDESTROY)
 void fCeedQFunctionDestroy(int *qf, int *err) {
-  if (CeedQFunction_n == 0 || CeedQFunction_dict[*qf] == NULL) return;
+  if (CeedQFunction_n == 0 || !CeedQFunction_dict[*qf]) return;
   bool fstatus;
   *err = CeedQFunctionIsFortran(CeedQFunction_dict[*qf], &fstatus);
   if (*err) return;
@@ -1128,7 +1128,7 @@ void fCeedOperatorApplyJacobian(int *op, int *qdatavec, int *ustatevec,
 #define fCeedOperatorDestroy \
     FORTRAN_NAME(ceedoperatordestroy, CEEDOPERATORDESTROY)
 void fCeedOperatorDestroy(int *op, int *err) {
-  if (CeedOperator_n == 0) return;
+  if (CeedOperator_n == 0 || !CeedOperator_dict[*op]) return;
   *err = CeedOperatorDestroy(&CeedOperator_dict[*op]);
   if (*err) return;
   CeedOperator_n--;

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -585,7 +585,7 @@ void fCeedBasisGetNumQuadraturePoints(int *basis, int *Q, int *err) {
 
 #define fCeedBasisDestroy FORTRAN_NAME(ceedbasisdestroy,CEEDBASISDESTROY)
 void fCeedBasisDestroy(int *basis, int *err) {
-  if (CeedBasis_n == 0 || ! CeedBasis_dict[*basis]) return;
+  if (CeedBasis_n == 0 || !CeedBasis_dict[*basis]) return;
   *err = CeedBasisDestroy(&CeedBasis_dict[*basis]);
 
   if (*err == 0) {

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -105,7 +105,7 @@ void fCeedView(int *ceed, int *err) {
 
 #define fCeedDestroy FORTRAN_NAME(ceeddestroy,CEEDDESTROY)
 void fCeedDestroy(int *ceed, int *err) {
-  if (Ceed_n == 0 || *ceed == FORTRAN_NULL || !Ceed_dict[*ceed]) return;
+  if (*ceed == FORTRAN_NULL) return;
   *err = CeedDestroy(&Ceed_dict[*ceed]);
 
   if (*err == 0) {
@@ -218,7 +218,7 @@ void fCeedVectorView(int *vec, int *err) {
 
 #define fCeedVectorDestroy FORTRAN_NAME(ceedvectordestroy,CEEDVECTORDESTROY)
 void fCeedVectorDestroy(int *vec, int *err) {
-  if (CeedVector_n == 0 || *vec == FORTRAN_NULL || !CeedVector_dict[*vec]) return;
+  if (*vec == FORTRAN_NULL) return;
   *err = CeedVectorDestroy(&CeedVector_dict[*vec]);
 
   if (*err == 0) {
@@ -444,8 +444,7 @@ void fCeedRequestWait(int *rqst, int *err) {
 #define fCeedElemRestrictionDestroy \
     FORTRAN_NAME(ceedelemrestrictiondestroy,CEEDELEMRESTRICTIONDESTROY)
 void fCeedElemRestrictionDestroy(int *elem, int *err) {
-  if (CeedElemRestriction_n == 0 ||
-      *elem == FORTRAN_NULL || !CeedElemRestriction_dict[*elem]) return;
+  if (*elem == FORTRAN_NULL) return;
   *err = CeedElemRestrictionDestroy(&CeedElemRestriction_dict[*elem]);
 
   if (*err == 0) {
@@ -589,8 +588,7 @@ void fCeedBasisGetNumQuadraturePoints(int *basis, int *Q, int *err) {
 
 #define fCeedBasisDestroy FORTRAN_NAME(ceedbasisdestroy,CEEDBASISDESTROY)
 void fCeedBasisDestroy(int *basis, int *err) {
-  if (CeedBasis_n == 0 || *basis == FORTRAN_NULL ||
-      !CeedBasis_dict[*basis]) return;
+  if (*basis == FORTRAN_NULL) return;
   *err = CeedBasisDestroy(&CeedBasis_dict[*basis]);
 
   if (*err == 0) {
@@ -827,8 +825,7 @@ void fCeedQFunctionApply(int *qf, int *Q,
 #define fCeedQFunctionDestroy \
     FORTRAN_NAME(ceedqfunctiondestroy,CEEDQFUNCTIONDESTROY)
 void fCeedQFunctionDestroy(int *qf, int *err) {
-  if (CeedQFunction_n == 0 || *qf == FORTRAN_NULL ||
-      !CeedQFunction_dict[*qf]) return;
+  if (*qf == FORTRAN_NULL) return;
   bool fstatus;
   *err = CeedQFunctionIsFortran(CeedQFunction_dict[*qf], &fstatus);
   if (*err) return;
@@ -1154,8 +1151,7 @@ void fCeedOperatorApplyJacobian(int *op, int *qdatavec, int *ustatevec,
 #define fCeedOperatorDestroy \
     FORTRAN_NAME(ceedoperatordestroy, CEEDOPERATORDESTROY)
 void fCeedOperatorDestroy(int *op, int *err) {
-  if (CeedOperator_n == 0 || *op == FORTRAN_NULL ||
-      !CeedOperator_dict[*op]) return;
+  if (*op == FORTRAN_NULL) return;
   *err = CeedOperatorDestroy(&CeedOperator_dict[*op]);
   if (*err == 0) {
     *op = FORTRAN_NULL;

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -65,6 +65,9 @@ typedef int fortran_charlen_t;
   strncpy(Splice(stringname, _c), stringname, Splice(stringname, _len)); \
   Splice(stringname, _c)[Splice(stringname, _len)] = 0;                 \
 
+// -----------------------------------------------------------------------------
+// Ceed
+// -----------------------------------------------------------------------------
 #define fCeedInit FORTRAN_NAME(ceedinit,CEEDINIT)
 void fCeedInit(const char *resource, int *ceed, int *err,
                fortran_charlen_t resource_len) {
@@ -115,6 +118,9 @@ void fCeedDestroy(int *ceed, int *err) {
   }
 }
 
+// -----------------------------------------------------------------------------
+// CeedVector
+// -----------------------------------------------------------------------------
 static CeedVector *CeedVector_dict = NULL;
 static int CeedVector_count = 0;
 static int CeedVector_n = 0;
@@ -224,6 +230,9 @@ void fCeedVectorDestroy(int *vec, int *err) {
   }
 }
 
+// -----------------------------------------------------------------------------
+// CeedElemRestriction
+// -----------------------------------------------------------------------------
 static CeedElemRestriction *CeedElemRestriction_dict = NULL;
 static int CeedElemRestriction_count = 0;
 static int CeedElemRestriction_n = 0;
@@ -446,6 +455,9 @@ void fCeedElemRestrictionDestroy(int *elem, int *err) {
   }
 }
 
+// -----------------------------------------------------------------------------
+// CeedBasis
+// -----------------------------------------------------------------------------
 static CeedBasis *CeedBasis_dict = NULL;
 static int CeedBasis_count = 0;
 static int CeedBasis_n = 0;
@@ -599,6 +611,9 @@ void fCeedLobattoQuadrature(int *Q, CeedScalar *qref1d, CeedScalar *qweight1d,
   *err = CeedLobattoQuadrature(*Q, qref1d, qweight1d);
 }
 
+// -----------------------------------------------------------------------------
+// CeedQFunction
+// -----------------------------------------------------------------------------
 static CeedQFunction *CeedQFunction_dict = NULL;
 static int CeedQFunction_count = 0;
 static int CeedQFunction_n = 0;
@@ -827,6 +842,9 @@ void fCeedQFunctionDestroy(int *qf, int *err) {
   }
 }
 
+// -----------------------------------------------------------------------------
+// CeedOperator
+// -----------------------------------------------------------------------------
 static CeedOperator *CeedOperator_dict = NULL;
 static int CeedOperator_count = 0;
 static int CeedOperator_n = 0;
@@ -1138,3 +1156,5 @@ void fCeedOperatorDestroy(int *op, int *err) {
     CeedOperator_count_max = 0;
   }
 }
+
+// -----------------------------------------------------------------------------

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -105,10 +105,11 @@ void fCeedView(int *ceed, int *err) {
 
 #define fCeedDestroy FORTRAN_NAME(ceeddestroy,CEEDDESTROY)
 void fCeedDestroy(int *ceed, int *err) {
-  if (Ceed_n == 0 || !Ceed_dict[*ceed]) return;
+  if (Ceed_n == 0 || *ceed == FORTRAN_NULL || !Ceed_dict[*ceed]) return;
   *err = CeedDestroy(&Ceed_dict[*ceed]);
 
   if (*err == 0) {
+    *ceed = FORTRAN_NULL;
     Ceed_n--;
     if (Ceed_n == 0) {
       CeedFree(&Ceed_dict);
@@ -217,10 +218,11 @@ void fCeedVectorView(int *vec, int *err) {
 
 #define fCeedVectorDestroy FORTRAN_NAME(ceedvectordestroy,CEEDVECTORDESTROY)
 void fCeedVectorDestroy(int *vec, int *err) {
-  if (CeedVector_n == 0 || !CeedVector_dict[*vec]) return;
+  if (CeedVector_n == 0 || *vec == FORTRAN_NULL || !CeedVector_dict[*vec]) return;
   *err = CeedVectorDestroy(&CeedVector_dict[*vec]);
 
   if (*err == 0) {
+    *vec = FORTRAN_NULL;
     CeedVector_n--;
     if (CeedVector_n == 0) {
       CeedFree(&CeedVector_dict);
@@ -442,10 +444,12 @@ void fCeedRequestWait(int *rqst, int *err) {
 #define fCeedElemRestrictionDestroy \
     FORTRAN_NAME(ceedelemrestrictiondestroy,CEEDELEMRESTRICTIONDESTROY)
 void fCeedElemRestrictionDestroy(int *elem, int *err) {
-  if (CeedElemRestriction_n == 0 || !CeedElemRestriction_dict[*elem]) return;
+  if (CeedElemRestriction_n == 0 ||
+      *elem == FORTRAN_NULL || !CeedElemRestriction_dict[*elem]) return;
   *err = CeedElemRestrictionDestroy(&CeedElemRestriction_dict[*elem]);
 
   if (*err == 0) {
+    *elem = FORTRAN_NULL;
     CeedElemRestriction_n--;
     if (CeedElemRestriction_n == 0) {
       CeedFree(&CeedElemRestriction_dict);
@@ -585,10 +589,12 @@ void fCeedBasisGetNumQuadraturePoints(int *basis, int *Q, int *err) {
 
 #define fCeedBasisDestroy FORTRAN_NAME(ceedbasisdestroy,CEEDBASISDESTROY)
 void fCeedBasisDestroy(int *basis, int *err) {
-  if (CeedBasis_n == 0 || !CeedBasis_dict[*basis]) return;
+  if (CeedBasis_n == 0 || *basis == FORTRAN_NULL ||
+      !CeedBasis_dict[*basis]) return;
   *err = CeedBasisDestroy(&CeedBasis_dict[*basis]);
 
   if (*err == 0) {
+    *basis = FORTRAN_NULL;
     CeedBasis_n--;
     if (CeedBasis_n == 0) {
       CeedFree(&CeedBasis_dict);
@@ -821,7 +827,8 @@ void fCeedQFunctionApply(int *qf, int *Q,
 #define fCeedQFunctionDestroy \
     FORTRAN_NAME(ceedqfunctiondestroy,CEEDQFUNCTIONDESTROY)
 void fCeedQFunctionDestroy(int *qf, int *err) {
-  if (CeedQFunction_n == 0 || !CeedQFunction_dict[*qf]) return;
+  if (CeedQFunction_n == 0 || *qf == FORTRAN_NULL ||
+      !CeedQFunction_dict[*qf]) return;
   bool fstatus;
   *err = CeedQFunctionIsFortran(CeedQFunction_dict[*qf], &fstatus);
   if (*err) return;
@@ -832,13 +839,14 @@ void fCeedQFunctionDestroy(int *qf, int *err) {
   }
 
   *err = CeedQFunctionDestroy(&CeedQFunction_dict[*qf]);
-  if (*err) return;
-
-  CeedQFunction_n--;
-  if (CeedQFunction_n == 0) {
-    *err = CeedFree(&CeedQFunction_dict);
-    CeedQFunction_count = 0;
-    CeedQFunction_count_max = 0;
+  if (*err == 0) {
+    *qf = FORTRAN_NULL;
+    CeedQFunction_n--;
+    if (CeedQFunction_n == 0) {
+      *err = CeedFree(&CeedQFunction_dict);
+      CeedQFunction_count = 0;
+      CeedQFunction_count_max = 0;
+    }
   }
 }
 
@@ -1146,14 +1154,17 @@ void fCeedOperatorApplyJacobian(int *op, int *qdatavec, int *ustatevec,
 #define fCeedOperatorDestroy \
     FORTRAN_NAME(ceedoperatordestroy, CEEDOPERATORDESTROY)
 void fCeedOperatorDestroy(int *op, int *err) {
-  if (CeedOperator_n == 0 || !CeedOperator_dict[*op]) return;
+  if (CeedOperator_n == 0 || *op == FORTRAN_NULL ||
+      !CeedOperator_dict[*op]) return;
   *err = CeedOperatorDestroy(&CeedOperator_dict[*op]);
-  if (*err) return;
-  CeedOperator_n--;
-  if (CeedOperator_n == 0) {
-    *err = CeedFree(&CeedOperator_dict);
-    CeedOperator_count = 0;
-    CeedOperator_count_max = 0;
+  if (*err == 0) {
+    *op = FORTRAN_NULL;
+    CeedOperator_n--;
+    if (CeedOperator_n == 0) {
+      *err = CeedFree(&CeedOperator_dict);
+      CeedOperator_count = 0;
+      CeedOperator_count_max = 0;
+    }
   }
 }
 

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -102,6 +102,7 @@ void fCeedView(int *ceed, int *err) {
 
 #define fCeedDestroy FORTRAN_NAME(ceeddestroy,CEEDDESTROY)
 void fCeedDestroy(int *ceed, int *err) {
+  if (Ceed_n == 0) return;
   *err = CeedDestroy(&Ceed_dict[*ceed]);
 
   if (*err == 0) {
@@ -210,6 +211,7 @@ void fCeedVectorView(int *vec, int *err) {
 
 #define fCeedVectorDestroy FORTRAN_NAME(ceedvectordestroy,CEEDVECTORDESTROY)
 void fCeedVectorDestroy(int *vec, int *err) {
+  if (CeedVector_n == 0) return;
   *err = CeedVectorDestroy(&CeedVector_dict[*vec]);
 
   if (*err == 0) {
@@ -431,6 +433,7 @@ void fCeedRequestWait(int *rqst, int *err) {
 #define fCeedElemRestrictionDestroy \
     FORTRAN_NAME(ceedelemrestrictiondestroy,CEEDELEMRESTRICTIONDESTROY)
 void fCeedElemRestrictionDestroy(int *elem, int *err) {
+  if (CeedElemRestriction_n == 0) return;
   *err = CeedElemRestrictionDestroy(&CeedElemRestriction_dict[*elem]);
 
   if (*err == 0) {
@@ -570,6 +573,7 @@ void fCeedBasisGetNumQuadraturePoints(int *basis, int *Q, int *err) {
 
 #define fCeedBasisDestroy FORTRAN_NAME(ceedbasisdestroy,CEEDBASISDESTROY)
 void fCeedBasisDestroy(int *basis, int *err) {
+  if (CeedBasis_n == 0) return;
   *err = CeedBasisDestroy(&CeedBasis_dict[*basis]);
 
   if (*err == 0) {
@@ -802,6 +806,7 @@ void fCeedQFunctionApply(int *qf, int *Q,
 #define fCeedQFunctionDestroy \
     FORTRAN_NAME(ceedqfunctiondestroy,CEEDQFUNCTIONDESTROY)
 void fCeedQFunctionDestroy(int *qf, int *err) {
+  if (CeedQFunction_n == 0 || CeedQFunction_dict[*qf] == NULL) return;
   bool fstatus;
   *err = CeedQFunctionIsFortran(CeedQFunction_dict[*qf], &fstatus);
   if (*err) return;
@@ -1123,6 +1128,7 @@ void fCeedOperatorApplyJacobian(int *op, int *qdatavec, int *ustatevec,
 #define fCeedOperatorDestroy \
     FORTRAN_NAME(ceedoperatordestroy, CEEDOPERATORDESTROY)
 void fCeedOperatorDestroy(int *op, int *err) {
+  if (CeedOperator_n == 0) return;
   *err = CeedOperatorDestroy(&CeedOperator_dict[*op]);
   if (*err) return;
   CeedOperator_n--;

--- a/tests/t000-ceed-f.f90
+++ b/tests/t000-ceed-f.f90
@@ -10,6 +10,7 @@
 
       call ceedinit(trim(arg)//char(0),ceed,err)
       call ceeddestroy(ceed,err)
+      call ceeddestroy(ceed,err)
 
       end
 !-----------------------------------------------------------------------

--- a/tests/t000-ceed-f.f90
+++ b/tests/t000-ceed-f.f90
@@ -10,6 +10,8 @@
 
       call ceedinit(trim(arg)//char(0),ceed,err)
       call ceeddestroy(ceed,err)
+
+! Test double destroy is safe
       call ceeddestroy(ceed,err)
 
       end

--- a/tests/t000-ceed.c
+++ b/tests/t000-ceed.c
@@ -8,5 +8,8 @@ int main(int argc, char **argv) {
 
   CeedInit(argv[1], &ceed);
   CeedDestroy(&ceed);
+
+  // Test double destroy is safe
+  CeedDestroy(&ceed);
   return 0;
 }


### PR DESCRIPTION
Unlike with the C interface, multiple calls to `Ceed*Destroy()` can cause crashes. This fixes this small issue.