### PR TITLE
Enable under-integration for cuda-shared and cuda-gen backends

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -130,8 +130,9 @@ inline __device__ void ContractX1d(BackendData& data, const CeedScalar *U, const
   data.slice[data.tidx] = *U;
   __syncthreads();
   *V = 0.0;
-  for (CeedInt i = 0; i < P1d; ++i)
-    *V += B[i + data.tidx*P1d] * data.slice[i]; // Contract x direction
+  if (data.tidx < Q1d)
+    for (CeedInt i = 0; i < P1d; ++i)
+      *V += B[i + data.tidx*P1d] * data.slice[i]; // Contract x direction
   __syncthreads();
 }
 
@@ -143,8 +144,9 @@ inline __device__ void ContractTransposeX1d(BackendData& data, const CeedScalar 
   data.slice[data.tidx] = *U;
   __syncthreads();
   *V = 0.0;
-  for (CeedInt i = 0; i < Q1d; ++i)
-    *V += B[data.tidx + i*P1d] * data.slice[i]; // Contract x direction
+  if (data.tidx < P1d)
+    for (CeedInt i = 0; i < Q1d; ++i)
+      *V += B[data.tidx + i*P1d] * data.slice[i]; // Contract x direction
   __syncthreads();
 }
 

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -787,16 +787,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   // Find dim and Q1d
   bool useCollograd = true;
   data->maxP1d = 0;
