### PR TITLE
doc: update to sphinxcontrib-bibtex 2.1

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -3,7 +3,7 @@ breathe>=4.17
 markdown==3.2.1
 recommonmark
 sphinx_rtd_theme
-sphinxcontrib-bibtex<2.0
+sphinxcontrib-bibtex>=2.1
 sphinxcontrib-katex
 sphinxcontrib-mermaid
 sphinxcontrib-svg2pdfconverter

--- a/doc/sphinx/source/references.rst
+++ b/doc/sphinx/source/references.rst
@@ -2,4 +2,3 @@ Bibliography
 ========================================
 
 .. bibliography::
-   references.bib


### PR DESCRIPTION
Now the source files are declared in bibtex_bibfiles in conf.py and the
`.. bibliography` directive does not need the path.

Thanks to https://github.com/mcmtroffaes/sphinxcontrib-bibtex/pull/219