### PR TITLE
Add hip-shared and hip-gen backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,11 @@ OMP_SIMD_FLAG.clang     := $(OMP_SIMD_FLAG.gcc)
 OMP_SIMD_FLAG.icc       := -qopenmp-simd
 OPT.gcc                 := -ffp-contract=fast
 OPT.clang               := $(OPT.gcc)
-CFLAGS.gcc              := -fPIC -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP
+CFLAGS.gcc              := -fPIC -std=c99 -Wall -Wextra -Wno-unused-parameter -MMD -MP
 CFLAGS.clang            := $(CFLAGS.gcc)
 CFLAGS.icc              := $(CFLAGS.gcc)
 CFLAGS.XL               := -qpic -MMD
-CXXFLAGS.gcc            := -fPIC -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP
+CXXFLAGS.gcc            := -fPIC -std=c++11 -Wall -Wextra -Wno-unused-parameter -MMD -MP
 CXXFLAGS.clang          := $(CXXFLAGS.gcc)
 CXXFLAGS.icc            := $(CXXFLAGS.gcc)
 CXXFLAGS.XL             := -qpic -std=c++11 -MMD

--- a/Makefile
+++ b/Makefile
@@ -615,10 +615,10 @@ style : style-c style-py
 CLANG_TIDY ?= clang-tidy
 
 %.c.tidy : %.c
-	$(CLANG_TIDY) $(TIDY_OPTS) $^ -- $(CPPFLAGS) --std=c99 -I$(CUDA_DIR)/include
+	$(CLANG_TIDY) $(TIDY_OPTS) $^ -- $(CPPFLAGS) --std=c99 -I$(CUDA_DIR)/include -I$(HIP_DIR)/include
 
 %.cpp.tidy : %.cpp
-	$(CLANG_TIDY) $(TIDY_OPTS) $^ -- $(CPPFLAGS) --std=c++11 -I$(CUDA_DIR)/include -I$(OCCA_DIR)/include
+	$(CLANG_TIDY) $(TIDY_OPTS) $^ -- $(CPPFLAGS) --std=c++11 -I$(CUDA_DIR)/include -I$(OCCA_DIR)/include -I$(HIP_DIR)/include
 
 tidy_c   : $(libceed.c:%=%.tidy)
 tidy_cpp : $(libceed.cpp:%=%.tidy)

--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,12 @@ OMP_SIMD_FLAG.clang     := $(OMP_SIMD_FLAG.gcc)
 OMP_SIMD_FLAG.icc       := -qopenmp-simd
 OPT.gcc                 := -ffp-contract=fast
 OPT.clang               := $(OPT.gcc)
-CFLAGS.gcc              := -fPIC -std=c99 -Wall -Wextra -Wno-unused-parameter -MMD -MP
-CFLAGS.clang            := $(CFLAGS.gcc) -Wno-unused-function
+CFLAGS.gcc              := -fPIC -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP
+CFLAGS.clang            := $(CFLAGS.gcc)
 CFLAGS.icc              := $(CFLAGS.gcc)
 CFLAGS.XL               := -qpic -MMD
-CXXFLAGS.gcc            := -fPIC -std=c++11 -Wall -Wextra -Wno-unused-parameter -MMD -MP
-CXXFLAGS.clang          := $(CXXFLAGS.gcc) -Wno-unused-function
+CXXFLAGS.gcc            := -fPIC -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP
+CXXFLAGS.clang          := $(CXXFLAGS.gcc)
 CXXFLAGS.icc            := $(CXXFLAGS.gcc)
 CXXFLAGS.XL             := -qpic -std=c++11 -MMD
 FFLAGS.GNU              := -fPIC -cpp -Wall -Wextra -Wno-unused-parameter -Wno-unused-dummy-argument -MMD -MP

--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,10 @@ There are multiple supported backends, which can be selected at runtime in the e
 +----------------------------+---------------------------------------------------+-----------------------+
 | ``/gpu/hip/ref``           | Reference pure HIP kernels                        | Yes                   |
 +----------------------------+---------------------------------------------------+-----------------------+
+| ``/gpu/hip/shared``        | Optimized pure HIP kernels using shared memory    | Yes                   |
++----------------------------+---------------------------------------------------+-----------------------+
+| ``/gpu/hip/gen``           | Optimized pure HIP kernels using code generation  | No                    |
++----------------------------+---------------------------------------------------+-----------------------+
 | MAGMA Backends                                                                                         |
 +----------------------------+---------------------------------------------------+-----------------------+
 | ``/gpu/cuda/magma``        | CUDA MAGMA kernels                                | No                    |
