### PR TITLE
CUDA - Fix Backend Setting LinearAssemble*

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -421,9 +421,9 @@ static inline int CeedOperatorRestoreInputs_Blocked(CeedInt numinputfields,
 //------------------------------------------------------------------------------
 // Operator Apply
 //------------------------------------------------------------------------------
-static int CeedOperatorApply_Blocked(CeedOperator op, CeedVector invec,
-                                     CeedVector outvec,
-                                     CeedRequest *request) {
+static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector invec,
+                                        CeedVector outvec,
+                                        CeedRequest *request) {
   int ierr;
   CeedOperator_Blocked *impl;
   ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
@@ -740,7 +740,7 @@ int CeedOperatorCreate_Blocked(CeedOperator op) {
                                 CeedOperatorLinearAssembleQFunction_Blocked);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
-                                CeedOperatorApply_Blocked); CeedChk(ierr);
+                                CeedOperatorApplyAdd_Blocked); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Blocked); CeedChk(ierr);
   return 0;

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -1132,7 +1132,7 @@ static inline int CeedOperatorAssembleDiagonalCore_Cuda(CeedOperator op,
 //------------------------------------------------------------------------------
 // Assemble composite diagonal common code
 //------------------------------------------------------------------------------
-static inline int CeedOperatorLinearAssembleDiagonalCompositeCore_Cuda(
+static inline int CeedOperatorLinearAssembleAddDiagonalCompositeCore_Cuda(
   CeedOperator op, CeedVector assembled, CeedRequest *request,
   const bool pointBlock) {
   int ierr;
@@ -1150,13 +1150,13 @@ static inline int CeedOperatorLinearAssembleDiagonalCompositeCore_Cuda(
 //------------------------------------------------------------------------------
 // Assemble Linear Diagonal
 //------------------------------------------------------------------------------
-static int CeedOperatorLinearAssembleDiagonal_Cuda(CeedOperator op,
+static int CeedOperatorLinearAssembleAddDiagonal_Cuda(CeedOperator op,
     CeedVector assembled, CeedRequest *request) {
   int ierr;
   bool isComposite;
   ierr = CeedOperatorIsComposite(op, &isComposite); CeedChk(ierr);
   if (isComposite) {
-    return CeedOperatorLinearAssembleDiagonalCompositeCore_Cuda(op, assembled,
+    return CeedOperatorLinearAssembleAddDiagonalCompositeCore_Cuda(op, assembled,
            request, false);
   } else {
     return CeedOperatorAssembleDiagonalCore_Cuda(op, assembled, request, false);
@@ -1166,13 +1166,13 @@ static int CeedOperatorLinearAssembleDiagonal_Cuda(CeedOperator op,
 //------------------------------------------------------------------------------
 // Assemble Linear Point Block Diagonal
 //------------------------------------------------------------------------------
-static int CeedOperatorLinearAssemblePointBlockDiagonal_Cuda(CeedOperator op,
+static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda(CeedOperator op,
     CeedVector assembled, CeedRequest *request) {
   int ierr;
   bool isComposite;
   ierr = CeedOperatorIsComposite(op, &isComposite); CeedChk(ierr);
   if (isComposite) {
-    return CeedOperatorLinearAssembleDiagonalCompositeCore_Cuda(op, assembled,
+    return CeedOperatorLinearAssembleAddDiagonalCompositeCore_Cuda(op, assembled,
            request, true);
   } else {
     return CeedOperatorAssembleDiagonalCore_Cuda(op, assembled, request, true);
@@ -1205,11 +1205,11 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
                                 CeedOperatorLinearAssembleQFunction_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal",
-                                CeedOperatorLinearAssembleDiagonal_Cuda);
+                                CeedOperatorLinearAssembleAddDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op,
                                 "LinearAssembleAddPointBlockDiagonal",
-                                CeedOperatorLinearAssemblePointBlockDiagonal_Cuda);
+                                CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",
                                 CeedOperatorCreateFDMElementInverse_Cuda);
@@ -1229,11 +1229,11 @@ int CeedCompositeOperatorCreate_Cuda(CeedOperator op) {
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal",
-                                CeedOperatorLinearAssembleDiagonal_Cuda);
+                                CeedOperatorLinearAssembleAddDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op,
                                 "LinearAssembleAddPointBlockDiagonal",
-                                CeedOperatorLinearAssemblePointBlockDiagonal_Cuda);
+                                CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda);
   CeedChk(ierr);
   return 0;
 }

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -1204,11 +1204,11 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleQFunction",
                                 CeedOperatorLinearAssembleQFunction_Cuda);
   CeedChk(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleDiagonal",
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal",
                                 CeedOperatorLinearAssembleDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op,
-                                "LinearAssemblePointBlockDiagonal",
+                                "LinearAssembleAddPointBlockDiagonal",
                                 CeedOperatorLinearAssemblePointBlockDiagonal_Cuda);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -447,8 +447,8 @@ static inline int CeedOperatorRestoreInputs_Opt(CeedInt numinputfields,
 //------------------------------------------------------------------------------
 // Operator Apply
 //------------------------------------------------------------------------------
-static int CeedOperatorApply_Opt(CeedOperator op, CeedVector invec,
-                                 CeedVector outvec, CeedRequest *request) {
+static int CeedOperatorApplyAdd_Opt(CeedOperator op, CeedVector invec,
+                                    CeedVector outvec, CeedRequest *request) {
   int ierr;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
@@ -762,7 +762,7 @@ int CeedOperatorCreate_Opt(CeedOperator op) {
                                 CeedOperatorLinearAssembleQFunction_Opt);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
-                                CeedOperatorApply_Opt); CeedChk(ierr);
+                                CeedOperatorApplyAdd_Opt); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Opt); CeedChk(ierr);
   return 0;

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -384,8 +384,8 @@ static inline int CeedOperatorRestoreInputs_Ref(CeedInt numinputfields,
 //------------------------------------------------------------------------------
 // Operator Apply
 //------------------------------------------------------------------------------
-static int CeedOperatorApply_Ref(CeedOperator op, CeedVector invec,
-                                 CeedVector outvec, CeedRequest *request) {
+static int CeedOperatorApplyAdd_Ref(CeedOperator op, CeedVector invec,
+                                    CeedVector outvec, CeedRequest *request) {
   int ierr;
   CeedOperator_Ref *impl;
   ierr = CeedOperatorGetData(op, (void *)&impl); CeedChk(ierr);
@@ -707,7 +707,7 @@ static int CreatePBRestriction_Ref(CeedElemRestriction rstr,
 //------------------------------------------------------------------------------
 // Assemble diagonal common code
 //------------------------------------------------------------------------------
-static inline int CeedOperatorAssembleDiagonalCore_Ref(CeedOperator op,
+static inline int CeedOperatorAssembleAddDiagonalCore_Ref(CeedOperator op,
     CeedVector assembled, CeedRequest *request, const bool pointBlock) {
   int ierr;
   Ceed ceed;
@@ -929,7 +929,7 @@ static inline int CeedOperatorAssembleDiagonalCore_Ref(CeedOperator op,
 //------------------------------------------------------------------------------
 // Assemble composite diagonal common code
 //------------------------------------------------------------------------------
-static inline int CeedOperatorLinearAssembleDiagonalCompositeCore_Ref(
+static inline int CeedOperatorLinearAssembleAddDiagonalCompositeCore_Ref(
   CeedOperator op, CeedVector assembled, CeedRequest *request,
   const bool pointBlock) {
   int ierr;
@@ -938,7 +938,7 @@ static inline int CeedOperatorLinearAssembleDiagonalCompositeCore_Ref(
   ierr = CeedOperatorGetNumSub(op, &numSub); CeedChk(ierr);
   ierr = CeedOperatorGetSubList(op, &subOperators); CeedChk(ierr);
   for (CeedInt i = 0; i < numSub; i++) {
-    ierr = CeedOperatorAssembleDiagonalCore_Ref(subOperators[i], assembled,
+    ierr = CeedOperatorAssembleAddDiagonalCore_Ref(subOperators[i], assembled,
            request, pointBlock); CeedChk(ierr);
   }
   return 0;
@@ -947,32 +947,32 @@ static inline int CeedOperatorLinearAssembleDiagonalCompositeCore_Ref(
 //------------------------------------------------------------------------------
 // Assemble Linear Diagonal
 //------------------------------------------------------------------------------
-static int CeedOperatorLinearAssembleDiagonal_Ref(CeedOperator op,
+static int CeedOperatorLinearAssembleAddDiagonal_Ref(CeedOperator op,
     CeedVector assembled, CeedRequest *request) {
   int ierr;
   bool isComposite;
   ierr = CeedOperatorIsComposite(op, &isComposite); CeedChk(ierr);
   if (isComposite) {
-    return CeedOperatorLinearAssembleDiagonalCompositeCore_Ref(op, assembled,
+    return CeedOperatorLinearAssembleAddDiagonalCompositeCore_Ref(op, assembled,
            request, false);
   } else {
-    return CeedOperatorAssembleDiagonalCore_Ref(op, assembled, request, false);
+    return CeedOperatorAssembleAddDiagonalCore_Ref(op, assembled, request, false);
   }
 }
 
 //------------------------------------------------------------------------------
 // Assemble Linear Point Block Diagonal
 //------------------------------------------------------------------------------
-static int CeedOperatorLinearAssemblePointBlockDiagonal_Ref(CeedOperator op,
+static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Ref(CeedOperator op,
     CeedVector assembled, CeedRequest *request) {
   int ierr;
   bool isComposite;
   ierr = CeedOperatorIsComposite(op, &isComposite); CeedChk(ierr);
   if (isComposite) {
-    return CeedOperatorLinearAssembleDiagonalCompositeCore_Ref(op, assembled,
+    return CeedOperatorLinearAssembleAddDiagonalCompositeCore_Ref(op, assembled,
            request, true);
   } else {
-    return CeedOperatorAssembleDiagonalCore_Ref(op, assembled, request, true);
+    return CeedOperatorAssembleAddDiagonalCore_Ref(op, assembled, request, true);
   }
 }
 
@@ -1227,17 +1227,17 @@ int CeedOperatorCreate_Ref(CeedOperator op) {
                                 CeedOperatorLinearAssembleQFunction_Ref);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal",
-                                CeedOperatorLinearAssembleDiagonal_Ref);
+                                CeedOperatorLinearAssembleAddDiagonal_Ref);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op,
                                 "LinearAssembleAddPointBlockDiagonal",
-                                CeedOperatorLinearAssemblePointBlockDiagonal_Ref);
+                                CeedOperatorLinearAssembleAddPointBlockDiagonal_Ref);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",
                                 CeedOperatorCreateFDMElementInverse_Ref);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
-                                CeedOperatorApply_Ref); CeedChk(ierr);
+                                CeedOperatorApplyAdd_Ref); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
                                 CeedOperatorDestroy_Ref); CeedChk(ierr);
   return 0;
@@ -1251,11 +1251,11 @@ int CeedCompositeOperatorCreate_Ref(CeedOperator op) {
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal",
-                                CeedOperatorLinearAssembleDiagonal_Ref);
+                                CeedOperatorLinearAssembleAddDiagonal_Ref);
   CeedChk(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op,
                                 "LinearAssembleAddPointBlockDiagonal",
-                                CeedOperatorLinearAssemblePointBlockDiagonal_Ref);
+                                CeedOperatorLinearAssembleAddPointBlockDiagonal_Ref);
   CeedChk(ierr);
   return 0;
 }


### PR DESCRIPTION
Small bug I added; wasn't caught because the function was accidentally generating correct results.

@nbeams, this should fix the issue you were seeing if you add the same fix to `hip-ref`.