### PR TITLE
change HIP blocksize

### DIFF
--- a/backends/hip/ceed-hip-restriction.c
+++ b/backends/hip/ceed-hip-restriction.c
@@ -148,14 +148,14 @@ static int CeedElemRestrictionApply_Hip(CeedElemRestriction r,
       // -- Offsets provided
       kernel = impl->noTrOffset;
       void *args[] = {&nelem, &impl->d_ind, &d_u, &d_v};
-      CeedInt blocksize = elemsize<1024?(elemsize>64?elemsize:64):1024;
+      CeedInt blocksize = elemsize<256?(elemsize>64?elemsize:64):256;
       ierr = CeedRunKernelHip(ceed, kernel, CeedDivUpInt(nnodes, blocksize),
                               blocksize, args); CeedChk(ierr);
     } else {
       // -- Strided restriction
       kernel = impl->noTrStrided;
       void *args[] = {&nelem, &d_u, &d_v};
-      CeedInt blocksize = elemsize<1024?(elemsize>64?elemsize:64):1024;
+      CeedInt blocksize = elemsize<256?(elemsize>64?elemsize:64):256;
       ierr = CeedRunKernelHip(ceed, kernel, CeedDivUpInt(nnodes, blocksize),
                               blocksize, args); CeedChk(ierr);
     }

--- a/backends/hip/ceed-hip.c
+++ b/backends/hip/ceed-hip.c
@@ -47,7 +47,7 @@ int CeedHipInit(Ceed ceed, const char *resource, int nrc) {
   Ceed_Hip *data;
   ierr = CeedGetData(ceed, &data); CeedChk(ierr);
   data->deviceId = deviceID;
-  data->optblocksize = deviceProp.maxThreadsPerBlock;
+  data->optblocksize = 256;
   return 0;
 }
 


### PR DESCRIPTION
This PR changes the HIP `optblocksize` (and max block size used for restrictions) to 256.  

Closes #642. 