### PR TITLE
Small Python Testing Fixes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,9 @@ codecov:
 fixes:
   - "build/backends/::backends/"
 
+# CodeCov shows up in the checks on GitHub pull requests
+comment: false
+
 coverage:
   status:
     project:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
      dist: bionic
      arch: amd64
      compiler: gcc
-     python: 3.8
+     python: 3.8-dev
      install:
        - pip install -r requirements.txt
        - pip install -r requirements-test.txt

--- a/tests/python/test-0-ceed.py
+++ b/tests/python/test-0-ceed.py
@@ -67,7 +67,7 @@ def test_003(ceed_resource):
 # -------------------------------------------------------------------------------
 
 
-def test_003(ceed_resource):
+def test_005(ceed_resource):
     with pytest.raises(Exception) as e_info:
         ceed = libceed.Ceed(ceed_resource)
 


### PR DESCRIPTION
This PR

1) Fixes a minor misnumbering for t005-python

2) Switches Travis to Python 3.8-dev over 3.8 (which is 3.8.1) due to deprecation warning in virtualenv distutils from use of imp

edit:

3) Turns off CodeCov comments now that they are checks (though I'm not sure why they don't also show up in the "Checks" tab in addition to the bottom of the PR 'conversation')