### PR TITLE
PETSc examples: Update DMPlexCreateSphereMesh() and DMAddBoundary() calls after changes in PETSc's API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ install:
         && export NEK5K_DIR=$PWD/Nek5000 PATH=$PWD/Nek5000/bin:$PATH MPI=0;
     fi
 # PETSc
-  - PETSC_COMMIT=afc36f2e62dc81f9d8cae345c2c65c61f89b0500 # master 2020-05-13
+  - PETSC_COMMIT=caa22a8a6959549f3567c51cb8028520e3252e52 # master 2020-08-04
   - export PETSC_INSTALL=$HOME/install/petsc-$PETSC_COMMIT
   - test -s "$PETSC_INSTALL/lib/pkgconfig/PETSc.pc"
         || (  curl -O https://gitlab.com/petsc/petsc/-/archive/$PETSC_COMMIT/petsc-$PETSC_COMMIT.tar.gz

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -56,6 +56,10 @@ const char help[] = "Solve Navier-Stokes using PETSc and libCEED\n";
 #  define DMPlexRestoreClosureIndices(a,b,c,d,e,f,g,h,i) DMPlexRestoreClosureIndices(a,b,c,d,f,g,i)
 #endif
 
+#if PETSC_VERSION_LT(3,14,0)
+#  define DMAddBoundary(a,b,c,d,e,f,g,h,i,j,k,l) DMAddBoundary(a,b,c,d,e,f,g,h,j,k,l)
+#endif
+
 // MemType Options
 static const char *const memTypes[] = {
   "host",
@@ -803,15 +807,15 @@ static PetscErrorCode SetUpDM(DM dm, problemData *problem, PetscInt degree,
     {
       PetscInt comps[1] = {1};
       ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipx", "Face Sets", 0,
-                           1, comps, (void(*)(void))NULL, bc->nslip[0],
+                           1, comps, (void(*)(void))NULL, NULL, bc->nslip[0],
                            bc->slips[0], ctxSetup); CHKERRQ(ierr);
       comps[0] = 2;
       ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipy", "Face Sets", 0,
-                           1, comps, (void(*)(void))NULL, bc->nslip[1],
+                           1, comps, (void(*)(void))NULL, NULL, bc->nslip[1],
                            bc->slips[1], ctxSetup); CHKERRQ(ierr);
       comps[0] = 3;
       ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipz", "Face Sets", 0,
-                           1, comps, (void(*)(void))NULL, bc->nslip[2],
+                           1, comps, (void(*)(void))NULL, NULL, bc->nslip[2],
                            bc->slips[2], ctxSetup); CHKERRQ(ierr);
     }
     if (bc->userbc == PETSC_TRUE) {
@@ -834,12 +838,12 @@ static PetscErrorCode SetUpDM(DM dm, problemData *problem, PetscInt degree,
       if (problem->bc == Exact_Advection || problem->bc == Exact_Advection2d) {
         PetscInt comps[1] = {4};
         ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "wall", "Face Sets", 0,
-                             1, comps, (void(*)(void))problem->bc,
+                             1, comps, (void(*)(void))problem->bc, NULL,
                              bc->nwall, bc->walls, ctxSetup); CHKERRQ(ierr);
       } else if (problem->bc == Exact_DC) {
         PetscInt comps[3] = {1, 2, 3};
         ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "wall", "Face Sets", 0,
-                             3, comps, (void(*)(void))problem->bc,
+                             3, comps, (void(*)(void))problem->bc, NULL,
                              bc->nwall, bc->walls, ctxSetup); CHKERRQ(ierr);
       } else
         SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_NULL,

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
     CHKERRQ(ierr);
   } else {
     // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box
-    ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topodim, simplex, &dm);
+    ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topodim, simplex, 1., &dm);
     CHKERRQ(ierr);
     // Set the object name
     ierr = PetscObjectSetName((PetscObject)dm, problemTypes[problemChoice]);

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     CHKERRQ(ierr);
   } else {
     // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box
-    ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topodim, simplex, &dm);
+    ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topodim, simplex, 1., &dm);
     CHKERRQ(ierr);
     // Set the object name
     ierr = PetscObjectSetName((PetscObject)dm, "Sphere"); CHKERRQ(ierr);

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -396,7 +396,7 @@ static int SetupDMByDegree(DM dm, PetscInt degree, PetscInt ncompu,
     DMHasLabel(dm, "marker", &hasLabel);
     if (!hasLabel) {CreateBCLabel(dm, "marker");}
     ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "wall", "marker", 0, 0, NULL,
-                         (void(*)(void))bpOptions[bpChoice].bcs_func,
+                         (void(*)(void))bpOptions[bpChoice].bcs_func, NULL,
                          1, marker_ids, NULL);
     CHKERRQ(ierr);
   }

