### PR TITLE
static link

### DIFF
--- a/.github/workflows/rust-test-with-style.yml
+++ b/.github/workflows/rust-test-with-style.yml
@@ -26,7 +26,6 @@ jobs:
       run: |
         make info
         make -j2
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
         cd rust && cargo build
         cargo test
         cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,23 @@ doc/sphinx/build/
 # Example docs automatically copied from source tree
 doc/sphinx/source/examples/
 
+# Output files, videos, and compressed archives should not be added accidentally
+*.avi
+*.bin
+*.bin.info
+*.bz2
+*.gif
+*.gz
+*.mkv
+*.mp4
+*.ogv
+*.vtu
+*.xz
+*.zstd
+perf.data
+
 # Editor Misc
+.cache/
 .history
 .vscode
 .ccls-cache

--- a/README.rst
+++ b/README.rst
@@ -126,13 +126,14 @@ in the Julia package manager or in a clone of the repository via::
     julia> # press ] to enter package manager
     (env) pkg> build LibCEED
 
-Rust users can build using::
+Rust users can include libCEED via ``Cargo.toml``:
 
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/libceed.so
-    cd rust
-    cargo build
+.. code-block:: toml
 
-The locally built Rust interface can be used as a path dependency, as per the `Rust documentation <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies>`_.
+   [dependencies]
+   libceed = { git = "https://github.com/CEED/libCEED", branch = "main" }
+
+See the `Cargo documentation <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories>`__ for details.
 
 Testing
 ----------------------------------------
@@ -398,6 +399,10 @@ To install libCEED, run::
 or (e.g., if creating packages)::
 
     make install prefix=/usr DESTDIR=/packaging/path
+
+The usual variables like ``CC`` and ``CFLAGS`` are used, and optimization flags
+for all languages can be set using the likes of ``OPT='-O3 -march=native'``. Use
+``STATIC=1`` to build static libraries (``libceed.a``).
 
 To install libCEED for Python, run::
 

--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -42,8 +42,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/avx/blocked", CeedInit_Avx, 30);
+CEED_INTERN int CeedRegister_Avx_Blocked(void) {
+  return CeedRegister("/cpu/self/avx/blocked", CeedInit_Avx, 30);
 }
 //------------------------------------------------------------------------------

--- a/backends/avx/ceed-avx-serial.c
+++ b/backends/avx/ceed-avx-serial.c
@@ -43,8 +43,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/avx/serial", CeedInit_Avx, 35);
+CEED_INTERN int CeedRegister_Avx_Serial(void) {
+  return CeedRegister("/cpu/self/avx/serial", CeedInit_Avx, 35);
 }
 //------------------------------------------------------------------------------

--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -19,7 +19,7 @@
 //------------------------------------------------------------------------------
 // Backend Init
 //------------------------------------------------------------------------------
