### PR TITLE
CI: move GitHub Actions to ubuntu 20.04

### DIFF
--- a/.github/workflows/c-fortran-test-hardware.yml
+++ b/.github/workflows/c-fortran-test-hardware.yml
@@ -10,6 +10,7 @@ jobs:
         os: [ubuntu-20.04]
         compiler: [gcc-9]
         arch: [aarch64, ppc64le]
+        distro: [ubuntu20.04]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/c-fortran-test-hardware.yml
+++ b/.github/workflows/c-fortran-test-hardware.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         compiler: [gcc-9]
         arch: [aarch64, ppc64le]
 

--- a/.github/workflows/c-fortran-test-linux-osx.yml
+++ b/.github/workflows/c-fortran-test-linux-osx.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         compiler: [gcc-9, clang]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/c-fortran-test-style.yml
+++ b/.github/workflows/c-fortran-test-style.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         compiler: [clang]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/julia-documentation.yml
+++ b/.github/workflows/julia-documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/julia-test-with-style.yml
+++ b/.github/workflows/julia-test-with-style.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         julia-version: ['1']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-test-with-style.yml
+++ b/.github/workflows/python-test-with-style.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         compiler: [gcc-9]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-documentation.yml
+++ b/.github/workflows/rust-documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rust-test-with-style.yml
+++ b/.github/workflows/rust-test-with-style.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         compiler: [gcc-9]
 
     runs-on: ${{ matrix.os }}

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -3,7 +3,7 @@ breathe>=4.17
 markdown==3.2.1
 recommonmark
 sphinx_rtd_theme
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0
 sphinxcontrib-katex
 sphinxcontrib-mermaid
 sphinxcontrib-svg2pdfconverter

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -115,6 +115,10 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+# sphinxcontrib-bibtex 2.0 requires listing all bibtex files here
+bibtex_bibfiles = [
+    'references.bib',
+]
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This avoids warnings when using `ubuntu-latest`.