### PR TITLE
Update 'factored form' link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ The goal of libCEED is to propose such a format, as well as supporting
 implementations and data structures, that enable efficient operator evaluation
 on a variety of computational device types (CPUs, GPUs, etc.). This new operator
 description is based on algebraically
-`factored form <https://libceed.readthedocs.io/en/latest/api.html>`_,
+`factored form <https://libceed.readthedocs.io/en/latest/libCEEDapi/#finite-element-operator-decomposition>`_,
 which is easy to incorporate in a wide variety of applications, without significant
 refactoring of their own discretization infrastructure.
 


### PR DESCRIPTION
Point to more appropriate page in documentation.

As pointed out by @jedbrown in https://github.com/CEED/libCEED/pull/612#discussion_r476121937