### PR TITLE
Julia: add [compat] entries for Julia dependencies

### DIFF
--- a/julia/LibCEED.jl/Project.toml
+++ b/julia/LibCEED.jl/Project.toml
@@ -18,3 +18,12 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
+
+[compat]
+julia = "1.5"
+CEnum = "0.4"
+Cassette = "0.3"
+Requires = "1"
+StaticArrays = "0.12"
+UnsafeArrays = "1"
+libCEED_jll = "0.7"


### PR DESCRIPTION
Add version compatibility bounds to the Julia interface `Project.toml` file.
This should address [this issue](https://github.com/JuliaRegistries/General/pull/24011#issuecomment-720134600) and allow the package to be registered.