### PR TITLE
gitlab - temporarily drop MAGMA ci until new hipMAGMA ready on Noether

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ noether-rocm:
     - rocm
   image: jedbrown/rocm:latest
   script:
-    - export COVERAGE=1 CC=gcc CXX=gcc FC=gfortran MAGMA_DIR=/projects/magma-hip
+    - export COVERAGE=1 CC=gcc CXX=gcc FC=gfortran # MAGMA_DIR=/projects/magma-hip
     - make info
     - make -j$(nproc)
     - echo '[{"subject":"/","metrics":[{"name":"Transfer Size (KB)","value":"19.5","desiredSize":"smaller"},{"name":"Speed Index","value":0,"desiredSize":"smaller"},{"name":"Total Score","value":92,"desiredSize":"larger"},{"name":"Requests","value":4,"desiredSize":"smaller"}]}]' > performance.json


### PR DESCRIPTION
This will let us test and merge #632 and #647