@@ -237,8 +241,8 @@ forced by setting the environment variable ``MKL=1``.
 
 The ``/gpu/cuda/*`` backends provide GPU performance strictly using CUDA.
 
-The ``/gpu/hip/ref`` backend provides GPU performance strictly using HIP.  It is based on
-the ``/gpu/cuda/ref`` backend.  ROCm version 3.5 or newer is required.
+The ``/gpu/hip/*`` backends provide GPU performance strictly using HIP. They are based on
+the ``/gpu/cuda/*`` backends.  ROCm version 3.5 or newer is required.
 
 The ``/gpu/*/magma/*`` backends rely upon the `MAGMA <https://bitbucket.org/icl/magma>`_ package.
 To enable the MAGMA backends, the environment variable ``MAGMA_DIR`` must point to the top-level

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -1,0 +1,1382 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+#define CEED_DEBUG_COLOR 12
+
+#include "ceed-hip-gen.h"
+#include <iostream>
+#include <sstream>
+#include "../hip-shared/ceed-hip-shared.h"
+#include "../hip/ceed-hip-compile.h"
+
+static const char *atomicAdd = QUOTE(
+//------------------------------------------------------------------------------
+// Atomic add, for older CUDA
+//------------------------------------------------------------------------------
+__device__ double atomicAdd(double *address, double val) {
+  unsigned long long int *address_as_ull = (unsigned long long int *)address;
+  unsigned long long int old = *address_as_ull, assumed;
+  do {
+    assumed = old;
+    old =
+      atomicCAS(address_as_ull, assumed,
+                __double_as_longlong(val +
+                                     __longlong_as_double(assumed)));
+    // Note: uses integer comparison to avoid hang in case of NaN
+    // (since NaN != NaN)
+  } while (assumed != old);
+  return __longlong_as_double(old);
+}
+);
+
+static const char *deviceFunctions = QUOTE(
+
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+typedef struct { const CeedScalar* in[16]; CeedScalar* out[16]; } HipFields;
+typedef struct { CeedInt* in[16]; CeedInt* out[16]; } HipFieldsInt;
+
+typedef struct {
+  CeedInt tidx;
+  CeedInt tidy;
+  CeedInt tidz;
+  CeedInt tid;
+  CeedScalar* slice;
+} BackendData;
+
+//------------------------------------------------------------------------------
+// Load matrices for basis actions
+//------------------------------------------------------------------------------
+template <int P, int Q>
+inline __device__ void loadMatrix(BackendData& data, const CeedScalar* d_B, CeedScalar* B) {
+  for (CeedInt i = data.tid; i < P*Q; i += blockDim.x*blockDim.y*blockDim.z)
+    B[i] = d_B[i];
+}
+
+//------------------------------------------------------------------------------
+// 1D
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, offsets provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int P1d>
+inline __device__ void readDofsOffset1d(BackendData& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < P1d) {
+    const CeedInt node = data.tidx;
+    const CeedInt ind = indices[node + elem * P1d];
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readDofsStrided1d(BackendData& data, const CeedInt elem, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < P1d) {
+    const CeedInt node = data.tidx;
+    const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, offsets provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int P1d>
+inline __device__ void writeDofsOffset1d(BackendData& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* r_v, CeedScalar* d_v) {
+  if (data.tidx < P1d) {
+    const CeedInt node = data.tidx;
+    const CeedInt ind = indices[node + elem * P1d];
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      atomicAdd(&d_v[ind + COMPSTRIDE * comp], r_v[comp]);
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void writeDofsStrided1d(BackendData& data, const CeedInt elem, const CeedScalar* r_v, CeedScalar* d_v) {
+  if (data.tidx < P1d) {
+    const CeedInt node = data.tidx;
+    const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      d_v[ind + comp * STRIDES_COMP] += r_v[comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// 1D tensor contraction x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractX1d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx] = *U;
+  __syncthreads();
+  *V = 0.0;
+  if (data.tidx < Q1d)
+    for (CeedInt i = 0; i < P1d; ++i)
+      *V += B[i + data.tidx*P1d] * data.slice[i]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 1D transpose tensor contraction x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractTransposeX1d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx] = *U;
+  __syncthreads();
+  *V = 0.0;
+  if (data.tidx < P1d)
+    for (CeedInt i = 0; i < Q1d; ++i)
+      *V += B[data.tidx + i*P1d] * data.slice[i]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 1D interpolate to quadrature points
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void interp1d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
+  for (CeedInt comp = 0; comp < NCOMP; comp++)
+    ContractX1d<NCOMP, P1d, Q1d>(data, r_U + comp, c_B, r_V + comp);
+}
+
+//------------------------------------------------------------------------------
+// 1D interpolate transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void interpTranspose1d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
+  for (CeedInt comp=0; comp<NCOMP; comp++)
+    ContractTransposeX1d<NCOMP, P1d, Q1d>(data, r_U + comp, c_B, r_V + comp);
+}
+
+//------------------------------------------------------------------------------
+// 1D derivatives at quadrature points
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void grad1d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  for (CeedInt comp = 0; comp < NCOMP; comp++)
+    ContractX1d<NCOMP, P1d, Q1d>(data, r_U + comp, c_G, r_V + comp);
+}
+
+//------------------------------------------------------------------------------
+// 1D derivatives transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void gradTranspose1d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  for (CeedInt comp = 0; comp < NCOMP; comp++)
+    ContractTransposeX1d<NCOMP, P1d, Q1d>(data, r_U + comp, c_G, r_V + comp);
+}
+
+//------------------------------------------------------------------------------
+// 2D
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, offsets provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int P1d>
+inline __device__ void readDofsOffset2d(BackendData& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < P1d && data.tidy < P1d) {
+    const CeedInt node = data.tidx + data.tidy*P1d;
+    const CeedInt ind = indices[node + elem * P1d*P1d];
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readDofsStrided2d(BackendData& data, const CeedInt elem, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < P1d && data.tidy < P1d) {
+    const CeedInt node = data.tidx + data.tidy*P1d;
+    const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, offsets provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int P1d>
+inline __device__ void writeDofsOffset2d(BackendData& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* r_v, CeedScalar* d_v) {
+  if (data.tidx < P1d && data.tidy < P1d) {
+    const CeedInt node = data.tidx + data.tidy*P1d;
+    const CeedInt ind = indices[node + elem * P1d*P1d];
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      atomicAdd(&d_v[ind + COMPSTRIDE * comp], r_v[comp]);
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void writeDofsStrided2d(BackendData& data, const CeedInt elem, const CeedScalar* r_v, CeedScalar* d_v) {
+  if (data.tidx < P1d && data.tidy < P1d) {
+    const CeedInt node = data.tidx + data.tidy*P1d;
+    const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      d_v[ind + comp * STRIDES_COMP] += r_v[comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D tensor contraction x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractX2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx+data.tidy*T1d] = *U;
+  __syncthreads();
+  *V = 0.0;
+  if (data.tidx < Q1d && data.tidy < P1d)
+    for (CeedInt i = 0; i < P1d; ++i)
+      *V += B[i + data.tidx*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D tensor contract y
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractY2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx+data.tidy*T1d] = *U;
+  __syncthreads();
+  *V = 0.0;
+  if (data.tidx < Q1d && data.tidy < Q1d)
+    for (CeedInt i = 0; i < P1d; ++i)
+      *V += B[i + data.tidy*P1d] * data.slice[data.tidx + i*T1d]; // Contract y direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D transpose tensor contract y
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractYTranspose2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx+data.tidy*T1d] = *U;
+  __syncthreads();
+  *V = 0.0;
+  if (data.tidx < Q1d && data.tidy < P1d)
+    for (CeedInt i = 0; i < Q1d; ++i)
+      *V += B[data.tidy + i*P1d] * data.slice[data.tidx + i*T1d]; // Contract y direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D transpose tensor contract x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractXTranspose2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx+data.tidy*T1d] = *U;
+  __syncthreads();
+  *V = 0.0;
+  if (data.tidx < P1d && data.tidy < P1d)
+    for (CeedInt i = 0; i < Q1d; ++i)
+      *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D transpose tensor contract and add x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractXTransposeAdd2d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  data.slice[data.tidx+data.tidy*T1d] = *U;
+  __syncthreads();
+  if (data.tidx < P1d && data.tidy < P1d)
+    for (CeedInt i = 0; i < Q1d; ++i)
+      *V += B[data.tidx + i*P1d] * data.slice[i + data.tidy*T1d]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D interpolate to quadrature points
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void interp2d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t[1];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractX2d<NCOMP, P1d, Q1d>(data, r_U + comp, c_B, r_t);
+    ContractY2d<NCOMP, P1d, Q1d>(data, r_t, c_B, r_V + comp);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D interpolate transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void interpTranspose2d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t[1];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractYTranspose2d<NCOMP, P1d, Q1d>(data, r_U + comp, c_B, r_t);
+    ContractXTranspose2d<NCOMP, P1d, Q1d>(data, r_t, c_B, r_V + comp);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D derivatives at quadrature points
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void grad2d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t[1];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractX2d<NCOMP, P1d, Q1d>(data, r_U + comp, c_G, r_t);
+    ContractY2d<NCOMP, P1d, Q1d>(data, r_t, c_B, r_V + comp + 0*NCOMP);
+    ContractX2d<NCOMP, P1d, Q1d>(data, r_U + comp, c_B, r_t);
+    ContractY2d<NCOMP, P1d, Q1d>(data, r_t, c_G, r_V + comp + 1*NCOMP);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D derivatives transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void gradTranspose2d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t[1];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractYTranspose2d<NCOMP, P1d, Q1d>(data, r_U + comp + 0*NCOMP, c_B, r_t);
+    ContractXTranspose2d<NCOMP, P1d, Q1d>(data, r_t, c_G, r_V + comp);
+    ContractYTranspose2d<NCOMP, P1d, Q1d>(data, r_U + comp + 1*NCOMP, c_G, r_t);
+    ContractXTransposeAdd2d<NCOMP, P1d, Q1d>(data, r_t, c_B, r_V + comp);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, offsets provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int P1d>
+inline __device__ void readDofsOffset3d(BackendData& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < P1d && data.tidy < P1d)
+    for (CeedInt z = 0; z < P1d; ++z) {
+      const CeedInt node = data.tidx + data.tidy*P1d + z*P1d*P1d;
+      const CeedInt ind = indices[node + elem * P1d*P1d*P1d];
+      for (CeedInt comp = 0; comp < NCOMP; ++comp)
+        r_u[z+comp*P1d] = d_u[ind + COMPSTRIDE * comp];
+    }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readDofsStrided3d(BackendData& data, const CeedInt elem, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < P1d && data.tidy < P1d)
+    for (CeedInt z = 0; z < P1d; ++z) {
+      const CeedInt node = data.tidx + data.tidy*P1d + z*P1d*P1d;
+      const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+      for (CeedInt comp = 0; comp < NCOMP; ++comp)
+        r_u[z+comp*P1d] = d_u[ind + comp * STRIDES_COMP];
+    }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> Q-vector, offests provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int Q1d>
+inline __device__ void readSliceQuadsOffset3d(BackendData& data, const CeedInt nquads, const CeedInt elem, const CeedInt q, const CeedInt* indices, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    const CeedInt node = data.tidx + data.tidy*Q1d + q*Q1d*Q1d;
+    const CeedInt ind = indices[node + elem * Q1d*Q1d*Q1d];;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> Q-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int Q1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readSliceQuadsStrided3d(BackendData& data, const CeedInt elem, const CeedInt q, const CeedScalar* d_u, CeedScalar* r_u) {
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    const CeedInt node = data.tidx + data.tidy*Q1d + q*Q1d*Q1d;
+    const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+    for (CeedInt comp = 0; comp < NCOMP; ++comp)
+      r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, offsets provided
+//------------------------------------------------------------------------------
+template <int NCOMP, int COMPSTRIDE, int P1d>
+inline __device__ void writeDofsOffset3d(BackendData& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* r_v, CeedScalar* d_v) {
+  if (data.tidx < P1d && data.tidy < P1d)
+    for (CeedInt z = 0; z < P1d; ++z) {
+      const CeedInt node = data.tidx + data.tidy*P1d + z*P1d*P1d;
+      const CeedInt ind = indices[node + elem * P1d*P1d*P1d];
+      for (CeedInt comp = 0; comp < NCOMP; ++comp)
+        atomicAdd(&d_v[ind + COMPSTRIDE * comp], r_v[z+comp*P1d]);
+    }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, strided
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void writeDofsStrided3d(BackendData& data, const CeedInt elem, const CeedScalar* r_v, CeedScalar* d_v) {
+  if (data.tidx < P1d && data.tidy < P1d)
+    for (CeedInt z = 0; z < P1d; ++z) {
+      const CeedInt node = data.tidx + data.tidy*P1d + z*P1d*P1d;
+      const CeedInt ind = node * STRIDES_NODE + elem * STRIDES_ELEM;
+      for (CeedInt comp = 0; comp < NCOMP; ++comp)
+        d_v[ind + comp * STRIDES_COMP] += r_v[z+comp*P1d];
+    }
+}
+
+//------------------------------------------------------------------------------
+// 3D tensor contract x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractX3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  CeedScalar r_B[P1d];
+  for (CeedInt i = 0; i < P1d; ++i)
+    r_B[i] = B[i + data.tidx*P1d];
+
+  for (CeedInt k = 0; k < P1d; ++k) {
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (data.tidx < Q1d && data.tidy < P1d)
+      for (CeedInt i = 0; i < P1d; ++i)
+        V[k] += r_B[i] * data.slice[i + data.tidy*T1d]; // Contract x direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D tensor contract y
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractY3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  CeedScalar r_B[P1d];
+  for (CeedInt i = 0; i < P1d; ++i)
+    r_B[i] = B[i + data.tidy*P1d];
+
+  for (CeedInt k = 0; k < P1d; ++k) {
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (data.tidx < Q1d && data.tidy < Q1d)
+      for (CeedInt i = 0; i < P1d; ++i)
+        V[k] += r_B[i] * data.slice[data.tidx + i*T1d]; // Contract y direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D tensor contract z
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractZ3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  for (CeedInt k = 0; k < Q1d; ++k) {
+    V[k] = 0.0;
+    if (data.tidx < Q1d && data.tidy < Q1d)
+      for (CeedInt i = 0; i < P1d; ++i)
+        V[k] += B[i + k*P1d] * U[i]; // Contract z direction
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract z
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractTransposeZ3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  for (CeedInt k = 0; k < P1d; ++k) {
+    V[k] = 0.0;
+    if (data.tidx < Q1d && data.tidy < Q1d)
+      for (CeedInt i = 0; i < Q1d; ++i)
+        V[k] += B[k + i*P1d] * U[i]; // Contract z direction
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract y
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractTransposeY3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  CeedScalar r_B[Q1d];
+  for (CeedInt i = 0; i < Q1d; ++i)
+    r_B[i] = B[data.tidy + i*P1d];
+
+  for (CeedInt k = 0; k < P1d; ++k) {
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (data.tidx < Q1d && data.tidy < P1d)
+      for (CeedInt i = 0; i < Q1d; ++i)
+        V[k] += r_B[i] * data.slice[data.tidx + i*T1d]; // Contract y direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract add y
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractTransposeAddY3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  CeedScalar r_B[Q1d];
+  for (CeedInt i = 0; i < Q1d; ++i)
+    r_B[i] = B[data.tidy + i*P1d];
+
+  for (CeedInt k = 0; k < P1d; ++k) {
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
+    __syncthreads();
+    if (data.tidx < Q1d && data.tidy < P1d)
+      for (CeedInt i = 0; i < Q1d; ++i)
+        V[k] += r_B[i] * data.slice[data.tidx + i*T1d]; // Contract y direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractTransposeX3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  CeedScalar r_B[Q1d];
+  for (CeedInt i = 0; i < Q1d; ++i)
+    r_B[i] = B[data.tidx + i*P1d];
+
+  for (CeedInt k = 0; k < P1d; ++k) {
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (data.tidx < P1d && data.tidy < P1d)
+      for (CeedInt i = 0; i < Q1d; ++i)
+        V[k] += r_B[i] * data.slice[i + data.tidy*T1d]; // Contract x direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract add x
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void ContractTransposeAddX3d(BackendData& data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  CeedScalar r_B[Q1d];
+  for (CeedInt i = 0; i < Q1d; ++i)
+    r_B[i] = B[data.tidx + i*P1d];
+
+  for (CeedInt k = 0; k < P1d; ++k) {
+    data.slice[data.tidx+data.tidy*T1d] = U[k];
+    __syncthreads();
+    if (data.tidx < P1d && data.tidy < P1d)
+      for (CeedInt i = 0; i < Q1d; ++i)
+        V[k] += r_B[i] * data.slice[i + data.tidy*T1d]; // Contract x direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D interpolate to quadrature points
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void interp3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractX3d<NCOMP, P1d, Q1d>(data, r_U + comp*P1d, c_B, r_t1);
+    ContractY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
+    ContractZ3d<NCOMP, P1d, Q1d>(data, r_t2, c_B, r_V + comp*Q1d);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D interpolate transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void interpTranspose3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractTransposeZ3d<NCOMP, P1d, Q1d>(data, r_U + comp*Q1d, c_B, r_t1);
+    ContractTransposeY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
+    ContractTransposeX3d<NCOMP, P1d, Q1d>(data, r_t2, c_B, r_V + comp*P1d);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D derivatives at quadrature points
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void grad3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractX3d<NCOMP, P1d, Q1d>(data, r_U + comp*P1d, c_G, r_t1);
+    ContractY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
+    ContractZ3d<NCOMP, P1d, Q1d>(data, r_t2, c_B, r_V + comp*Q1d + 0*NCOMP*Q1d);
+    ContractX3d<NCOMP, P1d, Q1d>(data, r_U + comp*P1d, c_B, r_t1);
+    ContractY3d<NCOMP, P1d, Q1d>(data, r_t1, c_G, r_t2);
+    ContractZ3d<NCOMP, P1d, Q1d>(data, r_t2, c_B, r_V + comp*Q1d + 1*NCOMP*Q1d);
+    ContractX3d<NCOMP, P1d, Q1d>(data, r_U + comp*P1d, c_B, r_t1);
+    ContractY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
+    ContractZ3d<NCOMP, P1d, Q1d>(data, r_t2, c_G, r_V + comp*Q1d + 2*NCOMP*Q1d);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D derivatives transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int P1d, int Q1d>
+inline __device__ void gradTranspose3d(BackendData& data, const CeedScalar *__restrict__ r_U, const CeedScalar *c_B, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  CeedScalar r_t1[T1d];
+  CeedScalar r_t2[T1d];
+  for (CeedInt comp = 0; comp < NCOMP; comp++) {
+    ContractTransposeZ3d<NCOMP, P1d, Q1d>(data, r_U + comp*Q1d + 0*NCOMP*Q1d, c_B, r_t1);
+    ContractTransposeY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
+    ContractTransposeX3d<NCOMP, P1d, Q1d>(data, r_t2, c_G, r_V + comp*P1d);
+    ContractTransposeZ3d<NCOMP, P1d, Q1d>(data, r_U + comp*Q1d + 1*NCOMP*Q1d, c_B, r_t1);
+    ContractTransposeY3d<NCOMP, P1d, Q1d>(data, r_t1, c_G, r_t2);
+    ContractTransposeAddX3d<NCOMP,P1d, Q1d>(data, r_t2, c_B, r_V + comp*P1d);
+    ContractTransposeZ3d<NCOMP, P1d, Q1d>(data, r_U + comp*Q1d + 2*NCOMP*Q1d, c_G, r_t1);
+    ContractTransposeY3d<NCOMP, P1d, Q1d>(data, r_t1, c_B, r_t2);
+    ContractTransposeAddX3d<NCOMP, P1d, Q1d>(data, r_t2, c_B, r_V + comp*P1d);
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D collocated derivatives computation
+//------------------------------------------------------------------------------
+template <int NCOMP, int Q1d>
+inline __device__ void gradCollo3d(BackendData& data, const CeedInt q, const CeedScalar *__restrict__ r_U, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    for (CeedInt comp = 0; comp < NCOMP; ++comp) {
+      data.slice[data.tidx + data.tidy*T1d] = r_U[q + comp*Q1d];
+      __syncthreads();
+      // X derivative
+      r_V[comp+0*NCOMP] = 0.0;
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[comp+0*NCOMP] += c_G[i + data.tidx*Q1d] * data.slice[i + data.tidy*T1d]; // Contract x direction (X derivative)
+      // Y derivative
+      r_V[comp+1*NCOMP] = 0.0;
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[comp+1*NCOMP] += c_G[i + data.tidy*Q1d] * data.slice[data.tidx + i*T1d]; // Contract y direction (Y derivative)
+      // Z derivative
+      r_V[comp+2*NCOMP] = 0.0;
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[comp+2*NCOMP] += c_G[i + q*Q1d] * r_U[i + comp*Q1d]; // Contract z direction (Z derivative)
+      __syncthreads();
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D collocated derivatives transpose
+//------------------------------------------------------------------------------
+template <int NCOMP, int Q1d>
+inline __device__ void gradColloTranspose3d(BackendData& data, const CeedInt q, const CeedScalar *__restrict__ r_U, const CeedScalar *c_G, CeedScalar *__restrict__ r_V) {
+  if (data.tidx < Q1d && data.tidy < Q1d) {
+    for (CeedInt comp = 0; comp < NCOMP; ++comp) {
+      // X derivative
+      data.slice[data.tidx + data.tidy*T1d] = r_U[comp + 0*NCOMP];
+      __syncthreads();
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[q+comp*Q1d] += c_G[data.tidx + i*Q1d] * data.slice[i + data.tidy*T1d]; // Contract x direction (X derivative)
+      __syncthreads();
+      // Y derivative
+      data.slice[data.tidx + data.tidy*T1d] = r_U[comp + 1*NCOMP];
+      __syncthreads();
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[q+comp*Q1d] += c_G[data.tidy + i*Q1d] * data.slice[data.tidx + i*T1d]; // Contract y direction (Y derivative)
+      __syncthreads();
+      // Z derivative
+      for (CeedInt i = 0; i < Q1d; ++i)
+        r_V[i+comp*Q1d] += c_G[i + q*Q1d] * r_U[comp + 2*NCOMP]; // PARTIAL contract z direction (Z derivative)
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 1D quadrature weights
+//------------------------------------------------------------------------------
+template <int Q1d>
+inline __device__ void weight1d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
+  *w = (data.tidx < Q1d) ? qweight1d[data.tidx] : 0.0;
+}
+
+//------------------------------------------------------------------------------
+// 2D quadrature weights
+//------------------------------------------------------------------------------
+template <int Q1d>
+inline __device__ void weight2d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
+  *w = (data.tidx < Q1d && data.tidy < Q1d) ?
+        qweight1d[data.tidx]*qweight1d[data.tidy] : 0.0;
+}
+
+//------------------------------------------------------------------------------
+// 3D quadrature weights
+//------------------------------------------------------------------------------
+template <int Q1d>
+inline __device__ void weight3d(BackendData& data, const CeedScalar *qweight1d, CeedScalar *w) {
+  const bool quad = (data.tidx < Q1d && data.tidy < Q1d);
+  const CeedScalar pw = quad ? qweight1d[data.tidx]*qweight1d[data.tidy] : 0.0;
+  for (CeedInt z = 0; z < Q1d; ++z)
+    w[z] = quad ? pw*qweight1d[z] : 0.0;
+}
+
+);
+//------------------------------------------------------------------------------
+// Build singe operator kernel
+//------------------------------------------------------------------------------
+extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
+
+  using std::ostringstream;
+  using std::string;
+  int ierr;
+  bool setupdone;
+  ierr = CeedOperatorIsSetupDone(op, &setupdone); CeedChk(ierr);
+  if (setupdone) return 0;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  CeedOperator_Hip_gen *data;
+  ierr = CeedOperatorGetData(op, &data); CeedChk(ierr);
+  CeedQFunction qf;
+  CeedQFunction_Hip_gen *qf_data;
+  ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, &qf_data); CeedChk(ierr);
+  CeedInt Q, P1d, Q1d = 0, numelements, elemsize, numinputfields,
+          numoutputfields, ncomp, dim = 0, lsize;
+  ierr = CeedOperatorGetNumQuadraturePoints(op, &Q); CeedChk(ierr);
+  ierr = CeedOperatorGetNumElements(op, &numelements); CeedChk(ierr);
+  ierr = CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
+  CeedChk(ierr);
+  CeedOperatorField *opinputfields, *opoutputfields;
+  ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
+  CeedChk(ierr);
+  CeedQFunctionField *qfinputfields, *qfoutputfields;
+  ierr = CeedQFunctionGetFields(qf, &qfinputfields, &qfoutputfields);
+  CeedChk(ierr);
+  CeedEvalMode emode;
+  CeedBasis basis;
+  CeedBasis_Hip_shared *basis_data;
+  CeedElemRestriction Erestrict;
+  CeedElemRestriction_Hip *restr_data;
+
+  ostringstream code;
+  string devFunctions(deviceFunctions);
+
+  // Add atomicAdd function for old NVidia architectures
+  struct hipDeviceProp_t prop;
+  Ceed_Hip *ceed_data;
+  ierr = CeedGetData(ceed, &ceed_data); CeedChk(ierr);
+  ierr = hipGetDeviceProperties(&prop, ceed_data->deviceId);
+  if (prop.major<6){
+    code << atomicAdd;
+  }
+
+  code << devFunctions;
+
+  string qFunction(qf_data->qFunctionSource);
+  string qFunctionName(qf_data->qFunctionName);
+  string oper;
+  oper = "CeedKernel_Hip_gen_" + qFunctionName;
+
+  code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
+  code << "\n#define CeedPragmaSIMD\n";
+
+  // Find dim and Q1d
+  bool useCollograd = true;
+  data->maxP1d = 0;
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
+    if (basis != CEED_BASIS_COLLOCATED) {
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+      CeedChk(ierr);
+
+      // Check for collocated gradient
+      useCollograd = useCollograd && basis_data->d_collograd1d; 
+
+      // Collect dim and Q1d
+      ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
+      bool isTensor;
+      ierr = CeedBasisIsTensor(basis, &isTensor); CeedChk(ierr); 
+      if (isTensor) {
+        ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+        ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+        if (P1d>data->maxP1d) data->maxP1d = P1d;
+      } else {
+        // LCOV_EXCL_START
+        return CeedError(ceed, 1, "Backend does not implement operators with non-tensor basis");
+        // LCOV_EXCL_STOP
+        }
+    }
+  }
+  // Check output bases for Q1d, dim as well
+  //   The only imput basis might be CEED_BASIS_COLLOCATED
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    ierr = CeedOperatorFieldGetBasis(opoutputfields[i], &basis); CeedChk(ierr);
+
+    if (basis != CEED_BASIS_COLLOCATED) {
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+      CeedChk(ierr);
+
+      // Collect dim and Q1d
+      ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
+      bool isTensor;
+      ierr = CeedBasisIsTensor(basis, &isTensor); CeedChk(ierr); 
+      if (isTensor) {
+        ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+      } else {
+        // LCOV_EXCL_START
+        return CeedError(ceed, 1, "Backend does not implement operators with non-tensor basis");
+        // LCOV_EXCL_STOP
+        }
+
+      // Check for collocated gradient
+      useCollograd = useCollograd && basis_data->d_collograd1d; 
+    }
+  }
+  data->dim = dim;
+  data->Q1d = Q1d;
+
+  // Define CEED_Q_VLA
+  if (dim != 3 || useCollograd) {
+    code << "\n#define CEED_Q_VLA 1\n\n";
+  } else {
+    code << "\n#define CEED_Q_VLA "<<Q1d<<"\n\n";
+  }
+
+  code << qFunction;
+
+  // Setup
+  code << "\n// -----------------------------------------------------------------------------\n";
+  code << "\nextern \"C\" __global__ void "<<oper<<"(CeedInt nelem, void* ctx, HipFieldsInt indices, HipFields fields, HipFields B, HipFields G, CeedScalar* W) {\n";
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+    CeedChk(ierr);
+    if (emode != CEED_EVAL_WEIGHT) { // Skip CEED_EVAL_WEIGHT
+      code << "  const CeedScalar* d_u" <<i<<" = fields.in["<<i<<"];\n";
+    }
+  }
+
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    code << "  CeedScalar* d_v"<<i<<" = fields.out["<<i<<"];\n";
+  }
+
+  code << "  const CeedInt Dim = "<<dim<<";\n";
+  code << "  const CeedInt Q1d = "<<Q1d<<";\n";
+
+  code << "  HIP_DYNAMIC_SHARED( CeedScalar, slice)\n";
+  code << "  BackendData data;\n";
+  code << "  data.tidx = threadIdx.x;\n";
+  code << "  data.tidy = threadIdx.y;\n";
+  code << "  data.tidz = threadIdx.z;\n";
+  code << "  data.tid  = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.y*blockDim.x;\n";
+  code << "  data.slice = slice+data.tidz*T1d"<<(dim>1?"*T1d":"")<<";\n";
+
+  code << "\n  // -- Input field constants and basis data --\n";
+  //Initialize constants, and matrices B and G
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    code << "  // ---- Input field "<<i<<" ----\n";
+    // Get elemsize, emode, ncomp
+    ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetElementSize(Erestrict, &elemsize);
+    CeedChk(ierr);
+    ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetNumComponents(Erestrict, &ncomp);
+    CeedChk(ierr);
+
+    // Set field constants
+    if (emode != CEED_EVAL_WEIGHT) {
+      ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
+      if (basis != CEED_BASIS_COLLOCATED) {
+        ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+        code << "  const CeedInt P_in_"<<i<<" = "<<P1d<<";\n";
+      } else {
+        code << "  const CeedInt P_in_"<<i<<" = "<<Q1d<<";\n";
+      }
+      code << "  const CeedInt ncomp_in_"<<i<<" = "<<ncomp<<";\n";
+    }
+
+    // Load basis data
+    code << "  // EvalMode: "<<CeedEvalModes[emode]<<"\n";
+    switch (emode) {
+    case CEED_EVAL_NONE:
+      break;
+    case CEED_EVAL_INTERP:
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      data->B.in[i] = basis_data->d_interp1d;
+      code << "  __shared__ double s_B_in_"<<i<<"["<<P1d*Q1d<<"];\n";
+      code << "  loadMatrix<P_in_"<<i<<",Q1d>(data, B.in["<<i<<"], s_B_in_"<<i<<");\n";
+      break;
+    case CEED_EVAL_GRAD:
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      data->B.in[i] = basis_data->d_interp1d;
+      code << "  __shared__ double s_B_in_"<<i<<"["<<P1d*Q1d<<"];\n";
+      code << "  loadMatrix<P_in_"<<i<<",Q1d>(data, B.in["<<i<<"], s_B_in_"<<i<<");\n";
+      if (useCollograd) {
+        data->G.in[i] = basis_data->d_collograd1d;
+        code << "  __shared__ double s_G_in_"<<i<<"["<<Q1d*Q1d<<"];\n";
+        code << "  loadMatrix<Q1d,Q1d>(data, G.in["<<i<<"], s_G_in_"<<i<<");\n";
+      } else {
+        data->G.in[i] = basis_data->d_grad1d;
+        code << "  __shared__ double s_G_in_"<<i<<"["<<P1d*Q1d<<"];\n";
+        code << "  loadMatrix<P_in_"<<i<<",Q1d>(data, G.in["<<i<<"], s_G_in_"<<i<<");\n";
+      }
+      break;
+    case CEED_EVAL_WEIGHT:
+      break; // No action
+    case CEED_EVAL_DIV:
+      break; // TODO: Not implemented
+    case CEED_EVAL_CURL:
+      break; // TODO: Not implemented
+    }
+  }
+
+  code << "\n  // -- Output field constants and basis data --\n";
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    code << "  // ---- Output field "<<i<<" ----\n";
+    // Get elemsize, emode, ncomp
+    ierr = CeedOperatorFieldGetElemRestriction(opoutputfields[i], &Erestrict);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetElementSize(Erestrict, &elemsize);
+    CeedChk(ierr);
+    ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetNumComponents(Erestrict, &ncomp);
+    CeedChk(ierr);
+
+    // Set field constants
+    ierr = CeedOperatorFieldGetBasis(opoutputfields[i], &basis); CeedChk(ierr);
+    if (basis != CEED_BASIS_COLLOCATED) {
+      ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+      code << "  const CeedInt P_out_"<<i<<" = "<<P1d<<";\n";
+    } else {
+      code << "  const CeedInt P_out_"<<i<<" = "<<Q1d<<";\n";
+    }
+    code << "  const CeedInt ncomp_out_"<<i<<" = "<<ncomp<<";\n";
+
+    // Load basis data
+    code << "  // EvalMode: "<<CeedEvalModes[emode]<<"\n";
+    switch (emode) {
+    case CEED_EVAL_NONE:
+      break; // No action
+    case CEED_EVAL_INTERP:
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      data->B.out[i] = basis_data->d_interp1d;
+      code << "  __shared__ double s_B_out_"<<i<<"["<<P1d*Q1d<<"];\n";
+      code << "  loadMatrix<P_out_"<<i<<",Q1d>(data, B.out["<<i<<"], s_B_out_"<<i<<");\n";
+      break;
+    case CEED_EVAL_GRAD:
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      data->B.out[i] = basis_data->d_interp1d;
+      code << "  __shared__ double s_B_out_"<<i<<"["<<P1d*Q1d<<"];\n";
+      code << "  loadMatrix<P_out_"<<i<<",Q1d>(data, B.out["<<i<<"], s_B_out_"<<i<<");\n";
+      if (useCollograd) {
+        data->G.out[i] = basis_data->d_collograd1d;
+        code << "  __shared__ double s_G_out_"<<i<<"["<<Q1d*Q1d<<"];\n";
+        code << "  loadMatrix<Q1d,Q1d>(data, G.out["<<i<<"], s_G_out_"<<i<<");\n";
+      } else {
+        data->G.out[i] = basis_data->d_grad1d;
+        code << "  __shared__ double s_G_out_"<<i<<"["<<P1d*Q1d<<"];\n";
+        code << "  loadMatrix<P_out_"<<i<<",Q1d>(data, G.out["<<i<<"], s_G_out_"<<i<<");\n";
+      }
+      break;
+    // LCOV_EXCL_START
+    case CEED_EVAL_WEIGHT: {
+      Ceed ceed;
+      ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+      return CeedError(ceed, 1,
+                       "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
+      break; // Should not occur
+    }
+    case CEED_EVAL_DIV:
+      break; // TODO: Not implemented
+    case CEED_EVAL_CURL:
+      break; // TODO: Not implemented
+      // LCOV_EXCL_STOP
+    }
+  }
+  code << "\n  // -- Element loop --\n";
+  code << "  __syncthreads();\n";
+  code << "  for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem; elem += gridDim.x*blockDim.z) {\n";
+  // Input basis apply if needed
+  // Generate the correct eval mode code for each input
+  code << "    // -- Input field restrictions and basis actions --\n";
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    code << "    // ---- Input field "<<i<<" ----\n";
+    // Get elemsize, emode, ncomp
+    ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetElementSize(Erestrict, &elemsize);
+    CeedChk(ierr);
+    ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetNumComponents(Erestrict, &ncomp);
+    CeedChk(ierr);
+
+    // Restriction
+    if (emode != CEED_EVAL_WEIGHT &&
+        !((emode == CEED_EVAL_NONE) && useCollograd)) {
+      code << "    CeedScalar r_u"<<i<<"[ncomp_in_"<<i<<"*P_in_"<<i<<"];\n";
+      
+      bool isStrided;
+      ierr = CeedElemRestrictionIsStrided(Erestrict, &isStrided); CeedChk(ierr);
+      if (!isStrided) {
+        ierr = CeedElemRestrictionGetLVectorSize(Erestrict, &lsize);
+        CeedChk(ierr);
+        code << "    const CeedInt lsize_in_"<<i<<" = "<<lsize<<";\n";
+        CeedInt compstride;
+        ierr = CeedElemRestrictionGetCompStride(Erestrict, &compstride); CeedChk(ierr);
+        code << "    // CompStride: "<<compstride<<"\n";
+        ierr = CeedElemRestrictionGetData(Erestrict, &restr_data); CeedChk(ierr);
+        data->indices.in[i] = restr_data->d_ind;
+        code << "    readDofsOffset"<<dim<<"d<ncomp_in_"<<i<<", "<<compstride<<", P_in_"<<i<<">(data, lsize_in_"<<i<<", elem, indices.in["<<i<<"], d_u"<<i<<", r_u"<<i<<");\n";
+      } else {
+        bool backendstrides;
+        ierr = CeedElemRestrictionHasBackendStrides(Erestrict, &backendstrides);
+        CeedChk(ierr);
+        CeedInt nelem;
+        ierr = CeedElemRestrictionGetNumElements(Erestrict, &nelem);
+        CeedChk(ierr);
+        CeedInt strides[3] = {1, elemsize*nelem, elemsize};
+        if (!backendstrides) {
+          ierr = CeedElemRestrictionGetStrides(Erestrict, &strides);
+          CeedChk(ierr);
+        }
+        code << "    // Strides: {"<<strides[0]<<", "<<strides[1]<<", "<<strides[2]<<"}\n";
+        code << "    readDofsStrided"<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<","<<strides[0]<<","<<strides[1]<<","<<strides[2]<<">(data, elem, d_u"<<i<<", r_u"<<i<<");\n";
+      }
+    }
+
+    // Basis action
+    code << "    // EvalMode: "<<CeedEvalModes[emode]<<"\n";
+    switch (emode) {
+    case CEED_EVAL_NONE:
+      if (!useCollograd) {
+        code << "    CeedScalar* r_t"<<i<<" = r_u"<<i<<";\n";
+      }
+      break;
+    case CEED_EVAL_INTERP:
+      code << "    CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Q1d];\n";
+      code << "    interp"<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<",Q1d>(data, r_u"<<i<<", s_B_in_"<<i<<", r_t"<<i<<");\n";
+      break;
+    case CEED_EVAL_GRAD:
+      if (useCollograd) {
+        code << "    CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Q1d];\n";
+        code << "    interp"<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<",Q1d>(data, r_u"<<i<<", s_B_in_"<<i<<", r_t"<<i<<");\n";
+      } else {
+        code << "    CeedScalar r_t"<<i<<"[ncomp_in_"<<i<<"*Dim*Q1d];\n";
+        code << "    grad"<<dim<<"d<ncomp_in_"<<i<<",P_in_"<<i<<",Q1d>(data, r_u"<<i<<", s_B_in_"<<i<<", s_G_in_"<<i<<", r_t"<<i<<");\n";
+      }
+      break;
+    case CEED_EVAL_WEIGHT:
+      code << "    CeedScalar r_t"<<i<<"[Q1d];\n";
+      ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChk(ierr);
+      ierr = CeedBasisGetData(basis, &basis_data); CeedChk(ierr);
+      data->W = basis_data->d_qweight1d;
+      code << "    weight"<<dim<<"d<Q1d>(data, W, r_t"<<i<<");\n";
+      break; // No action
+    case CEED_EVAL_DIV:
+      break; // TODO: Not implemented
+    case CEED_EVAL_CURL:
+      break; // TODO: Not implemented
+    }
+  }
+
+  // Q function
+  code << "\n    // -- Output field setup --\n";
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+      code << "\n    // ---- Output field "<<i<<" ----\n";
+    ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+    CeedChk(ierr);
+    if (emode==CEED_EVAL_GRAD)
+    {
+      if (useCollograd) {
+        //Accumulator for gradient slices
+        code << "    CeedScalar r_tt"<<i<<"[ncomp_out_"<<i<<"*Q1d];\n";
+        code << "    for (CeedInt i = 0; i < ncomp_out_"<<i<<"; ++i) {\n";
+        code << "      for (CeedInt j = 0; j < Q1d; ++j) {\n";
+        code << "        r_tt"<<i<<"[j + i*Q1d] = 0.0;\n";
+        code << "      }\n";
+        code << "    }\n";
+      } else {
+        code << "    CeedScalar r_tt"<<i<<"[ncomp_out_"<<i<<"*Dim*Q1d];\n";
+      }
+    }
+    if (emode==CEED_EVAL_NONE || emode==CEED_EVAL_INTERP)
+    {
+      code << "    CeedScalar r_tt"<<i<<"[ncomp_out_"<<i<<"*Q1d];\n";
+    }
+  }
+  // We treat quadrature points per slice in 3d to save registers
+  if (useCollograd) {
+    code << "\n    // Note: Collocated Gradient\n";
+    code << "#pragma unroll\n";
+    code << "    for (CeedInt q=0; q<Q1d; q++) {\n";
+    code << "      // -- Input fields --\n";
+    for (CeedInt i = 0; i < numinputfields; i++) {
+      code << "      // ---- Input field "<<i<<" ----\n";
+      // Get elemsize, emode, ncomp
+      ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+      CeedChk(ierr);
+      // Basis action
+      code << "      // EvalMode: "<<CeedEvalModes[emode]<<"\n";
+      switch (emode) {
+      case CEED_EVAL_NONE:
+        code << "      CeedScalar r_q"<<i<<"[ncomp_in_"<<i<<"];\n";
+
+        bool isStrided;
+        ierr = CeedOperatorFieldGetElemRestriction(opinputfields[i], &Erestrict); CeedChk(ierr);
+        ierr = CeedElemRestrictionGetElementSize(Erestrict, &elemsize); CeedChk(ierr);
+        ierr = CeedElemRestrictionIsStrided(Erestrict, &isStrided); CeedChk(ierr);
+        if (!isStrided) {
+          ierr = CeedElemRestrictionGetLVectorSize(Erestrict, &lsize);
+          CeedChk(ierr);
+          code << "      const CeedInt lsize_in_"<<i<<" = "<<lsize<<";\n";
+          CeedInt compstride;
+          ierr = CeedElemRestrictionGetCompStride(Erestrict, &compstride); CeedChk(ierr);
+          code << "      // CompStride: "<<compstride<<"\n";
+          ierr = CeedElemRestrictionGetData(Erestrict, &restr_data); CeedChk(ierr);
+          data->indices.in[i] = restr_data->d_ind;
+          code << "      readSliceQuadsOffset"<<"3d<ncomp_in_"<<i<<", "<<compstride<<", Q1d>(data, lsize_in_"<<i<<", elem, q, indices.in["<<i<<"], d_u"<<i<<", r_q"<<i<<");\n";
+        } else {
+          bool backendstrides;
+          ierr = CeedElemRestrictionHasBackendStrides(Erestrict, &backendstrides);
+          CeedChk(ierr);
+          CeedInt nelem;
+          ierr = CeedElemRestrictionGetNumElements(Erestrict, &nelem);
+          CeedChk(ierr);
+          CeedInt strides[3] = {1, elemsize*nelem, elemsize};
+          if (!backendstrides) {
+            ierr = CeedElemRestrictionGetStrides(Erestrict, &strides);
+            CeedChk(ierr);
+          }
+          code << "      // Strides: {"<<strides[0]<<", "<<strides[1]<<", "<<strides[2]<<"}\n";
+          code << "      readSliceQuadsStrided"<<"3d<ncomp_in_"<<i<<",Q1d"","<<strides[0]<<","<<strides[1]<<","<<strides[2]<<">(data, elem, q, d_u"<<i<<", r_q"<<i<<");\n";
+        }
+        break;
+      case CEED_EVAL_INTERP:
+        code << "      CeedScalar r_q"<<i<<"[ncomp_in_"<<i<<"];\n";
+        code << "      for (CeedInt j = 0; j < ncomp_in_"<<i<<" ; ++j) {\n";
+        code << "        r_q"<<i<<"[j] = r_t"<<i<<"[q + j*Q1d];\n";
+        code << "      }\n";
+        break;
+      case CEED_EVAL_GRAD:
+        code << "      CeedScalar r_q"<<i<<"[ncomp_in_"<<i<<"*Dim];\n";
+        code << "      gradCollo3d<ncomp_in_"<<i<<",Q1d>(data, q, r_t"<<i<<", s_G_in_"<<i<<", r_q"<<i<<");\n";
+        break;
+      case CEED_EVAL_WEIGHT:
+        code << "      CeedScalar r_q"<<i<<"[1];\n";
+        code << "      r_q"<<i<<"[0] = r_t"<<i<<"[q];\n";
+        break; // No action
+      case CEED_EVAL_DIV:
+        break; // TODO: Not implemented
+      case CEED_EVAL_CURL:
+        break; // TODO: Not implemented
+      }
+    }
+    code << "\n      // -- Output fields --\n";
+    for (CeedInt i = 0; i < numoutputfields; i++) {
+      code << "      // ---- Output field "<<i<<" ----\n";
+      ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+      CeedChk(ierr);
+      // Basis action
+      switch (emode) {
+      case CEED_EVAL_NONE:
+        code << "      CeedScalar r_qq"<<i<<"[ncomp_out_"<<i<<"];\n";
+        break; // No action
+      case CEED_EVAL_INTERP:
+        code << "      CeedScalar r_qq"<<i<<"[ncomp_out_"<<i<<"];\n";
+        break;
+      case CEED_EVAL_GRAD:
+        code << "      CeedScalar r_qq"<<i<<"[ncomp_out_"<<i<<"*Dim];\n";
+        break;
+      case CEED_EVAL_WEIGHT:
+        break; // Should not occur
+      case CEED_EVAL_DIV:
+        break; // TODO: Not implemented
+      case CEED_EVAL_CURL:
+        break; // TODO: Not implemented
+      }
+    }
+  } else {
+    code << "\n      // Note: No Collocated Gradient\n";
+    code << "      // -- Input fields --\n";
+    for (CeedInt i = 0; i < numinputfields; i++) {
+      code << "      // ---- Input field "<<i<<" ----\n";
+      code << "      CeedScalar* r_q"<<i<<" = r_t"<<i<<";\n";
+    }
+    code << "      // -- Output fields --\n";
+    for (CeedInt i = 0; i < numoutputfields; i++) {
+      code << "      // ---- Output field "<<i<<" ----\n";
+      code << "      CeedScalar* r_qq"<<i<<" = r_tt"<<i<<";\n";
+    }
+  }
+  code << "\n      // -- QFunction Inputs and outputs --\n";
+  code << "      CeedScalar* in["<<numinputfields<<"];\n";
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    code << "      // ---- Input field "<<i<<" ----\n";
+    code << "      in["<<i<<"] = r_q"<<i<<";\n";
+  }
+  code << "      CeedScalar* out["<<numoutputfields<<"];\n";
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    code << "      // ---- Output field "<<i<<" ----\n";
+    code << "      out["<<i<<"] = r_qq"<<i<<";\n";
+  }
+  code << "\n      // -- Apply QFunction --\n";
+  code << "      "<<qFunctionName<<"(ctx, ";
+  if (dim != 3 || useCollograd) {
+    code << "1";
+  } else {
+    code << "Q1d";
+  }
+  code << ", in, out);\n";
+  if (useCollograd) {
+    code << "\n      // Note: Collocated Gradient\n";
+    code << "      // -- Output fields --\n";
+    for (CeedInt i = 0; i < numoutputfields; i++) {
+      code << "      // ---- Output field "<<i<<" ----\n";
+      ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+      CeedChk(ierr);
+      // Basis action
+      code << "      // EvalMode: "<<CeedEvalModes[emode]<<"\n";
+      switch (emode) {
+      case CEED_EVAL_NONE:
+        code << "      for (CeedInt j = 0; j < ncomp_out_"<<i<<" ; ++j) {\n";
+        code << "        r_tt"<<i<<"[q + j*Q1d] = r_qq"<<i<<"[j];\n";
+        code << "      }\n";
+        break; // No action
+      case CEED_EVAL_INTERP:
+        code << "      for (CeedInt j = 0; j < ncomp_out_"<<i<<" ; ++j) {\n";
+        code << "        r_tt"<<i<<"[q + j*Q1d] = r_qq"<<i<<"[j];\n";
+        code << "      }\n";
+        break;
+      case CEED_EVAL_GRAD:
+        code << "      gradColloTranspose3d<ncomp_out_"<<i<<",Q1d>(data, q, r_qq"<<i<<", s_G_out_"<<i<<", r_tt"<<i<<");\n";
+        break;
+      case CEED_EVAL_WEIGHT:
+        break; // Should not occur
+      case CEED_EVAL_DIV:
+        break; // TODO: Not implemented
+      case CEED_EVAL_CURL:
+        break; // TODO: Not implemented
+      }
+    }
+    code << "    }\n";
+  }
+
+  // Output basis apply if needed
+  // Generate the correct eval mode code for each output
+  code << "\n    // -- Output field basis action and restrictions --\n";
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    code << "    // ---- Output field "<<i<<" ----\n";
+    // Get elemsize, emode, ncomp
+    ierr = CeedOperatorFieldGetElemRestriction(opoutputfields[i], &Erestrict);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetElementSize(Erestrict, &elemsize);
+    CeedChk(ierr);
+    ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+    CeedChk(ierr);
+    ierr = CeedElemRestrictionGetNumComponents(Erestrict, &ncomp);
+    CeedChk(ierr);
+    // Basis action
+    code << "    // EvalMode: "<<CeedEvalModes[emode]<<"\n";
+    switch (emode) {
+    case CEED_EVAL_NONE:
+      code << "    CeedScalar* r_v"<<i<<" = r_tt"<<i<<";\n";
+      break; // No action
+    case CEED_EVAL_INTERP:
+      code << "    CeedScalar r_v"<<i<<"[ncomp_out_"<<i<<"*P_out_"<<i<<"];\n";
+      code << "    interpTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", r_v"<<i<<");\n";
+      break;
+    case CEED_EVAL_GRAD:
+      code << "    CeedScalar r_v"<<i<<"[ncomp_out_"<<i<<"*P_out_"<<i<<"];\n";
+      if (useCollograd) {
+        code << "    interpTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", r_v"<<i<<");\n";
+      } else {
+        code << "    gradTranspose"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<",Q1d>(data, r_tt"<<i<<", s_B_out_"<<i<<", s_G_out_"<<i<<", r_v"<<i<<");\n";
+      }
+      break;
+    // LCOV_EXCL_START
+    case CEED_EVAL_WEIGHT: {
+      Ceed ceed;
+      ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+      return CeedError(ceed, 1,
+                       "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
+      break; // Should not occur
+    }
+    case CEED_EVAL_DIV:
+      break; // TODO: Not implemented
+    case CEED_EVAL_CURL:
+      break; // TODO: Not implemented
+      // LCOV_EXCL_STOP
+    }
+    // Restriction
+      bool isStrided;
+      ierr = CeedElemRestrictionIsStrided(Erestrict, &isStrided); CeedChk(ierr);
+    if (!isStrided) {
+      ierr = CeedElemRestrictionGetLVectorSize(Erestrict, &lsize);
+      CeedChk(ierr);
+      code << "    const CeedInt lsize_out_"<<i<<" = "<<lsize<<";\n";
+      CeedInt compstride;
+      ierr = CeedElemRestrictionGetCompStride(Erestrict, &compstride); CeedChk(ierr);
+      code << "    // CompStride: "<<compstride<<"\n";
+      ierr = CeedElemRestrictionGetData(Erestrict, &restr_data); CeedChk(ierr);
+      data->indices.out[i] = restr_data->d_ind;
+      code << "    writeDofsOffset"<<dim<<"d<ncomp_out_"<<i<<", "<<compstride<<", P_out_"<<i<<">(data, lsize_out_"<<i<<", elem, indices.out["<<i<<"], r_v"<<i<<", d_v"<<i<<");\n";
+    } else {
+      bool backendstrides;
+      ierr = CeedElemRestrictionHasBackendStrides(Erestrict, &backendstrides);
+      CeedChk(ierr);
+      CeedInt nelem;
+      ierr = CeedElemRestrictionGetNumElements(Erestrict, &nelem);
+      CeedChk(ierr);
+      CeedInt strides[3] = {1, elemsize*nelem, elemsize};
+      if (!backendstrides) {
+        ierr = CeedElemRestrictionGetStrides(Erestrict, &strides);
+        CeedChk(ierr);
+      }
+      code << "    // Strides: {"<<strides[0]<<", "<<strides[1]<<", "<<strides[2]<<"}\n";
+      code << "    writeDofsStrided"<<dim<<"d<ncomp_out_"<<i<<",P_out_"<<i<<","<<strides[0]<<","<<strides[1]<<","<<strides[2]<<">(data, elem, r_v"<<i<<", d_v"<<i<<");\n";
+    }
+  }
+
+  code << "  }\n";
+  code << "}\n";
+  code << "// -----------------------------------------------------------------------------\n\n";
+
+  // View kernel for debugging
+  CeedDebug(code.str().c_str());
+
+  ierr = CeedCompileHip(ceed, code.str().c_str(), &data->module, 1,
+                         "T1d", CeedIntMax(Q1d, data->maxP1d));
+  CeedChk(ierr);
+  ierr = CeedGetKernelHip(ceed, data->module, oper.c_str(), &data->op);
+  CeedChk(ierr);
+
+  ierr = CeedOperatorSetSetupDone(op); CeedChk(ierr);
+  return 0;
+}
+//------------------------------------------------------------------------------

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -745,7 +745,7 @@ inline __device__ void weight3d(BackendData& data, const CeedScalar *qweight1d, 
 //------------------------------------------------------------------------------
 // Build singe operator kernel
 //------------------------------------------------------------------------------
-extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
+CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op) {
 
   using std::ostringstream;
   using std::string;

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -786,7 +786,7 @@ extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
   struct hipDeviceProp_t prop;
   Ceed_Hip *ceed_data;
   ierr = CeedGetData(ceed, &ceed_data); CeedChk(ierr);
-  ierr = hipGetDeviceProperties(&prop, ceed_data->deviceId);
+  ierr = hipGetDeviceProperties(&prop, ceed_data->deviceId); CeedChk(ierr);
   if (prop.major<6){
     code << atomicAdd;
   }

--- a/backends/hip-gen/ceed-hip-gen-operator-build.h
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op);

--- a/backends/hip-gen/ceed-hip-gen-operator.c
+++ b/backends/hip-gen/ceed-hip-gen-operator.c
@@ -119,7 +119,7 @@ static int CeedOperatorApplyAdd_Hip_gen(CeedOperator op, CeedVector invec,
   const CeedInt P1d = data->maxP1d;
   const CeedInt thread1d = CeedIntMax(Q1d, P1d);
   if (dim==1) {
-    CeedInt elemsPerBlock = 32*thread1d > 256? 256/thread1d : 32;
+    CeedInt elemsPerBlock = 64*thread1d > 256? 256/thread1d : 64;
     elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
     CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                            ? 1 : 0 );

--- a/backends/hip-gen/ceed-hip-gen-operator.c
+++ b/backends/hip-gen/ceed-hip-gen-operator.c
@@ -1,0 +1,223 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include "ceed-hip-gen.h"
+#include "ceed-hip-gen-operator-build.h"
+#include "../hip/ceed-hip-compile.h"
+
+//------------------------------------------------------------------------------
+// Destroy operator
+//------------------------------------------------------------------------------
+static int CeedOperatorDestroy_Hip_gen(CeedOperator op) {
+  int ierr;
+  CeedOperator_Hip_gen *impl;
+  ierr = CeedOperatorGetData(op, &impl); CeedChk(ierr);
+  ierr = CeedFree(&impl); CeedChk(ierr);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Apply and add to output
+//------------------------------------------------------------------------------
+static int CeedOperatorApplyAdd_Hip_gen(CeedOperator op, CeedVector invec,
+                                        CeedVector outvec, CeedRequest *request) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  CeedOperator_Hip_gen *data;
+  ierr = CeedOperatorGetData(op, &data); CeedChk(ierr);
+  CeedQFunction qf;
+  CeedQFunction_Hip_gen *qf_data;
+  ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
+  ierr = CeedQFunctionGetData(qf, &qf_data); CeedChk(ierr);
+  CeedInt nelem, numinputfields, numoutputfields;
+  ierr = CeedOperatorGetNumElements(op, &nelem); CeedChk(ierr);
+  ierr = CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
+  CeedChk(ierr);
+  CeedOperatorField *opinputfields, *opoutputfields;
+  ierr = CeedOperatorGetFields(op, &opinputfields, &opoutputfields);
+  CeedChk(ierr);
+  CeedQFunctionField *qfinputfields, *qfoutputfields;
+  ierr = CeedQFunctionGetFields(qf, &qfinputfields, &qfoutputfields);
+  CeedChk(ierr);
+  CeedEvalMode emode;
+  CeedVector vec, outvecs[16] = {};
+
+  //Creation of the operator
+  ierr = CeedHipGenOperatorBuild(op); CeedChk(ierr);
+
+  // Input vectors
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+    CeedChk(ierr);
+    if (emode == CEED_EVAL_WEIGHT) { // Skip
+      data->fields.in[i] = NULL;
+    } else {
+      // Get input vector
+      ierr = CeedOperatorFieldGetVector(opinputfields[i], &vec); CeedChk(ierr);
+      if (vec == CEED_VECTOR_ACTIVE) vec = invec;
+      ierr = CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &data->fields.in[i]);
+      CeedChk(ierr);
+    }
+  }
+
+  // Output vectors
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+    CeedChk(ierr);
+    if (emode == CEED_EVAL_WEIGHT) { // Skip
+      data->fields.out[i] = NULL;
+    } else {
+      // Get output vector
+      ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
+      if (vec == CEED_VECTOR_ACTIVE) vec = outvec;
+      outvecs[i] = vec;
+      // Check for multiple output modes
+      CeedInt index = -1;
+      for (CeedInt j = 0; j < i; j++) {
+        if (vec == outvecs[j]) {
+          index = j;
+          break;
+        }
+      }
+      if (index == -1) {
+        ierr = CeedVectorGetArray(vec, CEED_MEM_DEVICE, &data->fields.out[i]);
+        CeedChk(ierr);
+      } else {
+        data->fields.out[i] = data->fields.out[index];
+      }
+    }
+  }
+
+  // Get context data
+  CeedQFunctionContext ctx;
+  ierr = CeedQFunctionGetInnerContext(qf, &ctx); CeedChk(ierr);
+  if (ctx) {
+    ierr = CeedQFunctionContextGetData(ctx, CEED_MEM_DEVICE, &qf_data->d_c);
+    CeedChk(ierr);
+  }
+
+  // Apply operator
+  void *opargs[] = {(void *) &nelem, &qf_data->d_c, &data->indices,
+                    &data->fields, &data->B, &data->G, &data->W
+                   };
+  const CeedInt dim = data->dim;
+  const CeedInt Q1d = data->Q1d;
+  const CeedInt P1d = data->maxP1d;
+  const CeedInt thread1d = CeedIntMax(Q1d, P1d);
+  if (dim==1) {
+    CeedInt elemsPerBlock = 32*thread1d > 256? 256/thread1d : 32;
+    elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
+    CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                           ? 1 : 0 );
+    CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
+    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, thread1d, 1,
+                                     elemsPerBlock, sharedMem, opargs);
+  } else if (dim==2) {
+    const CeedInt elemsPerBlock = thread1d<4? 16 : 2;
+    CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                           ? 1 : 0 );
+    CeedInt sharedMem = elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
+    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, thread1d, thread1d,
+                                     elemsPerBlock, sharedMem, opargs);
+  } else if (dim==3) {
+    const CeedInt elemsPerBlock = thread1d<6? 4 : (thread1d<8? 2 : 1);
+    CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                           ? 1 : 0 );
+    CeedInt sharedMem = elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
+    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, thread1d, thread1d,
+                                     elemsPerBlock, sharedMem, opargs);
+  }
+  CeedChk(ierr);
+
+  // Restore input arrays
+  for (CeedInt i = 0; i < numinputfields; i++) {
+    ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
+    CeedChk(ierr);
+    if (emode == CEED_EVAL_WEIGHT) { // Skip
+    } else {
+      ierr = CeedOperatorFieldGetVector(opinputfields[i], &vec); CeedChk(ierr);
+      if (vec == CEED_VECTOR_ACTIVE) vec = invec;
+      ierr = CeedVectorRestoreArrayRead(vec, &data->fields.in[i]);
+      CeedChk(ierr);
+    }
+  }
+
+  // Restore output arrays
+  for (CeedInt i = 0; i < numoutputfields; i++) {
+    ierr = CeedQFunctionFieldGetEvalMode(qfoutputfields[i], &emode);
+    CeedChk(ierr);
+    if (emode == CEED_EVAL_WEIGHT) { // Skip
+    } else {
+      ierr = CeedOperatorFieldGetVector(opoutputfields[i], &vec); CeedChk(ierr);
+      if (vec == CEED_VECTOR_ACTIVE) vec = outvec;
+      // Check for multiple output modes
+      CeedInt index = -1;
+      for (CeedInt j = 0; j < i; j++) {
+        if (vec == outvecs[j]) {
+          index = j;
+          break;
+        }
+      }
+      if (index == -1) {
+        ierr = CeedVectorRestoreArray(vec, &data->fields.out[i]);
+        CeedChk(ierr);
+      }
+    }
+  }
+
+  // Restore context data
+  if (ctx) {
+    ierr = CeedQFunctionContextRestoreData(ctx, &qf_data->d_c);
+    CeedChk(ierr);
+  }
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Create FDM element inverse not supported
+//------------------------------------------------------------------------------
+static int CeedOperatorCreateFDMElementInverse_Hip(CeedOperator op) {
+  // LCOV_EXCL_START
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement FDM inverse creation");
+  // LCOV_EXCL_STOP
+}
+
+//------------------------------------------------------------------------------
+// Create operator
+//------------------------------------------------------------------------------
+int CeedOperatorCreate_Hip_gen(CeedOperator op) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+  CeedOperator_Hip_gen *impl;
+
+  ierr = CeedCalloc(1, &impl); CeedChk(ierr);
+  ierr = CeedOperatorSetData(op, impl); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "CreateFDMElementInverse",
+                                CeedOperatorCreateFDMElementInverse_Hip);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
+                                CeedOperatorApplyAdd_Hip_gen); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Operator", op, "Destroy",
+                                CeedOperatorDestroy_Hip_gen); CeedChk(ierr);
+  return 0;
+}
+//------------------------------------------------------------------------------

--- a/backends/hip-gen/ceed-hip-gen-qfunction.c
+++ b/backends/hip-gen/ceed-hip-gen-qfunction.c
@@ -1,0 +1,138 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <string.h>
+#include <stdio.h>
+#include "ceed-hip-gen.h"
+
+//------------------------------------------------------------------------------
+// Apply QFunction
+//------------------------------------------------------------------------------
+static int CeedQFunctionApply_Hip_gen(CeedQFunction qf, CeedInt Q,
+                                      CeedVector *U, CeedVector *V) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
+  return CeedError(ceed, 1, "Backend does not implement QFunctionApply");
+}
+
+//------------------------------------------------------------------------------
+// Destroy QFunction
+//------------------------------------------------------------------------------
+static int CeedQFunctionDestroy_Hip_gen(CeedQFunction qf) {
+  int ierr;
+  CeedQFunction_Hip_gen *data;
+  ierr = CeedQFunctionGetData(qf, &data); CeedChk(ierr);
+  Ceed ceed;
+  ierr = CeedQFunctionGetCeed(qf, &ceed); CeedChk(ierr);
+  ierr = hipFree(data->d_c); CeedChk_Hip(ceed, ierr);
+  ierr = CeedFree(&data->qFunctionSource); CeedChk(ierr);
+  ierr = CeedFree(&data); CeedChk(ierr);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Load QFunction
+//------------------------------------------------------------------------------
+static int loadHipFunction(CeedQFunction qf, char *c_src_file) {
+  int ierr;
+  Ceed ceed;
+  CeedQFunctionGetCeed(qf, &ceed);
+  CeedQFunction_Hip_gen *data;
+  ierr = CeedQFunctionGetData(qf, &data); CeedChk(ierr);
+
+  // Find source file
+  char *hip_file;
+  ierr = CeedCalloc(HIP_MAX_PATH, &hip_file); CeedChk(ierr);
+  memcpy(hip_file, c_src_file, strlen(c_src_file));
+  const char *last_dot = strrchr(hip_file, '.');
+  if (!last_dot)
+    return CeedError(ceed, 1, "Cannot find file's extension!");
+  const size_t hip_path_len = last_dot - hip_file;
+  strncpy(&hip_file[hip_path_len], ".h", 3);
+
+  // Open source file
+  FILE *fp;
+  long lSize;
+  char *buffer;
+  fp = fopen (hip_file, "rb");
+  if (!fp)
+    // LCOV_EXCL_START
+    CeedError(ceed, 1, "Couldn't open the Hip file for the QFunction.");
+  // LCOV_EXCL_STOP
+
+  // Compute size of source file
+  fseek(fp, 0L, SEEK_END);
+  lSize = ftell(fp);
+  rewind(fp);
+
+  // Allocate memory for entire content
+  ierr = CeedCalloc(lSize+1, &buffer); CeedChk(ierr);
+
+  // Copy the file into the buffer
+  if (1 != fread(buffer, lSize, 1, fp)) {
+    // LCOV_EXCL_START
+    fclose(fp);
+    ierr = CeedFree(&buffer); CeedChk(ierr);
+    CeedError(ceed, 1, "Couldn't read the Hip file for the QFunction.");
+    // LCOV_EXCL_STOP
+  }
+
+  // Append typedef and save source string
+  // FIXME: the magic number 16 should be defined somewhere...
+  char *fields_string =
+    "typedef struct { const CeedScalar* inputs[16]; CeedScalar* outputs[16]; } Fields_Hip_gen;";
+  ierr = CeedMalloc(1 + strlen(fields_string) + strlen(buffer),
+                    &data->qFunctionSource); CeedChk(ierr);
+  memcpy(data->qFunctionSource, fields_string, strlen(fields_string));
+  memcpy(data->qFunctionSource + strlen(fields_string), buffer,
+         strlen(buffer) + 1);
+
+  // Cleanup
+  ierr = CeedFree(&buffer); CeedChk(ierr);
+  fclose(fp);
+  ierr = CeedFree(&hip_file); CeedChk(ierr);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Create QFunction
+//------------------------------------------------------------------------------
+int CeedQFunctionCreate_Hip_gen(CeedQFunction qf) {
+  int ierr;
+  Ceed ceed;
+  CeedQFunctionGetCeed(qf, &ceed);
+  CeedQFunction_Hip_gen *data;
+  ierr = CeedCalloc(1, &data); CeedChk(ierr);
+  ierr = CeedQFunctionSetData(qf, data); CeedChk(ierr);
+
+  char *source;
+  ierr = CeedQFunctionGetSourcePath(qf, &source); CeedChk(ierr);
+  const char *funname = strrchr(source, ':') + 1;
+  data->qFunctionName = (char *)funname;
+  const int filenamelen = funname - source;
+  char filename[filenamelen];
+  memcpy(filename, source, filenamelen - 1);
+  filename[filenamelen - 1] = '\0';
+  ierr = loadHipFunction(qf, filename); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "QFunction", qf, "Apply",
+                                CeedQFunctionApply_Hip_gen); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunction", qf, "Destroy",
+                                CeedQFunctionDestroy_Hip_gen); CeedChk(ierr);
+  return 0;
+}
+//------------------------------------------------------------------------------

--- a/backends/hip-gen/ceed-hip-gen.c
+++ b/backends/hip-gen/ceed-hip-gen.c
@@ -1,0 +1,60 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <string.h>
+#include <stdarg.h>
+#include "ceed-hip-gen.h"
+
+//------------------------------------------------------------------------------
+// Backend init
+//------------------------------------------------------------------------------
+static int CeedInit_Hip_gen(const char *resource, Ceed ceed) {
+  int ierr;
+  const int nrc = 8; // number of characters in resource
+  if (strncmp(resource, "/gpu/hip/gen", nrc))
+    // LCOV_EXCL_START
+    return CeedError(ceed, 1, "Hip backend cannot use resource: %s", resource);
+  // LCOV_EXCL_STOP
+
+  Ceed ceedshared;
+  CeedInit("/gpu/hip/shared", &ceedshared);
+  ierr = CeedSetDelegate(ceed, ceedshared); CeedChk(ierr);
+
+  Ceed_Hip_gen *data;
+  ierr = CeedCalloc(1, &data); CeedChk(ierr);
+  ierr = CeedSetData(ceed, data); CeedChk(ierr);
+  ierr = CeedHipInit(ceed, resource, nrc); CeedChk(ierr);
+
+  const char fallbackresource[] = "/gpu/hip/ref";
+  ierr = CeedSetOperatorFallbackResource(ceed, fallbackresource); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",
+                                CeedQFunctionCreate_Hip_gen); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
+                                CeedOperatorCreate_Hip_gen); CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "Destroy",
+                                CeedDestroy_Hip); CeedChk(ierr);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Register backend
+//------------------------------------------------------------------------------
+__attribute__((constructor))
+static void Register(void) {
+  CeedRegister("/gpu/hip/gen", CeedInit_Hip_gen, 20);
+}
+//------------------------------------------------------------------------------

--- a/backends/hip-gen/ceed-hip-gen.h
+++ b/backends/hip-gen/ceed-hip-gen.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include "../hip/ceed-hip.h"
+
+typedef struct { const CeedScalar *in[16]; CeedScalar *out[16]; } HipFields;
+typedef struct { CeedInt *in[16]; CeedInt *out[16]; } HipFieldsInt;
+
+typedef struct {
+  CeedInt dim;
+  CeedInt Q1d;
+  CeedInt maxP1d;
+  hipModule_t module;
+  hipFunction_t op;
+  HipFieldsInt indices;
+  HipFields fields;
+  HipFields B;
+  HipFields G;
+  CeedScalar *W;
+} CeedOperator_Hip_gen;
+
+typedef struct {
+  char *qFunctionName;
+  char *qFunctionSource;
+  void *d_c;
+} CeedQFunction_Hip_gen;
+
+typedef struct {
+  Ceed_Hip base;
+} Ceed_Hip_gen;
+
+CEED_INTERN int CeedQFunctionCreate_Hip_gen(CeedQFunction qf);
+
+CEED_INTERN int CeedOperatorCreate_Hip_gen(CeedOperator op);
+
+CEED_INTERN int CeedCompositeOperatorCreate_Hip_gen(CeedOperator op);

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -825,15 +825,6 @@ static int ComputeBasisThreadBlockSizes(const CeedInt dim, const CeedInt P1d,
 }
 
 //------------------------------------------------------------------------------
-// Device initalization
-//------------------------------------------------------------------------------
-int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
-                      CeedScalar **c_B);
-int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G, CeedInt P1d,
-                          CeedInt Q1d, CeedScalar **c_B_ptr,
-                          CeedScalar **c_G_ptr);
-
-//------------------------------------------------------------------------------
 // Apply basis
 //------------------------------------------------------------------------------
 int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -1,0 +1,1024 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include "ceed-hip-shared.h"
+#include "../hip/ceed-hip-compile.h"
+
+//------------------------------------------------------------------------------
+// Shared mem kernels
+//------------------------------------------------------------------------------
+// *INDENT-OFF*
+static const char *kernelsShared = QUOTE(
+
+//------------------------------------------------------------------------------
+// Sum input into output
+//------------------------------------------------------------------------------
+inline __device__ void add(CeedScalar *r_V, const CeedScalar *r_U) {
+  for (int i = 0; i < P1D; i++)
+    r_V[i] += r_U[i];
+}
+
+//------------------------------------------------------------------------------
+// 1D
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Read DoFs
+//------------------------------------------------------------------------------
+inline __device__ void readDofs1d(const int elem, const int tidx,
+                                  const int tidy, const int tidz,const int comp,
+                                  const int nelem, const CeedScalar *d_U,
+                                  CeedScalar *slice) {
+  for (int i = 0; i < P1D; i++)
+    slice[i + tidz*T1D] = d_U[i + elem*P1D + comp*P1D*nelem];
+  for (int i = P1D; i < Q1D; i++)
+    slice[i + tidz*T1D] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+// Write DoFs
+//------------------------------------------------------------------------------
+inline __device__ void writeDofs1d(const int elem, const int tidx,
+                                   const int tidy, const int comp,
+                                   const int nelem, const CeedScalar &r_V,
+                                   CeedScalar *d_V) {
+  if (tidx<P1D)
+    d_V[tidx + elem*P1D + comp*P1D*nelem] = r_V;
+}
+
+//------------------------------------------------------------------------------
+// Read quadrature point data
+//------------------------------------------------------------------------------
+inline __device__ void readQuads1d(const int elem, const int tidx,
+                                   const int tidy, const int tidz, const int comp,
+                                   const int dim, const int nelem,
+                                   const CeedScalar *d_U, CeedScalar *slice) {
+  for (int i = 0; i < Q1D; i++)
+    slice[i + tidz*T1D] = d_U[i + elem*Q1D + comp*Q1D*nelem +
+                            dim*BASIS_NCOMP*nelem*Q1D];
+  for (int i = Q1D; i < P1D; i++)
+    slice[i + tidz*T1D] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+// Write quadrature point data
+//------------------------------------------------------------------------------
+inline __device__ void writeQuads1d(const int elem, const int tidx,
+                                    const int tidy, const int comp,
+                                    const int dim, const int nelem,
+                                    const CeedScalar &r_V, CeedScalar *d_V) {
+  if (tidx<Q1D)
+    d_V[tidx + elem*Q1D + comp*Q1D*nelem + dim*BASIS_NCOMP*nelem*Q1D] = r_V;
+}
+
+//------------------------------------------------------------------------------
+// 1D tensor contraction
+//------------------------------------------------------------------------------
+inline __device__ void ContractX1d(CeedScalar *slice, const int tidx,
+                                   const int tidy, const int tidz,
+                                   const CeedScalar &U, const CeedScalar *B,
+                                   CeedScalar &V) {
+  V = 0.0;
+  for (int i = 0; i < P1D; ++i)
+    V += B[i + tidx*P1D] * slice[i + tidz*T1D]; // Contract x direction
+}
+
+//------------------------------------------------------------------------------
+// 1D transpose tensor contraction
+//------------------------------------------------------------------------------
+inline __device__ void ContractTransposeX1d(CeedScalar *slice, const int tidx,
+    const int tidy, const int tidz,
+    const CeedScalar &U, const CeedScalar *B, CeedScalar &V) {
+  V = 0.0;
+  for (int i = 0; i < Q1D; ++i)
+    V += B[tidx + i*P1D] * slice[i + tidz*T1D]; // Contract x direction
+}
+
+//------------------------------------------------------------------------------
+// 1D interpolate to quadrature points
+//------------------------------------------------------------------------------
+inline __device__ void interp1d(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B,
+                                const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V,
+                                CeedScalar *slice) {
+  CeedScalar r_V;
+  CeedScalar r_t;
+
+  const int tidx = threadIdx.x;
+  const int tidy = threadIdx.y;
+  const int tidz = threadIdx.z;
+
+
+  for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
+       elem += gridDim.x*blockDim.z) {
+    for (int comp = 0; comp < BASIS_NCOMP; comp++) {
+      if (!transpose) {
+        readDofs1d(elem, tidx, tidy, tidz, comp, nelem, d_U, slice);
+        ContractX1d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+        writeQuads1d(elem, tidx, tidy, comp, 0, nelem, r_V, d_V);
+      } else {
+        readQuads1d(elem, tidx, tidy, tidz, comp, 0, nelem, d_U, slice);
+        ContractTransposeX1d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+        writeDofs1d(elem, tidx, tidy, comp, nelem, r_V, d_V);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 1D derivatives at quadrature points
+//------------------------------------------------------------------------------
+inline __device__ void grad1d(const CeedInt nelem, const int transpose,
+                              const CeedScalar *c_B, const CeedScalar *c_G,
+                              const CeedScalar *__restrict__ d_U,
+                              CeedScalar *__restrict__ d_V,
+                              CeedScalar *slice) {
+  CeedScalar r_U;
+  CeedScalar r_V;
+
+  const int tidx = threadIdx.x;
+  const int tidy = threadIdx.y;
+  const int tidz = threadIdx.z;
+  int dim;
+
+  for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
+       elem += gridDim.x*blockDim.z) {
+    for(int comp = 0; comp < BASIS_NCOMP; comp++) {
+      if (!transpose) {
+        readDofs1d(elem, tidx, tidy, tidz, comp, nelem, d_U, slice);
+        ContractX1d(slice, tidx, tidy, tidz, r_U, c_G, r_V);
+        dim = 0;
+        writeQuads1d(elem, tidx, tidy, comp, dim, nelem, r_V, d_V);
+      } else {
+        dim = 0;
+        readQuads1d(elem, tidx, tidy, tidz, comp, dim, nelem, d_U, slice);
+        ContractTransposeX1d(slice, tidx, tidy, tidz, r_U, c_G, r_V);
+        writeDofs1d(elem, tidx, tidy, comp, nelem, r_V, d_V);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 1D Quadrature weights
+//------------------------------------------------------------------------------
+__device__ void weight1d(const CeedInt nelem, const CeedScalar *qweight1d,
+                         CeedScalar *w) {
+  const int tid = threadIdx.x;
+  const CeedScalar weight = qweight1d[tid];
+  for (CeedInt elem = blockIdx.x*blockDim.y + threadIdx.y; elem < nelem;
+       elem += gridDim.x*blockDim.y) {
+    const int ind = elem*Q1D + tid;
+    w[ind] = weight;
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Read DoFs
+//------------------------------------------------------------------------------
+inline __device__ void readDofs2d(const int elem, const int tidx,
+                                  const int tidy, const int comp,
+                                  const int nelem, const CeedScalar *d_U,
+                                  CeedScalar &U) {
+  U = (tidx<P1D && tidy<P1D) ?
+      d_U[tidx + tidy*P1D + elem*P1D*P1D + comp*P1D*P1D*nelem] : 0.0;
+}
+
+//------------------------------------------------------------------------------
+// Write DoFs
+//------------------------------------------------------------------------------
+inline __device__ void writeDofs2d(const int elem, const int tidx,
+                                   const int tidy, const int comp,
+                                   const int nelem, const CeedScalar &r_V,
+                                   CeedScalar *d_V) {
+  if (tidx<P1D && tidy<P1D)
+    d_V[tidx + tidy*P1D + elem*P1D*P1D + comp*P1D*P1D*nelem] = r_V;
+}
+
+//------------------------------------------------------------------------------
+// Read quadrature point data
+//------------------------------------------------------------------------------
+inline __device__ void readQuads2d(const int elem, const int tidx,
+                                   const int tidy, const int comp,
+                                   const int dim, const int nelem,
+                                   const CeedScalar *d_U, CeedScalar &U ) {
+  U = (tidx<Q1D && tidy<Q1D) ?
+      d_U[tidx + tidy*Q1D + elem*Q1D*Q1D + comp*Q1D*Q1D*nelem +
+      dim*BASIS_NCOMP*nelem*Q1D*Q1D] : 0.0;
+}
+
+//------------------------------------------------------------------------------
+// Write quadrature point data
+//------------------------------------------------------------------------------
+inline __device__ void writeQuads2d(const int elem, const int tidx,
+                                    const int tidy, const int comp,
+                                    const int dim, const int nelem,
+                                    const CeedScalar &r_V, CeedScalar *d_V) {
+  if (tidx<Q1D && tidy<Q1D)
+    d_V[tidx + tidy*Q1D + elem*Q1D*Q1D + comp*Q1D*Q1D*nelem +
+    dim*BASIS_NCOMP*nelem*Q1D*Q1D] = r_V;
+}
+
+//------------------------------------------------------------------------------
+// 2D tensor contraction x
+//------------------------------------------------------------------------------
+inline __device__ void ContractX2d(CeedScalar *slice, const int tidx,
+                                   const int tidy, const int tidz,
+                                   const CeedScalar &U, const CeedScalar *B,
+                                   CeedScalar &V) {
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
+  __syncthreads();
+  V = 0.0;
+  if (tidx < Q1D)
+    for (int i = 0; i < P1D; ++i)
+      V += B[i + tidx*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D tensor contraction y
+//------------------------------------------------------------------------------
+inline __device__ void ContractY2d(CeedScalar *slice, const int tidx,
+                                   const int tidy, const int tidz,
+                                   const CeedScalar &U, const CeedScalar *B,
+                                   CeedScalar &V) {
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
+  __syncthreads();
+  V = 0.0;
+  if (tidy < Q1D)
+    for (int i = 0; i < P1D; ++i)
+      V += B[i + tidy*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D transpose tensor contraction y
+//------------------------------------------------------------------------------
+inline __device__ void ContractTransposeY2d(CeedScalar *slice, const int tidx,
+    const int tidy, const int tidz,
+    const CeedScalar &U, const CeedScalar *B, CeedScalar &V) {
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
+  __syncthreads();
+  V = 0.0;
+  if (tidy < P1D)
+    for (int i = 0; i < Q1D; ++i)
+      V += B[tidy + i*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D transpose tensor contraction x
+//------------------------------------------------------------------------------
+inline __device__ void ContractTransposeX2d(CeedScalar *slice, const int tidx,
+    const int tidy, const int tidz,
+    const CeedScalar &U, const CeedScalar *B, CeedScalar &V) {
+  slice[tidx + tidy*T1D + tidz*T1D*T1D] = U;
+  __syncthreads();
+  V = 0.0;
+  if (tidx < P1D)
+    for (int i = 0; i < Q1D; ++i)
+      V += B[tidx + i*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
+  __syncthreads();
+}
+
+//------------------------------------------------------------------------------
+// 2D interpolate to quadrature points
+//------------------------------------------------------------------------------
+inline __device__ void interp2d(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B,
+                                const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V,
+                                CeedScalar *slice) {
+  CeedScalar r_V;
+  CeedScalar r_t;
+
+  const int tidx = threadIdx.x;
+  const int tidy = threadIdx.y;
+  const int tidz = threadIdx.z;
+  const int blockElem = tidz/BASIS_NCOMP;
+  const int elemsPerBlock = blockDim.z/BASIS_NCOMP;
+  const int comp = tidz%BASIS_NCOMP;
+
+  for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
+       elem += gridDim.x*elemsPerBlock) {
+    const int comp = tidz%BASIS_NCOMP;
+    r_V = 0.0;
+    r_t = 0.0;
+    if (!transpose) {
+      readDofs2d(elem, tidx, tidy, comp, nelem, d_U, r_V);
+      ContractX2d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      ContractY2d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      writeQuads2d(elem, tidx, tidy, comp, 0, nelem, r_V, d_V);
+    } else {
+      readQuads2d(elem, tidx, tidy, comp, 0, nelem, d_U, r_V);
+      ContractTransposeY2d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      ContractTransposeX2d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      writeDofs2d(elem, tidx, tidy, comp, nelem, r_V, d_V);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D derivatives at quadrature points
+//------------------------------------------------------------------------------
+inline __device__ void grad2d(const CeedInt nelem, const int transpose,
+                              const CeedScalar *c_B, const CeedScalar *c_G,
+                              const CeedScalar *__restrict__ d_U,
+                              CeedScalar *__restrict__ d_V, CeedScalar *slice) {
+  CeedScalar r_U;
+  CeedScalar r_V;
+  CeedScalar r_t;
+
+  const int tidx = threadIdx.x;
+  const int tidy = threadIdx.y;
+  const int tidz = threadIdx.z;
+  const int blockElem = tidz/BASIS_NCOMP;
+  const int elemsPerBlock = blockDim.z/BASIS_NCOMP;
+  const int comp = tidz%BASIS_NCOMP;
+  int dim;
+
+  for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
+       elem += gridDim.x*elemsPerBlock) {
+    if (!transpose) {
+      readDofs2d(elem, tidx, tidy, comp, nelem, d_U, r_U);
+      ContractX2d(slice, tidx, tidy, tidz, r_U, c_G, r_t);
+      ContractY2d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      dim = 0;
+      writeQuads2d(elem, tidx, tidy, comp, dim, nelem, r_V, d_V);
+      ContractX2d(slice, tidx, tidy, tidz, r_U, c_B, r_t);
+      ContractY2d(slice, tidx, tidy, tidz, r_t, c_G, r_V);
+      dim = 1;
+      writeQuads2d(elem, tidx, tidy, comp, dim, nelem, r_V, d_V);
+    } else {
+      dim = 0;
+      readQuads2d(elem, tidx, tidy, comp, dim, nelem, d_U, r_U);
+      ContractTransposeY2d(slice, tidx, tidy, tidz, r_U, c_B, r_t);
+      ContractTransposeX2d(slice, tidx, tidy, tidz, r_t, c_G, r_V);
+      dim = 1;
+      readQuads2d(elem, tidx, tidy, comp, dim, nelem, d_U, r_U);
+      ContractTransposeY2d(slice, tidx, tidy, tidz, r_U, c_G, r_t);
+      ContractTransposeX2d(slice, tidx, tidy, tidz, r_t, c_B, r_U);
+      r_V += r_U;
+      writeDofs2d(elem, tidx, tidy, comp, nelem, r_V, d_V);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 2D quadrature weights
+//------------------------------------------------------------------------------
+__device__ void weight2d(const CeedInt nelem, const CeedScalar *qweight1d,
+                         CeedScalar *w) {
+  const int i = threadIdx.x;
+  const int j = threadIdx.y;
+  const CeedScalar weight = qweight1d[i]*qweight1d[j];
+  for (CeedInt elem = blockIdx.x*blockDim.z + threadIdx.z; elem < nelem;
+       elem += gridDim.x*blockDim.z) {
+    const int ind = elem*Q1D*Q1D + i + j*Q1D;
+    w[ind] = weight;
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Read DoFs
+//------------------------------------------------------------------------------
+inline __device__ void readDofs3d(const int elem, const int tidx,
+                                  const int tidy, const int comp,
+                                  const int nelem, const CeedScalar *d_U,
+                                  CeedScalar *r_U) {
+  for (int i = 0; i < P1D; i++)
+    r_U[i] = (tidx < P1D && tidy < P1D) ?
+              d_U[tidx + tidy*P1D + i*P1D*P1D + elem*P1D*P1D*P1D +
+                  comp*P1D*P1D*P1D*nelem] : 0.0;
+  for (int i = P1D; i < Q1D; i++)
+    r_U[i] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+// Write DoFs
+//------------------------------------------------------------------------------
+inline __device__ void writeDofs3d(const int elem, const int tidx,
+                                   const int tidy, const int comp,
+                                   const int nelem, const CeedScalar *r_V,
+                                   CeedScalar *d_V) {
+  if (tidx < P1D && tidy < P1D) {
+    for (int i = 0; i < P1D; i++)
+      d_V[tidx + tidy*P1D + i*P1D*P1D + elem*P1D*P1D*P1D +
+          comp*P1D*P1D*P1D*nelem] = r_V[i];
+  }
+}
+
+//------------------------------------------------------------------------------
+// Read quadrature point data
+//------------------------------------------------------------------------------
+inline __device__ void readQuads3d(const int elem, const int tidx,
+                                   const int tidy, const int comp,
+                                   const int dim, const int nelem,
+                                   const CeedScalar *d_U, CeedScalar *r_U) {
+  for (int i = 0; i < Q1D; i++)
+    r_U[i] = (tidx < Q1D && tidy < Q1D) ? 
+              d_U[tidx + tidy*Q1D + i*Q1D*Q1D + elem*Q1D*Q1D*Q1D +
+              comp*Q1D*Q1D*Q1D*nelem + dim*BASIS_NCOMP*nelem*Q1D*Q1D*Q1D] : 0.0;
+  for (int i = Q1D; i < P1D; i++)
+    r_U[i] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+// Write quadrature point data
+//------------------------------------------------------------------------------
+inline __device__ void writeQuads3d(const int elem, const int tidx,
+                                    const int tidy, const int comp,
+                                    const int dim, const int nelem,
+                                    const CeedScalar *r_V, CeedScalar *d_V) {
+  if (tidx < Q1D && tidy < Q1D) {
+    for (int i = 0; i < Q1D; i++)
+      d_V[tidx + tidy*Q1D + i*Q1D*Q1D + elem*Q1D*Q1D*Q1D + comp*Q1D*Q1D*Q1D*nelem +
+          dim*BASIS_NCOMP*nelem*Q1D*Q1D*Q1D] = r_V[i];
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D tensor contract x
+//------------------------------------------------------------------------------
+inline __device__ void ContractX3d(CeedScalar *slice, const int tidx,
+                                   const int tidy, const int tidz,
+                                   const CeedScalar *U,
+                                   const CeedScalar *B,
+                                   CeedScalar *V) {
+  for (int k = 0; k < P1D; ++k) {
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (tidx < Q1D && tidy < P1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + tidx*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D tensor contract y
+//------------------------------------------------------------------------------
+inline __device__ void ContractY3d(CeedScalar *slice, const int tidx,
+                                   const int tidy, const int tidz,
+                                   const CeedScalar *U,
+                                   const CeedScalar *B,
+                                   CeedScalar *V) {
+  for (int k = 0; k < P1D; ++k) {
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (tidx < Q1D && tidy < Q1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + tidy*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D tensor contract z
+//------------------------------------------------------------------------------
+inline __device__ void ContractZ3d(CeedScalar *slice, const int tidx,
+                                   const int tidy, const int tidz,
+                                   const CeedScalar *U,
+                                   const CeedScalar *B,
+                                   CeedScalar *V) {
+  for (int k = 0; k < Q1D; ++k) {
+    V[k] = 0.0;
+    if (tidx < Q1D && tidy < Q1D)
+      for (int i = 0; i < P1D; ++i)
+        V[k] += B[i + k*P1D] * U[i]; // Contract z direction
+  }
+  for (int k = Q1D; k < P1D; ++k)
+    V[k] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract z
+//------------------------------------------------------------------------------
+inline __device__ void ContractTransposeZ3d(CeedScalar *slice, const int tidx,
+                                            const int tidy, const int tidz,
+                                            const CeedScalar *U,
+                                            const CeedScalar *B,
+                                            CeedScalar *V) {
+  for (int k = 0; k < P1D; ++k) {
+    V[k] = 0.0;
+    if (tidx < Q1D && tidy < Q1D)
+      for (int i = 0; i < Q1D; ++i)
+        V[k] += B[k + i*P1D] * U[i]; // Contract z direction
+  }
+  for (int k = P1D; k < Q1D; ++k)
+    V[k] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract y
+//------------------------------------------------------------------------------
+inline __device__ void ContractTransposeY3d(CeedScalar *slice, const int tidx,
+                                            const int tidy, const int tidz,
+                                            const CeedScalar *U,
+                                            const CeedScalar *B,
+                                            CeedScalar *V) {
+  for (int k = 0; k < P1D; ++k) {
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (tidx < Q1D && tidy < P1D)
+      for (int i = 0; i < Q1D; ++i)
+        V[k] += B[tidy + i*P1D] * slice[tidx + i*T1D + tidz*T1D*T1D]; // Contract y direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D transpose tensor contract x
+//------------------------------------------------------------------------------
+inline __device__ void ContractTransposeX3d(CeedScalar *slice, const int tidx,
+                                            const int tidy, const int tidz,
+                                            const CeedScalar *U,
+                                            const CeedScalar *B,
+                                            CeedScalar *V) {
+  for (int k = 0; k < P1D; ++k) {
+    slice[tidx + tidy*T1D + tidz*T1D*T1D] = U[k];
+    __syncthreads();
+    V[k] = 0.0;
+    if (tidx < P1D && tidy < P1D)
+      for (int i = 0; i < Q1D; ++i)
+        V[k] += B[tidx + i*P1D] * slice[i + tidy*T1D + tidz*T1D*T1D]; // Contract x direction
+    __syncthreads();
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D interpolate to quadrature points
+//------------------------------------------------------------------------------
+inline __device__ void interp3d(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B,
+                                const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V,
+                                CeedScalar *slice) {
+  CeedScalar r_V[T1D];
+  CeedScalar r_t[T1D];
+
+  const int tidx = threadIdx.x;
+  const int tidy = threadIdx.y;
+  const int tidz = threadIdx.z;
+  const int blockElem = tidz/BASIS_NCOMP;
+  const int elemsPerBlock = blockDim.z/BASIS_NCOMP;
+  const int comp = tidz%BASIS_NCOMP;
+
+  for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
+       elem += gridDim.x*elemsPerBlock) {
+    for (int i = 0; i < T1D; ++i) {
+      r_V[i] = 0.0;
+      r_t[i] = 0.0;
+    }
+    if (!transpose) {
+      readDofs3d(elem, tidx, tidy, comp, nelem, d_U, r_V);
+      ContractX3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      ContractY3d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      ContractZ3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      writeQuads3d(elem, tidx, tidy, comp, 0, nelem, r_t, d_V);
+    } else {
+      readQuads3d(elem, tidx, tidy, comp, 0, nelem, d_U, r_V);
+      ContractTransposeZ3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      ContractTransposeY3d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      ContractTransposeX3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      writeDofs3d(elem, tidx, tidy, comp, nelem, r_t, d_V);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D derivatives at quadrature points
+//------------------------------------------------------------------------------
+inline __device__ void grad3d(const CeedInt nelem, const int transpose,
+                              const CeedScalar *c_B, const CeedScalar *c_G,
+                              const CeedScalar *__restrict__ d_U,
+                              CeedScalar *__restrict__ d_V,
+                              CeedScalar *slice) {
+  // Use P1D for one of these
+  CeedScalar r_U[T1D];
+  CeedScalar r_V[T1D];
+  CeedScalar r_t[T1D];
+
+  const int tidx = threadIdx.x;
+  const int tidy = threadIdx.y;
+  const int tidz = threadIdx.z;
+  const int blockElem = tidz/BASIS_NCOMP;
+  const int elemsPerBlock = blockDim.z/BASIS_NCOMP;
+  const int comp = tidz%BASIS_NCOMP;
+  int dim;
+
+  for (CeedInt elem = blockIdx.x*elemsPerBlock + blockElem; elem < nelem;
+       elem += gridDim.x*elemsPerBlock) {
+    for (int i = 0; i < T1D; ++i) {
+      r_U[i] = 0.0;
+      r_V[i] = 0.0;
+      r_t[i] = 0.0;
+    }
+    if (!transpose) {
+      readDofs3d(elem, tidx, tidy, comp, nelem, d_U, r_U);
+      ContractX3d(slice, tidx, tidy, tidz, r_U, c_G, r_V);
+      ContractY3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      ContractZ3d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      dim = 0;
+      writeQuads3d(elem, tidx, tidy, comp, dim, nelem, r_V, d_V);
+      ContractX3d(slice, tidx, tidy, tidz, r_U, c_B, r_V);
+      ContractY3d(slice, tidx, tidy, tidz, r_V, c_G, r_t);
+      ContractZ3d(slice, tidx, tidy, tidz, r_t, c_B, r_V);
+      dim = 1;
+      writeQuads3d(elem, tidx, tidy, comp, dim, nelem, r_V, d_V);
+      ContractX3d(slice, tidx, tidy, tidz, r_U, c_B, r_V);
+      ContractY3d(slice, tidx, tidy, tidz, r_V, c_B, r_t);
+      ContractZ3d(slice, tidx, tidy, tidz, r_t, c_G, r_V);
+      dim = 2;
+      writeQuads3d(elem, tidx, tidy, comp, dim, nelem, r_V, d_V);
+    } else {
+      dim = 0;
+      readQuads3d(elem, tidx, tidy, comp, dim, nelem, d_U, r_U);
+      ContractTransposeZ3d(slice, tidx, tidy, tidz, r_U, c_B, r_t);
+      ContractTransposeY3d(slice, tidx, tidy, tidz, r_t, c_B, r_U);
+      ContractTransposeX3d(slice, tidx, tidy, tidz, r_U, c_G, r_V);
+      dim = 1;
+      readQuads3d(elem, tidx, tidy, comp, dim, nelem, d_U, r_U);
+      ContractTransposeZ3d(slice, tidx, tidy, tidz, r_U, c_B, r_t);
+      ContractTransposeY3d(slice, tidx, tidy, tidz, r_t, c_G, r_U);
+      ContractTransposeX3d(slice, tidx, tidy, tidz, r_U, c_B, r_t);
+      add(r_V, r_t);
+      dim = 2;
+      readQuads3d(elem, tidx, tidy, comp, dim, nelem, d_U, r_U);
+      ContractTransposeZ3d(slice, tidx, tidy, tidz, r_U, c_G, r_t);
+      ContractTransposeY3d(slice, tidx, tidy, tidz, r_t, c_B, r_U);
+      ContractTransposeX3d(slice, tidx, tidy, tidz, r_U, c_B, r_t);
+      add(r_V, r_t);
+      writeDofs3d(elem, tidx, tidy, comp, nelem, r_V, d_V);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// 3D quadrature weights
+//------------------------------------------------------------------------------
+__device__ void weight3d(const CeedInt nelem, const CeedScalar *qweight1d,
+                         CeedScalar *w) {
+  const int i = threadIdx.x;
+  const int j = threadIdx.y;
+  const int k = threadIdx.z;
+  const CeedScalar weight = qweight1d[i]*qweight1d[j]*qweight1d[k];
+  for (int e = blockIdx.x; e < nelem; e += gridDim.x) {
+    const int ind = e*Q1D*Q1D*Q1D + i + j*Q1D + k*Q1D*Q1D;
+    w[ind] = weight;
+  }
+}
+
+
+//------------------------------------------------------------------------------
+// Basis kernels
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Interp kernel by dim
+//------------------------------------------------------------------------------
+extern "C" __global__ void interp(const CeedInt nelem, const int transpose,
+                                  const CeedScalar *c_B,
+                                  const CeedScalar *__restrict__ d_U,
+                                  CeedScalar *__restrict__ d_V) {
+  HIP_DYNAMIC_SHARED( double, slice)
+  if (BASIS_DIM == 1) {
+    interp1d(nelem, transpose, c_B, d_U, d_V, slice);
+  } else if (BASIS_DIM == 2) {
+    interp2d(nelem, transpose, c_B, d_U, d_V, slice);
+  } else if (BASIS_DIM == 3) {
+    interp3d(nelem, transpose, c_B, d_U, d_V, slice);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Grad kernel by dim
+//------------------------------------------------------------------------------
+extern "C" __global__ void grad(const CeedInt nelem, const int transpose,
+                                const CeedScalar *c_B, const CeedScalar *c_G,
+                                const CeedScalar *__restrict__ d_U,
+                                CeedScalar *__restrict__ d_V) {
+  HIP_DYNAMIC_SHARED( double, slice)
+  if (BASIS_DIM == 1) {
+    grad1d(nelem, transpose, c_B, c_G, d_U, d_V, slice);
+  } else if (BASIS_DIM == 2) {
+    grad2d(nelem, transpose, c_B, c_G, d_U, d_V, slice);
+  } else if (BASIS_DIM == 3) {
+    grad3d(nelem, transpose, c_B, c_G, d_U, d_V, slice);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Weight kernels by dim
+//------------------------------------------------------------------------------
+extern "C" __global__ void weight(const CeedInt nelem,
+                                  const CeedScalar *__restrict__ qweight1d,
+                                  CeedScalar *__restrict__ v) {
+  if (BASIS_DIM == 1) {
+    weight1d(nelem, qweight1d, v);
+  } else if (BASIS_DIM == 2) {
+    weight2d(nelem, qweight1d, v);
+  } else if (BASIS_DIM == 3) {
+    weight3d(nelem, qweight1d, v);
+  }
+}
+
+);
+// *INDENT-ON*
+
+//------------------------------------------------------------------------------
+// Device initalization
+//------------------------------------------------------------------------------
+int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
+                      CeedScalar **c_B);
+int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G, CeedInt P1d,
+                          CeedInt Q1d, CeedScalar **c_B_ptr,
+                          CeedScalar **c_G_ptr);
+
+//------------------------------------------------------------------------------
+// Apply basis
+//------------------------------------------------------------------------------
+int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,
+                                    CeedTransposeMode tmode,
+                                    CeedEvalMode emode, CeedVector u,
+                                    CeedVector v) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
+  Ceed_Hip_shared *ceed_Hip;
+  CeedGetData(ceed, &ceed_Hip); CeedChk(ierr);
+  CeedBasis_Hip_shared *data;
+  CeedBasisGetData(basis, &data); CeedChk(ierr);
+  const CeedInt transpose = tmode == CEED_TRANSPOSE;
+  CeedInt dim, ncomp;
+  ierr = CeedBasisGetDimension(basis, &dim); CeedChk(ierr);
+  ierr = CeedBasisGetNumComponents(basis, &ncomp); CeedChk(ierr);
+
+  // Read vectors
+  const CeedScalar *d_u;
+  CeedScalar *d_v;
+  if (emode != CEED_EVAL_WEIGHT) {
+    ierr = CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u); CeedChk(ierr);
+  }
+  ierr = CeedVectorGetArray(v, CEED_MEM_DEVICE, &d_v); CeedChk(ierr);
+
+  // Clear v for transpose mode
+  if (tmode == CEED_TRANSPOSE) {
+    CeedInt length;
+    ierr = CeedVectorGetLength(v, &length); CeedChk(ierr);
+    ierr = hipMemset(d_v, 0, length * sizeof(CeedScalar)); CeedChk(ierr);
+  }
+
+  // Apply basis operation
+  switch (emode) {
+  case CEED_EVAL_INTERP: {
+    CeedInt P1d, Q1d;
+    ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+    ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+    CeedInt thread1d = CeedIntMax(Q1d, P1d);
+    ierr = CeedHipInitInterp(data->d_interp1d, P1d, Q1d, &data->c_B);
+    CeedChk(ierr);
+    void *interpargs[] = {(void *) &nelem, (void *) &transpose, &data->c_B,
+                          &d_u, &d_v
+                         };
+    if (dim == 1) {
+      CeedInt elemsPerBlock = 32*thread1d > 256? 256/thread1d : 32;
+      elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
+      CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                             ? 1 : 0 );
+      CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
+      ierr = CeedRunKernelDimSharedHip(ceed, data->interp, grid, thread1d, 1,
+                                       elemsPerBlock, sharedMem,
+                                       interpargs); CeedChk(ierr);
+    } else if (dim == 2) {
+      const CeedInt optElems[7] = {0,32,8,6,4,2,6};
+      // elemsPerBlock must be at least 1
+      CeedInt elemsPerBlock = CeedIntMax(thread1d<7?optElems[thread1d]/ncomp:1, 1);
+      CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                             ? 1 : 0 );
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
+      ierr = CeedRunKernelDimSharedHip(ceed, data->interp, grid, thread1d, thread1d,
+                                       ncomp*elemsPerBlock, sharedMem,
+                                       interpargs); CeedChk(ierr);
+    } else if (dim == 3) {
+      CeedInt elemsPerBlock = 1;
+      CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                             ? 1 : 0 );
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
+      ierr = CeedRunKernelDimSharedHip(ceed, data->interp, grid, thread1d, thread1d,
+                                       ncomp*elemsPerBlock, sharedMem,
+                                       interpargs); CeedChk(ierr);
+    }
+  } break;
+  case CEED_EVAL_GRAD: {
+    CeedInt P1d, Q1d;
+    ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+    ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+    CeedInt thread1d = CeedIntMax(Q1d, P1d);
+    ierr = CeedHipInitInterpGrad(data->d_interp1d, data->d_grad1d, P1d,
+                                 Q1d, &data->c_B, &data->c_G);
+    CeedChk(ierr);
+    void *gradargs[] = {(void *) &nelem, (void *) &transpose, &data->c_B,
+                        &data->c_G, &d_u, &d_v
+                       };
+    if (dim == 1) {
+      CeedInt elemsPerBlock = 32*thread1d > 256? 256/thread1d : 32;
+      elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
+      CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                             ? 1 : 0 );
+      CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
+      ierr = CeedRunKernelDimSharedHip(ceed, data->grad, grid, thread1d, 1,
+                                       elemsPerBlock, sharedMem, gradargs);
+      CeedChk(ierr);
+    } else if (dim == 2) {
+      const CeedInt optElems[7] = {0,32,8,6,4,2,6};
+      // elemsPerBlock must be at least 1
+      CeedInt elemsPerBlock = CeedIntMax(thread1d<7?optElems[thread1d]/ncomp:1, 1);
+      CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                             ? 1 : 0 );
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
+      ierr = CeedRunKernelDimSharedHip(ceed, data->grad, grid, thread1d, thread1d,
+                                       ncomp*elemsPerBlock, sharedMem,
+                                       gradargs); CeedChk(ierr);
+    } else if (dim == 3) {
+      CeedInt elemsPerBlock = 1;
+      CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
+                                             ? 1 : 0 );
+      CeedInt sharedMem = ncomp*elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
+      ierr = CeedRunKernelDimSharedHip(ceed, data->grad, grid, thread1d, thread1d,
+                                       ncomp*elemsPerBlock, sharedMem,
+                                       gradargs); CeedChk(ierr);
+    }
+  } break;
+  case CEED_EVAL_WEIGHT: {
+    CeedInt Q1d;
+    ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
+    void *weightargs[] = {(void *) &nelem, (void *) &data->d_qweight1d, &d_v};
+    if (dim == 1) {
+      const CeedInt optElems = 32/Q1d;
+      const CeedInt elemsPerBlock = optElems>0?optElems:1;
+      const CeedInt gridsize = nelem/elemsPerBlock + ( (
+                                 nelem/elemsPerBlock*elemsPerBlock<nelem)? 1 : 0 );
+      ierr = CeedRunKernelDimHip(ceed, data->weight, gridsize, Q1d,
+                                 elemsPerBlock, 1, weightargs);
+      CeedChk(ierr);
+    } else if (dim == 2) {
+      const CeedInt optElems = 32/(Q1d*Q1d);
+      const CeedInt elemsPerBlock = optElems>0?optElems:1;
+      const CeedInt gridsize = nelem/elemsPerBlock + ( (
+                                 nelem/elemsPerBlock*elemsPerBlock<nelem)? 1 : 0 );
+      ierr = CeedRunKernelDimHip(ceed, data->weight, gridsize, Q1d, Q1d,
+                                 elemsPerBlock, weightargs);
+      CeedChk(ierr);
+    } else if (dim == 3) {
+      const CeedInt gridsize = nelem;
+      ierr = CeedRunKernelDimHip(ceed, data->weight, gridsize, Q1d, Q1d, Q1d,
+                                 weightargs);
+      CeedChk(ierr);
+    }
+  } break;
+  // LCOV_EXCL_START
+  // Evaluate the divergence to/from the quadrature points
+  case CEED_EVAL_DIV:
+    return CeedError(ceed, 1, "CEED_EVAL_DIV not supported");
+  // Evaluate the curl to/from the quadrature points
+  case CEED_EVAL_CURL:
+    return CeedError(ceed, 1, "CEED_EVAL_CURL not supported");
+  // Take no action, BasisApply should not have been called
+  case CEED_EVAL_NONE:
+    return CeedError(ceed, 1,
+                     "CEED_EVAL_NONE does not make sense in this context");
+    // LCOV_EXCL_STOP
+  }
+
+  // Restore vectors
+  if (emode != CEED_EVAL_WEIGHT) {
+    ierr = CeedVectorRestoreArrayRead(u, &d_u); CeedChk(ierr);
+  }
+  ierr = CeedVectorRestoreArray(v, &d_v); CeedChk(ierr);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Destroy basis
+//------------------------------------------------------------------------------
+static int CeedBasisDestroy_Hip_shared(CeedBasis basis) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
+
+  CeedBasis_Hip_shared *data;
+  ierr = CeedBasisGetData(basis, &data); CeedChk(ierr);
+
+  CeedChk_Hip(ceed, hipModuleUnload(data->module));
+
+  ierr = hipFree(data->d_qweight1d); CeedChk_Hip(ceed, ierr);
+  ierr = hipFree(data->d_interp1d); CeedChk_Hip(ceed, ierr);
+  ierr = hipFree(data->d_grad1d); CeedChk_Hip(ceed, ierr);
+  ierr = hipFree(data->d_collograd1d); CeedChk_Hip(ceed, ierr);
+
+  ierr = CeedFree(&data); CeedChk(ierr);
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Create tensor basis
+//------------------------------------------------------------------------------
+int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P1d, CeedInt Q1d,
+                                       const CeedScalar *interp1d,
+                                       const CeedScalar *grad1d,
+                                       const CeedScalar *qref1d,
+                                       const CeedScalar *qweight1d,
+                                       CeedBasis basis) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis, &ceed); CeedChk(ierr);
+  CeedBasis_Hip_shared *data;
+  ierr = CeedCalloc(1, &data); CeedChk(ierr);
+
+  // Copy basis data to GPU
+  const CeedInt qBytes = Q1d * sizeof(CeedScalar);
+  ierr = hipMalloc((void **)&data->d_qweight1d, qBytes); CeedChk_Hip(ceed, ierr);
+  ierr = hipMemcpy(data->d_qweight1d, qweight1d, qBytes,
+                   hipMemcpyHostToDevice); CeedChk_Hip(ceed, ierr);
+
+  const CeedInt iBytes = qBytes * P1d;
+  ierr = hipMalloc((void **)&data->d_interp1d, iBytes); CeedChk_Hip(ceed, ierr);
+  ierr = hipMemcpy(data->d_interp1d, interp1d, iBytes,
+                   hipMemcpyHostToDevice); CeedChk_Hip(ceed, ierr);
+
+  ierr = hipMalloc((void **)&data->d_grad1d, iBytes); CeedChk_Hip(ceed, ierr);
+  ierr = hipMemcpy(data->d_grad1d, grad1d, iBytes,
+                   hipMemcpyHostToDevice); CeedChk_Hip(ceed, ierr);
+
+  // Compute collocated gradient and copy to GPU
+  data->d_collograd1d = NULL;
+  if (dim == 3 && Q1d >= P1d) {
+    CeedScalar *collograd1d;
+    ierr = CeedMalloc(Q1d*Q1d, &collograd1d); CeedChk(ierr);
+    ierr = CeedBasisGetCollocatedGrad(basis, collograd1d); CeedChk(ierr);
+    ierr = hipMalloc((void **)&data->d_collograd1d, qBytes * Q1d);
+    CeedChk_Hip(ceed, ierr);
+    ierr = hipMemcpy(data->d_collograd1d, collograd1d, qBytes * Q1d,
+                     hipMemcpyHostToDevice); CeedChk_Hip(ceed, ierr);
+    ierr = CeedFree(&collograd1d); CeedChk(ierr);
+  }
+
+  // Compile basis kernels
+  CeedInt ncomp;
+  ierr = CeedBasisGetNumComponents(basis, &ncomp); CeedChk(ierr);
+  ierr = CeedCompileHip(ceed, kernelsShared, &data->module, 8,
+                        "Q1D", Q1d,
+                        "P1D", P1d,
+                        "T1D", CeedIntMax(Q1d, P1d),
+                        "BASIS_BUF_LEN", ncomp * CeedIntPow(Q1d > P1d ?
+                            Q1d : P1d, dim),
+                        "BASIS_DIM", dim,
+                        "BASIS_NCOMP", ncomp,
+                        "BASIS_ELEMSIZE", CeedIntPow(P1d, dim),
+                        "BASIS_NQPT", CeedIntPow(Q1d, dim)
+                       ); CeedChk(ierr);
+  ierr = CeedGetKernelHip(ceed, data->module, "interp", &data->interp);
+  CeedChk(ierr);
+  ierr = CeedGetKernelHip(ceed, data->module, "grad", &data->grad);
+  CeedChk(ierr);
+  ierr = CeedGetKernelHip(ceed, data->module, "weight", &data->weight);
+  CeedChk(ierr);
+
+  ierr = CeedBasisSetData(basis, data); CeedChk(ierr);
+
+  // Register backend functions
+  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
+                                CeedBasisApplyTensor_Hip_shared);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Destroy",
+                                CeedBasisDestroy_Hip_shared); CeedChk(ierr);
+  return 0;
+}
+//------------------------------------------------------------------------------

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -807,7 +807,7 @@ int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,
                           &d_u, &d_v
                          };
     if (dim == 1) {
-      CeedInt elemsPerBlock = 32*thread1d > 256? 256/thread1d : 32;
+      CeedInt elemsPerBlock = 64*thread1d > 256? 256/thread1d : 64;
       elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
@@ -847,7 +847,7 @@ int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,
                         &data->c_G, &d_u, &d_v
                        };
     if (dim == 1) {
-      CeedInt elemsPerBlock = 32*thread1d > 256? 256/thread1d : 32;
+      CeedInt elemsPerBlock = 64*thread1d > 256? 256/thread1d : 64;
       elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
       CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
                                              ? 1 : 0 );
@@ -880,7 +880,7 @@ int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,
     ierr = CeedBasisGetNumQuadraturePoints1D(basis, &Q1d); CeedChk(ierr);
     void *weightargs[] = {(void *) &nelem, (void *) &data->d_qweight1d, &d_v};
     if (dim == 1) {
-      const CeedInt optElems = 32/Q1d;
+      const CeedInt optElems = 64/Q1d;
       const CeedInt elemsPerBlock = optElems>0?optElems:1;
       const CeedInt gridsize = nelem/elemsPerBlock + ( (
                                  nelem/elemsPerBlock*elemsPerBlock<nelem)? 1 : 0 );
@@ -888,7 +888,7 @@ int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,
                                  elemsPerBlock, 1, weightargs);
       CeedChk(ierr);
     } else if (dim == 2) {
-      const CeedInt optElems = 32/(Q1d*Q1d);
+      const CeedInt optElems = 64/(Q1d*Q1d);
       const CeedInt elemsPerBlock = optElems>0?optElems:1;
       const CeedInt gridsize = nelem/elemsPerBlock + ( (
                                  nelem/elemsPerBlock*elemsPerBlock<nelem)? 1 : 0 );

--- a/backends/hip-shared/ceed-hip-shared.c
+++ b/backends/hip-shared/ceed-hip-shared.c
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <string.h>
+#include <stdarg.h>
+#include "ceed-hip-shared.h"
+
+//------------------------------------------------------------------------------
+// Backend init
+//------------------------------------------------------------------------------
+static int CeedInit_Hip_shared(const char *resource, Ceed ceed) {
+  int ierr;
+  const int nrc = 8; // number of characters in resource
+  if (strncmp(resource, "/gpu/hip/shared", nrc))
+    // LCOV_EXCL_START
+    return CeedError(ceed, 1, "Hip backend cannot use resource: %s", resource);
+  // LCOV_EXCL_STOP
+  ierr = CeedSetDeterministic(ceed, true); CeedChk(ierr);
+
+  Ceed ceedref;
+  CeedInit("/gpu/hip/ref", &ceedref);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
+
+  Ceed_Hip_shared *data;
+  ierr = CeedCalloc(1, &data); CeedChk(ierr);
+  ierr = CeedSetData(ceed, data); CeedChk(ierr);
+  ierr = CeedHipInit(ceed, resource, nrc); CeedChk(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
+                                CeedBasisCreateTensorH1_Hip_shared);
+  CeedChk(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "Destroy",
+                                CeedDestroy_Hip); CeedChk(ierr);
+  CeedChk(ierr);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Register backend
+//------------------------------------------------------------------------------
+__attribute__((constructor))
+static void Register(void) {
+  CeedRegister("/gpu/hip/shared", CeedInit_Hip_shared, 25);
+}
+//------------------------------------------------------------------------------

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -36,3 +36,10 @@ typedef struct {
 CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P1d,
     CeedInt Q1d, const CeedScalar *interp1d, const CeedScalar *grad1d,
     const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);
+
+CEED_INTERN int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
+                      CeedScalar **c_B);
+
+CEED_INTERN int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G, CeedInt P1d,
+                          CeedInt Q1d, CeedScalar **c_B_ptr,
+                          CeedScalar **c_G_ptr);

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -38,8 +38,9 @@ CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P1d,
     const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);
 
 CEED_INTERN int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
-                      CeedScalar **c_B);
+                                  CeedScalar **c_B);
 
-CEED_INTERN int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G, CeedInt P1d,
-                          CeedInt Q1d, CeedScalar **c_B_ptr,
-                          CeedScalar **c_G_ptr);
+CEED_INTERN int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G,
+                                      CeedInt P1d,
+                                      CeedInt Q1d, CeedScalar **c_B_ptr,
+                                      CeedScalar **c_G_ptr);

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -20,6 +20,7 @@ typedef struct {
   hipFunction_t interp;
   hipFunction_t grad;
   hipFunction_t weight;
+  CeedInt blksizes[3]; // interp, grad, weight thread block sizes
   CeedScalar *d_interp1d;
   CeedScalar *d_grad1d;
   CeedScalar *d_collograd1d;

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
+// All Rights reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+#include "../hip/ceed-hip.h"
+
+typedef struct {
+  hipModule_t module;
+  hipFunction_t interp;
+  hipFunction_t grad;
+  hipFunction_t weight;
+  CeedScalar *d_interp1d;
+  CeedScalar *d_grad1d;
+  CeedScalar *d_collograd1d;
+  CeedScalar *d_qweight1d;
+  CeedScalar *c_B;
+  CeedScalar *c_G;
+} CeedBasis_Hip_shared;
+
+typedef struct {
+  Ceed_Hip base;
+} Ceed_Hip_shared;
+
+CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P1d,
+    CeedInt Q1d, const CeedScalar *interp1d, const CeedScalar *grad1d,
+    const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);

--- a/backends/hip-shared/kernels/hip-shared-basis.hip.cpp
+++ b/backends/hip-shared/kernels/hip-shared-basis.hip.cpp
@@ -15,6 +15,7 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 
 #include <ceed.h>
+#include <ceed-backend.h>
 #include <hip/hip_runtime.h>
 
 const int sizeMax = 16;
@@ -24,7 +25,7 @@ __constant__ double c_G[sizeMax*sizeMax];
 //------------------------------------------------------------------------------
 // Interp device initalization
 //------------------------------------------------------------------------------
-extern "C" int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
+CEED_INTERN int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
                                   CeedScalar **c_B_ptr) {
   const int Bsize = P1d*Q1d*sizeof(CeedScalar);
   hipMemcpyToSymbol(HIP_SYMBOL(c_B), d_B, Bsize, 0, hipMemcpyDeviceToDevice);
@@ -36,8 +37,10 @@ extern "C" int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
 //------------------------------------------------------------------------------
 // Grad device initalization
 //------------------------------------------------------------------------------
-extern "C" int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G,
-    CeedInt P1d, CeedInt Q1d, CeedScalar **c_B_ptr, CeedScalar **c_G_ptr) {
+CEED_INTERN int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G,
+                                      CeedInt P1d, CeedInt Q1d,
+                                      CeedScalar **c_B_ptr,
+                                      CeedScalar **c_G_ptr) {
   const int Bsize = P1d*Q1d*sizeof(CeedScalar);
   hipMemcpyToSymbol(HIP_SYMBOL(c_B), d_B, Bsize, 0, hipMemcpyDeviceToDevice);
   hipGetSymbolAddress((void **)c_B_ptr, HIP_SYMBOL(c_B));

--- a/backends/hip-shared/kernels/hip-shared-basis.hip.cpp
+++ b/backends/hip-shared/kernels/hip-shared-basis.hip.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include <ceed.h>
+#include <hip/hip_runtime.h>
+
+const int sizeMax = 16;
+__constant__ double c_B[sizeMax*sizeMax];
+__constant__ double c_G[sizeMax*sizeMax];
+
+//------------------------------------------------------------------------------
+// Interp device initalization
+//------------------------------------------------------------------------------
+extern "C" int CeedHipInitInterp(CeedScalar *d_B, CeedInt P1d, CeedInt Q1d,
+                                  CeedScalar **c_B_ptr) {
+  const int Bsize = P1d*Q1d*sizeof(CeedScalar);
+  hipMemcpyToSymbol(HIP_SYMBOL(c_B), d_B, Bsize, 0, hipMemcpyDeviceToDevice);
+  hipGetSymbolAddress((void **)c_B_ptr, HIP_SYMBOL(c_B));
+
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// Grad device initalization
+//------------------------------------------------------------------------------
+extern "C" int CeedHipInitInterpGrad(CeedScalar *d_B, CeedScalar *d_G,
+    CeedInt P1d, CeedInt Q1d, CeedScalar **c_B_ptr, CeedScalar **c_G_ptr) {
+  const int Bsize = P1d*Q1d*sizeof(CeedScalar);
+  hipMemcpyToSymbol(HIP_SYMBOL(c_B), d_B, Bsize, 0, hipMemcpyDeviceToDevice);
+  hipGetSymbolAddress((void **)c_B_ptr, HIP_SYMBOL(c_B));
+  hipMemcpyToSymbol(HIP_SYMBOL(c_G), d_G, Bsize, 0, hipMemcpyDeviceToDevice);
+  hipGetSymbolAddress((void **)c_G_ptr, HIP_SYMBOL(c_G));
+
+  return 0;
+}
+//------------------------------------------------------------------------------

--- a/backends/hip/ceed-hip.c
+++ b/backends/hip/ceed-hip.c
@@ -129,6 +129,6 @@ static int CeedInit_Hip(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 __attribute__((constructor))
 static void Register(void) {
-  CeedRegister("/gpu/hip/ref", CeedInit_Hip, 20);
+  CeedRegister("/gpu/hip/ref", CeedInit_Hip, 40);
 }
 //------------------------------------------------------------------------------

--- a/backends/hip/ceed-hip.h
+++ b/backends/hip/ceed-hip.h
@@ -45,7 +45,7 @@ do { \
 
 #define CASE(name) case name: return #name
 // LCOV_EXCL_START
-static const char *hipblasGetErrorName(hipblasStatus_t error) {
+CEED_UNUSED static const char *hipblasGetErrorName(hipblasStatus_t error) {
   switch (error) {
     CASE(HIPBLAS_STATUS_SUCCESS);
     CASE(HIPBLAS_STATUS_NOT_INITIALIZED);

--- a/doc/sphinx/source/releasenotes.rst
+++ b/doc/sphinx/source/releasenotes.rst
@@ -18,6 +18,7 @@ New features
 ^^^^^^^^^^^^
 * New HIP MAGMA backends for hipMAGMA library users: ``/gpu/hip/magma`` and ``/gpu/hip/magma/det``.
 * Julia and Rust interfaces added, providing a nearly 1-1 correspondence with the C interface, plus some convenience features.
+* New HIP backends for improved tensor basis performance: ``/gpu/hip/shared`` and ``/gpu/hip/gen``.
 
 Performance improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 
 #define CEED_INTERN CEED_EXTERN __attribute__((visibility ("hidden")))
+#define CEED_UNUSED __attribute__((unused))
 
 #define CEED_MAX_RESOURCE_LEN 1024
 #define CEED_ALIGN 64


### PR DESCRIPTION
This PR adds ported versions of the `cuda-shared` and `cuda-gen` backends for AMD GPUs.

On an MI50 GPU, this version of `hip-gen` offers up to 4x speedup over `hip-ref` for BP3 (though many more cases are in the 2x-3x range).  This initial version of `hip-shared` has a more modest advantage over `hip-ref`, and seemingly only for higher orders of basis functions (> 4).

1ac155d3f1d39377a1304752acd8a47f26513007 contains a somewhat noticeable departure from a direct port of `cuda-shared`.  This is a proposed idea to deal with potential failures if the minimum required threads for the basis kernels is more than 256 (before making this change, `hip-shared` would fail for a 3D diffusion problem with P1d=8/Q1d = 10, for example). It could also be used to do further performance optimizations in terms of optimal thread configurations.

I also made some minor changes to flags related to the HIP backends, and changed the default HIP backend (with `/gpu/hip`) to be `hip-gen`.

~~I'm really not sure what's causing the GitLab failures on Noether.  I just built this branch manually on Noether and ran all the tests, and everything passed...~~ The failures have been fixed -- MAGMA needed updates with ROCm 3.10. (Thanks @jedbrown)