-static int CeedInit_Blocked(const char *resource, Ceed ceed) {
+CEED_INTERN int CeedInit_Blocked(const char *resource, Ceed ceed) {
   int ierr;
   if (strcmp(resource, "/cpu/self")
       && strcmp(resource, "/cpu/self/ref/blocked"))
@@ -43,8 +43,7 @@ static int CeedInit_Blocked(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/ref/blocked", CeedInit_Blocked, 55);
+CEED_INTERN int CeedRegister_Ref_Blocked(void) {
+  return CeedRegister("/cpu/self/ref/blocked", CeedInit_Blocked, 55);
 }
 //------------------------------------------------------------------------------

--- a/backends/ceed-backend-list.h
+++ b/backends/ceed-backend-list.h
@@ -1,0 +1,28 @@
+// This header does not have guards because it is included multiple times.
+
+// List each backend registration function once here. This will be expanded
+// inside CeedRegisterAll() to call each registration function in the order
+// listed, and also to define weak symbol aliases for backends that are not
+// configured.
+
+MACRO(CeedRegister_Avx_Blocked)
+MACRO(CeedRegister_Avx_Serial)
+MACRO(CeedRegister_Cuda)
+MACRO(CeedRegister_Cuda_Gen)
+MACRO(CeedRegister_Cuda_Shared)
+MACRO(CeedRegister_Hip)
+MACRO(CeedRegister_Hip_Gen)
+MACRO(CeedRegister_Hip_Shared)
+MACRO(CeedRegister_Magma)
+MACRO(CeedRegister_Magma_Det)
+MACRO(CeedRegister_Memcheck_Blocked)
+MACRO(CeedRegister_Memcheck_Serial)
+MACRO(CeedRegister_Occa)
+MACRO(CeedRegister_Opt_Blocked)
+MACRO(CeedRegister_Opt_Serial)
+MACRO(CeedRegister_Ref)
+MACRO(CeedRegister_Ref_Blocked)
+MACRO(CeedRegister_Tmpl)
+MACRO(CeedRegister_Tmpl_Sub)
+MACRO(CeedRegister_Xsmm_Blocked)
+MACRO(CeedRegister_Xsmm_Serial)

--- a/backends/ceed-backend-weak.c
+++ b/backends/ceed-backend-weak.c
@@ -1,0 +1,14 @@
+#include <ceed-backend.h>
+#include <stdlib.h>
+
+// This function provides a debug target for weak symbols
+static int CeedRegister_Weak(const char *name) {
+  if (getenv("CEED_DEBUG")) fprintf(stderr, "Weak %s\n", name);
+  return 0;
+}
+
+#define MACRO(name)                                                     \
+  CEED_INTERN int name(void) __attribute__((weak));                     \
+  int name(void) { return CeedRegister_Weak(__func__); }
+#include "ceed-backend-list.h"
+#undef MACRO

--- a/backends/cuda-gen/ceed-cuda-gen.c
+++ b/backends/cuda-gen/ceed-cuda-gen.c
@@ -53,8 +53,7 @@ static int CeedInit_Cuda_gen(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Register backend
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/gpu/cuda/gen", CeedInit_Cuda_gen, 20);
+CEED_INTERN int CeedRegister_Cuda_Gen(void) {
+  return CeedRegister("/gpu/cuda/gen", CeedInit_Cuda_gen, 20);
 }
 //------------------------------------------------------------------------------

--- a/backends/cuda-shared/ceed-cuda-shared.c
+++ b/backends/cuda-shared/ceed-cuda-shared.c
@@ -51,8 +51,7 @@ static int CeedInit_Cuda_shared(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Register backend
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/gpu/cuda/shared", CeedInit_Cuda_shared, 25);
+CEED_INTERN int CeedRegister_Cuda_Shared(void) {
+  return CeedRegister("/gpu/cuda/shared", CeedInit_Cuda_shared, 25);
 }
 //------------------------------------------------------------------------------

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -235,8 +235,7 @@ static int CeedInit_Cuda(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/gpu/cuda/ref", CeedInit_Cuda, 40);
+CEED_INTERN int CeedRegister_Cuda(void) {
+  return CeedRegister("/gpu/cuda/ref", CeedInit_Cuda, 40);
 }
 //------------------------------------------------------------------------------

--- a/backends/hip-gen/ceed-hip-gen.c
+++ b/backends/hip-gen/ceed-hip-gen.c
@@ -53,8 +53,7 @@ static int CeedInit_Hip_gen(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Register backend
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/gpu/hip/gen", CeedInit_Hip_gen, 20);
+CEED_INTERN int CeedRegister_Hip_Gen(void) {
+  return CeedRegister("/gpu/hip/gen", CeedInit_Hip_gen, 20);
 }
 //------------------------------------------------------------------------------

--- a/backends/hip-shared/ceed-hip-shared.c
+++ b/backends/hip-shared/ceed-hip-shared.c
@@ -51,8 +51,7 @@ static int CeedInit_Hip_shared(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Register backend
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/gpu/hip/shared", CeedInit_Hip_shared, 25);
+CEED_INTERN int CeedRegister_Hip_Shared(void) {
+  return CeedRegister("/gpu/hip/shared", CeedInit_Hip_shared, 25);
 }
 //------------------------------------------------------------------------------

--- a/backends/hip/ceed-hip.c
+++ b/backends/hip/ceed-hip.c
@@ -127,8 +127,7 @@ static int CeedInit_Hip(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/gpu/hip/ref", CeedInit_Hip, 40);
+CEED_INTERN int CeedRegister_Hip(void) {
+  return CeedRegister("/gpu/hip/ref", CeedInit_Hip, 40);
 }
 //------------------------------------------------------------------------------

--- a/backends/magma/ceed-magma-det.c
+++ b/backends/magma/ceed-magma-det.c
@@ -16,7 +16,7 @@
 
 #include "ceed-magma.h"
 
-static int CeedInit_Magma_Det(const char *resource, Ceed ceed) {
+CEED_INTERN int CeedInit_Magma_Det(const char *resource, Ceed ceed) {
   int ierr;
   if (strcmp(resource, "/gpu/cuda/magma/det")
       && strcmp(resource, "/gpu/hip/magma/det"))
@@ -48,11 +48,10 @@ static int CeedInit_Magma_Det(const char *resource, Ceed ceed) {
   return 0;
 }
 
-__attribute__((constructor))
-static void Register(void) {
+CEED_INTERN int CeedRegister_Magma_Det(void) {
   #ifdef HAVE_HIP
-  CeedRegister("/gpu/hip/magma/det", CeedInit_Magma_Det, 125);
+  return CeedRegister("/gpu/hip/magma/det", CeedInit_Magma_Det, 125);
   #else
-  CeedRegister("/gpu/cuda/magma/det", CeedInit_Magma_Det, 125);
+  return CeedRegister("/gpu/cuda/magma/det", CeedInit_Magma_Det, 125);
   #endif
 }

--- a/backends/magma/ceed-magma.c
+++ b/backends/magma/ceed-magma.c
@@ -82,11 +82,10 @@ static int CeedInit_Magma(const char *resource, Ceed ceed) {
   return 0;
 }
 
-__attribute__((constructor))
-static void Register(void) {
+CEED_INTERN int CeedRegister_Magma(void) {
   #ifdef HAVE_HIP
-  CeedRegister("/gpu/hip/magma", CeedInit_Magma, 120);
+  return CeedRegister("/gpu/hip/magma", CeedInit_Magma, 120);
   #else
-  CeedRegister("/gpu/cuda/magma", CeedInit_Magma, 120);
+  return CeedRegister("/gpu/cuda/magma", CeedInit_Magma, 120);
   #endif
 }

--- a/backends/memcheck/ceed-memcheck-blocked.c
+++ b/backends/memcheck/ceed-memcheck-blocked.c
@@ -42,8 +42,7 @@ static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/memcheck/blocked", CeedInit_Memcheck, 110);
+CEED_INTERN int CeedRegister_Memcheck_Blocked(void) {
+  return CeedRegister("/cpu/self/memcheck/blocked", CeedInit_Memcheck, 110);
 }
 //------------------------------------------------------------------------------

--- a/backends/memcheck/ceed-memcheck-serial.c
+++ b/backends/memcheck/ceed-memcheck-serial.c
@@ -43,8 +43,7 @@ static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/memcheck/serial", CeedInit_Memcheck, 100);
+CEED_INTERN int CeedRegister_Memcheck_Serial(void) {
+  return CeedRegister("/cpu/self/memcheck/serial", CeedInit_Memcheck, 100);
 }
 //------------------------------------------------------------------------------

--- a/backends/occa/ceed-occa.cpp
+++ b/backends/occa/ceed-occa.cpp
@@ -336,19 +336,19 @@ namespace ceed {
   }
 }
 
-__attribute__((constructor))
-static void Register(void) {
+CEED_INTERN int CeedRegister_Occa(void) {
+  int ierr;
   // General mode
-  CeedRegister("/*/occa", ceed::occa::registerBackend, 260);
+  ierr = CeedRegister("/*/occa", ceed::occa::registerBackend, 260); CeedChk(ierr);
   // CPU Modes
-  CeedRegister("/cpu/self/occa", ceed::occa::registerBackend, 250);
-  CeedRegister("/cpu/openmp/occa", ceed::occa::registerBackend, 240);
+  ierr = CeedRegister("/cpu/self/occa", ceed::occa::registerBackend, 250); CeedChk(ierr);
+  ierr = CeedRegister("/cpu/openmp/occa", ceed::occa::registerBackend, 240); CeedChk(ierr);
   // OpenCL Mode
   /* OpenCL not fully supported in OCCA
-  CeedRegister("/gpu/opencl/occa", ceed::occa::registerBackend, 230);
+  ierr = CeedRegister("/gpu/opencl/occa", ceed::occa::registerBackend, 230); CeedChk(ierr);
   */
   // GPU Modes
-  CeedRegister("/gpu/hip/occa", ceed::occa::registerBackend, 220);
-  CeedRegister("/gpu/cuda/occa", ceed::occa::registerBackend, 210);
-
+  ierr = CeedRegister("/gpu/hip/occa", ceed::occa::registerBackend, 220); CeedChk(ierr);
+  ierr = CeedRegister("/gpu/cuda/occa", ceed::occa::registerBackend, 210); CeedChk(ierr);
+  return 0;
 }

--- a/backends/opt/ceed-opt-blocked.c
+++ b/backends/opt/ceed-opt-blocked.c
@@ -64,8 +64,7 @@ static int CeedInit_Opt_Blocked(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/opt/blocked", CeedInit_Opt_Blocked, 40);
+CEED_INTERN int CeedRegister_Opt_Blocked(void) {
+  return CeedRegister("/cpu/self/opt/blocked", CeedInit_Opt_Blocked, 40);
 }
 //------------------------------------------------------------------------------

--- a/backends/opt/ceed-opt-serial.c
+++ b/backends/opt/ceed-opt-serial.c
@@ -64,8 +64,8 @@ static int CeedInit_Opt_Serial(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/opt/serial", CeedInit_Opt_Serial, 45);
+CEED_INTERN int CeedRegister_Opt_Serial(void) {
+  return CeedRegister("/cpu/self/opt/serial", CeedInit_Opt_Serial, 45);
 }
+
 //------------------------------------------------------------------------------

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -55,10 +55,10 @@ static int CeedInit_Ref(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
+CEED_INTERN int CeedRegister_Ref(void) {
+  return
 //! [Register]
-  CeedRegister("/cpu/self/ref/serial", CeedInit_Ref, 50);
+    CeedRegister("/cpu/self/ref/serial", CeedInit_Ref, 50);
 //! [Register]
 }
 //------------------------------------------------------------------------------

--- a/backends/template/ceed-tmpl-sub.c
+++ b/backends/template/ceed-tmpl-sub.c
@@ -54,8 +54,7 @@ static int CeedInit_Tmpl(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/tmpl/sub", CeedInit_Tmpl, 70);
+CEED_INTERN int CeedRegister_Tmpl_Sub(void) {
+  return CeedRegister("/cpu/self/tmpl/sub", CeedInit_Tmpl, 70);
 }
 //------------------------------------------------------------------------------

--- a/backends/template/ceed-tmpl.c
+++ b/backends/template/ceed-tmpl.c
@@ -40,8 +40,7 @@ static int CeedInit_Tmpl(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/tmpl", CeedInit_Tmpl, 60);
+CEED_INTERN int CeedRegister_Tmpl(void) {
+  return CeedRegister("/cpu/self/tmpl", CeedInit_Tmpl, 60);
 }
 //------------------------------------------------------------------------------

--- a/backends/xsmm/ceed-xsmm-blocked.c
+++ b/backends/xsmm/ceed-xsmm-blocked.c
@@ -44,8 +44,7 @@ static int CeedInit_Xsmm_Blocked(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/xsmm/blocked", CeedInit_Xsmm_Blocked, 20);
+CEED_INTERN int CeedRegister_Xsmm_Blocked(void) {
+  return CeedRegister("/cpu/self/xsmm/blocked", CeedInit_Xsmm_Blocked, 20);
 }
 //------------------------------------------------------------------------------

--- a/backends/xsmm/ceed-xsmm-serial.c
+++ b/backends/xsmm/ceed-xsmm-serial.c
@@ -44,8 +44,7 @@ static int CeedInit_Xsmm_Serial(const char *resource, Ceed ceed) {
 //------------------------------------------------------------------------------
 // Backend Register
 //------------------------------------------------------------------------------
-__attribute__((constructor))
-static void Register(void) {
-  CeedRegister("/cpu/self/xsmm/serial", CeedInit_Xsmm_Serial, 25);
+CEED_INTERN int CeedRegister_Xsmm_Serial(void) {
+  return CeedRegister("/cpu/self/xsmm/serial", CeedInit_Xsmm_Serial, 25);
 }
 //------------------------------------------------------------------------------

--- a/ceed.pc.template
+++ b/ceed.pc.template
@@ -7,3 +7,4 @@ Description: Code for Efficient Extensible Discretization
 Version: 0.7
 Cflags: -I${includedir}
 Libs: -L${libdir} -lceed
+Libs.private: %libs_private%

--- a/doc/sphinx/source/libCEEDapi.rst
+++ b/doc/sphinx/source/libCEEDapi.rst
@@ -501,10 +501,12 @@ code). Backends are registered by calling
 typically in a library initializer or "constructor" that runs automatically.
 ``CeedInit`` uses this prefix to find an appropriate backend for the resource.
 
-Source (API) and binary (ABI) stability are important to libCEED. LibCEED is
-evolving rapidly at present, but we expect it to stabilize soon at which point
-we will adopt semantic versioning. User code, including libraries of
-:ref:`CeedQFunction`\s, will not need to be recompiled except between major releases.
-The backends currently have some dependence beyond the public user interface,
-but we intent to remove that dependence and will prioritize if anyone expresses
-interest in distributing a backend outside the libCEED repository.
+Source (API) and binary (ABI) stability are important to libCEED. Prior to
+reaching version 1.0, libCEED does not implement strict `semantic versioning
+<https://semver.org>`__ across the entire interface. However, user code,
+including libraries of :ref:`CeedQFunction`\s, should be source and binary
+compatible moving from 0.x.y to any later release 0.x.z. We have less experience
+with external packaging of backends and do not presently guarantee source or
+binary stability, but we intend to define stability guarantees for libCEED 1.0.
+We'd love to talk with you if you're interested in packaging backends
+externally, and will work with you on a practical stability policy.

--- a/doc/sphinx/source/releasenotes.rst
+++ b/doc/sphinx/source/releasenotes.rst
@@ -19,6 +19,7 @@ New features
 * New HIP MAGMA backends for hipMAGMA library users: ``/gpu/hip/magma`` and ``/gpu/hip/magma/det``.
 * Julia and Rust interfaces added, providing a nearly 1-1 correspondence with the C interface, plus some convenience features.
 * New HIP backends for improved tensor basis performance: ``/gpu/hip/shared`` and ``/gpu/hip/gen``.
+* Static libraries can be built with ``make STATIC=1`` and the pkg-config file is installed accordingly.
 
 Performance improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gallery/ceed-gallery-list.h
+++ b/gallery/ceed-gallery-list.h
@@ -1,0 +1,24 @@
+// This header does not have guards because it is included multiple times.
+
+// List each gallery registration function once here. This will be expanded
+// inside CeedQFunctionRegisterAll() to call each registration function in the
+// order listed, and also to define weak symbol aliases for backends that are
+// not configured.
+//
+// At the time of this writing, all the gallery functions are defined, but we're
+// adopting the same strategy here as for the backends because future gallery
+// functions might depend on external libraries.
+
+MACRO(CeedQFunctionRegister_Identity)
+MACRO(CeedQFunctionRegister_Mass1DBuild)
+MACRO(CeedQFunctionRegister_Mass2DBuild)
+MACRO(CeedQFunctionRegister_Mass3DBuild)
+MACRO(CeedQFunctionRegister_MassApply)
+MACRO(CeedQFunctionRegister_Poisson1DApply)
+MACRO(CeedQFunctionRegister_Poisson1DBuild)
+MACRO(CeedQFunctionRegister_Poisson2DApply)
+MACRO(CeedQFunctionRegister_Poisson2DBuild)
+MACRO(CeedQFunctionRegister_Poisson3DApply)
+MACRO(CeedQFunctionRegister_Poisson3DBuild)
+MACRO(CeedQFunctionRegister_Scale)
+MACRO(CeedQFunctionRegister_Template)

--- a/gallery/ceed-gallery-weak.c
+++ b/gallery/ceed-gallery-weak.c
@@ -1,0 +1,14 @@
+#include <ceed-backend.h>
+#include <stdlib.h>
+
+// This function provides a debug target for weak symbols
+static int CeedQFunctionRegister_Weak(const char *name) {
+  if (getenv("CEED_DEBUG")) fprintf(stderr, "Weak %s\n", name);
+  return 0;
+}
+
+#define MACRO(name)                                                     \
+  CEED_INTERN int name(void) __attribute__((weak));                     \
+  int name(void) { return CeedQFunctionRegister_Weak(__func__); }
+#include "ceed-gallery-list.h"
+#undef MACRO

--- a/gallery/ceed-gallerytemplate.c
+++ b/gallery/ceed-gallerytemplate.c
@@ -48,8 +48,7 @@ static int CeedQFunctionInit_GalleryTemplate(Ceed ceed, const char *requested,
 /**
   @brief Register new Ceed QFunction
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("GalleryTemplate", GalleryTemplate_loc, 1,
+CEED_INTERN int CeedQFunctionRegister_Template(void) {
+  return CeedQFunctionRegister("GalleryTemplate", GalleryTemplate_loc, 1,
                         GalleryTemplate, CeedQFunctionInit_GalleryTemplate);
 }

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -40,8 +40,7 @@ static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
 /**
   @brief Register identity QFunction that copies inputs directly into outputs
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Identity", Identity_loc, 1, Identity,
-                        CeedQFunctionInit_Identity);
+CEED_INTERN int CeedQFunctionRegister_Identity(void) {
+  return CeedQFunctionRegister("Identity", Identity_loc, 1, Identity,
+                               CeedQFunctionInit_Identity);
 }

--- a/gallery/mass1d/ceed-mass1dbuild.c
+++ b/gallery/mass1d/ceed-mass1dbuild.c
@@ -49,8 +49,7 @@ static int CeedQFunctionInit_Mass1DBuild(Ceed ceed, const char *requested,
   @brief Register Ceed QFunction for building the geometric data for the 1D mass
            matrix
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Mass1DBuild", Mass1DBuild_loc, 1, Mass1DBuild,
-                        CeedQFunctionInit_Mass1DBuild);
+CEED_INTERN int CeedQFunctionRegister_Mass1DBuild(void) {
+  return CeedQFunctionRegister("Mass1DBuild", Mass1DBuild_loc, 1, Mass1DBuild,
+                               CeedQFunctionInit_Mass1DBuild);
 }

--- a/gallery/mass1d/ceed-massapply.c
+++ b/gallery/mass1d/ceed-massapply.c
@@ -44,8 +44,7 @@ static int CeedQFunctionInit_MassApply(Ceed ceed, const char *requested,
 /**
   @brief Register Ceed QFunction for applying the mass matrix
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("MassApply", MassApply_loc, 1, MassApply,
-                        CeedQFunctionInit_MassApply);
+CEED_INTERN int CeedQFunctionRegister_MassApply(void) {
+  return CeedQFunctionRegister("MassApply", MassApply_loc, 1, MassApply,
+                               CeedQFunctionInit_MassApply);
 }

--- a/gallery/mass2d/ceed-mass2dbuild.c
+++ b/gallery/mass2d/ceed-mass2dbuild.c
@@ -49,8 +49,7 @@ static int CeedQFunctionInit_Mass2DBuild(Ceed ceed, const char *requested,
   @brief Register Ceed QFunction for building the geometric data for the 2D mass
            matrix
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Mass2Dbuild", Mass2DBuild_loc, 1, Mass2DBuild,
-                        CeedQFunctionInit_Mass2DBuild);
+CEED_INTERN int CeedQFunctionRegister_Mass2DBuild(void) {
+  return CeedQFunctionRegister("Mass2DBuild", Mass2DBuild_loc, 1, Mass2DBuild,
+                               CeedQFunctionInit_Mass2DBuild);
 }

--- a/gallery/mass3d/ceed-mass3dbuild.c
+++ b/gallery/mass3d/ceed-mass3dbuild.c
@@ -49,8 +49,7 @@ static int CeedQFunctionInit_Mass3DBuild(Ceed ceed, const char *requested,
   @brief Register Ceed QFunction for building the geometric data for the 3D mass
            matrix
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Mass3DBuild", Mass3DBuild_loc, 1, Mass3DBuild,
-                        CeedQFunctionInit_Mass3DBuild);
+CEED_INTERN int CeedQFunctionRegister_Mass3DBuild(void) {
+  return CeedQFunctionRegister("Mass3DBuild", Mass3DBuild_loc, 1, Mass3DBuild,
+                               CeedQFunctionInit_Mass3DBuild);
 }

--- a/gallery/poisson1d/ceed-poisson1dapply.c
+++ b/gallery/poisson1d/ceed-poisson1dapply.c
@@ -46,8 +46,7 @@ static int CeedQFunctionInit_Poisson1DApply(Ceed ceed, const char *requested,
 /**
   @brief Register Ceed QFunction for applying the 1D Poisson operator
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Poisson1DApply", Poisson1DApply_loc, 1, Poisson1DApply,
-                        CeedQFunctionInit_Poisson1DApply);
+CEED_INTERN int CeedQFunctionRegister_Poisson1DApply(void) {
+  return CeedQFunctionRegister("Poisson1DApply", Poisson1DApply_loc, 1,
+                               Poisson1DApply, CeedQFunctionInit_Poisson1DApply);
 }

--- a/gallery/poisson1d/ceed-poisson1dbuild.c
+++ b/gallery/poisson1d/ceed-poisson1dbuild.c
@@ -50,8 +50,7 @@ static int CeedQFunctionInit_Poisson1DBuild(Ceed ceed, const char *requested,
   @brief Register Ceed QFunction for building the geometric data for the 1D
            Poisson operator
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Poisson1DBuild", Poisson1DBuild_loc, 1, Poisson1DBuild,
-                        CeedQFunctionInit_Poisson1DBuild);
+CEED_INTERN int CeedQFunctionRegister_Poisson1DBuild(void) {
+  return CeedQFunctionRegister("Poisson1DBuild", Poisson1DBuild_loc, 1,
+                               Poisson1DBuild, CeedQFunctionInit_Poisson1DBuild);
 }

--- a/gallery/poisson2d/ceed-poisson2dapply.c
+++ b/gallery/poisson2d/ceed-poisson2dapply.c
@@ -46,8 +46,7 @@ static int CeedQFunctionInit_Poisson2DApply(Ceed ceed, const char *requested,
 /**
   @brief Register Ceed QFunction for applying the 2D Poisson operator
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Poisson2DApply", Poisson2DApply_loc, 1, Poisson2DApply,
-                        CeedQFunctionInit_Poisson2DApply);
+CEED_INTERN int CeedQFunctionRegister_Poisson2DApply(void) {
+  return CeedQFunctionRegister("Poisson2DApply", Poisson2DApply_loc, 1,
+                               Poisson2DApply, CeedQFunctionInit_Poisson2DApply);
 }

--- a/gallery/poisson2d/ceed-poisson2dbuild.c
+++ b/gallery/poisson2d/ceed-poisson2dbuild.c
@@ -50,8 +50,7 @@ static int CeedQFunctionInit_Poisson2DBuild(Ceed ceed, const char *requested,
   @brief Register Ceed QFunction for building the geometric data for the 2D
            Poisson operator
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Poisson2DBuild", Poisson2DBuild_loc, 1, Poisson2DBuild,
-                        CeedQFunctionInit_Poisson2DBuild);
+CEED_INTERN int CeedQFunctionRegister_Poisson2DBuild(void) {
+  return CeedQFunctionRegister("Poisson2DBuild", Poisson2DBuild_loc, 1,
+                               Poisson2DBuild, CeedQFunctionInit_Poisson2DBuild);
 }

--- a/gallery/poisson3d/ceed-poisson3dapply.c
+++ b/gallery/poisson3d/ceed-poisson3dapply.c
@@ -46,8 +46,7 @@ static int CeedQFunctionInit_Poisson3DApply(Ceed ceed, const char *requested,
 /**
   @brief Register Ceed QFunction for applying the 3D Poisson operator
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Poisson3DApply", Poisson3DApply_loc, 1, Poisson3DApply,
-                        CeedQFunctionInit_Poisson3DApply);
+CEED_INTERN int CeedQFunctionRegister_Poisson3DApply(void) {
+  return CeedQFunctionRegister("Poisson3DApply", Poisson3DApply_loc, 1,
+                               Poisson3DApply, CeedQFunctionInit_Poisson3DApply);
 }

--- a/gallery/poisson3d/ceed-poisson3dbuild.c
+++ b/gallery/poisson3d/ceed-poisson3dbuild.c
@@ -50,8 +50,7 @@ static int CeedQFunctionInit_Poisson3DBuild(Ceed ceed, const char *requested,
   @brief Register Ceed QFunction for building the geometric data for the 3D
            Poisson operator
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Poisson3DBuild", Poisson3DBuild_loc, 1, Poisson3DBuild,
-                        CeedQFunctionInit_Poisson3DBuild);
+CEED_INTERN int CeedQFunctionRegister_Poisson3DBuild(void) {
+  return CeedQFunctionRegister("Poisson3DBuild", Poisson3DBuild_loc, 1,
+                               Poisson3DBuild, CeedQFunctionInit_Poisson3DBuild);
 }

--- a/gallery/scale/ceed-scale.c
+++ b/gallery/scale/ceed-scale.c
@@ -40,8 +40,7 @@ static int CeedQFunctionInit_Scale(Ceed ceed, const char *requested,
 /**
   @brief Register scaling QFunction
 **/
-__attribute__((constructor))
-static void Register(void) {
-  CeedQFunctionRegister("Scale", Scale_loc, 1, Scale,
-                        CeedQFunctionInit_Scale);
+CEED_INTERN int CeedQFunctionRegister_Scale(void) {
+  return CeedQFunctionRegister("Scale", Scale_loc, 1, Scale,
+                               CeedQFunctionInit_Scale);
 }

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -52,7 +52,7 @@ CEED_INTERN int CeedCallocArray(size_t n, size_t unit, void *p);
 CEED_INTERN int CeedReallocArray(size_t n, size_t unit, void *p);
 CEED_INTERN int CeedFree(void *p);
 
-#define CeedChk(ierr) do { if (ierr) return ierr; } while (0)
+#define CeedChk(ierr) do { int ierr_ = ierr; if (ierr_) return ierr_; } while (0)
 /* Note that CeedMalloc and CeedCalloc will, generally, return pointers with
    different memory alignments: CeedMalloc returns pointers aligned at
    CEED_ALIGN bytes, while CeedCalloc uses the alignment of calloc. */
@@ -70,6 +70,7 @@ typedef struct CeedOperatorField_private *CeedOperatorField;
 CEED_EXTERN int CeedRegister(const char *prefix,
                              int (*init)(const char *, Ceed),
                              unsigned int priority);
+CEED_EXTERN int CeedRegisterAll(void);
 
 CEED_EXTERN int CeedIsDebug(Ceed ceed, bool *isDebug);
 CEED_EXTERN int CeedGetParent(Ceed ceed, Ceed *parent);
@@ -152,6 +153,7 @@ CEED_EXTERN int CeedTensorContractSetData(CeedTensorContract contract,
     void *data);
 CEED_EXTERN int CeedTensorContractDestroy(CeedTensorContract *contract);
 
+CEED_EXTERN int CeedQFunctionRegisterAll(void);
 CEED_EXTERN int CeedQFunctionRegister(const char *, const char *, CeedInt,
                                       CeedQFunctionUser, int (*init)(Ceed, const char *, CeedQFunction));
 CEED_EXTERN int CeedQFunctionSetFortranStatus(CeedQFunction qf, bool status);

--- a/interface/ceed-qfunction-register.c
+++ b/interface/ceed-qfunction-register.c
@@ -1,0 +1,30 @@
+#include <ceed-impl.h>
+#include <stdio.h>
+
+static bool register_all_called;
+
+#define MACRO(name) CEED_INTERN int name(void);
+#include "../gallery/ceed-gallery-list.h"
+#undef MACRO
+
+/**
+  @brief Register the gallery of preconfigured QFunctions.
+
+  This is called automatically by CeedQFunctionCreateInteriorByName() and thus normally need not be called by users.
+  Users can call CeedQFunctionRegister() to register additional backends.
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @sa CeedQFunctionRegister()
+
+  @ref Backend
+**/
+int CeedQFunctionRegisterAll() {
+  if (register_all_called) return 0;
+  register_all_called = true;
+
+#define MACRO(name) CeedChk(name());
+#include "../gallery/ceed-gallery-list.h"
+#undef MACRO
+  return 0;
+}

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -486,6 +486,7 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
   size_t matchlen = 0, matchidx = UINT_MAX;
   char *name_copy;
 
+  ierr = CeedQFunctionRegisterAll(); CeedChk(ierr);
   // Find matching backend
   if (!name) return CeedError(ceed, 1, "No QFunction name provided");
   for (size_t i=0; i<num_qfunctions; i++) {

--- a/interface/ceed-register.c
+++ b/interface/ceed-register.c
@@ -1,0 +1,30 @@
+#include <ceed-impl.h>
+#include <stdio.h>
+
+static bool register_all_called;
+
+#define MACRO(name) CEED_INTERN int name(void);
+#include "../backends/ceed-backend-list.h"
+#undef MACRO
+
+/**
+  @brief Register all preconfigured backends.
+
+  This is called automatically by CeedInit() and thus normally need not be called by users.
+  Users can call CeedRegister() to register additional backends.
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @sa CeedRegister()
+
+  @ref Backend
+**/
+int CeedRegisterAll() {
+  if (register_all_called) return 0;
+  register_all_called = true;
+
+#define MACRO(name) CeedChk(name());
+#include "../backends/ceed-backend-list.h"
+#undef MACRO
+  return 0;
+}

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -614,6 +614,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
     // LCOV_EXCL_START
     return CeedError(NULL, 1, "No resource provided");
   // LCOV_EXCL_STOP
+  ierr = CeedRegisterAll(); CeedChk(ierr);
 
   for (size_t i=0; i<num_backends; i++) {
     size_t n;

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-authors = ["Jed Brown <jed@jedbrown.org",
-           "Yohann Dudouit <dudouit1@llnl.gov>",
-           "Jeremy L Thompson <thompson.jeremy.luke@gmail.com>",]
+authors = [
+    "Jed Brown <jed@jedbrown.org>",
+    "Yohann Dudouit <dudouit1@llnl.gov>",
+    "Jeremy L Thompson <thompson.jeremy.luke@gmail.com>",
+]
 build = "build.rs"
 name = "libceed"
 version = "0.7.0"
@@ -11,5 +13,11 @@ edition = "2018"
 [lib]
 name = "libceed"
 
+[features]
+default = ["static"]
+static = []
+system = []
+
 [build-dependencies]
 bindgen = "*"
+pkg-config = "0.3.19"

--- a/rust/src/basis.rs
+++ b/rust/src/basis.rs
@@ -191,35 +191,35 @@ impl Basis {
     /// ```
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
-    /// const q: usize = 6;
-    /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, q, q, QuadMode::GaussLobatto);
-    /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
+    /// const Q: usize = 6;
+    /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, Q, Q, QuadMode::GaussLobatto);
+    /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, Q, QuadMode::Gauss);
     ///
     /// let x_corners = ceed.vector_from_slice(&[-1., 1.]);
-    /// let mut x_qpts = ceed.vector(q);
-    /// let mut x_nodes = ceed.vector(q);
+    /// let mut x_qpts = ceed.vector(Q);
+    /// let mut x_nodes = ceed.vector(Q);
     /// bx.apply(1, TransposeMode::NoTranspose, EvalMode::Interp,
     ///          &x_corners, &mut x_nodes);
     /// bu.apply(1, TransposeMode::NoTranspose, EvalMode::Interp,
     ///          &x_nodes, &mut x_qpts);
     ///
     /// // Create function x^3 + 1 on Gauss Lobatto points
-    /// let mut u_arr = [0.; q];
+    /// let mut u_arr = [0.; Q];
     /// let x_nodes_arr = x_nodes.view();
-    /// for i in 0..q {
+    /// for i in 0..Q {
     ///   u_arr[i] = x_nodes_arr[i]*x_nodes_arr[i]*x_nodes_arr[i] + 1.;
     /// }
     /// let u = ceed.vector_from_slice(&u_arr);
     ///
     /// // Map function to Gauss points
-    /// let mut v = ceed.vector(q);
+    /// let mut v = ceed.vector(Q);
     /// v.set_value(0.);
     /// bu.apply(1, TransposeMode::NoTranspose, EvalMode::Interp, &u, &mut v);
     ///
     /// // Verify results
     /// let v_arr = v.view();
     /// let x_qpts_arr = x_qpts.view();
-    /// for i in 0..q {
+    /// for i in 0..Q {
     ///   let true_value = x_qpts_arr[i]*x_qpts_arr[i]*x_qpts_arr[i] + 1.;
     ///   assert_eq!(v_arr[i], true_value, "Incorrect basis application");
     /// }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,11 +19,41 @@
 //! This is the documentation for the high level libCEED Rust interface.
 //! See the full libCEED user manual [here](https://libceed.readthedocs.io).
 //!
-//! ## Installing
+//! ## Usage
 //!
-//! First, libCEED needs to be built and `LD_LIBRARY_PATH` updated to contain
-//! the filepath to `libceed.so`. Then `cargo` commands may be used as usual in
-//! the `libCEED/rust` folder, such as `cargo build` and `cargo test`.
+//! To call libCEED from a Rust package, the following `Cargo.toml` can be used.
+//! ```toml
+//! [dependencies]
+//! libceed = { git = "https://github.com/CEED/libCEED", branch = "main" }
+//! ```
+//!
+//! Supported features:
+//! * `static` (default): link to static libceed.a
+//! * `system`: use libceed from a system directory (otherwise, install from source)
+//!
+//! ```
+//! extern crate libceed;
+//!
+//! fn main() {
+//!     let ceed = libceed::Ceed::init("/cpu/self/ref");
+//!     let xc = ceed.vector_from_slice(&[0., 0.5, 1.0]);
+//!     let xs = xc.view();
+//!     assert_eq!(xs[..], [0., 0.5, 1.0]);
+//! }
+//! ```
+//!
+//! ## Development
+//!
+//! To develop libCEED, use `cargo build` in the `rust/` directory to install a
+//! local copy and build the bindings. If you need custom flags for the C
+//! project, we recommend using `make configure` to cache arguments. If you
+//! disable the `static` feature, then you'll need to set `LD_LIBRARY_PATH` for
+//! doctests to be able to find it. You can do this in `$CEED_DIR/lib` and set
+//! `PKG_CONFIG_PATH`.
+//!
+//! Note: the `LD_LIBRARY_PATH` workarounds will become unnecessary if [this
+//! issue](https://github.com/rust-lang/cargo/issues/1592) is resolved -- it's
+//! currently closed, but the problem still exists.
 
 // -----------------------------------------------------------------------------
 // Exceptions

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -348,18 +348,18 @@ impl QFunction {
     ///   v[i] = u[i] * w[i];
     /// }
     ///
-    /// let U = ceed.vector_from_slice(&u);
-    /// let W = ceed.vector_from_slice(&w);
-    /// let mut V = ceed.vector(Q);
-    /// V.set_value(0.0);
+    /// let uu = ceed.vector_from_slice(&u);
+    /// let ww = ceed.vector_from_slice(&w);
+    /// let mut vv = ceed.vector(Q);
+    /// vv.set_value(0.0);
     /// {
-    ///   let input = vec![U, W];
-    ///   let mut output = vec![V];
+    ///   let input = vec![uu, ww];
+    ///   let mut output = vec![vv];
     ///   qf.apply(Q as i32, &input, &output);
-    ///   V = output.remove(0);
+    ///   vv = output.remove(0);
     /// }
     ///
-    /// let array = V.view();
+    /// let array = vv.view();
     /// for i in 0..Q {
     ///   assert_eq!(array[i], v[i], "Incorrect value in QFunction application");
     /// }
@@ -493,29 +493,29 @@ impl QFunctionByName {
     ///   v[i] = w[i] * u[i];
     /// }
     ///
-    /// let J = ceed.vector_from_slice(&j);
-    /// let W = ceed.vector_from_slice(&w);
-    /// let U = ceed.vector_from_slice(&u);
-    /// let mut V = ceed.vector(Q);
-    /// V.set_value(0.0);
+    /// let jj = ceed.vector_from_slice(&j);
+    /// let ww = ceed.vector_from_slice(&w);
+    /// let uu = ceed.vector_from_slice(&u);
+    /// let mut vv = ceed.vector(Q);
+    /// vv.set_value(0.0);
     /// let mut qdata = ceed.vector(Q);
     /// qdata.set_value(0.0);
     ///
     /// {
-    ///   let mut input = vec![J, W];
+    ///   let mut input = vec![jj, ww];
     ///   let mut output = vec![qdata];
     ///   qf_build.apply(Q as i32, &input, &output);
     ///   qdata = output.remove(0);
     /// }
     ///
     /// {
-    ///   let mut input = vec![qdata, U];
-    ///   let mut output = vec![V];
+    ///   let mut input = vec![qdata, uu];
+    ///   let mut output = vec![vv];
     ///   qf_mass.apply(Q as i32, &input, &output);
-    ///   V = output.remove(0);
+    ///   vv = output.remove(0);
     /// }
     ///
-    /// let array = V.view();
+    /// let array = vv.view();
     /// for i in 0..Q {
     ///   assert_eq!(array[i], v[i], "Incorrect value in QFunction application");
     /// }


### PR DESCRIPTION
Add ability to link statically (requires refactoring registration pattern) and update the Rust crate to be installable and not need `LD_LIBRARY_PATH` hacks.