### PR TITLE
Make - add cpp files to code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ FFLAGS ?= $(OPT) $(FFLAGS.$(FC_VENDOR))
 
 ifeq ($(COVERAGE), 1)
   CFLAGS += --coverage
+  CXXFLAGS += --coverage
   LDFLAGS += --coverage
 endif
 


### PR DESCRIPTION
This might fix the fact that OCCA is missing from CodeCov.

Closes #611