### PR TITLE
Cuda - reorder loops in diagonal assembly for better memory access

### DIFF
--- a/backends/hip/ceed-hip-operator.c
+++ b/backends/hip/ceed-hip-operator.c
@@ -718,8 +718,7 @@ extern "C" __device__ void CeedOperatorGetBasisPointer_Hip(const CeedScalar **ba
 //------------------------------------------------------------------------------
 // Core code for diagonal assembly
 //------------------------------------------------------------------------------
-__device__ void diagonalCore(const CeedInt nelem,
-    const CeedScalar maxnorm, const bool pointBlock,
+__device__ void diagonalCore(const CeedInt nelem, const bool pointBlock,
     const CeedScalar *identity,
     const CeedScalar *interpin, const CeedScalar *gradin,
     const CeedScalar *interpout, const CeedScalar *gradout,
@@ -727,54 +726,53 @@ __device__ void diagonalCore(const CeedInt nelem,
     const CeedScalar *__restrict__ assembledqfarray,
     CeedScalar *__restrict__ elemdiagarray) {
   const int tid = threadIdx.x; // running with P threads, tid is evec node
-  const CeedScalar qfvaluebound = maxnorm*1e-12;
 
   // Compute the diagonal of B^T D B
-  // Each element
-  for (CeedInt e = blockIdx.x*blockDim.z + threadIdx.z; e < nelem;
-       e += gridDim.x*blockDim.z) {
-    CeedInt dout = -1;
-    // Each basis eval mode pair
-    for (CeedInt eout = 0; eout < NUMEMODEOUT; eout++) {
-      const CeedScalar *bt = NULL;
-      if (emodeout[eout] == CEED_EVAL_GRAD)
-        dout += 1;
-      CeedOperatorGetBasisPointer_Hip(&bt, emodeout[eout], identity, interpout,
-                                      &gradout[dout*NQPTS*NNODES]);
-      CeedInt din = -1;
-      for (CeedInt ein = 0; ein < NUMEMODEIN; ein++) {
-        const CeedScalar *b = NULL;
-        if (emodein[ein] == CEED_EVAL_GRAD)
-          din += 1;
-        CeedOperatorGetBasisPointer_Hip(&b, emodein[ein], identity, interpin,
-                                        &gradin[din*NQPTS*NNODES]);
-        // Each component
-        for (CeedInt compOut = 0; compOut < NCOMP; compOut++) {
-          // Each qpoint/node pair
-          if (pointBlock) {
-            // Point Block Diagonal
-            for (CeedInt compIn = 0; compIn < NCOMP; compIn++) {
-              CeedScalar evalue = 0.;
-              for (CeedInt q = 0; q < NQPTS; q++) {
+  CeedInt dout = -1;
+  // Each basis eval mode pair
+  for (CeedInt eout = 0; eout < NUMEMODEOUT; eout++) {
+    const CeedScalar *bt = NULL;
+    if (emodeout[eout] == CEED_EVAL_GRAD)
+      dout += 1;
+    CeedOperatorGetBasisPointer_Hip(&bt, emodeout[eout], identity, interpout,
+                                    &gradout[dout*NQPTS*NNODES]);
+    CeedInt din = -1;
+    for (CeedInt ein = 0; ein < NUMEMODEIN; ein++) {
+      const CeedScalar *b = NULL;
+      if (emodein[ein] == CEED_EVAL_GRAD)
+        din += 1;
+      CeedOperatorGetBasisPointer_Hip(&b, emodein[ein], identity, interpin,
+                                      &gradin[din*NQPTS*NNODES]);
+      // Each component
+      for (CeedInt compOut = 0; compOut < NCOMP; compOut++) {
+        // Each qpoint/node pair
+        if (pointBlock) {
+          // Point Block Diagonal
+          for (CeedInt compIn = 0; compIn < NCOMP; compIn++) {
+            for (CeedInt q = 0; q < NQPTS; q++) {
+              const CeedScalar bt_q = bt[q*NNODES+tid], b_q = b[q*NNODES+tid];
+              // Each element
+              for (CeedInt e = blockIdx.x*blockDim.z + threadIdx.z; e < nelem;
+                   e += gridDim.x*blockDim.z) {
                 const CeedScalar qfvalue =
                   assembledqfarray[((((ein*NCOMP+compIn)*NUMEMODEOUT+eout)*
                                      NCOMP+compOut)*nelem+e)*NQPTS+q];
-                if (abs(qfvalue) > qfvaluebound)
-                  evalue += bt[q*NNODES+tid] * qfvalue * b[q*NNODES+tid];
+                elemdiagarray[((compOut*NCOMP+compIn)*nelem+e)*NNODES+tid] += bt_q * qfvalue * b_q;
               }
-              elemdiagarray[((compOut*NCOMP+compIn)*nelem+e)*NNODES+tid] += evalue;
             }
-          } else {
-            // Diagonal Only
-            CeedScalar evalue = 0.;
-            for (CeedInt q = 0; q < NQPTS; q++) {
+          }
+        } else {
+          // Diagonal Only
+          for (CeedInt q = 0; q < NQPTS; q++) {
+            const CeedScalar bt_q = bt[q*NNODES+tid], b_q = b[q*NNODES+tid];
+            // Each element
+            for (CeedInt e = blockIdx.x*blockDim.z + threadIdx.z; e < nelem;
+                 e += gridDim.x*blockDim.z) {
               const CeedScalar qfvalue =
                 assembledqfarray[((((ein*NCOMP+compOut)*NUMEMODEOUT+eout)*
                                    NCOMP+compOut)*nelem+e)*NQPTS+q];
-              if (abs(qfvalue) > qfvaluebound)
-                evalue += bt[q*NNODES+tid] * qfvalue * b[q*NNODES+tid];
+              elemdiagarray[(compOut*nelem+e)*NNODES+tid] += bt_q * qfvalue * b_q;
             }
-            elemdiagarray[(compOut*nelem+e)*NNODES+tid] += evalue;
           }
         }
       }
@@ -786,13 +784,13 @@ __device__ void diagonalCore(const CeedInt nelem,
 // Linear diagonal
 //------------------------------------------------------------------------------
 extern "C" __global__ void linearDiagonal(const CeedInt nelem,
-    const CeedScalar maxnorm, const CeedScalar *identity,
+    const CeedScalar *identity,
     const CeedScalar *interpin, const CeedScalar *gradin,
     const CeedScalar *interpout, const CeedScalar *gradout,
     const CeedEvalMode *emodein, const CeedEvalMode *emodeout,
     const CeedScalar *__restrict__ assembledqfarray,
     CeedScalar *__restrict__ elemdiagarray) {
-  diagonalCore(nelem, maxnorm, false, identity, interpin, gradin, interpout,
+  diagonalCore(nelem, false, identity, interpin, gradin, interpout,
                gradout, emodein, emodeout, assembledqfarray, elemdiagarray);
 }
 
@@ -800,13 +798,13 @@ extern "C" __global__ void linearDiagonal(const CeedInt nelem,
 // Linear point block diagonal
 //------------------------------------------------------------------------------
 extern "C" __global__ void linearPointBlockDiagonal(const CeedInt nelem,
-    const CeedScalar maxnorm, const CeedScalar *identity,
+    const CeedScalar *identity,
     const CeedScalar *interpin, const CeedScalar *gradin,
     const CeedScalar *interpout, const CeedScalar *gradout,
     const CeedEvalMode *emodein, const CeedEvalMode *emodeout,
     const CeedScalar *__restrict__ assembledqfarray,
     CeedScalar *__restrict__ elemdiagarray) {
-  diagonalCore(nelem, maxnorm, true, identity, interpin, gradin, interpout,
+  diagonalCore(nelem, true, identity, interpin, gradin, interpout,
                gradout, emodein, emodeout, assembledqfarray, elemdiagarray);
 }
 
@@ -1066,8 +1064,6 @@ static inline int CeedOperatorAssembleDiagonalCore_Hip(CeedOperator op,
   ierr = CeedOperatorLinearAssembleQFunction(op,  &assembledqf, &rstr, request);
   CeedChk(ierr);
   ierr = CeedElemRestrictionDestroy(&rstr); CeedChk(ierr);
-  CeedScalar maxnorm = 0;
-  ierr = CeedVectorNorm(assembledqf, CEED_NORM_MAX, &maxnorm); CeedChk(ierr);
 
   // Setup
   if (!impl->diag) {
@@ -1102,7 +1098,7 @@ static inline int CeedOperatorAssembleDiagonalCore_Hip(CeedOperator op,
   // Compute the diagonal of B^T D B
   int elemsPerBlock = 1;
   int grid = nelem/elemsPerBlock+((nelem/elemsPerBlock*elemsPerBlock<nelem)?1:0);
-  void *args[] = {(void *) &nelem, (void *) &maxnorm, &diag->d_identity,
+  void *args[] = {(void *) &nelem, &diag->d_identity,
                   &diag->d_interpin, &diag->d_gradin, &diag->d_interpout,
                   &diag->d_gradout, &diag->d_emodein, &diag->d_emodeout,
                   &assembledqfarray, &elemdiagarray

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -724,8 +724,6 @@ static inline int CeedOperatorAssembleAddDiagonalCore_Ref(CeedOperator op,
   ierr = CeedOperatorLinearAssembleQFunction(op,  &assembledqf, &rstr, request);
   CeedChk(ierr);
   ierr = CeedElemRestrictionDestroy(&rstr); CeedChk(ierr);
-  CeedScalar maxnorm = 0;
-  ierr = CeedVectorNorm(assembledqf, CEED_NORM_MAX, &maxnorm); CeedChk(ierr);
 
   // Determine active input basis
   CeedOperatorField *opfields;
@@ -861,7 +859,6 @@ static inline int CeedOperatorAssembleAddDiagonalCore_Ref(CeedOperator op,
   ierr = CeedBasisGetGrad(basisout, &gradout); CeedChk(ierr);
   // Compute the diagonal of B^T D B
   // Each element
-  const CeedScalar qfvaluebound = maxnorm*1e-12;
   for (CeedInt e=0; e<nelem; e++) {
     CeedInt dout = -1;
     // Each basis eval mode pair
@@ -888,20 +885,18 @@ static inline int CeedOperatorAssembleAddDiagonalCore_Ref(CeedOperator op,
                 const CeedScalar qfvalue =
                   assembledqfarray[((((e*numemodein+ein)*ncomp+compIn)*
                                      numemodeout+eout)*ncomp+compOut)*nqpts+q];
-                if (fabs(qfvalue) > qfvaluebound)
-                  for (CeedInt n=0; n<nnodes; n++)
-                    elemdiagarray[((e*ncomp+compOut)*ncomp+compIn)*nnodes+n] +=
-                      bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
+                for (CeedInt n=0; n<nnodes; n++)
+                  elemdiagarray[((e*ncomp+compOut)*ncomp+compIn)*nnodes+n] +=
+                    bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
               }
             } else {
               // Diagonal Only
               const CeedScalar qfvalue =
                 assembledqfarray[((((e*numemodein+ein)*ncomp+compOut)*
                                    numemodeout+eout)*ncomp+compOut)*nqpts+q];
-              if (fabs(qfvalue) > qfvaluebound)
-                for (CeedInt n=0; n<nnodes; n++)
-                  elemdiagarray[(e*ncomp+compOut)*nnodes+n] +=
-                    bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
+              for (CeedInt n=0; n<nnodes; n++)
+                elemdiagarray[(e*ncomp+compOut)*nnodes+n] +=
+                  bt[q*nnodes+n] * qfvalue * b[q*nnodes+n];
             }
       }
     }


### PR DESCRIPTION
@YohannDudouit, this is a small tweak, but I think it might offer a little bit of help for performance