-  bool isTensor = false;
   for (CeedInt i = 0; i < numinputfields; i++) {
     ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
-    ierr = CeedBasisIsTensor(basis, &isTensor); CeedChk(ierr);
-    if (isTensor) {
-      ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
-    } else {
-      return CeedError(ceed, 1, "Backend does not implement non-tensor basis.");
-    }
-    if (P1d>data->maxP1d) data->maxP1d = P1d;
     if (basis != CEED_BASIS_COLLOCATED) {
       ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
       ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
@@ -812,6 +804,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       ierr = CeedBasisIsTensor(basis, &isTensor); CeedChk(ierr); 
       if (isTensor) {
         ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+        ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+        if (P1d>data->maxP1d) data->maxP1d = P1d;
       } else {
         // LCOV_EXCL_START
         return CeedError(ceed, 1, "Backend does not implement operators with non-tensor basis");

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -787,9 +787,15 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   // Find dim and Q1d
   bool useCollograd = true;
   data->maxP1d = 0;
+  bool isTensor = false;
   for (CeedInt i = 0; i < numinputfields; i++) {
     ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
-    ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+    ierr = CeedBasisIsTensor(basis, &isTensor); CeedChk(ierr);
+    if (isTensor) {
+      ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+    } else {
+      return CeedError(ceed, 1, "Backend does not implement non-tensor basis.");
+    }
     if (P1d>data->maxP1d) data->maxP1d = P1d;
     if (basis != CEED_BASIS_COLLOCATED) {
       ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -290,7 +290,7 @@ inline __device__ void ContractXTranspose2d(BackendData& data, const CeedScalar 
   data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
   *V = 0.0;
-  if (data.tidx < P1d && data.tidx < P1d)
+  if (data.tidx < P1d && data.tidy < P1d)
     for (CeedInt i = 0; i < Q1d; ++i)
       *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
   __syncthreads();
@@ -303,7 +303,7 @@ template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractXTransposeAdd2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
   data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
-  if (data.tidx < P1d && data.tidx < P1d)
+  if (data.tidx < P1d && data.tidy < P1d)
     for (CeedInt i = 0; i < Q1d; ++i)
       *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
   __syncthreads();
@@ -511,8 +511,6 @@ inline __device__ void ContractTransposeZ3d(BackendData& data, const CeedScalar 
       for (CeedInt i = 0; i < Q1d; ++i)
         V[k] += B[k + i*P1d] * U[i]; // Contract z direction
   }
-  for (int k = P1d; k < Q1d; ++k)
-    V[k] = 0.0;
 }
 
 //------------------------------------------------------------------------------

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -245,11 +245,12 @@ inline __device__ void writeDofsStrided2d(BackendData& data, const CeedInt elem,
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractX2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  data.slice[data.tidx+data.tidy*Q1d] = *U;
+  data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
   *V = 0.0;
-  for (CeedInt i = 0; i < P1d; ++i)
-    *V += B[i + data.tidx*P1d] * data.slice[i + data.tidy*Q1d]; // Contract x direction
+  if (data.tidx < Q1d && data.tidy < P1d)
+    for (CeedInt i = 0; i < P1d; ++i)
+      *V += B[i + data.tidx*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
   __syncthreads();
 }
 
@@ -258,11 +259,12 @@ inline __device__ void ContractX2d(BackendData& data, const CeedScalar *U, const
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractY2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  data.slice[data.tidx+data.tidy*Q1d] = *U;
+  data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
   *V = 0.0;
-  for (CeedInt i = 0; i < P1d; ++i)
-    *V += B[i + data.tidy*P1d] * data.slice[data.tidx + i*Q1d]; // Contract y direction
+  if (data.tidx < Q1d && data.tidy < Q1d)
+    for (CeedInt i = 0; i < P1d; ++i)
+      *V += B[i + data.tidy*P1d] * data.slice[data.tidx + i*T1d]; // Contract y direction
   __syncthreads();
 }
 
@@ -271,12 +273,12 @@ inline __device__ void ContractY2d(BackendData& data, const CeedScalar *U, const
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractYTranspose2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  data.slice[data.tidx+data.tidy*Q1d] = *U;
+  data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
   *V = 0.0;
-  if (data.tidy < P1d)
+  if (data.tidx < Q1d && data.tidy < P1d)
     for (CeedInt i = 0; i < Q1d; ++i)
-      *V += B[data.tidy + i*P1d] * data.slice[data.tidx + i*Q1d]; // Contract y direction
+      *V += B[data.tidy + i*P1d] * data.slice[data.tidx + i*T1d]; // Contract y direction
   __syncthreads();
 }
 
@@ -285,12 +287,12 @@ inline __device__ void ContractYTranspose2d(BackendData& data, const CeedScalar 
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractXTranspose2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  data.slice[data.tidx+data.tidy*Q1d] = *U;
+  data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
   *V = 0.0;
-  if (data.tidx < P1d)
+  if (data.tidx < P1d && data.tidx < P1d)
     for (CeedInt i = 0; i < Q1d; ++i)
-      *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*Q1d]; // Contract x direction
+      *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
   __syncthreads();
 }
 
@@ -299,11 +301,11 @@ inline __device__ void ContractXTranspose2d(BackendData& data, const CeedScalar 
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractXTransposeAdd2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  data.slice[data.tidx+data.tidy*Q1d] = *U;
+  data.slice[data.tidx+data.tidy*T1d] = *U;
   __syncthreads();
-  if (data.tidx < P1d)
+  if (data.tidx < P1d && data.tidx < P1d)
     for (CeedInt i = 0; i < Q1d; ++i)
-      *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*Q1d]; // Contract x direction
+      *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
   __syncthreads();
 }
 
@@ -396,10 +398,12 @@ inline __device__ void readDofsStrided3d(BackendData& data, const CeedInt elem, 
 //------------------------------------------------------------------------------
 template <int NCOMP, int COMPSTRIDE, int Q1d>
 inline __device__ void readSliceQuadsOffset3d(BackendData& data, const CeedInt nquads, const CeedInt elem, const CeedInt q, const CeedInt* indices, const CeedScalar* d_u, CeedScalar* r_u) {
-  const CeedInt node = data.tidx + data.tidy*Q1d + q*Q1d*Q1d;
-  const CeedInt ind = indices[node + elem * Q1d*Q1d*Q1d];;
-  for (CeedInt comp = 0; comp < NCOMP; ++comp)
-    r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    const CeedInt node = data.tidx + data.tidy*Q1d + q*Q1d*Q1d;
+    const CeedInt ind = indices[node + elem * Q1d*Q1d*Q1d];;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -407,10 +411,12 @@ inline __device__ void readSliceQuadsOffset3d(BackendData& data, const CeedInt n
 //------------------------------------------------------------------------------
 template <int NCOMP, int Q1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
 inline __device__ void readSliceQuadsStrided3d(BackendData& data, const CeedInt elem, const CeedInt q, const CeedScalar* d_u, CeedScalar* r_u) {
-  const CeedInt node = data.tidx + data.tidy*Q1d + q*Q1d*Q1d;
-  const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
-  for (CeedInt comp = 0; comp < NCOMP; ++comp)
-    r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    const CeedInt node = data.tidx + data.tidy*Q1d + q*Q1d*Q1d;
+    const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -451,11 +457,12 @@ inline __device__ void ContractX3d(BackendData& data, const CeedScalar *U, const
     r_B[i] = B[i + data.tidx*P1d];
 
   for (CeedInt k = 0; k < P1d; ++k) {
-    data.slice[data.tidx+data.tidy*Q1d] = U[k];
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    for (CeedInt i = 0; i < P1d; ++i)
-      V[k] += r_B[i] * data.slice[i + data.tidy*Q1d]; // Contract x direction
+    if (data.tidx < Q1d && data.tidy < P1d)
+      for (CeedInt i = 0; i < P1d; ++i)
+        V[k] += r_B[i] * data.slice[i + data.tidy*T1d]; // Contract x direction
     __syncthreads();
   }
 }
@@ -470,11 +477,12 @@ inline __device__ void ContractY3d(BackendData& data, const CeedScalar *U, const
     r_B[i] = B[i + data.tidy*P1d];
 
   for (CeedInt k = 0; k < P1d; ++k) {
-    data.slice[data.tidx+data.tidy*Q1d] = U[k];
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    for (CeedInt i = 0; i < P1d; ++i)
-      V[k] += r_B[i] * data.slice[data.tidx + i*Q1d]; // Contract y direction
+    if (data.tidx < Q1d && data.tidy < Q1d)
+      for (CeedInt i = 0; i < P1d; ++i)
+        V[k] += r_B[i] * data.slice[data.tidx + i*T1d]; // Contract y direction
     __syncthreads();
   }
 }
@@ -486,8 +494,9 @@ template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractZ3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
   for (CeedInt k = 0; k < Q1d; ++k) {
     V[k] = 0.0;
-    for (CeedInt i = 0; i < P1d; ++i)
-      V[k] += B[i + k*P1d] * U[i]; // Contract z direction
+    if (data.tidx < Q1d && data.tidy < Q1d)
+      for (CeedInt i = 0; i < P1d; ++i)
+        V[k] += B[i + k*P1d] * U[i]; // Contract z direction
   }
 }
 
@@ -496,12 +505,14 @@ inline __device__ void ContractZ3d(BackendData& data, const CeedScalar *U, const
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void ContractTransposeZ3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  for (CeedInt k = 0; k < Q1d; ++k) {
+  for (CeedInt k = 0; k < P1d; ++k) {
     V[k] = 0.0;
-    if (k < P1d)
+    if (data.tidx < Q1d && data.tidy < Q1d)
       for (CeedInt i = 0; i < Q1d; ++i)
         V[k] += B[k + i*P1d] * U[i]; // Contract z direction
   }
+  for (int k = P1d; k < Q1d; ++k)
+    V[k] = 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -514,12 +525,12 @@ inline __device__ void ContractTransposeY3d(BackendData& data, const CeedScalar 
     r_B[i] = B[data.tidy + i*P1d];
 
   for (CeedInt k = 0; k < P1d; ++k) {
-    data.slice[data.tidx+data.tidy*Q1d] = U[k];
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    if (data.tidy < P1d)
+    if (data.tidx < Q1d && data.tidy < P1d)
       for (CeedInt i = 0; i < Q1d; ++i)
-        V[k] += r_B[i] * data.slice[data.tidx + i*Q1d]; // Contract y direction
+        V[k] += r_B[i] * data.slice[data.tidx + i*T1d]; // Contract y direction
     __syncthreads();
   }
 }
@@ -534,11 +545,11 @@ inline __device__ void ContractTransposeAddY3d(BackendData& data, const CeedScal
     r_B[i] = B[data.tidy + i*P1d];
 
   for (CeedInt k = 0; k < P1d; ++k) {
-    data.slice[data.tidx+data.tidy*Q1d] = U[k];
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
     __syncthreads();
-    if (data.tidy < P1d)
+    if (data.tidx < Q1d && data.tidy < P1d)
       for (CeedInt i = 0; i < Q1d; ++i)
-        V[k] += r_B[i] * data.slice[data.tidx + i*Q1d]; // Contract y direction
+        V[k] += r_B[i] * data.slice[data.tidx + i*T1d]; // Contract y direction
     __syncthreads();
   }
 }
@@ -553,12 +564,12 @@ inline __device__ void ContractTransposeX3d(BackendData& data, const CeedScalar 
     r_B[i] = B[data.tidx + i*P1d];
 
   for (CeedInt k = 0; k < P1d; ++k) {
-    data.slice[data.tidx+data.tidy*Q1d] = U[k];
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    if (data.tidx < P1d)
+    if (data.tidx < P1d && data.tidy < P1d)
       for (CeedInt i = 0; i < Q1d; ++i)
-        V[k] += r_B[i] * data.slice[i + data.tidy*Q1d]; // Contract x direction
+        V[k] += r_B[i] * data.slice[i + data.tidy*T1d]; // Contract x direction
     __syncthreads();
   }
 }
@@ -573,11 +584,11 @@ inline __device__ void ContractTransposeAddX3d(BackendData& data, const CeedScal
     r_B[i] = B[data.tidx + i*P1d];
 
   for (CeedInt k = 0; k < P1d; ++k) {
-    data.slice[data.tidx+data.tidy*Q1d] = U[k];
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
     __syncthreads();
-    if (data.tidx < P1d)
+    if (data.tidx < P1d && data.tidy < P1d)
       for (CeedInt i = 0; i < Q1d; ++i)
-        V[k] += r_B[i] * data.slice[i + data.tidy*Q1d]; // Contract x direction
+        V[k] += r_B[i] * data.slice[i + data.tidy*T1d]; // Contract x direction
     __syncthreads();
   }
 }
@@ -587,8 +598,8 @@ inline __device__ void ContractTransposeAddX3d(BackendData& data, const CeedScal
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void interp3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
-  CeedScalar r_t1[Q1d];
-  CeedScalar r_t2[Q1d];
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
   for (CeedInt comp = 0; comp < NCOMP; comp++) {
     ContractX3d<NCOMP, P1d, Q1d>(data, r_U + comp*P1d, c_B, r_t1);
     ContractY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
@@ -601,8 +612,8 @@ inline __device__ void interp3d(BackendData& data, const CeedScalar *__restrict_
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void interpTranspose3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
-  CeedScalar r_t1[Q1d];
-  CeedScalar r_t2[Q1d];
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
   for (CeedInt comp = 0; comp < NCOMP; comp++) {
     ContractTransposeZ3d<NCOMP, P1d, Q1d>(data, r_U + comp*Q1d, c_B, r_t1);
     ContractTransposeY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
@@ -615,8 +626,8 @@ inline __device__ void interpTranspose3d(BackendData& data, const CeedScalar *__
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void grad3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
-  CeedScalar r_t1[Q1d];
-  CeedScalar r_t2[Q1d];
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
   for (CeedInt comp = 0; comp < NCOMP; comp++) {
     ContractX3d<NCOMP, P1d, Q1d>(data, r_U + comp*P1d, c_G, r_t1);
     ContractY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
@@ -635,8 +646,8 @@ inline __device__ void grad3d(BackendData& data, const CeedScalar *__restrict__ 
 //------------------------------------------------------------------------------
 template <int NCOMP, int P1d, int Q1d>
 inline __device__ void gradTranspose3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
-  CeedScalar r_t1[Q1d];
-  CeedScalar r_t2[Q1d];
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
   for (CeedInt comp = 0; comp < NCOMP; comp++) {
     ContractTransposeZ3d<NCOMP, P1d, Q1d>(data, r_U + comp*Q1d + 0*NCOMP*Q1d, c_B, r_t1);
     ContractTransposeY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
@@ -655,22 +666,24 @@ inline __device__ void gradTranspose3d(BackendData& data, const CeedScalar *__re
 //------------------------------------------------------------------------------
 template <int NCOMP, int Q1d>
 inline __device__ void gradCollo3d(BackendData& data, const CeedInt q, const CeedScalar *__restrict__ r_U, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
-  for (CeedInt comp = 0; comp < NCOMP; ++comp) {
-    data.slice[data.tidx + data.tidy*Q1d] = r_U[q + comp*Q1d];
-    __syncthreads();
-    // X derivative
-    r_V[comp+0*NCOMP] = 0.0;
-    for (CeedInt i = 0; i < Q1d; ++i)
-      r_V[comp+0*NCOMP] += c_G[i + data.tidx*Q1d] * data.slice[i + data.tidy*Q1d]; // Contract x direction (X derivative)
-    // Y derivative
-    r_V[comp+1*NCOMP] = 0.0;
-    for (CeedInt i = 0; i < Q1d; ++i)
-      r_V[comp+1*NCOMP] += c_G[i + data.tidy*Q1d] * data.slice[data.tidx + i*Q1d]; // Contract y direction (Y derivative)
-    // Z derivative
-    r_V[comp+2*NCOMP] = 0.0;
-    for (CeedInt i = 0; i < Q1d; ++i)
-      r_V[comp+2*NCOMP] += c_G[i + q*Q1d] * r_U[i + comp*Q1d]; // Contract z direction (Z derivative)
-    __syncthreads();
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    for (CeedInt comp = 0; comp < NCOMP; ++comp) {
+      data.slice[data.tidx + data.tidy*T1d] = r_U[q + comp*Q1d];
+      __syncthreads();
+      // X derivative
+      r_V[comp+0*NCOMP] = 0.0;
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[comp+0*NCOMP] += c_G[i + data.tidx*Q1d] * data.slice[i + data.tidy*T1d]; // Contract x direction (X derivative)
+      // Y derivative
+      r_V[comp+1*NCOMP] = 0.0;
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[comp+1*NCOMP] += c_G[i + data.tidy*Q1d] * data.slice[data.tidx + i*T1d]; // Contract y direction (Y derivative)
+      // Z derivative
+      r_V[comp+2*NCOMP] = 0.0;
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[comp+2*NCOMP] += c_G[i + q*Q1d] * r_U[i + comp*Q1d]; // Contract z direction (Z derivative)
+      __syncthreads();
+    }
   }
 }
 
@@ -679,22 +692,24 @@ inline __device__ void gradCollo3d(BackendData& data, const CeedInt q, const Cee
 //------------------------------------------------------------------------------
 template <int NCOMP, int Q1d>
 inline __device__ void gradColloTranspose3d(BackendData& data, const CeedInt q, const CeedScalar *__restrict__ r_U, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
-  for (CeedInt comp = 0; comp < NCOMP; ++comp) {
-    // X derivative
-    data.slice[data.tidx + data.tidy*Q1d] = r_U[comp + 0*NCOMP];
-    __syncthreads();
-    for (CeedInt i = 0; i < Q1d; ++i)
-      r_V[q+comp*Q1d] += c_G[data.tidx + i*Q1d] * data.slice[i + data.tidy*Q1d]; // Contract x direction (X derivative)
-    __syncthreads();
-    // Y derivative
-    data.slice[data.tidx + data.tidy*Q1d] = r_U[comp + 1*NCOMP];
-    __syncthreads();
-    for (CeedInt i = 0; i < Q1d; ++i)
-      r_V[q+comp*Q1d] += c_G[data.tidy + i*Q1d] * data.slice[data.tidx + i*Q1d]; // Contract y direction (Y derivative)
-    __syncthreads();
-    // Z derivative
-    for (CeedInt i = 0; i < Q1d; ++i)
-      r_V[i+comp*Q1d] += c_G[i + q*Q1d] * r_U[comp + 2*NCOMP]; // PARTIAL contract z direction (Z derivative)
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    for (CeedInt comp = 0; comp < NCOMP; ++comp) {
+      // X derivative
+      data.slice[data.tidx + data.tidy*T1d] = r_U[comp + 0*NCOMP];
+      __syncthreads();
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[q+comp*Q1d] += c_G[data.tidx + i*Q1d] * data.slice[i + data.tidy*T1d]; // Contract x direction (X derivative)
+      __syncthreads();
+      // Y derivative
+      data.slice[data.tidx + data.tidy*T1d] = r_U[comp + 1*NCOMP];
+      __syncthreads();
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[q+comp*Q1d] += c_G[data.tidy + i*Q1d] * data.slice[data.tidx + i*T1d]; // Contract y direction (Y derivative)
+      __syncthreads();
+      // Z derivative
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[i+comp*Q1d] += c_G[i + q*Q1d] * r_U[comp + 2*NCOMP]; // PARTIAL contract z direction (Z derivative)
+    }
   }
 }
 
@@ -703,7 +718,8 @@ inline __device__ void gradColloTranspose3d(BackendData& data, const CeedInt q, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight1d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  *w = qweight1d[data.tidx];
+  if (data.tidx < Q1d)
+    *w = qweight1d[data.tidx];
 }
 
 //------------------------------------------------------------------------------
@@ -711,7 +727,8 @@ inline __device__ void weight1d(BackendData& data, const CeedScalar *qweight1d, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight2d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  *w = qweight1d[data.tidx]*qweight1d[data.tidy];
+  if (data.tidx < Q1d && data.tidy < Q1d)
+    *w = qweight1d[data.tidx]*qweight1d[data.tidy];
 }
 
 //------------------------------------------------------------------------------
@@ -719,9 +736,11 @@ inline __device__ void weight2d(BackendData& data, const CeedScalar *qweight1d, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight3d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  const CeedScalar pw = qweight1d[data.tidx]*qweight1d[data.tidy];
-  for (CeedInt z = 0; z < Q1d; ++z)
-    w[z] = pw*qweight1d[z];
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    const CeedScalar pw = qweight1d[data.tidx]*qweight1d[data.tidy];
+    for (CeedInt z = 0; z < Q1d; ++z)
+      w[z] = pw*qweight1d[z];
+  }
 }
 
 );
@@ -876,7 +895,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   code << "  data.tidy = threadIdx.y;\n";
   code << "  data.tidz = threadIdx.z;\n";
   code << "  data.tid  = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.y*blockDim.x;\n";
-  code << "  data.slice = slice+data.tidz*Q1d"<<(dim>1?"*Q1d":"")<<";\n";
+  code << "  data.slice = slice+data.tidz*T1d"<<(dim>1?"*T1d":"")<<";\n";
 
   code << "\n  // -- Input field constants and basis data --\n";
   //Initialize constants, and matrices B and G
@@ -1355,7 +1374,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
   // View kernel for debugging
   CeedDebug(code.str().c_str());
 
-  ierr = CeedCompileCuda(ceed, code.str().c_str(), &data->module, 0);
+  ierr = CeedCompileCuda(ceed, code.str().c_str(), &data->module, 1,
+                         "T1d", CeedIntMax(Q1d, data->maxP1d));
   CeedChk(ierr);
   ierr = CeedGetKernelCuda(ceed, data->module, oper.c_str(), &data->op);
   CeedChk(ierr);

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -812,8 +812,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       CeedChk(ierr);
 
       // Check for collocated gradient
-      if (emode == CEED_EVAL_GRAD)
-        useCollograd = useCollograd && !!basis_data->d_collograd1d; 
+      useCollograd = useCollograd && basis_data->d_collograd1d; 
 
       // Collect dim and Q1d
       ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
@@ -853,8 +852,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
         }
 
       // Check for collocated gradient
-      if (emode == CEED_EVAL_GRAD)
-        useCollograd = useCollograd && basis_data->d_collograd1d; 
+      useCollograd = useCollograd && basis_data->d_collograd1d; 
     }
   }
   data->dim = dim;

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -786,8 +786,11 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
 
   // Find dim and Q1d
   bool useCollograd = true;
+  data->maxP1d = 0;
   for (CeedInt i = 0; i < numinputfields; i++) {
     ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+    if (P1d>data->maxP1d) data->maxP1d = P1d;
     if (basis != CEED_BASIS_COLLOCATED) {
       ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
       ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -718,8 +718,7 @@ inline __device__ void gradColloTranspose3d(BackendData& data, const CeedInt q, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight1d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  if (data.tidx < Q1d)
-    *w = qweight1d[data.tidx];
+  *w = (data.tidx < Q1d) ? qweight1d[data.tidx] 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -727,8 +726,8 @@ inline __device__ void weight1d(BackendData& data, const CeedScalar *qweight1d, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight2d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  if (data.tidx < Q1d && data.tidy < Q1d)
-    *w = qweight1d[data.tidx]*qweight1d[data.tidy];
+  *w = (data.tidx < Q1d && data.tidy < Q1d) ?
+        qweight1d[data.tidx]*qweight1d[data.tidy] : 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -736,11 +735,10 @@ inline __device__ void weight2d(BackendData& data, const CeedScalar *qweight1d, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight3d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  if (data.tidx < Q1d && data.tidy < Q1d) {
-    const CeedScalar pw = qweight1d[data.tidx]*qweight1d[data.tidy];
-    for (CeedInt z = 0; z < Q1d; ++z)
-      w[z] = pw*qweight1d[z];
-  }
+  const bool quad = (data.tidx < Q1d && data.tidy < Q1d);
+  const CeedScalar pw = quad ? qweight1d[data.tidx]*qweight1d[data.tidy] : 0.0;
+  for (CeedInt z = 0; z < Q1d; ++z)
+    w[z] = quad ? pw*qweight1d[z] : 0.0;
 }
 
 );

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -718,7 +718,7 @@ inline __device__ void gradColloTranspose3d(BackendData& data, const CeedInt q, 
 //------------------------------------------------------------------------------
 template <int Q1d>
 inline __device__ void weight1d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
-  *w = (data.tidx < Q1d) ? qweight1d[data.tidx] 0.0;
+  *w = (data.tidx < Q1d) ? qweight1d[data.tidx] : 0.0;
 }
 
 //------------------------------------------------------------------------------

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -115,26 +115,30 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
                    };
   const CeedInt dim = data->dim;
   const CeedInt Q1d = data->Q1d;
+  const CeedInt P1d = data->maxP1d;
   if (dim==1) {
     const CeedInt elemsPerBlock = 32;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
+    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
     CeedInt sharedMem = elemsPerBlock*Q1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, Q1d, 1, elemsPerBlock,
+    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, 1, elemsPerBlock,
                                       sharedMem, opargs);
   } else if (dim==2) {
     const CeedInt elemsPerBlock = Q1d<4? 16 : 2;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
+    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
     CeedInt sharedMem = elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, Q1d, Q1d,
+    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, thread1d,
                                       elemsPerBlock, sharedMem, opargs);
   } else if (dim==3) {
     const CeedInt elemsPerBlock = Q1d<6? 4 : (Q1d<8? 2 : 1);
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
+    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
     CeedInt sharedMem = elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, Q1d, Q1d,
+    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, thread1d,
                                       elemsPerBlock, sharedMem, opargs);
   }
   CeedChk(ierr);

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -116,7 +116,7 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
   const CeedInt dim = data->dim;
   const CeedInt Q1d = data->Q1d;
   const CeedInt P1d = data->maxP1d;
-  const CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
+  const CeedInt thread1d = CeedIntMax(Q1d, P1d);
   if (dim==1) {
     const CeedInt elemsPerBlock = 32;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -116,28 +116,26 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
   const CeedInt dim = data->dim;
   const CeedInt Q1d = data->Q1d;
   const CeedInt P1d = data->maxP1d;
+  const CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
   if (dim==1) {
     const CeedInt elemsPerBlock = 32;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
-    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-    CeedInt sharedMem = elemsPerBlock*Q1d*sizeof(CeedScalar);
+    CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
     ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, 1, elemsPerBlock,
                                       sharedMem, opargs);
   } else if (dim==2) {
-    const CeedInt elemsPerBlock = Q1d<4? 16 : 2;
+    const CeedInt elemsPerBlock = thread1d<4? 16 : 2;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
-    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-    CeedInt sharedMem = elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
+    CeedInt sharedMem = elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
     ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, thread1d,
                                       elemsPerBlock, sharedMem, opargs);
   } else if (dim==3) {
-    const CeedInt elemsPerBlock = Q1d<6? 4 : (Q1d<8? 2 : 1);
+    const CeedInt elemsPerBlock = thread1d<6? 4 : (thread1d<8? 2 : 1);
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
-    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-    CeedInt sharedMem = elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
+    CeedInt sharedMem = elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
     ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, thread1d,
                                       elemsPerBlock, sharedMem, opargs);
   }

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -122,8 +122,8 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );
     CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, 1, elemsPerBlock,
-                                      sharedMem, opargs);
+    ierr = CeedRunKernelDimSharedCuda(ceed, data->op, grid, thread1d, 1,
+                                      elemsPerBlock, sharedMem, opargs);
   } else if (dim==2) {
     const CeedInt elemsPerBlock = thread1d<4? 16 : 2;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)

--- a/backends/cuda-gen/ceed-cuda-gen.h
+++ b/backends/cuda-gen/ceed-cuda-gen.h
@@ -25,6 +25,7 @@ typedef struct { CeedInt *in[16]; CeedInt *out[16]; } CudaFieldsInt;
 typedef struct {
   CeedInt dim;
   CeedInt Q1d;
+  CeedInt maxP1d;
   CUmodule module;
   CUfunction op;
   CudaFieldsInt indices;

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -26,7 +26,7 @@ static const char *kernelsShared = QUOTE(
 // Sum input into output
 //------------------------------------------------------------------------------
 inline __device__ void add(CeedScalar *r_V, const CeedScalar *r_U) {
-  for (int i = 0; i < Q1D; i++)
+  for (int i = 0; i < P1D; i++)
     r_V[i] += r_U[i];
 }
 

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -799,7 +799,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     CeedInt P1d, Q1d;
     ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
-    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
+    CeedInt thread1d = CeedIntMax(Q1d, P1d);
     ierr = CeedCudaInitInterp(data->d_interp1d, P1d, Q1d, &data->c_B);
     CeedChk(ierr);
     void *interpargs[] = {(void *) &nelem, (void *) &transpose, &data->c_B,
@@ -837,7 +837,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     CeedInt P1d, Q1d;
     ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
-    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
+    CeedInt thread1d = CeedIntMax(Q1d, P1d);
     ierr = CeedCudaInitInterpGrad(data->d_interp1d, data->d_grad1d, P1d,
                                   Q1d, &data->c_B, &data->c_G);
     CeedChk(ierr);
@@ -992,7 +992,7 @@ int CeedBasisCreateTensorH1_Cuda_shared(CeedInt dim, CeedInt P1d, CeedInt Q1d,
   ierr = CeedCompileCuda(ceed, kernelsShared, &data->module, 8,
                          "Q1D", Q1d,
                          "P1D", P1d,
-                         "T1D", Q1d>P1d?Q1d:P1d,
+                         "T1D", CeedIntMax(Q1d, P1d),
                          "BASIS_BUF_LEN", ncomp * CeedIntPow(Q1d > P1d ?
                              Q1d : P1d, dim),
                          "BASIS_DIM", dim,

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -775,6 +775,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     CeedInt P1d, Q1d;
     ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
     ierr = CeedCudaInitInterp(data->d_interp1d, P1d, Q1d, &data->c_B);
     CeedChk(ierr);
     void *interpargs[] = {(void *) &nelem, (void *) &transpose, &data->c_B,
@@ -784,7 +785,6 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt elemsPerBlock = 32;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
       CeedInt sharedMem = elemsPerBlock*Q1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->interp, grid, thread1d, 1,
                                         elemsPerBlock, sharedMem,
@@ -792,7 +792,6 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
       // elemsPerBlock must be at least 1
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
       CeedInt elemsPerBlock = CeedIntMax(thread1d < 7 ? optElems[thread1d]/ncomp : 1, 1);
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
@@ -804,7 +803,6 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt elemsPerBlock = 1;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
       CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->interp, grid, thread1d, thread1d,
                                         ncomp*elemsPerBlock, sharedMem,
@@ -815,6 +813,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     CeedInt P1d, Q1d;
     ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+    CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
     ierr = CeedCudaInitInterpGrad(data->d_interp1d, data->d_grad1d, P1d,
                                   Q1d, &data->c_B, &data->c_G);
     CeedChk(ierr);
@@ -825,7 +824,6 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt elemsPerBlock = 32;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
       CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->grad, grid, thread1d, 1,
                                         elemsPerBlock, sharedMem, gradargs);
@@ -833,7 +831,6 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
       // elemsPerBlock must be at least 1
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
       CeedInt elemsPerBlock = CeedIntMax(thread1d < 7 ? optElems[thread1d]/ncomp : 1, 1);
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
@@ -845,7 +842,6 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt elemsPerBlock = 1;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
       CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->grad, grid, thread1d, thread1d,
                                         ncomp*elemsPerBlock, sharedMem,

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -26,10 +26,8 @@ static const char *kernelsShared = QUOTE(
 // Sum input into output
 //------------------------------------------------------------------------------
 inline __device__ void add(CeedScalar *r_V, const CeedScalar *r_U) {
-  if (tidx < P1D && tidy < P1D) {
-    for (int i = 0; i < Q1D; i++)
-      r_V[i] += r_U[i];
-  }
+  for (int i = 0; i < Q1D; i++)
+    r_V[i] += r_U[i];
 }
 
 //------------------------------------------------------------------------------

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -42,9 +42,9 @@ inline __device__ void readDofs1d(const int elem, const int tidx,
                                   const int nelem, const CeedScalar *d_U,
                                   CeedScalar *slice) {
   for (int i = 0; i < P1D; i++)
-    slice[i + tidz*Q1D] = d_U[i + elem*P1D + comp*P1D*nelem];
+    slice[i + tidz*T1D] = d_U[i + elem*P1D + comp*P1D*nelem];
   for (int i = P1D; i < Q1D; i++)
-    slice[i + tidz*Q1D] = 0.0;
+    slice[i + tidz*T1D] = 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -66,10 +66,10 @@ inline __device__ void readQuads1d(const int elem, const int tidx,
                                    const int dim, const int nelem,
                                    const CeedScalar *d_U, CeedScalar *slice) {
   for (int i = 0; i < Q1D; i++)
-    slice[i + tidz*Q1D] = d_U[i + elem*Q1D + comp*Q1D*nelem +
+    slice[i + tidz*T1D] = d_U[i + elem*Q1D + comp*Q1D*nelem +
                             dim*BASIS_NCOMP*nelem*Q1D];
   for (int i = Q1D; i < P1D; i++)
-    slice[i + tidz*Q1D] = 0.0;
+    slice[i + tidz*T1D] = 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ inline __device__ void ContractX1d(CeedScalar *slice, const int tidx,
                                    CeedScalar &V) {
   V = 0.0;
   for (int i = 0; i < P1D; ++i)
-    V += B[i + tidx*P1D] * slice[i + tidz*Q1D]; // Contract x direction
+    V += B[i + tidx*P1D] * slice[i + tidz*T1D]; // Contract x direction
 }
 
 //------------------------------------------------------------------------------
@@ -103,7 +103,7 @@ inline __device__ void ContractTransposeX1d(CeedScalar *slice, const int tidx,
     const CeedScalar &U, const CeedScalar *B, CeedScalar &V) {
   V = 0.0;
   for (int i = 0; i < Q1D; ++i)
-    V += B[tidx + i*P1D] * slice[i + tidz*Q1D]; // Contract x direction
+    V += B[tidx + i*P1D] * slice[i + tidz*T1D]; // Contract x direction
 }
 
 //------------------------------------------------------------------------------
@@ -243,12 +243,12 @@ inline __device__ void ContractX2d(CeedScalar *slice, const int tidx,
                                    const int tidy, const int tidz,
                                    const CeedScalar &U, const CeedScalar *B,
                                    CeedScalar &V) {
-  slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U;
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
   __syncthreads();
   V = 0.0;
   if (tidx < Q1D)
     for (int i = 0; i < P1D; ++i)
-      V += B[i + tidx*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
+      V += B[i + tidx*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
   __syncthreads();
 }
 
@@ -259,12 +259,12 @@ inline __device__ void ContractY2d(CeedScalar *slice, const int tidx,
                                    const int tidy, const int tidz,
                                    const CeedScalar &U, const CeedScalar *B,
                                    CeedScalar &V) {
-  slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U;
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
   __syncthreads();
   V = 0.0;
   if (tidy < Q1D)
     for (int i = 0; i < P1D; ++i)
-      V += B[i + tidy*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
+      V += B[i + tidy*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
   __syncthreads();
 }
 
@@ -274,12 +274,12 @@ inline __device__ void ContractY2d(CeedScalar *slice, const int tidx,
 inline __device__ void ContractTransposeY2d(CeedScalar *slice, const int tidx,
     const int tidy, const int tidz,
     const CeedScalar &U, const CeedScalar *B, CeedScalar &V) {
-  slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U;
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
   __syncthreads();
   V = 0.0;
   if (tidy < P1D)
     for (int i = 0; i < Q1D; ++i)
-      V += B[tidy + i*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
+      V += B[tidy + i*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
   __syncthreads();
 }
 
@@ -289,12 +289,12 @@ inline __device__ void ContractTransposeY2d(CeedScalar *slice, const int tidx,
 inline __device__ void ContractTransposeX2d(CeedScalar *slice, const int tidx,
     const int tidy, const int tidz,
     const CeedScalar &U, const CeedScalar *B, CeedScalar &V) {
-  slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U;
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
   __syncthreads();
   V = 0.0;
   if (tidx < P1D)
     for (int i = 0; i < Q1D; ++i)
-      V += B[tidx + i*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
+      V += B[tidx + i*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
   __syncthreads();
 }
 
@@ -465,12 +465,12 @@ inline __device__ void ContractX3d(CeedScalar *slice, const int tidx,
                                    const CeedScalar *U, const CeedScalar *B,
                                    CeedScalar *V) {
   for (int k = 0; k < P1D; ++k) {
-    slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U[k];
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
     if (tidx < Q1D)
       for (int i = 0; i < P1D; ++i)
-        V[k] += B[i + tidx*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
+        V[k] += B[i + tidx*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
     __syncthreads();
   }
 }
@@ -483,12 +483,12 @@ inline __device__ void ContractY3d(CeedScalar *slice, const int tidx,
                                    const CeedScalar *U, const CeedScalar *B,
                                    CeedScalar *V) {
   for (int k = 0; k < P1D; ++k) {
-    slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U[k];
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
     if (tidy < Q1D)
       for (int i = 0; i < P1D; ++i)
-        V[k] += B[i + tidy*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
+        V[k] += B[i + tidy*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
     __syncthreads();
   }
 }
@@ -529,12 +529,12 @@ inline __device__ void ContractTransposeY3d(CeedScalar *slice, const int tidx,
     const int tidy, const int tidz,
     const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
   for (int k = 0; k < P1D; ++k) {
-    slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U[k];
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
     if (tidy < P1D)
       for (int i = 0; i < Q1D; ++i)
-        V[k] += B[tidy + i*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
+        V[k] += B[tidy + i*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
     __syncthreads();
   }
 }
@@ -546,12 +546,12 @@ inline __device__ void ContractTransposeX3d(CeedScalar *slice, const int tidx,
     const int tidy, const int tidz,
     const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
   for (int k = 0; k < P1D; ++k) {
-    slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U[k];
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
     if (tidx < P1D)
       for (int i = 0; i < Q1D; ++i)
-        V[k] += B[tidx + i*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
+        V[k] += B[tidx + i*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
     __syncthreads();
   }
 }
@@ -790,7 +790,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt elemsPerBlock = 32;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt sharedMem = elemsPerBlock*Q1d*sizeof(CeedScalar);
+      CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->interp, grid, thread1d, 1,
                                         elemsPerBlock, sharedMem,
                                         interpargs); CeedChk(ierr);
@@ -970,9 +970,10 @@ int CeedBasisCreateTensorH1_Cuda_shared(CeedInt dim, CeedInt P1d, CeedInt Q1d,
   // Compile basis kernels
   CeedInt ncomp;
   ierr = CeedBasisGetNumComponents(basis, &ncomp); CeedChk(ierr);
-  ierr = CeedCompileCuda(ceed, kernelsShared, &data->module, 7,
+  ierr = CeedCompileCuda(ceed, kernelsShared, &data->module, 8,
                          "Q1D", Q1d,
                          "P1D", P1d,
+                         "T1D", Q1d>P1d?Q1d:P1d,
                          "BASIS_BUF_LEN", ncomp * CeedIntPow(Q1d > P1d ?
                              Q1d : P1d, dim),
                          "BASIS_DIM", dim,

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -506,7 +506,7 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
     for (int i = 0; i < P1D; ++i)
       V[k] += B[i + k*P1D] * U[i]; // Contract z direction
   }
-  for (int Q1D = 0; k < P1D; ++k)
+  for (int k = Q1D; k < P1D; ++k)
     V[k] = 0.0;
 }
 

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -501,13 +501,15 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
                                    const int tidy, const int tidz,
                                    const CeedScalar *U, const CeedScalar *B,
                                    CeedScalar *V) {
-  for (int k = 0; k < Q1D; ++k) {
-    V[k] = 0.0;
-    for (int i = 0; i < P1D; ++i)
-      V[k] += B[i + k*P1D] * U[i]; // Contract z direction
+  if (tidx < Q1D && tidy <Q1D) {
+    for (int k = 0; k < Q1D; ++k) {
+      V[k] = 0.0;
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + k*P1D] * U[i]; // Contract z direction
+    }
+    for (int k = Q1D; k < P1D; ++k)
+      V[k] = 0.0;
   }
-  for (int k = Q1D; k < P1D; ++k)
-    V[k] = 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -516,13 +518,15 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
 inline __device__ void ContractTransposeZ3d(CeedScalar *slice, const int tidx,
     const int tidy, const int tidz,
     const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  for (int k = 0; k < P1D; ++k) {
-    V[k] = 0.0;
-    for (int i = 0; i < Q1D; ++i)
-      V[k] += B[k + i*P1D] * U[i]; // Contract z direction
+  if (tidx < Q1D && tidy <Q1D) {
+    for (int k = 0; k < P1D; ++k) {
+      V[k] = 0.0;
+      for (int i = 0; i < Q1D; ++i)
+        V[k] += B[k + i*P1D] * U[i]; // Contract z direction
+    }
+    for (int k = P1D; k < Q1D; ++k)
+      V[k] = 0.0;
   }
-  for (int k = P1D; k < Q1D; ++k)
-    V[k] = 0.0;
 }
 
 //------------------------------------------------------------------------------

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -489,7 +489,7 @@ inline __device__ void ContractY3d(CeedScalar *slice, const int tidx,
     slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    if (tidy < Q1D)
+    if (tidx < Q1D && tidy < Q1D)
       for (int i = 0; i < P1D; ++i)
         V[k] += B[i + tidy*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
     __syncthreads();
@@ -506,8 +506,9 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
                                    CeedScalar *V) {
   for (int k = 0; k < Q1D; ++k) {
     V[k] = 0.0;
-    for (int i = 0; i < P1D; ++i)
-      V[k] += B[i + k*P1D] * U[i]; // Contract z direction
+    if (tidx < Q1D && tidy < Q1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + k*P1D] * U[i]; // Contract z direction
   }
   for (int k = Q1D; k < P1D; ++k)
     V[k] = 0.0;
@@ -523,8 +524,9 @@ inline __device__ void ContractTransposeZ3d(CeedScalar *slice, const int tidx,
                                             CeedScalar *V) {
   for (int k = 0; k < P1D; ++k) {
     V[k] = 0.0;
-    for (int i = 0; i < Q1D; ++i)
-      V[k] += B[k + i*P1D] * U[i]; // Contract z direction
+    if (tidx < Q1D && tidy < Q1D)
+      for (int i = 0; i < Q1D; ++i)
+        V[k] += B[k + i*P1D] * U[i]; // Contract z direction
   }
   for (int k = P1D; k < Q1D; ++k)
     V[k] = 0.0;
@@ -542,7 +544,7 @@ inline __device__ void ContractTransposeY3d(CeedScalar *slice, const int tidx,
     slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    if (tidy < P1D)
+    if (tidx < Q1D && tidy < P1D)
       for (int i = 0; i < Q1D; ++i)
         V[k] += B[tidy + i*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
     __syncthreads();
@@ -561,7 +563,7 @@ inline __device__ void ContractTransposeX3d(CeedScalar *slice, const int tidx,
     slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    if (tidx < P1D)
+    if (tidx < P1D && tidy < P1D)
       for (int i = 0; i < Q1D; ++i)
         V[k] += B[tidx + i*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
     __syncthreads();

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -816,7 +816,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
       // elemsPerBlock must be at least 1
-      CeedInt elemsPerBlock = CeedIntMax(thread1d < 7 ? optElems[thread1d]/ncomp : 1, 1);
+      CeedInt elemsPerBlock = CeedIntMax(thread1d<7?optElems[thread1d]/ncomp:1, 1);
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
@@ -855,7 +855,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
       // elemsPerBlock must be at least 1
-      CeedInt elemsPerBlock = CeedIntMax(thread1d < 7 ? optElems[thread1d]/ncomp : 1, 1);
+      CeedInt elemsPerBlock = CeedIntMax(thread1d<7?optElems[thread1d]/ncomp:1, 1);
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -246,8 +246,9 @@ inline __device__ void ContractX2d(CeedScalar *slice, const int tidx,
   slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U;
   __syncthreads();
   V = 0.0;
-  for (int i = 0; i < P1D; ++i)
-    V += B[i + tidx*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
+  if (tidx < Q1D)
+    for (int i = 0; i < P1D; ++i)
+      V += B[i + tidx*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
   __syncthreads();
 }
 
@@ -261,8 +262,9 @@ inline __device__ void ContractY2d(CeedScalar *slice, const int tidx,
   slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U;
   __syncthreads();
   V = 0.0;
-  for (int i = 0; i < P1D; ++i)
-    V += B[i + tidy*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
+  if (tidy < Q1D)
+    for (int i = 0; i < P1D; ++i)
+      V += B[i + tidy*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
   __syncthreads();
 }
 
@@ -466,8 +468,9 @@ inline __device__ void ContractX3d(CeedScalar *slice, const int tidx,
     slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    for (int i = 0; i < P1D; ++i)
-      V[k] += B[i + tidx*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
+    if (tidx < Q1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + tidx*P1D] * slice[i + tidy*Q1D + tidz*Q1D*Q1D]; // Contract x direction
     __syncthreads();
   }
 }
@@ -483,8 +486,9 @@ inline __device__ void ContractY3d(CeedScalar *slice, const int tidx,
     slice[tidx + tidy*Q1D + tidz*Q1D*Q1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    for (int i = 0; i < P1D; ++i)
-      V[k] += B[i + tidy*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
+    if (tidy < Q1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + tidy*P1D] * slice[tidx + i*Q1D + tidz*Q1D*Q1D]; // Contract y direction
     __syncthreads();
   }
 }
@@ -498,8 +502,9 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
                                    CeedScalar *V) {
   for (int k = 0; k < Q1D; ++k) {
     V[k] = 0.0;
-    for (int i = 0; i < P1D; ++i)
-      V[k] += B[i + k*P1D] * U[i]; // Contract z direction
+    if (k < Q1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + k*P1D] * U[i]; // Contract z direction
   }
 }
 

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -503,10 +503,11 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
                                    CeedScalar *V) {
   for (int k = 0; k < Q1D; ++k) {
     V[k] = 0.0;
-    if (k < Q1D)
-      for (int i = 0; i < P1D; ++i)
-        V[k] += B[i + k*P1D] * U[i]; // Contract z direction
+    for (int i = 0; i < P1D; ++i)
+      V[k] += B[i + k*P1D] * U[i]; // Contract z direction
   }
+  for (int Q1D = 0; k < P1D; ++k)
+    V[k] = 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -515,12 +516,13 @@ inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
 inline __device__ void ContractTransposeZ3d(CeedScalar *slice, const int tidx,
     const int tidy, const int tidz,
     const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
-  for (int k = 0; k < Q1D; ++k) {
+  for (int k = 0; k < P1D; ++k) {
     V[k] = 0.0;
-    if (k < P1D)
-      for (int i = 0; i < Q1D; ++i)
-        V[k] += B[k + i*P1D] * U[i]; // Contract z direction
+    for (int i = 0; i < Q1D; ++i)
+      V[k] += B[k + i*P1D] * U[i]; // Contract z direction
   }
+  for (int k = P1D; k < Q1D; ++k)
+    V[k] = 0.0;
 }
 
 //------------------------------------------------------------------------------
@@ -565,8 +567,8 @@ inline __device__ void interp3d(const CeedInt nelem, const int transpose,
                                 const CeedScalar *__restrict__ d_U,
                                 CeedScalar *__restrict__ d_V,
                                 CeedScalar *slice) {
-  CeedScalar r_V[Q1D];
-  CeedScalar r_t[Q1D];
+  CeedScalar r_V[T1D];
+  CeedScalar r_t[T1D];
 
   const int tidx = threadIdx.x;
   const int tidy = threadIdx.y;
@@ -577,7 +579,7 @@ inline __device__ void interp3d(const CeedInt nelem, const int transpose,
 
   for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
        elem += gridDim.x*elemsPerBlock) {
-    for (int i = 0; i < Q1D; ++i) {
+    for (int i = 0; i < T1D; ++i) {
       r_V[i] = 0.0;
       r_t[i] = 0.0;
     }
@@ -606,9 +608,9 @@ inline __device__ void grad3d(const CeedInt nelem, const int transpose,
                               CeedScalar *__restrict__ d_V,
                               CeedScalar *slice) {
   // Use P1D for one of these
-  CeedScalar r_U[Q1D];
-  CeedScalar r_V[Q1D];
-  CeedScalar r_t[Q1D];
+  CeedScalar r_U[T1D];
+  CeedScalar r_V[T1D];
+  CeedScalar r_t[T1D];
 
   const int tidx = threadIdx.x;
   const int tidy = threadIdx.y;

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -792,11 +792,11 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
       // elemsPerBlock must be at least 1
-      CeedInt elemsPerBlock = CeedIntMax(Q1d < 7 ? optElems[Q1d]/ncomp : 1, 1);
+      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
+      CeedInt elemsPerBlock = CeedIntMax(thread1d < 7 ? optElems[thread1d]/ncomp : 1, 1);
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-      CeedInt sharedMem = ncomp*elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->interp, grid, thread1d, thread1d,
                                         ncomp*elemsPerBlock, sharedMem,
                                         interpargs); CeedChk(ierr);
@@ -805,7 +805,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-      CeedInt sharedMem = ncomp*elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->interp, grid, thread1d, thread1d,
                                         ncomp*elemsPerBlock, sharedMem,
                                         interpargs); CeedChk(ierr);
@@ -826,18 +826,18 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-      CeedInt sharedMem = elemsPerBlock*Q1d*sizeof(CeedScalar);
+      CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->grad, grid, thread1d, 1,
                                         elemsPerBlock, sharedMem, gradargs);
       CeedChk(ierr);
     } else if (dim == 2) {
       const CeedInt optElems[7] = {0,32,8,6,4,2,8};
       // elemsPerBlock must be at least 1
-      CeedInt elemsPerBlock = CeedIntMax(Q1d < 7 ? optElems[Q1d]/ncomp : 1, 1);
+      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
+      CeedInt elemsPerBlock = CeedIntMax(thread1d < 7 ? optElems[thread1d]/ncomp : 1, 1);
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
-      CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-      CeedInt sharedMem = ncomp*elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->grad, grid, thread1d, thread1d,
                                         ncomp*elemsPerBlock, sharedMem,
                                         gradargs); CeedChk(ierr);
@@ -846,7 +846,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
       CeedInt thread1d = Q1d > P1d ? Q1d : P1d;
-      CeedInt sharedMem = ncomp*elemsPerBlock*Q1d*Q1d*sizeof(CeedScalar);
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
       ierr = CeedRunKernelDimSharedCuda(ceed, data->grad, grid, thread1d, thread1d,
                                         ncomp*elemsPerBlock, sharedMem,
                                         gradargs); CeedChk(ierr);

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -437,8 +437,9 @@ inline __device__ void readQuads3d(const int elem, const int tidx,
                                    const int dim, const int nelem,
                                    const CeedScalar *d_U, CeedScalar *r_U) {
   for (int i = 0; i < Q1D; i++)
-    r_U[i] = d_U[tidx + tidy*Q1D + i*Q1D*Q1D + elem*Q1D*Q1D*Q1D +
-                 comp*Q1D*Q1D*Q1D*nelem + dim*BASIS_NCOMP*nelem*Q1D*Q1D*Q1D];
+    r_U[i] = (tidx < Q1D && tidy < Q1D) ? 
+              d_U[tidx + tidy*Q1D + i*Q1D*Q1D + elem*Q1D*Q1D*Q1D +
+              comp*Q1D*Q1D*Q1D*nelem + dim*BASIS_NCOMP*nelem*Q1D*Q1D*Q1D] : 0.0;
   for (int i = Q1D; i < P1D; i++)
     r_U[i] = 0.0;
 }

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -470,7 +470,7 @@ inline __device__ void ContractX3d(CeedScalar *slice, const int tidx,
     slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
-    if (tidx < Q1D)
+    if (tidx < Q1D && tidy < P1D)
       for (int i = 0; i < P1D; ++i)
         V[k] += B[i + tidx*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
     __syncthreads();

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -622,6 +622,11 @@ inline __device__ void grad3d(const CeedInt nelem, const int transpose,
 
   for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
        elem += gridDim.x*elemsPerBlock) {
+    for (int i = 0; i < T1D; ++i) {
+      r_U[i] = 0.0;
+      r_V[i] = 0.0;
+      r_t[i] = 0.0;
+    }
     if (!transpose) {
       readDofs3d(elem, tidx, tidy, comp, nelem, d_U, r_U);
       ContractX3d(slice, tidx, tidy, tidz, r_U, c_G, r_V);


### PR DESCRIPTION
Allows to use quadrature rules with less quadrature points than degrees of freedom with the `cuda-shared` and `cuda-gen` backends.