### PR TITLE
Python - drop class variables

### DIFF
--- a/python/ceed.py
+++ b/python/ceed.py
@@ -33,8 +33,6 @@ from .ceed_constants import *
 
 class Ceed():
     """Ceed: core components."""
-    # Attributes
-    _pointer = ffi.NULL
 
     # Constructor
     def __init__(self, resource="/cpu/self", on_error="store"):

--- a/python/ceed_basis.py
+++ b/python/ceed_basis.py
@@ -26,10 +26,6 @@ from .ceed_constants import TRANSPOSE, NOTRANSPOSE
 class Basis(ABC):
     """Ceed Basis: finite element basis objects."""
 
-    # Attributes
-    _ceed = None
-    _pointer = ffi.NULL
-
     # Representation
     def __repr__(self):
         return "<CeedBasis instance at " + hex(id(self)) + ">"

--- a/python/ceed_elemrestriction.py
+++ b/python/ceed_elemrestriction.py
@@ -27,11 +27,6 @@ from .ceed_vector import _VectorWrap
 class _ElemRestrictionBase(ABC):
     """Ceed ElemRestriction: restriction from local vectors to elements."""
 
-    # Attributes
-    _ceed = None
-    _pointer = ffi.NULL
-    _array_reference = None
-
     # Destructor
     def __del__(self):
         # libCEED call

--- a/python/ceed_operator.py
+++ b/python/ceed_operator.py
@@ -25,10 +25,6 @@ from .ceed_constants import REQUEST_IMMEDIATE, REQUEST_ORDERED, NOTRANSPOSE
 class _OperatorBase(ABC):
     """Ceed Operator: composed FE-type operations on vectors."""
 
-    # Attributes
-    _ceed = None
-    _pointer = ffi.NULL
-
     # Destructor
     def __del__(self):
         # libCEED call

--- a/python/ceed_qfunction.py
+++ b/python/ceed_qfunction.py
@@ -26,10 +26,6 @@ class _QFunctionBase(ABC):
     """Ceed QFunction: point-wise operation at quadrature points for evaluating
          volumetric terms."""
 
-    # Attributes
-    _ceed = None
-    _pointer = ffi.NULL
-
     # Destructor
     def __del__(self):
         # libCEED call

--- a/python/ceed_qfunctioncontext.py
+++ b/python/ceed_qfunctioncontext.py
@@ -26,11 +26,6 @@ from .ceed_constants import MEM_HOST, USE_POINTER, COPY_VALUES
 class QFunctionContext():
     """Ceed QFunction Context: stores Ceed QFunction user context data."""
 
-    # Attributes
-    _ceed = None
-    _pointer = ffi.NULL
-    _array_reference = None
-
     # Constructor
     def __init__(self, ceed):
         # CeedQFunctionContext object

--- a/python/ceed_vector.py
+++ b/python/ceed_vector.py
@@ -26,11 +26,6 @@ from .ceed_constants import MEM_HOST, USE_POINTER, COPY_VALUES, NORM_2
 class Vector():
     """Ceed Vector: storing and manipulating vectors."""
 
-    # Attributes
-    _ceed = None
-    _pointer = ffi.NULL
-    _array_reference = None
-
     # Constructor
     def __init__(self, ceed, size):
         # CeedVector object


### PR DESCRIPTION
This PR drops class variables; they are globally shared mutable values used by all instances of the class.