### PR TITLE
Update citing info with user manual

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,6 +10,7 @@ Jean-Sylvain Camier <camier1@llnl.gov>
 Jeremy L. Thompson <jeremy.thompson@colorado.edu>
 Jeremy L. Thompson <jeremy.thompson@colorado.edu>          <25011573+jeremylt@users.noreply.github.com>
 Jeremy L. Thompson <jeremy.thompson@colorado.edu>          <thompson.jeremy.luke@gmail.com>
+Jeremy L. Thompson <jeremy.thompson@colorado.edu>          <jeth8984@noether>
 Thilina Rathnayake <thilinarmtb@gmail.com>              <thilinarmtb@users.noreply.github.com>
 Tzanio Kolev <tzanio@llnl.gov>
 David Medina <dmed256@gmail.com>
@@ -22,4 +23,6 @@ Yohann Dudouit <yohann.dudouit@gmail.com>
 Yohann Dudouit <yohann.dudouit@gmail.com>               <dudouit1@llnl.gov>
 Natalie Beams <nbeams@icl.utk.edu>                      <246972+nbeams@users.noreply.github.com>
 Leila Ghaffari <Leila.Ghaffari@colorado.edu>            <leila@Leilas-MacBook-Pro.local>
+Leila Ghaffari <Leila.Ghaffari@colorado.edu>            <49916147+LeilaGhaffari@users.noreply.github.com>
 Ahmad Abdelfattah <ahmad@icl.utk.edu>                   <36712794+abdelfattah83@users.noreply.github.com>
+James Wright <james@jameswright.xyz>                    <jameswright@jameswright.xyz>

--- a/README.rst
+++ b/README.rst
@@ -429,11 +429,27 @@ How to Cite
 
 If you utilize libCEED please cite::
 
-   @misc{libceed-dev-site,
-     title =  {lib{CEED} development site},
-     url =    {https://github.com/ceed/libceed},
-     howpublished = {\url{https://github.com/ceed/libceed}},
-     year = 2020
+   @misc{libceed-user-manual,
+     author       = {Abdelfattah, Ahmad and
+                     Barra, Valeria and
+                     Beams, Natalie and
+                     Brown, Jed and
+                     Camier, Jean-Sylvain and
+                     Dobrev, Veselin and
+                     Dudouit, Yohann and
+                     Ghaffari, Leila and
+                     Kolev, Tzanio and
+                     Medina, David and
+                     Rathnayake, Thilina and
+                     Thompson, Jeremy L and
+                     Tomov, Stanimire},
+     title        = {libCEED User Manual},
+     month        = sep,
+     year         = 2020,
+     publisher    = {Zenodo},
+     version      = {0.7},
+     doi          = {10.5281/zenodo.4302737},
+     url          = {https://doi.org/10.5281/zenodo.4302737}
    }
 
 For libCEED's Python interface please cite::

--- a/doc/bib/references.bib
+++ b/doc/bib/references.bib
@@ -5,6 +5,29 @@
   year = 2020
 }
 
+@misc{libceed-user-manual,
+  author       = {Abdelfattah, Ahmad and
+                  Barra, Valeria and
+                  Beams, Natalie and
+                  Brown, Jed and
+                  Camier, Jean-Sylvain and
+                  Dobrev, Veselin and
+                  Dudouit, Yohann and
+                  Ghaffari, Leila and
+                  Kolev, Tzanio and
+                  Medina, David and
+                  Rathnayake, Thilina and
+                  Thompson, Jeremy L and
+                  Tomov, Stanimire},
+  title        = {libCEED User Manual},
+  month        = sep,
+  year         = 2020,
+  publisher    = {Zenodo},
+  version      = {0.7},
+  doi          = {10.5281/zenodo.4302737},
+  url          = {https://doi.org/10.5281/zenodo.4302737}
+}
+
 @InProceedings{libceed-paper-proc-scipy-2020,
   author    = {{V}aleria {B}arra and {J}ed {B}rown and {J}eremy {T}hompson and {Y}ohann {D}udouit},
   title     = {{H}igh-performance operator evaluations with ease of use: lib{C}{E}{E}{D}'s {P}ython interface},

--- a/doc/sphinx/source/releasenotes.rst
+++ b/doc/sphinx/source/releasenotes.rst
@@ -26,7 +26,7 @@ Examples
 ^^^^^^^^
 * :ref:`example-petsc-elasticity` example updated with traction boundary conditions.
 
-.. _v0.7
+.. _v0.7:
 
 v0.7 (Sep 29, 2020)
 -------------------


### PR DESCRIPTION
This PR adds the bib file for libCEED's user manual and updates this info on our "How to Cite" section of the README. 

Tentatively, I replaced the dev-site info that was sitting there and does not have a DOI (to avoid the spread of possible citation modes mentioned in our recent conversation). But if this is not desired, I can put that piece back. 

Also while building the docs, I stumbled upon a small linking bug in the `v0.7` section of the release notes and fixed it.