### PR TITLE
Travis - skip OCCA on non-AMD64 hardware to avoid random failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,10 +111,13 @@ install:
         && brew link --overwrite gcc;
     fi
 # OCCA (pinned before OCCA changed destructor syntax)
-  - git clone https://github.com/libocca/occa.git
+# Note: OCCA currently intermittantly failing on ARM and IBM
+  - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
+        git clone https://github.com/libocca/occa.git
         && cd occa && git reset --hard 327badb && cd ..
         && make -C occa -j2
         && export OCCA_DIR=$PWD/occa;
+    fi
 # LIBXSMM v1.16.1
   - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
         git clone --depth=1 --branch 1.16.1 https://github.com/hfp/libxsmm.git


### PR DESCRIPTION
Any objection to dropping the OCCA testing for the ARM and IBM chips to prevent the frequent but inconsistent failures? This has been making our CI less useful.

We would drop this change when the new OCCA backend is merged.