### PR TITLE
Update configuration for sphinxcontrib-bibtex 2.0

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -57,6 +57,8 @@ extensions = [
     'sphinxcontrib.rsvgconverter',
 ]
 
+bibtex_bibfiles = ['references.bib']
+
 # The following, if true, allows figures, tables and code-blocks to be
 # automatically numbered if they have a caption.
 numfig = True


### PR DESCRIPTION
sphinxcontrib-bibtex 2.0 had some changes that are backward incompatible: https://sphinxcontrib-bibtex.readthedocs.io/en/latest/changes.html

This PR is for updating the Sphinx configurations.