### PR TITLE
examples/petsc: use VecGetArrayAndMemType() to support CUDA/HIP/Kokkos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,8 @@ noether-rocm:
     - $CC --version && $CXX --version && $FC --version && $HIPCC --version
 # MAGMA from dev branch
     - export MAGMA_DIR=/projects/hipMAGMA && git -C $MAGMA_DIR describe
+# PETSc with HIP (minimal)
+    - export PETSC_DIR=/projects/jed/petsc PETSC_ARCH=mpich-hip-g && git -C $PETSC_DIR describe && make -C $PETSC_DIR info
 # LIBXSMM v1.16.1
     - cd .. && export XSMM_VERSION=libxsmm-1.16.1 && { [[ -d $XSMM_VERSION ]] || { git clone --depth 1 --branch 1.16.1 https://github.com/hfp/libxsmm.git $XSMM_VERSION && make -C $XSMM_VERSION -j$(nproc); }; } && git -C $XSMM_VERSION describe --tags && export XSMM_DIR=$PWD/$XSMM_VERSION && cd libCEED
 # OCCA v1.1.0

--- a/backends/cuda/ceed-cuda.c
+++ b/backends/cuda/ceed-cuda.c
@@ -142,11 +142,11 @@ int CeedCudaInit(Ceed ceed, const char *resource, int nrc) {
   int ierr;
   const int rlen = strlen(resource);
   const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;
-  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : 0;
+  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : -1;
 
   int currentDeviceID;
   ierr = cudaGetDevice(&currentDeviceID); CeedChk_Cu(ceed,ierr);
-  if (currentDeviceID!=deviceID) {
+  if (deviceID >= 0 && currentDeviceID != deviceID) {
     ierr = cudaSetDevice(deviceID); CeedChk_Cu(ceed,ierr);
   }
 

--- a/backends/hip/ceed-hip.c
+++ b/backends/hip/ceed-hip.c
@@ -33,11 +33,11 @@ int CeedHipInit(Ceed ceed, const char *resource, int nrc) {
   int ierr;
   const int rlen = strlen(resource);
   const bool slash = (rlen>nrc) ? (resource[nrc] == '/') : false;
-  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : 0;
+  const int deviceID = (slash && rlen > nrc + 1) ? atoi(&resource[nrc + 1]) : -1;
 
   int currentDeviceID;
   ierr = hipGetDevice(&currentDeviceID); CeedChk_Hip(ceed,ierr);
-  if (currentDeviceID!=deviceID) {
+  if (deviceID >= 0 && currentDeviceID != deviceID) {
     ierr = hipSetDevice(deviceID); CeedChk_Hip(ceed,ierr);
   }
 

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -156,6 +156,8 @@ int main(int argc, char **argv) {
     const char *resolved;
     CeedGetResource(ceed, &resolved);
     if (strstr(resolved, "/gpu/cuda")) vectype = VECCUDA;
+    else if (strstr(resolved, "/gpu/hip/occa"))
+      vectype = VECSTANDARD; // https://github.com/CEED/libCEED/issues/678
     else if (strstr(resolved, "/gpu/hip")) vectype = VECHIP;
     else vectype = VECSTANDARD;
   }

--- a/examples/solids/elasticity.c
+++ b/examples/solids/elasticity.c
@@ -113,12 +113,6 @@ int main(int argc, char **argv) {
   // Check preferred MemType
   CeedMemType memTypeBackend;
   CeedGetPreferredMemType(ceed, &memTypeBackend);
-  if (!appCtx->setMemTypeRequest)
-    appCtx->memTypeRequested = memTypeBackend;
-  else if (!appCtx->petscHaveCuda && appCtx->memTypeRequested == CEED_MEM_DEVICE)
-    SETERRQ1(PETSC_COMM_WORLD, PETSC_ERR_SUP_SYS,
-             "PETSc was not built with CUDA. "
-             "Requested MemType CEED_MEM_DEVICE is not supported.", NULL);
 
   // Wrap context in libCEED objects
   CeedQFunctionContextCreate(ceed, &ctxPhys);
@@ -140,14 +134,26 @@ int main(int argc, char **argv) {
 
   // -- Create distributed DM from mesh file
   ierr = CreateDistributedDM(comm, appCtx, &dmOrig); CHKERRQ(ierr);
+  VecType vectype;
+  switch (memTypeBackend) {
+  case CEED_MEM_HOST: vectype = VECSTANDARD; break;
+  case CEED_MEM_DEVICE: {
+    const char *resolved;
+    CeedGetResource(ceed, &resolved);
+    if (strstr(resolved, "/gpu/cuda")) vectype = VECCUDA;
+    else if (strstr(resolved, "/gpu/hip")) vectype = VECHIP;
+    else vectype = VECSTANDARD;
+  }
+  }
+  ierr = DMSetVecType(dmOrig, vectype); CHKERRQ(ierr);
+  ierr = DMSetFromOptions(dmOrig); CHKERRQ(ierr);
 
   // -- Setup DM by polynomial degree
   ierr = PetscMalloc1(numLevels, &levelDMs); CHKERRQ(ierr);
   for (PetscInt level = 0; level < numLevels; level++) {
     ierr = DMClone(dmOrig, &levelDMs[level]); CHKERRQ(ierr);
-    if (appCtx->memTypeRequested == CEED_MEM_DEVICE) {
-      ierr = DMSetVecType(levelDMs[level], VECCUDA); CHKERRQ(ierr);
-    }
+    ierr = DMGetVecType(dmOrig, &vectype); CHKERRQ(ierr);
+    ierr = DMSetVecType(levelDMs[level], vectype); CHKERRQ(ierr);
     ierr = SetupDMByDegree(levelDMs[level], appCtx, appCtx->levelDegrees[level],
                            PETSC_TRUE, ncompu); CHKERRQ(ierr);
     // -- Label field components for viewing
@@ -170,10 +176,8 @@ int main(int argc, char **argv) {
   ierr = DMClone(dmOrig, &dmDiagnostic); CHKERRQ(ierr);
   ierr = SetupDMByDegree(dmDiagnostic, appCtx, appCtx->levelDegrees[fineLevel],
                          PETSC_FALSE, ncompu + ncompd); CHKERRQ(ierr);
-  if (appCtx->memTypeRequested == CEED_MEM_DEVICE) {
-    ierr = DMSetVecType(dmEnergy, VECCUDA); CHKERRQ(ierr);
-    ierr = DMSetVecType(dmDiagnostic, VECCUDA); CHKERRQ(ierr);
-  }
+  ierr = DMSetVecType(dmEnergy, vectype); CHKERRQ(ierr);
+  ierr = DMSetVecType(dmDiagnostic, vectype); CHKERRQ(ierr);
   {
     // -- Label field components for viewing
     // Empty name for conserved field (because there is only one field)
@@ -243,29 +247,23 @@ int main(int argc, char **argv) {
   // -- Create libCEED local forcing vector
   CeedVector forceCeed;
   CeedScalar *f;
+  PetscMemType fmemtype;
   if (appCtx->forcingChoice != FORCE_NONE) {
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecGetArray(Floc, &f); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDAGetArray(Floc, &f); CHKERRQ(ierr);
-    }
+    ierr = VecGetArrayAndMemType(Floc, &f, &fmemtype); CHKERRQ(ierr);
     CeedVectorCreate(ceed, Ulocsz[fineLevel], &forceCeed);
-    CeedVectorSetArray(forceCeed, appCtx->memTypeRequested, CEED_USE_POINTER, f);
+    CeedVectorSetArray(forceCeed, MemTypeP2C(fmemtype), CEED_USE_POINTER, f);
   }
 
   // -- Create libCEED local Neumann BCs vector
   CeedVector neumannCeed;
   CeedScalar *n;
+  PetscMemType nmemtype;
   if (appCtx->bcTractionCount > 0) {
     ierr = VecDuplicate(U, &NBCs); CHKERRQ(ierr);
     ierr = VecDuplicate(Uloc[fineLevel], &NBCsloc); CHKERRQ(ierr);
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecGetArray(NBCsloc, &n); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDAGetArray(NBCsloc, &n); CHKERRQ(ierr);
-    }
+    ierr = VecGetArrayAndMemType(NBCsloc, &n, &nmemtype); CHKERRQ(ierr);
     CeedVectorCreate(ceed, Ulocsz[fineLevel], &neumannCeed);
-    CeedVectorSetArray(neumannCeed, appCtx->memTypeRequested,
+    CeedVectorSetArray(neumannCeed, MemTypeP2C(nmemtype),
                        CEED_USE_POINTER, n);
   }
 
@@ -294,12 +292,9 @@ int main(int argc, char **argv) {
 
     // Place in libCEED array
     const PetscScalar *m;
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecGetArrayRead(Uloc[level+1], &m); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDAGetArrayRead(Uloc[level+1], &m); CHKERRQ(ierr);
-    }
-    CeedVectorSetArray(ceedData[level+1]->xceed, appCtx->memTypeRequested,
+    PetscMemType mmemtype;
+    ierr = VecGetArrayReadAndMemType(Uloc[level+1], &m, &mmemtype); CHKERRQ(ierr);
+    CeedVectorSetArray(ceedData[level+1]->xceed, MemTypeP2C(mmemtype),
                        CEED_USE_POINTER, (CeedScalar *)m);
 
     // Note: use high order ceed, if specified and degree > 4
@@ -309,13 +304,9 @@ int main(int argc, char **argv) {
     CHKERRQ(ierr);
 
     // Restore PETSc vector
-    CeedVectorTakeArray(ceedData[level+1]->xceed, appCtx->memTypeRequested,
+    CeedVectorTakeArray(ceedData[level+1]->xceed, MemTypeP2C(mmemtype),
                         (CeedScalar **)&m);
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecRestoreArrayRead(Uloc[level+1], &m); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDARestoreArrayRead(Uloc[level+1], &m); CHKERRQ(ierr);
-    }
+    ierr = VecRestoreArrayReadAndMemType(Uloc[level+1], &m); CHKERRQ(ierr);
     ierr = VecZeroEntries(Ug[level+1]); CHKERRQ(ierr);
     ierr = VecZeroEntries(Uloc[level+1]); CHKERRQ(ierr);
   }
@@ -329,12 +320,8 @@ int main(int argc, char **argv) {
   ierr = VecZeroEntries(F); CHKERRQ(ierr);
 
   if (appCtx->forcingChoice != FORCE_NONE) {
-    CeedVectorTakeArray(forceCeed, appCtx->memTypeRequested, NULL);
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecRestoreArray(Floc, &f); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDARestoreArray(Floc, &f); CHKERRQ(ierr);
-    }
+    CeedVectorTakeArray(forceCeed, MemTypeP2C(fmemtype), NULL);
+    ierr = VecRestoreArrayAndMemType(Floc, &f); CHKERRQ(ierr);
     ierr = DMLocalToGlobal(levelDMs[fineLevel], Floc, ADD_VALUES, F);
     CHKERRQ(ierr);
     CeedVectorDestroy(&forceCeed);
@@ -342,12 +329,8 @@ int main(int argc, char **argv) {
 
   if (appCtx->bcTractionCount > 0) {
     ierr = VecZeroEntries(NBCs); CHKERRQ(ierr);
-    CeedVectorTakeArray(neumannCeed, appCtx->memTypeRequested, NULL);
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecRestoreArray(NBCsloc, &n); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDARestoreArray(NBCsloc, &n); CHKERRQ(ierr);
-    }
+    CeedVectorTakeArray(neumannCeed, MemTypeP2C(nmemtype), NULL);
+    ierr = VecRestoreArrayAndMemType(NBCsloc, &n); CHKERRQ(ierr);
     ierr = DMLocalToGlobal(levelDMs[fineLevel], NBCsloc, ADD_VALUES, NBCs);
     CHKERRQ(ierr);
     CeedVectorDestroy(&neumannCeed);
@@ -364,11 +347,8 @@ int main(int argc, char **argv) {
                        "\n-- Elasticity Example - libCEED + PETSc --\n"
                        "  libCEED:\n"
                        "    libCEED Backend                    : %s\n"
-                       "    libCEED Backend MemType            : %s\n"
-                       "    libCEED User Requested MemType     : %s\n",
-                       usedresource, CeedMemTypes[memTypeBackend],
-                       (appCtx->setMemTypeRequest) ?
-                       CeedMemTypes[appCtx->memTypeRequested] : "none");
+                       "    libCEED Backend MemType            : %s\n",
+                       usedresource, CeedMemTypes[memTypeBackend]);
     CHKERRQ(ierr);
 
     VecType vecType;
@@ -452,9 +432,7 @@ int main(int argc, char **argv) {
     CHKERRQ(ierr);
     ierr = MatShellSetOperation(jacobMat[level], MATOP_GET_DIAGONAL,
                                 (void(*)(void))GetDiag_Ceed);
-    if (appCtx->memTypeRequested == CEED_MEM_DEVICE) {
-      ierr = MatShellSetVecType(jacobMat[level], VECCUDA); CHKERRQ(ierr);
-    }
+    ierr = MatShellSetVecType(jacobMat[level], vectype); CHKERRQ(ierr);
   }
   // Note: FormJacobian updates Jacobian matrices on each level
   //   and assembles the Jpre matrix, if needed
@@ -497,9 +475,7 @@ int main(int argc, char **argv) {
     ierr = MatShellSetOperation(prolongRestrMat[level], MATOP_MULT_TRANSPOSE,
                                 (void (*)(void))Restrict_Ceed);
     CHKERRQ(ierr);
-    if (appCtx->memTypeRequested == CEED_MEM_DEVICE) {
-      ierr = MatShellSetVecType(prolongRestrMat[level], VECCUDA); CHKERRQ(ierr);
-    }
+    ierr = MatShellSetVecType(prolongRestrMat[level], vectype); CHKERRQ(ierr);
   }
 
   // ---------------------------------------------------------------------------
@@ -831,21 +807,12 @@ int main(int argc, char **argv) {
 
     // -- Assemble global true solution vector
     CeedVectorGetArrayRead(ceedData[fineLevel]->truesoln,
-                           appCtx->memTypeRequested, &truearray);
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecPlaceArray(resCtx->Yloc, (PetscScalar *)truearray);
-      CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDAPlaceArray(resCtx->Yloc, (PetscScalar *)truearray);
-      CHKERRQ(ierr);
-    }
+                           CEED_MEM_HOST, &truearray);
+    ierr = VecPlaceArray(resCtx->Yloc, (PetscScalar *)truearray);
+    CHKERRQ(ierr);
     ierr = DMLocalToGlobal(resCtx->dm, resCtx->Yloc, INSERT_VALUES, trueVec);
     CHKERRQ(ierr);
-    if (appCtx->memTypeRequested == CEED_MEM_HOST) {
-      ierr = VecResetArray(resCtx->Yloc); CHKERRQ(ierr);
-    } else {
-      ierr = VecCUDAResetArray(resCtx->Yloc); CHKERRQ(ierr);
-    }
+    ierr = VecResetArray(resCtx->Yloc); CHKERRQ(ierr);
     CeedVectorRestoreArrayRead(ceedData[fineLevel]->truesoln, &truearray);
 
     // -- Compute L2 error

--- a/examples/solids/elasticity.h
+++ b/examples/solids/elasticity.h
@@ -91,11 +91,6 @@ typedef PetscErrorCode BCFunc(PetscInt, PetscReal, const PetscReal *, PetscInt,
 //         are added to boundary.c.
 BCFunc BCMMS, BCZero, BCClamp;
 
-// MemType Options
-static const char *const memTypes[] = {"host","device","memType",
-                                       "CEED_MEM_",0
-                                      };
-
 // -----------------------------------------------------------------------------
 // Structs
 // -----------------------------------------------------------------------------
@@ -134,8 +129,6 @@ struct AppCtx_private {
   PetscInt      bcTractionFaces[16];
   PetscScalar   bcTractionVector[16][3];
   PetscScalar   forcingVector[3];
-  PetscBool     petscHaveCuda, setMemTypeRequest;
-  CeedMemType   memTypeRequested;
 };
 
 // Problem specific data
@@ -172,11 +165,6 @@ struct UserMult_private {
   Ceed            ceed;
   PetscScalar     loadIncrement;
   CeedQFunctionContext ctxPhys, ctxPhysSmoother;
-  CeedMemType     memType;
-  int (*VecGetArray)(Vec, PetscScalar **);
-  int (*VecGetArrayRead)(Vec, const PetscScalar **);
-  int (*VecRestoreArray)(Vec, PetscScalar **);
-  int (*VecRestoreArrayRead)(Vec, const PetscScalar **);
 };
 
 // Data for Jacobian setup routine
@@ -198,11 +186,6 @@ struct UserMultProlongRestr_private {
   CeedVector   ceedVecC, ceedVecF;
   CeedOperator opProlong, opRestrict;
   Ceed         ceed;
-  CeedMemType   memType;
-  int (*VecGetArray)(Vec, PetscScalar **);
-  int (*VecGetArrayRead)(Vec, const PetscScalar **);
-  int (*VecRestoreArray)(Vec, PetscScalar **);
-  int (*VecRestoreArrayRead)(Vec, const PetscScalar **);
 };
 
 // libCEED data struct for level
@@ -218,6 +201,11 @@ struct CeedData_private {
                       opDiagnostic;
   CeedVector          qdata, qdataDiagnostic, gradu, xceed, yceed, truesoln;
 };
+
+// Translate PetscMemType to CeedMemType
+static inline CeedMemType MemTypeP2C(PetscMemType mtype) {
+  return PetscMemTypeDevice(mtype) ? CEED_MEM_DEVICE : CEED_MEM_HOST;
+}
 
 // -----------------------------------------------------------------------------
 // Process command line options

--- a/examples/solids/src/cloptions.c
+++ b/examples/solids/src/cloptions.c
@@ -179,23 +179,6 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx appCtx) {
                           "Write out final solution vector for viewing",
                           NULL, appCtx->viewFinalSoln, &(appCtx->viewFinalSoln),
                           NULL); CHKERRQ(ierr);
-
-  // Check PETSc CUDA support
-  // *INDENT-OFF*
-  #ifdef PETSC_HAVE_CUDA
-  appCtx->petscHaveCuda = PETSC_TRUE;
-  #else
-  appCtx->petscHaveCuda = PETSC_FALSE;
-  #endif
-  // *INDENT-ON*
-
-  appCtx->memTypeRequested = appCtx->petscHaveCuda ? CEED_MEM_DEVICE :
-                             CEED_MEM_HOST;
-  ierr = PetscOptionsEnum("-memtype", "CEED MemType requested", NULL, memTypes,
-                          (PetscEnum)appCtx->memTypeRequested,
-                          (PetscEnum *)&appCtx->memTypeRequested,
-                          &appCtx->setMemTypeRequest); CHKERRQ(ierr);
-
   ierr = PetscOptionsEnd(); CHKERRQ(ierr); // End of setting AppCtx
 
   // Check for all required values set

--- a/tests/junit.py
+++ b/tests/junit.py
@@ -69,7 +69,7 @@ def run(test, backends):
             if skip_rule(test, ceed_resource):
                 case = TestCase('{} {}'.format(test, ceed_resource),
                                 elapsed_sec=0,
-                                timestamp=time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime(start)),
+                                timestamp=time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime()),
                                 stdout='',
                                 stderr='')
                 case.add_skipped_info('Pre-run skip rule')

--- a/tests/junit.py
+++ b/tests/junit.py
@@ -47,7 +47,6 @@ def skip_rule(test, resource):
     return any((
         test.startswith('fluids-') and contains_any(resource, ['occa', 'gpu']) and not contains_any(resource, ['/gpu/cuda/gen']),
         test.startswith('solids-') and contains_any(resource, ['occa']),
-        test.startswith('petsc-multigrid') and contains_any(resource, ['occa']),
         test.startswith('nek') and contains_any(resource, ['occa']),
         test.startswith('t507') and contains_any(resource, ['occa']),
         test.startswith('t318') and contains_any(resource, ['magma']),


### PR DESCRIPTION
We resolve default VECCUDA or VECHIP based on /gpu/cuda or /gpu/hip. For
others, one should pass -dm_vec_type kokkos or -dm_vec_type standard.

There is no longer a "libCEED User Requested MemType" field in the
output.

Enable CI testing using PETSc built locally with HIP. This should be
converted to building a specified version once some bugs are fixed and
the branch merges.

Exclude automatic selection of VECHIP for /gpu/hip/occa due to SEGV:
https://github.com/CEED/libCEED/issues/678

* Resolve #219 (a pretty complete test suite on GPUs)
* Resolve #660 (PETSc tests on Noether)