--- a/examples/petsc/setup.h
+++ b/examples/petsc/setup.h
@@ -43,6 +43,10 @@
 #  define DMPlexRestoreClosureIndices(a,b,c,d,e,f,g,h,i) DMPlexRestoreClosureIndices(a,b,c,d,f,g,i)
 #endif
 
+#if PETSC_VERSION_LT(3,14,0)
+#  define DMAddBoundary(a,b,c,d,e,f,g,h,i,j,k,l) DMAddBoundary(a,b,c,d,e,f,g,h,j,k,l)
+#endif
+
 // -----------------------------------------------------------------------------
 // PETSc Operator Structs
 // -----------------------------------------------------------------------------

--- a/examples/petsc/setuparea.h
+++ b/examples/petsc/setuparea.h
@@ -31,6 +31,10 @@
 #  define DMPlexRestoreClosureIndices(a,b,c,d,e,f,g,h,i) DMPlexRestoreClosureIndices(a,b,c,d,f,g,i)
 #endif
 
+#if PETSC_VERSION_LT(3,14,0)
+#  define DMPlexCreateSphereMesh(a,b,c,d,e) DMPlexCreateSphereMesh(a,b,c,e)
+#endif
+
 // -----------------------------------------------------------------------------
 // PETSc Operator Structs
 // -----------------------------------------------------------------------------

--- a/examples/petsc/setupsphere.h
+++ b/examples/petsc/setupsphere.h
@@ -34,6 +34,10 @@
 #  define DMPlexRestoreClosureIndices(a,b,c,d,e,f,g,h,i) DMPlexRestoreClosureIndices(a,b,c,d,f,g,i)
 #endif
 
+#if PETSC_VERSION_LT(3,14,0)
+#  define DMPlexCreateSphereMesh(a,b,c,d,e) DMPlexCreateSphereMesh(a,b,c,e)
+#endif
+
 // -----------------------------------------------------------------------------
 // PETSc Operator Structs
 // -----------------------------------------------------------------------------

--- a/examples/solids/elasticity.h
+++ b/examples/solids/elasticity.h
@@ -27,6 +27,10 @@
 
 #include <ceed.h>
 
+#if PETSC_VERSION_LT(3,14,0)
+#  define DMAddBoundary(a,b,c,d,e,f,g,h,i,j,k,l) DMAddBoundary(a,b,c,d,e,f,g,h,j,k,l)
+#endif
+
 #ifndef PHYSICS_STRUCT
 #define PHYSICS_STRUCT
 typedef struct Physics_private *Physics;

--- a/examples/solids/src/setupdm.c
+++ b/examples/solids/src/setupdm.c
@@ -166,7 +166,7 @@ PetscErrorCode SetupDMByDegree(DM dm, AppCtx appCtx, PetscInt order,
         ierr = CreateBCLabel(dm, "marker"); CHKERRQ(ierr);
       }
       ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "mms", "marker", 0, 0, NULL,
-                           (void(*)(void))BCMMS, 1, marker_ids, NULL);
+                           (void(*)(void))BCMMS, NULL, 1, marker_ids, NULL);
       CHKERRQ(ierr);
     } else if (appCtx->forcingChoice == FORCE_MMS) {
       // -- ExodusII mesh with MMS
@@ -174,7 +174,7 @@ PetscErrorCode SetupDMByDegree(DM dm, AppCtx appCtx, PetscInt order,
       ierr = ISGetSize(faceSetIS,&numFaceSets); CHKERRQ(ierr);
       ierr = ISGetIndices(faceSetIS, &faceSetIds); CHKERRQ(ierr);
       ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "mms", "Face Sets", 0, 0, NULL,
-                           (void(*)(void))BCMMS, numFaceSets, faceSetIds, NULL);
+                           (void(*)(void))BCMMS, NULL, numFaceSets, faceSetIds, NULL);
       CHKERRQ(ierr);
       ierr = ISRestoreIndices(faceSetIS, &faceSetIds); CHKERRQ(ierr);
       ierr = ISDestroy(&faceSetIS); CHKERRQ(ierr);
@@ -185,7 +185,7 @@ PetscErrorCode SetupDMByDegree(DM dm, AppCtx appCtx, PetscInt order,
         char bcName[25];
         snprintf(bcName, sizeof bcName, "clamp_%d", appCtx->bcClampFaces[i]);
         ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, bcName, "Face Sets", 0, 0,
-                             NULL, (void(*)(void))BCClamp, 1,
+                             NULL, (void(*)(void))BCClamp, NULL, 1,
                              &appCtx->bcClampFaces[i],
                              (void *)&appCtx->bcClampMax[i]); CHKERRQ(ierr);
       }


### PR DESCRIPTION
I have updated the couple of instances where we were calling `DMPlexCreateSphereMesh` after changes in PETSc.