### PR TITLE
Add the C++11 flag to the XL C++ flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ CFLAGS.XL               := -qpic -MMD
 CXXFLAGS.gcc            := -fPIC -std=c++11 -Wall -Wextra -Wno-unused-parameter -MMD -MP
 CXXFLAGS.clang          := $(CXXFLAGS.gcc)
 CXXFLAGS.icc            := $(CXXFLAGS.gcc)
-CXXFLAGS.XL             := -qpic -MMD
+CXXFLAGS.XL             := -qpic -std=c++11 -MMD
 FFLAGS.GNU              := -fPIC -cpp -Wall -Wextra -Wno-unused-parameter -Wno-unused-dummy-argument -MMD -MP
 FFLAGS.ifort            := -fPIC -cpp
 FFLAGS.XL               := -qpic -ffree-form -qpreprocess -qextname -MMD


### PR DESCRIPTION
Noticed this on Lassen when building libCEED with OCCA.