### PR TITLE
PETSc area and bpssphere examples: Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ install:
         && export NEK5K_DIR=$PWD/Nek5000 PATH=$PWD/Nek5000/bin:$PATH MPI=0;
     fi
 # PETSc
-  - PETSC_COMMIT=caa22a8a6959549f3567c51cb8028520e3252e52 # master 2020-08-04
+  - PETSC_COMMIT=3d912c81999b7ffb45730f99dafc47138dbf1d99 # master 2020-08-08
   - export PETSC_INSTALL=$HOME/install/petsc-$PETSC_COMMIT
   - test -s "$PETSC_INSTALL/lib/pkgconfig/PETSc.pc"
         || (  curl -O https://gitlab.com/petsc/petsc/-/archive/$PETSC_COMMIT/petsc-$PETSC_COMMIT.tar.gz

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -42,7 +42,7 @@
 //   The above example runs use 2 levels of refinement for the mesh.
 //   Use -dm_refine k, for k levels of uniform refinement.
 //
-//TESTARGS -ceed {ceed_resource} -test -petscspace_degree 3
+//TESTARGS -ceed {ceed_resource} -test -degree 3 -dm_refine 1
 
 /// @file
 /// libCEED example using the mass operator to compute a cube or a cubed-sphere surface area using PETSc with DMPlex
@@ -225,13 +225,15 @@ int main(int argc, char **argv) {
     exact_surfarea = 6 * (2*l) * (2*l);
   }
 
-  if (!test_mode) {
+  PetscReal error = fabs(area - exact_surfarea);
+  PetscReal tol = 5e-6;
+  if (!test_mode || error > tol) {
     ierr = PetscPrintf(comm, "Exact mesh surface area    : % .14g\n",
                        exact_surfarea); CHKERRQ(ierr);
     ierr = PetscPrintf(comm, "Computed mesh surface area : % .14g\n", area);
     CHKERRQ(ierr);
     ierr = PetscPrintf(comm, "Area error                 : % .14g\n",
-                       fabs(area - exact_surfarea)); CHKERRQ(ierr);
+                       (double)error); CHKERRQ(ierr);
   }
 
   // Cleanup

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -35,7 +35,7 @@
 //     bpssphere -problem bp5 -ceed /cpu/occa -degree 3
 //     bpssphere -problem bp6 -ceed /cpu/self -degree 3
 //
-//TESTARGS -ceed {ceed_resource} -test -problem bp3 -degree 3
+//TESTARGS -ceed {ceed_resource} -test -problem bp3 -degree 3 -dm_refine 2
 
 /// @file
 /// CEED BPs example using PETSc with DMPlex
@@ -319,7 +319,7 @@ int main(int argc, char **argv) {
       PetscReal maxerror;
       ierr = ComputeErrorMax(userO, op_error, X, target, &maxerror);
       CHKERRQ(ierr);
-      PetscReal tol = 6e-2;
+      PetscReal tol = 5e-4;
       if (!test_mode || maxerror > tol) {
         ierr = MPI_Allreduce(&my_rt, &rt_min, 1, MPI_DOUBLE, MPI_MIN, comm);
         CHKERRQ(ierr);


### PR DESCRIPTION
This PR adds the command line argument `-dm_refine` to our `petsc/examples/bpssphere` and `petsc/examples/area` problem `TESTARGS`. This could have caught the bug in PETSc that was introduced lately. And while at it, I realized that the area problem test was not checking for any tolerance, so I added that, and I tightened the tolerance of the other test, too.

This PR is downstream of a PETSc's [MR](https://gitlab.com/petsc/petsc/-/merge_requests/3034?commit_id=68317524b39380e49bbfefbbf59f91b5b48300b3) for which I reported a bug. The PETSc MR and this PR will close issue #603

As soon as that one merges, this one can follow.

