### PR TITLE
Rust - drop get_/set_/add_ syntax

### DIFF
--- a/rust/src/basis.rs
+++ b/rust/src/basis.rs
@@ -205,10 +205,7 @@ impl Basis {
     ///
     /// // Create function x^3 + 1 on Gauss Lobatto points
     /// let mut u_arr = [0.; Q];
-    /// let x_nodes_arr = x_nodes.view();
-    /// for i in 0..Q {
-    ///   u_arr[i] = x_nodes_arr[i]*x_nodes_arr[i]*x_nodes_arr[i] + 1.;
-    /// }
+    /// u_arr.iter_mut().zip(x_nodes.view().iter()).for_each(|(u, x)| *u = x * x * x + 1.);
     /// let u = ceed.vector_from_slice(&u_arr);
     ///
     /// // Map function to Gauss points
@@ -217,12 +214,13 @@ impl Basis {
     /// bu.apply(1, TransposeMode::NoTranspose, EvalMode::Interp, &u, &mut v);
     ///
     /// // Verify results
-    /// let v_arr = v.view();
-    /// let x_qpts_arr = x_qpts.view();
-    /// for i in 0..Q {
-    ///   let true_value = x_qpts_arr[i]*x_qpts_arr[i]*x_qpts_arr[i] + 1.;
-    ///   assert_eq!(v_arr[i], true_value, "Incorrect basis application");
-    /// }
+    /// v.view()
+    ///     .iter()
+    ///     .zip(x_qpts.view().iter())
+    ///     .for_each(|(v, x)| {
+    ///         let true_value = x * x * x + 1.;
+    ///         assert_eq!(*v, true_value, "Incorrect basis application");
+    ///     });
     /// ```
     pub fn apply(
         &self,
@@ -282,7 +280,7 @@ impl Basis {
     /// let b = ceed.basis_tensor_H1_Lagrange(2, 1, p, 4, QuadMode::Gauss);
     ///
     /// let nnodes = b.num_nodes();
-    /// assert_eq!(nnodes, (p*p) as i32, "Incorrect number of nodes");
+    /// assert_eq!(nnodes, (p * p) as i32, "Incorrect number of nodes");
     /// ```
     pub fn num_nodes(&self) -> i32 {
         let mut nnodes = 0;
@@ -300,7 +298,7 @@ impl Basis {
     /// let b = ceed.basis_tensor_H1_Lagrange(2, 1, 3, q, QuadMode::Gauss);
     ///
     /// let nqpts = b.num_quadrature_points();
-    /// assert_eq!(nqpts, (q*q) as i32, "Incorrect number of quadrature points");
+    /// assert_eq!(nqpts, (q * q) as i32, "Incorrect number of quadrature points");
     /// ```
     pub fn num_quadrature_points(&self) -> i32 {
         let mut Q = 0;

--- a/rust/src/basis.rs
+++ b/rust/src/basis.rs
@@ -247,10 +247,10 @@ impl Basis {
     /// let dim = 2;
     /// let b = ceed.basis_tensor_H1_Lagrange(dim, 1, 3, 4, QuadMode::Gauss);
     ///
-    /// let d = b.get_dimension();
+    /// let d = b.dimension();
     /// assert_eq!(d, dim as i32, "Incorrect dimension");
     /// ```
-    pub fn get_dimension(&self) -> i32 {
+    pub fn dimension(&self) -> i32 {
         let mut dim = 0;
         unsafe { bind_ceed::CeedBasisGetDimension(self.ptr, &mut dim) };
         dim
@@ -264,10 +264,10 @@ impl Basis {
     /// let ncomp = 2;
     /// let b = ceed.basis_tensor_H1_Lagrange(1, ncomp, 3, 4, QuadMode::Gauss);
     ///
-    /// let n = b.get_num_components();
+    /// let n = b.num_components();
     /// assert_eq!(n, ncomp as i32, "Incorrect number of components");
     /// ```
-    pub fn get_num_components(&self) -> i32 {
+    pub fn num_components(&self) -> i32 {
         let mut ncomp = 0;
         unsafe { bind_ceed::CeedBasisGetNumComponents(self.ptr, &mut ncomp) };
         ncomp
@@ -281,10 +281,10 @@ impl Basis {
     /// let p = 3;
     /// let b = ceed.basis_tensor_H1_Lagrange(2, 1, p, 4, QuadMode::Gauss);
     ///
-    /// let nnodes = b.get_num_nodes();
+    /// let nnodes = b.num_nodes();
     /// assert_eq!(nnodes, (p*p) as i32, "Incorrect number of nodes");
     /// ```
-    pub fn get_num_nodes(&self) -> i32 {
+    pub fn num_nodes(&self) -> i32 {
         let mut nnodes = 0;
         unsafe { bind_ceed::CeedBasisGetNumNodes(self.ptr, &mut nnodes) };
         nnodes
@@ -299,10 +299,10 @@ impl Basis {
     /// let q = 4;
     /// let b = ceed.basis_tensor_H1_Lagrange(2, 1, 3, q, QuadMode::Gauss);
     ///
-    /// let nqpts = b.get_num_quadrature_points();
+    /// let nqpts = b.num_quadrature_points();
     /// assert_eq!(nqpts, (q*q) as i32, "Incorrect number of quadrature points");
     /// ```
-    pub fn get_num_quadrature_points(&self) -> i32 {
+    pub fn num_quadrature_points(&self) -> i32 {
         let mut Q = 0;
         unsafe {
             bind_ceed::CeedBasisGetNumQuadraturePoints(self.ptr, &mut Q);

--- a/rust/src/elem_restriction.rs
+++ b/rust/src/elem_restriction.rs
@@ -75,12 +75,12 @@ impl fmt::Display for ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     /// println!("{}", r);
     /// ```
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -167,16 +167,16 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let lvector = r.create_lvector();
     ///
-    /// assert_eq!(lvector.length(), nelem+1, "Incorrect Lvector size");
+    /// assert_eq!(lvector.length(), nelem + 1, "Incorrect Lvector size");
     /// ```
     pub fn create_lvector(&self) -> Vector {
         let mut ptr_lvector = std::ptr::null_mut();
@@ -191,16 +191,16 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let evector = r.create_evector();
     ///
-    /// assert_eq!(evector.length(), nelem*2, "Incorrect Evector size");
+    /// assert_eq!(evector.length(), nelem * 2, "Incorrect Evector size");
     /// ```
     pub fn create_evector(&self) -> Vector {
         let mut ptr_evector = std::ptr::null_mut();
@@ -215,17 +215,17 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let (lvector, evector) = r.create_vectors();
     ///
-    /// assert_eq!(lvector.length(), nelem+1, "Incorrect Lvector size");
-    /// assert_eq!(evector.length(), nelem*2, "Incorrect Evector size");
+    /// assert_eq!(lvector.length(), nelem + 1, "Incorrect Lvector size");
+    /// assert_eq!(evector.length(), nelem * 2, "Incorrect Evector size");
     /// ```
     pub fn create_vectors(&self) -> (Vector, Vector) {
         let mut ptr_lvector = std::ptr::null_mut();
@@ -250,12 +250,12 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let x = ceed.vector_from_slice(&[0., 1., 2., 3.]);
     /// let mut y = ceed.vector(nelem*2);
@@ -263,10 +263,12 @@ impl ElemRestriction {
     ///
     /// r.apply(TransposeMode::NoTranspose, &x, &mut y);
     ///
-    /// let array = y.view();
-    /// for i in 0..(nelem*2) {
-    ///   assert_eq!(array[i], ((i+1)/2) as f64, "Incorrect value in restricted vector");
-    /// }
+    /// y.view()
+    ///     .iter()
+    ///     .enumerate()
+    ///     .for_each(|(i, arr)| {
+    ///         assert_eq!(*arr, ((i + 1) / 2) as f64, "Incorrect value in restricted vector");
+    ///     });
     /// ```
     pub fn apply(&self, tmode: TransposeMode, u: &Vector, ru: &mut Vector) {
         let tmode = tmode as bind_ceed::CeedTransposeMode;
@@ -288,12 +290,12 @@ impl ElemRestriction {
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
     /// let compstride = 1;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, compstride, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, compstride, nelem + 1, MemType::Host, &ind);
     ///
     /// let c = r.comp_stride();
     /// assert_eq!(c, compstride as i32, "Incorrect component stride");
@@ -310,12 +312,12 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let n = r.num_elements();
     /// assert_eq!(n, nelem as i32, "Incorrect number of elements");
@@ -333,12 +335,12 @@ impl ElemRestriction {
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
     /// let elem_size = 2;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, elem_size, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, elem_size, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let e = r.elem_size();
     /// assert_eq!(e, elem_size as i32, "Incorrect element size");
@@ -355,15 +357,15 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind : Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
     /// let lsize = r.lvector_size();
-    /// assert_eq!(lsize, (nelem+1) as i32);
+    /// assert_eq!(lsize, (nelem + 1) as i32);
     /// ```
     pub fn lvector_size(&self) -> i32 {
         let mut lsize = 0;
@@ -378,12 +380,12 @@ impl ElemRestriction {
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
     /// let ncomp = 42;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 42, 1, ncomp*(nelem+1), MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 42, 1, ncomp * (nelem + 1), MemType::Host, &ind);
     ///
     /// let n = r.num_components();
     /// assert_eq!(n, ncomp as i32, "Incorrect number of components");
@@ -400,25 +402,27 @@ impl ElemRestriction {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind: Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind: Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     ///
-    /// let mut mult = ceed.vector(nelem+1);
+    /// let mut mult = ceed.vector(nelem + 1);
     /// mult.set_value(0.0);
     ///
     /// r.multiplicity(&mut mult);
     ///
-    /// let array = mult.view();
-    /// for i in 0..(nelem+1) {
-    ///   assert_eq!(
-    ///     if (i == 0 || i == nelem) { 1. } else { 2. },
-    ///     array[i],
-    ///     "Incorrect multiplicity array");
-    /// }
+    /// mult.view()
+    ///     .iter()
+    ///     .enumerate()
+    ///     .for_each(|(i, arr)| {
+    ///         assert_eq!(
+    ///             if (i == 0 || i == nelem) { 1. } else { 2. },
+    ///             *arr,
+    ///             "Incorrect multiplicity array");
+    ///     });
     /// ```
     pub fn multiplicity(&self, mult: &mut Vector) {
         unsafe { bind_ceed::CeedElemRestrictionGetMultiplicity(self.ptr, mult.ptr) };

--- a/rust/src/elem_restriction.rs
+++ b/rust/src/elem_restriction.rs
@@ -295,10 +295,10 @@ impl ElemRestriction {
     /// }
     /// let r = ceed.elem_restriction(nelem, 2, 1, compstride, nelem+1, MemType::Host, &ind);
     ///
-    /// let c = r.get_comp_stride();
+    /// let c = r.comp_stride();
     /// assert_eq!(c, compstride as i32, "Incorrect component stride");
     /// ```
-    pub fn get_comp_stride(&self) -> i32 {
+    pub fn comp_stride(&self) -> i32 {
         let mut compstride = 0;
         unsafe { bind_ceed::CeedElemRestrictionGetCompStride(self.ptr, &mut compstride) };
         compstride
@@ -317,10 +317,10 @@ impl ElemRestriction {
     /// }
     /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
     ///
-    /// let n = r.get_num_elements();
+    /// let n = r.num_elements();
     /// assert_eq!(n, nelem as i32, "Incorrect number of elements");
     /// ```
-    pub fn get_num_elements(&self) -> i32 {
+    pub fn num_elements(&self) -> i32 {
         let mut numelem = 0;
         unsafe { bind_ceed::CeedElemRestrictionGetNumElements(self.ptr, &mut numelem) };
         numelem
@@ -340,10 +340,10 @@ impl ElemRestriction {
     /// }
     /// let r = ceed.elem_restriction(nelem, elem_size, 1, 1, nelem+1, MemType::Host, &ind);
     ///
-    /// let e = r.get_elem_size();
+    /// let e = r.elem_size();
     /// assert_eq!(e, elem_size as i32, "Incorrect element size");
     /// ```
-    pub fn get_elem_size(&self) -> i32 {
+    pub fn elem_size(&self) -> i32 {
         let mut elemsize = 0;
         unsafe { bind_ceed::CeedElemRestrictionGetElementSize(self.ptr, &mut elemsize) };
         elemsize
@@ -362,10 +362,10 @@ impl ElemRestriction {
     /// }
     /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
     ///
-    /// let lsize = r.get_lvector_size();
+    /// let lsize = r.lvector_size();
     /// assert_eq!(lsize, (nelem+1) as i32);
     /// ```
-    pub fn get_lvector_size(&self) -> i32 {
+    pub fn lvector_size(&self) -> i32 {
         let mut lsize = 0;
         unsafe { bind_ceed::CeedElemRestrictionGetLVectorSize(self.ptr, &mut lsize) };
         lsize
@@ -385,10 +385,10 @@ impl ElemRestriction {
     /// }
     /// let r = ceed.elem_restriction(nelem, 2, 42, 1, ncomp*(nelem+1), MemType::Host, &ind);
     ///
-    /// let n = r.get_num_components();
+    /// let n = r.num_components();
     /// assert_eq!(n, ncomp as i32, "Incorrect number of components");
     /// ```
-    pub fn get_num_components(&self) -> i32 {
+    pub fn num_components(&self) -> i32 {
         let mut numcomp = 0;
         unsafe { bind_ceed::CeedElemRestrictionGetNumComponents(self.ptr, &mut numcomp) };
         numcomp
@@ -410,7 +410,7 @@ impl ElemRestriction {
     /// let mut mult = ceed.vector(nelem+1);
     /// mult.set_value(0.0);
     ///
-    /// r.get_multiplicity(&mut mult);
+    /// r.multiplicity(&mut mult);
     ///
     /// let array = mult.view();
     /// for i in 0..(nelem+1) {
@@ -420,7 +420,7 @@ impl ElemRestriction {
     ///     "Incorrect multiplicity array");
     /// }
     /// ```
-    pub fn get_multiplicity(&self, mult: &mut Vector) {
+    pub fn multiplicity(&self, mult: &mut Vector) {
         unsafe { bind_ceed::CeedElemRestrictionGetMultiplicity(self.ptr, mult.ptr) };
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -625,19 +625,23 @@ mod tests {
 
         // Set up operator
         let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-        let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-        op_build.field("dx", &rx, &bx, VectorOpt::Active);
-        op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-        op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+        let op_build = ceed
+            .operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+            .field("dx", &rx, &bx, VectorOpt::Active)
+            .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+            .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+            .build();
 
         op_build.apply(&x, &mut qdata);
 
         // Mass operator
         let qf_mass = ceed.q_function_interior_by_name("MassApply");
-        let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-        op_mass.field("u", &ru, &bu, VectorOpt::Active);
-        op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-        op_mass.field("v", &ru, &bu, VectorOpt::Active);
+        let op_mass = ceed
+            .operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+            .field("u", &ru, &bu, VectorOpt::Active)
+            .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+            .field("v", &ru, &bu, VectorOpt::Active)
+            .build();
 
         v.set_value(0.0);
         op_mass.apply(&u, &mut v);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -626,18 +626,18 @@ mod tests {
         // Set up operator
         let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
         let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-        op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-        op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-        op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+        op_build.field("dx", &rx, &bx, VectorOpt::Active);
+        op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+        op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
 
         op_build.apply(&x, &mut qdata);
 
         // Mass operator
         let qf_mass = ceed.q_function_interior_by_name("MassApply");
         let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-        op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-        op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-        op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+        op_mass.field("u", &ru, &bu, VectorOpt::Active);
+        op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+        op_mass.field("v", &ru, &bu, VectorOpt::Active);
 
         v.set_value(0.0);
         op_mass.apply(&u, &mut v);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -643,11 +643,7 @@ mod tests {
         op_mass.apply(&u, &mut v);
 
         // Check
-        let array = v.view();
-        let mut sum = 0.0;
-        for i in 0..ndofs {
-            sum += array[i];
-        }
+        let sum: f64 = v.view().iter().sum();
         assert!(
             (sum - 2.0).abs() < 1e-15,
             "Incorrect interval length computed"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -637,8 +637,7 @@ mod tests {
             .operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
             .field("u", &ru, &bu, VectorOpt::Active)
             .field("qdata", &rq, BasisOpt::Collocated, &qdata)
-            .field("v", &ru, &bu, VectorOpt::Active)
-            .build();
+            .field("v", &ru, &bu, VectorOpt::Active);
 
         v.set_value(0.0);
         op_mass.apply(&u, &mut v);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -299,12 +299,12 @@ impl Ceed {
     /// # use libceed::prelude::*;
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
-    /// let mut ind : Vec<i32> = vec![0; 2*nelem];
+    /// let mut ind : Vec<i32> = vec![0; 2 * nelem];
     /// for i in 0..nelem {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(nelem, 2, 1, 1, nelem + 1, MemType::Host, &ind);
     /// ```
     pub fn elem_restriction(
         &self,
@@ -347,7 +347,7 @@ impl Ceed {
     /// # let ceed = libceed::Ceed::default_init();
     /// let nelem = 3;
     /// let strides : [i32; 3] = [1, 2, 2];
-    /// let r = ceed.strided_elem_restriction(nelem, 2, 1, nelem*2, strides);
+    /// let r = ceed.strided_elem_restriction(nelem, 2, 1, nelem * 2, strides);
     /// ```
     pub fn strided_elem_restriction(
         &self,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -623,16 +623,13 @@ mod tests {
         let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
         let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
 
-        // Set up operator
+        // Build quadrature data
         let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-        let op_build = ceed
-            .operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+        ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
             .field("dx", &rx, &bx, VectorOpt::Active)
             .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
             .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-            .build();
-
-        op_build.apply(&x, &mut qdata);
+            .apply(&x, &mut qdata);
 
         // Mass operator
         let qf_mass = ceed.q_function_interior_by_name("MassApply");

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -86,9 +86,9 @@ impl fmt::Display for OperatorCore {
 /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
 ///
 /// // Operator fields
-/// op.set_field("dx", &r, &b, VectorOpt::Active);
-/// op.set_field("weights", ElemRestrictionOpt::None, &b, VectorOpt::None);
-/// op.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+/// op.field("dx", &r, &b, VectorOpt::Active);
+/// op.field("weights", ElemRestrictionOpt::None, &b, VectorOpt::None);
+/// op.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
 ///
 /// println!("{}", op);
 /// ```
@@ -124,19 +124,19 @@ impl fmt::Display for Operator {
 ///
 /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
 /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-/// op_mass.set_field("u", &r, &b, VectorOpt::Active);
-/// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
-/// op_mass.set_field("v", &r, &b, VectorOpt::Active);
+/// op_mass.field("u", &r, &b, VectorOpt::Active);
+/// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
+/// op_mass.field("v", &r, &b, VectorOpt::Active);
 ///
-/// op.add_sub_operator(&op_mass);
+/// op.sub_operator(&op_mass);
 ///
 /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
 /// let mut op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-/// op_diff.set_field("du", &r, &b, VectorOpt::Active);
-/// op_diff.set_field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
-/// op_diff.set_field("dv", &r, &b, VectorOpt::Active);
+/// op_diff.field("du", &r, &b, VectorOpt::Active);
+/// op_diff.field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
+/// op_diff.field("dv", &r, &b, VectorOpt::Active);
 ///
-/// op.add_sub_operator(&op_diff);
+/// op.sub_operator(&op_diff);
 ///
 /// println!("{}", op);
 /// ```
@@ -290,18 +290,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// v.set_value(0.0);
     /// op_mass.apply(&u, &mut v);
@@ -363,18 +363,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// v.set_value(1.0);
     /// op_mass.apply_add(&u, &mut v);
@@ -425,9 +425,9 @@ impl Operator {
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     ///
     /// // Operator field
-    /// op.set_field("dx", &r, &b, VectorOpt::Active);
+    /// op.field("dx", &r, &b, VectorOpt::Active);
     /// ```
-    pub fn set_field<'b>(
+    pub fn field<'b>(
         &mut self,
         fieldname: &str,
         r: impl Into<ElemRestrictionOpt<'b>>,
@@ -498,18 +498,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ndofs);
@@ -600,18 +600,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ndofs);
@@ -708,9 +708,9 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
@@ -734,14 +734,14 @@ impl Operator {
     /// };
     ///
     /// let mut qf_mass = ceed.q_function_interior(1, Box::new(mass_2_comp));
-    /// qf_mass.add_input("u", 2, EvalMode::Interp);
-    /// qf_mass.add_input("qdata", 1, EvalMode::None);
-    /// qf_mass.add_output("v", 2, EvalMode::Interp);
+    /// qf_mass.input("u", 2, EvalMode::Interp);
+    /// qf_mass.input("qdata", 1, EvalMode::None);
+    /// qf_mass.output("v", 2, EvalMode::Interp);
     ///
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ncomp*ncomp*ndofs);
@@ -842,9 +842,9 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
@@ -868,14 +868,14 @@ impl Operator {
     /// };
     ///
     /// let mut qf_mass = ceed.q_function_interior(1, Box::new(mass_2_comp));
-    /// qf_mass.add_input("u", 2, EvalMode::Interp);
-    /// qf_mass.add_input("qdata", 1, EvalMode::None);
-    /// qf_mass.add_output("v", 2, EvalMode::Interp);
+    /// qf_mass.input("u", 2, EvalMode::Interp);
+    /// qf_mass.input("qdata", 1, EvalMode::None);
+    /// qf_mass.output("v", 2, EvalMode::Interp);
     ///
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ncomp*ncomp*ndofs);
@@ -988,18 +988,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass_fine.set_field("u", &ru_fine, &bu_fine, VectorOpt::Active);
-    /// op_mass_fine.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass_fine.set_field("v", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// op_mass_fine.field("u", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// op_mass_fine.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass_fine.field("v", &ru_fine, &bu_fine, VectorOpt::Active);
     ///
     /// // Multigrid setup
     /// let (op_mass_coarse, op_prolong, op_restrict) =
@@ -1139,18 +1139,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass_fine.set_field("u", &ru_fine, &bu_fine, VectorOpt::Active);
-    /// op_mass_fine.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass_fine.set_field("v", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// op_mass_fine.field("u", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// op_mass_fine.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass_fine.field("v", &ru_fine, &bu_fine, VectorOpt::Active);
     ///
     /// // Multigrid setup
     /// let mut interp_c_to_f : Vec<f64> = vec![0.; p_coarse*p_fine];
@@ -1311,18 +1311,18 @@ impl Operator {
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass_fine.set_field("u", &ru_fine, &bu_fine, VectorOpt::Active);
-    /// op_mass_fine.set_field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass_fine.set_field("v", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// op_mass_fine.field("u", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// op_mass_fine.field("qdata", &rq, BasisOpt::Collocated, &qdata);
+    /// op_mass_fine.field("v", &ru_fine, &bu_fine, VectorOpt::Active);
     ///
     /// // Multigrid setup
     /// let mut interp_c_to_f : Vec<f64> = vec![0.; p_coarse*p_fine];
@@ -1475,17 +1475,17 @@ impl CompositeOperator {
     /// // Set up operators
     /// let qf_build_mass = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_mass.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_mass.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_mass.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build_mass.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build_mass.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build_mass.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build_mass.apply(&x, &mut qdata_mass);
     ///
     /// let qf_build_diff = ceed.q_function_interior_by_name("Poisson1DBuild");
     /// let mut op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_diff.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_diff.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_diff.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build_diff.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build_diff.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build_diff.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build_diff.apply(&x, &mut qdata_diff);
     ///
@@ -1494,19 +1494,19 @@ impl CompositeOperator {
     ///
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
-    /// op_composite.add_sub_operator(&op_mass);
+    /// op_composite.sub_operator(&op_mass);
     ///
     /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
     /// let mut op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_diff.set_field("du", &ru, &bu, VectorOpt::Active);
-    /// op_diff.set_field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
-    /// op_diff.set_field("dv", &ru, &bu, VectorOpt::Active);
+    /// op_diff.field("du", &ru, &bu, VectorOpt::Active);
+    /// op_diff.field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
+    /// op_diff.field("dv", &ru, &bu, VectorOpt::Active);
     ///
-    /// op_composite.add_sub_operator(&op_diff);
+    /// op_composite.sub_operator(&op_diff);
     ///
     /// v.set_value(0.0);
     /// op_composite.apply(&u, &mut v);
@@ -1571,17 +1571,17 @@ impl CompositeOperator {
     /// // Set up operators
     /// let qf_build_mass = ceed.q_function_interior_by_name("Mass1DBuild");
     /// let mut op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_mass.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_mass.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_mass.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build_mass.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build_mass.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build_mass.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build_mass.apply(&x, &mut qdata_mass);
     ///
     /// let qf_build_diff = ceed.q_function_interior_by_name("Poisson1DBuild");
     /// let mut op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_diff.set_field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_diff.set_field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_diff.set_field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// op_build_diff.field("dx", &rx, &bx, VectorOpt::Active);
+    /// op_build_diff.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
+    /// op_build_diff.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
     ///
     /// op_build_diff.apply(&x, &mut qdata_diff);
     ///
@@ -1590,19 +1590,19 @@ impl CompositeOperator {
     ///
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.set_field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.set_field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
-    /// op_mass.set_field("v", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
+    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
+    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
     ///
-    /// op_composite.add_sub_operator(&op_mass);
+    /// op_composite.sub_operator(&op_mass);
     ///
     /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
     /// let mut op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_diff.set_field("du", &ru, &bu, VectorOpt::Active);
-    /// op_diff.set_field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
-    /// op_diff.set_field("dv", &ru, &bu, VectorOpt::Active);
+    /// op_diff.field("du", &ru, &bu, VectorOpt::Active);
+    /// op_diff.field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
+    /// op_diff.field("dv", &ru, &bu, VectorOpt::Active);
     ///
-    /// op_composite.add_sub_operator(&op_diff);
+    /// op_composite.sub_operator(&op_diff);
     ///
     /// v.set_value(1.0);
     /// op_composite.apply_add(&u, &mut v);
@@ -1630,13 +1630,13 @@ impl CompositeOperator {
     ///
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
     /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op.add_sub_operator(&op_mass);
+    /// op.sub_operator(&op_mass);
     ///
     /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
     /// let op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op.add_sub_operator(&op_diff);
+    /// op.sub_operator(&op_diff);
     /// ```
-    pub fn add_sub_operator(&mut self, subop: &Operator) {
+    pub fn sub_operator(&mut self, subop: &Operator) {
         unsafe { bind_ceed::CeedCompositeOperatorAddSub(self.op_core.ptr, subop.op_core.ptr) };
     }
 

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -123,18 +123,20 @@ impl fmt::Display for Operator {
 /// let qdata_diff = ceed.vector(q*ne);
 ///
 /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-/// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-/// op_mass.field("u", &r, &b, VectorOpt::Active);
-/// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
-/// op_mass.field("v", &r, &b, VectorOpt::Active);
+/// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+///     .field("u", &r, &b, VectorOpt::Active)
+///     .field("qdata", &rq, BasisOpt::Collocated, &qdata_mass)
+///     .field("v", &r, &b, VectorOpt::Active)
+///     .build();
 ///
 /// op.sub_operator(&op_mass);
 ///
 /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
-/// let mut op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-/// op_diff.field("du", &r, &b, VectorOpt::Active);
-/// op_diff.field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
-/// op_diff.field("dv", &r, &b, VectorOpt::Active);
+/// let op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None)
+///     .field("du", &r, &b, VectorOpt::Active)
+///     .field("qdata", &rq, BasisOpt::Collocated, &qdata_diff)
+///     .field("dv", &r, &b, VectorOpt::Active)
+///     .build();
 ///
 /// op.sub_operator(&op_diff);
 ///
@@ -244,6 +246,14 @@ impl Operator {
         Self { op_core }
     }
 
+    pub fn build(&mut self) -> Operator {
+        let ptr = self.op_core.ptr;
+        self.op_core.ptr = std::ptr::null_mut();
+        Self {
+            op_core: OperatorCore { ptr },
+        }
+    }
+
     /// Apply Operator to a vector
     ///
     /// * `input`  - Input Vector
@@ -289,19 +299,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// v.set_value(0.0);
     /// op_mass.apply(&u, &mut v);
@@ -362,19 +374,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// v.set_value(1.0);
     /// op_mass.apply_add(&u, &mut v);
@@ -427,13 +441,13 @@ impl Operator {
     /// // Operator field
     /// op.field("dx", &r, &b, VectorOpt::Active);
     /// ```
-    pub fn field<'b>(
-        &mut self,
+    pub fn field<'a, 'b>(
+        &'a mut self,
         fieldname: &str,
         r: impl Into<ElemRestrictionOpt<'b>>,
         b: impl Into<BasisOpt<'b>>,
         v: impl Into<VectorOpt<'b>>,
-    ) {
+    ) -> &'a mut Operator {
         let fieldname = CString::new(fieldname).expect("CString::new failed");
         let fieldname = fieldname.as_ptr() as *const i8;
         unsafe {
@@ -445,6 +459,7 @@ impl Operator {
                 v.into().to_raw(),
             )
         };
+        self
     }
 
     /// Assemble the diagonal of a square linear Operator
@@ -497,19 +512,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ndofs);
@@ -599,19 +616,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ndofs);
@@ -707,10 +726,11 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
@@ -738,10 +758,11 @@ impl Operator {
     /// qf_mass.input("qdata", 1, EvalMode::None);
     /// qf_mass.output("v", 2, EvalMode::Interp);
     ///
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ncomp*ncomp*ndofs);
@@ -841,10 +862,11 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
@@ -872,10 +894,11 @@ impl Operator {
     /// qf_mass.input("qdata", 1, EvalMode::None);
     /// qf_mass.output("v", 2, EvalMode::Interp);
     ///
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Diagonal
     /// let mut diag = ceed.vector(ncomp*ncomp*ndofs);
@@ -987,19 +1010,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass_fine.field("u", &ru_fine, &bu_fine, VectorOpt::Active);
-    /// op_mass_fine.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass_fine.field("v", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// let op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru_fine, &bu_fine, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru_fine, &bu_fine, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Multigrid setup
     /// let (op_mass_coarse, op_prolong, op_restrict) =
@@ -1138,19 +1163,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass_fine.field("u", &ru_fine, &bu_fine, VectorOpt::Active);
-    /// op_mass_fine.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass_fine.field("v", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// let op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru_fine, &bu_fine, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru_fine, &bu_fine, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Multigrid setup
     /// let mut interp_c_to_f : Vec<f64> = vec![0.; p_coarse*p_fine];
@@ -1310,19 +1337,21 @@ impl Operator {
     ///
     /// // Set up operator
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build.apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass_fine.field("u", &ru_fine, &bu_fine, VectorOpt::Active);
-    /// op_mass_fine.field("qdata", &rq, BasisOpt::Collocated, &qdata);
-    /// op_mass_fine.field("v", &ru_fine, &bu_fine, VectorOpt::Active);
+    /// let op_mass_fine = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru_fine, &bu_fine, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata)
+    ///     .field("v", &ru_fine, &bu_fine, VectorOpt::Active)
+    ///     .build();
     ///
     /// // Multigrid setup
     /// let mut interp_c_to_f : Vec<f64> = vec![0.; p_coarse*p_fine];
@@ -1474,18 +1503,20 @@ impl CompositeOperator {
     ///
     /// // Set up operators
     /// let qf_build_mass = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_mass.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_mass.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_mass.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build_mass.apply(&x, &mut qdata_mass);
     ///
     /// let qf_build_diff = ceed.q_function_interior_by_name("Poisson1DBuild");
-    /// let mut op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_diff.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_diff.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_diff.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build_diff.apply(&x, &mut qdata_diff);
     ///
@@ -1493,18 +1524,20 @@ impl CompositeOperator {
     /// let mut op_composite = ceed.composite_operator();
     ///
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata_mass)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_composite.sub_operator(&op_mass);
     ///
     /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
-    /// let mut op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_diff.field("du", &ru, &bu, VectorOpt::Active);
-    /// op_diff.field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
-    /// op_diff.field("dv", &ru, &bu, VectorOpt::Active);
+    /// let op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("du", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata_diff)
+    ///     .field("dv", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_composite.sub_operator(&op_diff);
     ///
@@ -1570,18 +1603,20 @@ impl CompositeOperator {
     ///
     /// // Set up operators
     /// let qf_build_mass = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let mut op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_mass.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_mass.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_mass.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build_mass.apply(&x, &mut qdata_mass);
     ///
     /// let qf_build_diff = ceed.q_function_interior_by_name("Poisson1DBuild");
-    /// let mut op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_build_diff.field("dx", &rx, &bx, VectorOpt::Active);
-    /// op_build_diff.field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None);
-    /// op_build_diff.field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active);
+    /// let op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("dx", &rx, &bx, VectorOpt::Active)
+    ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_build_diff.apply(&x, &mut qdata_diff);
     ///
@@ -1589,18 +1624,20 @@ impl CompositeOperator {
     /// let mut op_composite = ceed.composite_operator();
     ///
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
-    /// let mut op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_mass.field("u", &ru, &bu, VectorOpt::Active);
-    /// op_mass.field("qdata", &rq, BasisOpt::Collocated, &qdata_mass);
-    /// op_mass.field("v", &ru, &bu, VectorOpt::Active);
+    /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("u", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata_mass)
+    ///     .field("v", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_composite.sub_operator(&op_mass);
     ///
     /// let qf_diff = ceed.q_function_interior_by_name("Poisson1DApply");
-    /// let mut op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
-    /// op_diff.field("du", &ru, &bu, VectorOpt::Active);
-    /// op_diff.field("qdata", &rq, BasisOpt::Collocated, &qdata_diff);
-    /// op_diff.field("dv", &ru, &bu, VectorOpt::Active);
+    /// let op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None)
+    ///     .field("du", &ru, &bu, VectorOpt::Active)
+    ///     .field("qdata", &rq, BasisOpt::Collocated, &qdata_diff)
+    ///     .field("dv", &ru, &bu, VectorOpt::Active)
+    ///     .build();
     ///
     /// op_composite.sub_operator(&op_diff);
     ///

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -297,15 +297,13 @@ impl Operator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -372,15 +370,13 @@ impl Operator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -510,15 +506,13 @@ impl Operator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -614,15 +608,13 @@ impl Operator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -724,15 +716,13 @@ impl Operator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, ncomp, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let mut mass_2_comp = |
@@ -860,15 +850,13 @@ impl Operator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, ncomp, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let mut mass_2_comp = |
@@ -1008,15 +996,13 @@ impl Operator {
     /// let bu_coarse = ceed.basis_tensor_H1_Lagrange(1, 1, p_coarse, q, QuadMode::Gauss);
     /// let bu_fine = ceed.basis_tensor_H1_Lagrange(1, 1, p_fine, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -1161,15 +1147,13 @@ impl Operator {
     /// let bu_coarse = ceed.basis_tensor_H1_Lagrange(1, 1, p_coarse, q, QuadMode::Gauss);
     /// let bu_fine = ceed.basis_tensor_H1_Lagrange(1, 1, p_fine, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -1335,15 +1319,13 @@ impl Operator {
     /// let bu_coarse = ceed.basis_tensor_H1_Lagrange(1, 1, p_coarse, q, QuadMode::Gauss);
     /// let bu_fine = ceed.basis_tensor_H1_Lagrange(1, 1, p_fine, q, QuadMode::Gauss);
     ///
-    /// // Set up operator
+    /// // Build quadrature data
     /// let qf_build = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build = ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build.apply(&x, &mut qdata);
+    ///     .apply(&x, &mut qdata);
     ///
     /// // Mass operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -1509,24 +1491,20 @@ impl CompositeOperator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operators
+    /// // Build quadrature data
     /// let qf_build_mass = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build_mass.apply(&x, &mut qdata_mass);
+    ///     .apply(&x, &mut qdata_mass);
     ///
     /// let qf_build_diff = ceed.q_function_interior_by_name("Poisson1DBuild");
-    /// let op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build_diff.apply(&x, &mut qdata_diff);
+    ///     .apply(&x, &mut qdata_diff);
     ///
     /// // Application operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
@@ -1608,24 +1586,20 @@ impl CompositeOperator {
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     /// let bu = ceed.basis_tensor_H1_Lagrange(1, 1, p, q, QuadMode::Gauss);
     ///
-    /// // Set up operators
+    /// // Build quadrature data
     /// let qf_build_mass = ceed.q_function_interior_by_name("Mass1DBuild");
-    /// let op_build_mass = ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build_mass, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build_mass.apply(&x, &mut qdata_mass);
+    ///     .apply(&x, &mut qdata_mass);
     ///
     /// let qf_build_diff = ceed.q_function_interior_by_name("Poisson1DBuild");
-    /// let op_build_diff = ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None)
+    /// ceed.operator(&qf_build_diff, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("dx", &rx, &bx, VectorOpt::Active)
     ///     .field("weights", ElemRestrictionOpt::None, &bx, VectorOpt::None)
     ///     .field("qdata", &rq, BasisOpt::Collocated, VectorOpt::Active)
-    ///     .build();
-    ///
-    /// op_build_diff.apply(&x, &mut qdata_diff);
+    ///     .apply(&x, &mut qdata_diff);
     ///
     /// // Application operator
     /// let qf_mass = ceed.q_function_interior_by_name("MassApply");

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -247,10 +247,10 @@ impl Operator {
     }
 
     pub fn build(&mut self) -> Self {
-        let ptr = self.op_core.ptr;
-        self.op_core.ptr = std::ptr::null_mut();
         Self {
-            op_core: OperatorCore { ptr },
+            op_core: OperatorCore {
+                ptr: std::mem::replace(&mut self.op_core.ptr, std::ptr::null_mut()),
+            },
         }
     }
 
@@ -1439,10 +1439,10 @@ impl CompositeOperator {
     }
 
     pub fn build(&mut self) -> Self {
-        let ptr = self.op_core.ptr;
-        self.op_core.ptr = std::ptr::null_mut();
         Self {
-            op_core: OperatorCore { ptr },
+            op_core: OperatorCore {
+                ptr: std::mem::replace(&mut self.op_core.ptr, std::ptr::null_mut()),
+            },
         }
     }
 

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -437,13 +437,13 @@ impl Operator {
     /// // Operator field
     /// op.field("dx", &r, &b, VectorOpt::Active);
     /// ```
-    pub fn field<'a, 'b>(
-        &'a mut self,
+    pub fn field<'b>(
+        &mut self,
         fieldname: &str,
         r: impl Into<ElemRestrictionOpt<'b>>,
         b: impl Into<BasisOpt<'b>>,
         v: impl Into<VectorOpt<'b>>,
-    ) -> &'a mut Self {
+    ) -> &mut Self {
         let fieldname = CString::new(fieldname).expect("CString::new failed");
         let fieldname = fieldname.as_ptr() as *const i8;
         unsafe {
@@ -1655,7 +1655,7 @@ impl CompositeOperator {
     /// let op_diff = ceed.operator(&qf_diff, QFunctionOpt::None, QFunctionOpt::None);
     /// op.sub_operator(&op_diff);
     /// ```
-    pub fn sub_operator<'a>(&'a mut self, subop: &Operator) -> &'a mut Self {
+    pub fn sub_operator(&mut self, subop: &Operator) -> &mut Self {
         unsafe { bind_ceed::CeedCompositeOperatorAddSub(self.op_core.ptr, subop.op_core.ptr) };
         self
     }

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -743,10 +743,11 @@ impl Operator {
     ///   0
     /// };
     ///
-    /// let mut qf_mass = ceed.q_function_interior(1, Box::new(mass_2_comp));
-    /// qf_mass.input("u", 2, EvalMode::Interp);
-    /// qf_mass.input("qdata", 1, EvalMode::None);
-    /// qf_mass.output("v", 2, EvalMode::Interp);
+    /// let qf_mass = ceed.q_function_interior(1, Box::new(mass_2_comp))
+    ///     .input("u", 2, EvalMode::Interp)
+    ///     .input("qdata", 1, EvalMode::None)
+    ///     .output("v", 2, EvalMode::Interp)
+    ///     .build();
     ///
     /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("u", &ru, &bu, VectorOpt::Active)
@@ -877,10 +878,11 @@ impl Operator {
     ///   0
     /// };
     ///
-    /// let mut qf_mass = ceed.q_function_interior(1, Box::new(mass_2_comp));
-    /// qf_mass.input("u", 2, EvalMode::Interp);
-    /// qf_mass.input("qdata", 1, EvalMode::None);
-    /// qf_mass.output("v", 2, EvalMode::Interp);
+    /// let qf_mass = ceed.q_function_interior(1, Box::new(mass_2_comp))
+    ///     .input("u", 2, EvalMode::Interp)
+    ///     .input("qdata", 1, EvalMode::None)
+    ///     .output("v", 2, EvalMode::Interp)
+    ///     .build();
     ///
     /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
     ///     .field("u", &ru, &bu, VectorOpt::Active)

--- a/rust/src/operator.rs
+++ b/rust/src/operator.rs
@@ -73,12 +73,12 @@ impl fmt::Display for OperatorCore {
 /// // Operator field arguments
 /// let ne = 3;
 /// let q = 4 as usize;
-/// let mut ind : Vec<i32> = vec![0; 2*ne];
+/// let mut ind : Vec<i32> = vec![0; 2 * ne];
 /// for i in 0..ne {
-///   ind[2*i+0] = i as i32;
-///   ind[2*i+1] = (i+1) as i32;
+///   ind[2 * i + 0] = i as i32;
+///   ind[2 * i + 1] = (i + 1) as i32;
 /// }
-/// let r = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &ind);
+/// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind);
 /// let strides : [i32; 3] = [1, q as i32, q as i32];
 /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q*ne, strides);
 ///
@@ -107,19 +107,19 @@ impl fmt::Display for Operator {
 /// // Sub operator field arguments
 /// let ne = 3;
 /// let q = 4 as usize;
-/// let mut ind : Vec<i32> = vec![0; 2*ne];
+/// let mut ind : Vec<i32> = vec![0; 2 * ne];
 /// for i in 0..ne {
-///   ind[2*i+0] = i as i32;
-///   ind[2*i+1] = (i+1) as i32;
+///   ind[2 * i + 0] = i as i32;
+///   ind[2 * i + 1] = (i + 1) as i32;
 /// }
-/// let r = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &ind);
+/// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind);
 /// let strides : [i32; 3] = [1, q as i32, q as i32];
-/// let rq = ceed.strided_elem_restriction(ne, 2, 1, q*ne, strides);
+/// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides);
 ///
 /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
 ///
-/// let qdata_mass = ceed.vector(q*ne);
-/// let qdata_diff = ceed.vector(q*ne);
+/// let qdata_mass = ceed.vector(q * ne);
+/// let qdata_diff = ceed.vector(q * ne);
 ///
 /// let qf_mass = ceed.q_function_interior_by_name("MassApply");
 /// let op_mass = ceed.operator(&qf_mass, QFunctionOpt::None, QFunctionOpt::None)
@@ -255,33 +255,32 @@ impl Operator {
     /// let ne = 4;
     /// let p = 3;
     /// let q = 4;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
     /// let mut qdata = ceed.vector(ne*q);
     /// qdata.set_value(0.0);
-    /// let mut u = ceed.vector(ndofs);
-    /// u.set_value(1.0);
+    /// let u = ceed.vector_from_slice(&vec![1.0; ndofs]);
     /// let mut v = ceed.vector(ndofs);
     /// v.set_value(0.0);
     ///
     /// // Restrictions
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
-    /// let mut indu : Vec<i32> = vec![0; p*ne];
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
+    /// let mut indu : Vec<i32> = vec![0; p * ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = i as i32;
-    ///   indu[p*i+1] = (i+1) as i32;
-    ///   indu[p*i+2] = (i+2) as i32;
+    ///   indu[p * i + 0] = i as i32;
+    ///   indu[p * i + 1] = (i + 1) as i32;
+    ///   indu[p * i + 2] = (i + 2) as i32;
     /// }
     /// let ru = ceed.elem_restriction(ne, 3, 1, 1, ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -324,32 +323,31 @@ impl Operator {
     /// let ne = 4;
     /// let p = 3;
     /// let q = 4;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
     /// let mut qdata = ceed.vector(ne*q);
     /// qdata.set_value(0.0);
-    /// let mut u = ceed.vector(ndofs);
-    /// u.set_value(1.0);
+    /// let u = ceed.vector_from_slice(&vec![1.0; ndofs]);
     /// let mut v = ceed.vector(ndofs);
     ///
     /// // Restrictions
     /// let mut indx : Vec<i32> = vec![0; 2*ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
-    /// let mut indu : Vec<i32> = vec![0; p*ne];
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
+    /// let mut indu : Vec<i32> = vec![0; p * ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = i as i32;
-    ///   indu[p*i+1] = (i+1) as i32;
-    ///   indu[p*i+2] = (i+2) as i32;
+    ///   indu[p * i + 0] = i as i32;
+    ///   indu[p * i + 1] = (i + 1) as i32;
+    ///   indu[p * i + 2] = (i + 2) as i32;
     /// }
     /// let ru = ceed.elem_restriction(ne, 3, 1, 1, ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -405,12 +403,12 @@ impl Operator {
     /// // Operator field arguments
     /// let ne = 3;
     /// let q = 4;
-    /// let mut ind : Vec<i32> = vec![0; 2*ne];
+    /// let mut ind : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   ind[2*i+0] = i as i32;
-    ///   ind[2*i+1] = (i+1) as i32;
+    ///   ind[2 * i + 0] = i as i32;
+    ///   ind[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &ind);
+    /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind);
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
     ///
@@ -455,7 +453,7 @@ impl Operator {
     /// let ne = 4;
     /// let p = 3;
     /// let q = 4;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
@@ -469,19 +467,19 @@ impl Operator {
     /// // Restrictions
     /// let mut indx : Vec<i32> = vec![0; 2*ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
     /// let mut indu : Vec<i32> = vec![0; p*ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = (2*i) as i32;
-    ///   indu[p*i+1] = (2*i+1) as i32;
-    ///   indu[p*i+2] = (2*i+2) as i32;
+    ///   indu[p * i + 0] = (2 * i) as i32;
+    ///   indu[p * i + 1] = (2 * i + 1) as i32;
+    ///   indu[p * i + 2] = (2 * i + 2) as i32;
     /// }
     /// let ru = ceed.elem_restriction(ne, p, 1, 1, ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -526,14 +524,15 @@ impl Operator {
     /// }
     ///
     /// // Check
-    /// let diag_array = diag.view();
-    /// let true_array = true_diag.view();
-    /// for i in 0..ndofs {
-    ///   assert!(
-    ///     (diag_array[i] - true_array[i]).abs() < 1e-15,
-    ///     "Diagonal entry incorrect"
-    ///   );
-    /// }
+    /// diag.view()
+    ///     .iter()
+    ///     .zip(true_diag.view().iter())
+    ///     .for_each(|(computed, actual)| {
+    ///         assert!(
+    ///             (*computed - *actual).abs() < 1e-15,
+    ///             "Diagonal entry incorrect"
+    ///         );
+    ///     });
     /// ```
     pub fn linear_assemble_diagonal(&self, assembled: &mut Vector) {
         self.op_core.linear_assemble_diagonal(assembled)
@@ -556,7 +555,7 @@ impl Operator {
     /// let ne = 4;
     /// let p = 3;
     /// let q = 4;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
@@ -568,21 +567,21 @@ impl Operator {
     /// v.set_value(0.0);
     ///
     /// // Restrictions
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
-    /// let mut indu : Vec<i32> = vec![0; p*ne];
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
+    /// let mut indu : Vec<i32> = vec![0; p * ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = (2*i) as i32;
-    ///   indu[p*i+1] = (2*i+1) as i32;
-    ///   indu[p*i+2] = (2*i+2) as i32;
+    ///   indu[p * i + 0] = (2 * i) as i32;
+    ///   indu[p * i + 1] = (2 * i + 1) as i32;
+    ///   indu[p * i + 2] = (2 * i + 2) as i32;
     /// }
     /// let ru = ceed.elem_restriction(ne, p, 1, 1, ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -627,14 +626,15 @@ impl Operator {
     /// }
     ///
     /// // Check
-    /// let diag_array = diag.view();
-    /// let true_array = true_diag.view();
-    /// for i in 0..ndofs {
-    ///   assert!(
-    ///     (diag_array[i] - true_array[i]).abs() < 1e-15,
-    ///     "Diagonal entry incorrect"
-    ///   );
-    /// }
+    /// diag.view()
+    ///     .iter()
+    ///     .zip(true_diag.view().iter())
+    ///     .for_each(|(computed, actual)| {
+    ///         assert!(
+    ///             (*computed - *actual).abs() < 1e-15,
+    ///             "Diagonal entry incorrect"
+    ///         );
+    ///     });
     /// ```
     pub fn linear_assemble_add_diagonal(&self, assembled: &mut Vector) {
         self.op_core.linear_assemble_add_diagonal(assembled)
@@ -663,7 +663,7 @@ impl Operator {
     /// let p = 3;
     /// let q = 4;
     /// let ncomp = 2;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
@@ -677,19 +677,19 @@ impl Operator {
     /// // Restrictions
     /// let mut indx : Vec<i32> = vec![0; 2*ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
     /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
-    /// let mut indu : Vec<i32> = vec![0; p*ne];
+    /// let mut indu : Vec<i32> = vec![0; p * ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = (2*i) as i32;
-    ///   indu[p*i+1] = (2*i+1) as i32;
-    ///   indu[p*i+2] = (2*i+2) as i32;
+    ///   indu[p * i + 0] = (2 * i) as i32;
+    ///   indu[p * i + 1] = (2 * i + 1) as i32;
+    ///   indu[p * i + 2] = (2 * i + 2) as i32;
     /// }
-    /// let ru = ceed.elem_restriction(ne, p, ncomp, ndofs, ncomp*ndofs, MemType::Host, &indu);
+    /// let ru = ceed.elem_restriction(ne, p, ncomp, ndofs, ncomp * ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -714,8 +714,8 @@ impl Operator {
     ///
     ///   // Iterate over quadrature points
     ///   for i in 0..q {
-    ///     v[i + 0*q] = u[i + 1*q] * qdata[i];
-    ///     v[i + 1*q] = u[i + 0*q] * qdata[i];
+    ///     v[i + 0 * q] = u[i + 1 * q] * qdata[i];
+    ///     v[i + 1 * q] = u[i + 0 * q] * qdata[i];
     ///   }
     ///
     ///   // Return clean error code
@@ -733,18 +733,18 @@ impl Operator {
     ///     .field("v", &ru, &bu, VectorOpt::Active);
     ///
     /// // Diagonal
-    /// let mut diag = ceed.vector(ncomp*ncomp*ndofs);
+    /// let mut diag = ceed.vector(ncomp * ncomp * ndofs);
     /// diag.set_value(0.0);
     /// op_mass.linear_assemble_point_block_diagonal(&mut diag);
     ///
     /// // Manual diagonal computation
-    /// let mut true_diag = ceed.vector(ncomp*ncomp*ndofs);
+    /// let mut true_diag = ceed.vector(ncomp * ncomp * ndofs);
     /// for i in 0..ndofs {
     ///   for j in 0..ncomp {
     ///     u.set_value(0.0);
     ///     {
     ///       let mut u_array = u.view_mut();
-    ///       u_array[i + j*ndofs] = 1.;
+    ///       u_array[i + j * ndofs] = 1.;
     ///     }
     ///
     ///     op_mass.apply(&u, &mut v);
@@ -753,21 +753,22 @@ impl Operator {
     ///       let v_array = v.view_mut();
     ///       let mut true_array = true_diag.view_mut();
     ///       for k in 0..ncomp {
-    ///         true_array[i*ncomp*ncomp + k*ncomp + j] = v_array[i + k*ndofs];
+    ///         true_array[i * ncomp * ncomp + k * ncomp + j] = v_array[i + k * ndofs];
     ///       }
     ///     }
     ///   }
     /// }
     ///
     /// // Check
-    /// let diag_array = diag.view();
-    /// let true_array = true_diag.view();
-    /// for i in 0..ncomp*ncomp*ndofs {
-    ///   assert!(
-    ///     (diag_array[i] - true_array[i]).abs() < 1e-15,
-    ///     "Diagonal entry incorrect"
-    ///   );
-    /// }
+    /// diag.view()
+    ///     .iter()
+    ///     .zip(true_diag.view().iter())
+    ///     .for_each(|(computed, actual)| {
+    ///         assert!(
+    ///             (*computed - *actual).abs() < 1e-15,
+    ///             "Diagonal entry incorrect"
+    ///         );
+    ///     });
     /// ```
     pub fn linear_assemble_point_block_diagonal(&self, assembled: &mut Vector) {
         self.op_core.linear_assemble_point_block_diagonal(assembled)
@@ -796,7 +797,7 @@ impl Operator {
     /// let p = 3;
     /// let q = 4;
     /// let ncomp = 2;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
@@ -808,21 +809,21 @@ impl Operator {
     /// v.set_value(0.0);
     ///
     /// // Restrictions
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
-    /// let mut indu : Vec<i32> = vec![0; p*ne];
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
+    /// let mut indu : Vec<i32> = vec![0; p * ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = (2*i) as i32;
-    ///   indu[p*i+1] = (2*i+1) as i32;
-    ///   indu[p*i+2] = (2*i+2) as i32;
+    ///   indu[p * i + 0] = (2 * i) as i32;
+    ///   indu[p * i + 1] = (2 * i + 1) as i32;
+    ///   indu[p * i + 2] = (2 * i + 2) as i32;
     /// }
-    /// let ru = ceed.elem_restriction(ne, p, ncomp, ndofs, ncomp*ndofs, MemType::Host, &indu);
+    /// let ru = ceed.elem_restriction(ne, p, ncomp, ndofs, ncomp * ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -847,8 +848,8 @@ impl Operator {
     ///
     ///   // Iterate over quadrature points
     ///   for i in 0..q {
-    ///     v[i + 0*q] = u[i + 1*q] * qdata[i];
-    ///     v[i + 1*q] = u[i + 0*q] * qdata[i];
+    ///     v[i + 0 * q] = u[i + 1 * q] * qdata[i];
+    ///     v[i + 1 * q] = u[i + 0 * q] * qdata[i];
     ///   }
     ///
     ///   // Return clean error code
@@ -893,14 +894,15 @@ impl Operator {
     /// }
     ///
     /// // Check
-    /// let diag_array = diag.view();
-    /// let true_array = true_diag.view();
-    /// for i in 0..ncomp*ncomp*ndofs {
-    ///   assert!(
-    ///     (diag_array[i] - 1.0 - true_array[i]).abs() < 1e-15,
-    ///     "Diagonal entry incorrect"
-    ///   );
-    /// }
+    /// diag.view()
+    ///     .iter()
+    ///     .zip(true_diag.view().iter())
+    ///     .for_each(|(computed, actual)| {
+    ///         assert!(
+    ///             (*computed -  1.0 - *actual).abs() < 1e-15,
+    ///             "Diagonal entry incorrect"
+    ///         );
+    ///     });
     /// ```
     pub fn linear_assemble_add_point_block_diagonal(&self, assembled: &mut Vector) {
         self.op_core
@@ -922,13 +924,13 @@ impl Operator {
     /// let p_coarse = 3;
     /// let p_fine = 5;
     /// let q = 6;
-    /// let ndofs_coarse = p_coarse*ne-ne+1;
-    /// let ndofs_fine = p_fine*ne-ne+1;
+    /// let ndofs_coarse = p_coarse * ne - ne + 1;
+    /// let ndofs_fine = p_fine * ne - ne + 1;
     ///
     /// // Vectors
-    /// let x_array = (0..ne+1).map(|i| 2.0 * i as f64 / ne as f64 - 1.0).collect::<Vec<f64>>();
+    /// let x_array = (0..ne + 1).map(|i| 2.0 * i as f64 / ne as f64 - 1.0).collect::<Vec<f64>>();
     /// let x = ceed.vector_from_slice(&x_array);
-    /// let mut qdata = ceed.vector(ne*q);
+    /// let mut qdata = ceed.vector(ne * q);
     /// qdata.set_value(0.0);
     /// let mut u_coarse = ceed.vector(ndofs_coarse);
     /// u_coarse.set_value(1.0);
@@ -943,27 +945,27 @@ impl Operator {
     ///
     /// // Restrictions
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
     ///
-    /// let mut indu_coarse : Vec<i32> = vec![0; p_coarse*ne];
+    /// let mut indu_coarse : Vec<i32> = vec![0; p_coarse * ne];
     /// for i in 0..ne {
     ///   for j in 0..p_coarse {
-    ///     indu_coarse[p_coarse*i+j] = (i+j) as i32;
+    ///     indu_coarse[p_coarse * i + j] = (i + j) as i32;
     ///   }
     /// }
     /// let ru_coarse = ceed.elem_restriction(ne, p_coarse, 1, 1, ndofs_coarse, MemType::Host, &indu_coarse);
     ///
-    /// let mut indu_fine : Vec<i32> = vec![0; p_fine*ne];
+    /// let mut indu_fine : Vec<i32> = vec![0; p_fine * ne];
     /// for i in 0..ne {
     ///   for j in 0..p_fine {
-    ///     indu_fine[p_fine*i+j] = (i+j) as i32;
+    ///     indu_fine[p_fine * i + j] = (i + j) as i32;
     ///   }
     /// }
     /// let ru_fine = ceed.elem_restriction(ne, p_fine, 1, 1, ndofs_fine, MemType::Host, &indu_fine);
@@ -1059,11 +1061,11 @@ impl Operator {
     /// let p_coarse = 3;
     /// let p_fine = 5;
     /// let q = 6;
-    /// let ndofs_coarse = p_coarse*ne-ne+1;
-    /// let ndofs_fine = p_fine*ne-ne+1;
+    /// let ndofs_coarse = p_coarse * ne - ne + 1;
+    /// let ndofs_fine = p_fine * ne - ne + 1;
     ///
     /// // Vectors
-    /// let x_array = (0..ne+1).map(|i| 2.0 * i as f64 / ne as f64 - 1.0).collect::<Vec<f64>>();
+    /// let x_array = (0..ne + 1).map(|i| 2.0 * i as f64 / ne as f64 - 1.0).collect::<Vec<f64>>();
     /// let x = ceed.vector_from_slice(&x_array);
     /// let mut qdata = ceed.vector(ne*q);
     /// qdata.set_value(0.0);
@@ -1080,27 +1082,27 @@ impl Operator {
     ///
     /// // Restrictions
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
     ///
-    /// let mut indu_coarse : Vec<i32> = vec![0; p_coarse*ne];
+    /// let mut indu_coarse : Vec<i32> = vec![0; p_coarse * ne];
     /// for i in 0..ne {
     ///   for j in 0..p_coarse {
-    ///     indu_coarse[p_coarse*i+j] = (i+j) as i32;
+    ///     indu_coarse[p_coarse * i + j] = (i + j) as i32;
     ///   }
     /// }
     /// let ru_coarse = ceed.elem_restriction(ne, p_coarse, 1, 1, ndofs_coarse, MemType::Host, &indu_coarse);
     ///
-    /// let mut indu_fine : Vec<i32> = vec![0; p_fine*ne];
+    /// let mut indu_fine : Vec<i32> = vec![0; p_fine * ne];
     /// for i in 0..ne {
     ///   for j in 0..p_fine {
-    ///     indu_fine[p_fine*i+j] = (i+j) as i32;
+    ///     indu_fine[p_fine * i + j] = (i + j) as i32;
     ///   }
     /// }
     /// let ru_fine = ceed.elem_restriction(ne, p_fine, 1, 1, ndofs_fine, MemType::Host, &indu_fine);
@@ -1126,7 +1128,7 @@ impl Operator {
     ///     .field("v", &ru_fine, &bu_fine, VectorOpt::Active);
     ///
     /// // Multigrid setup
-    /// let mut interp_c_to_f : Vec<f64> = vec![0.; p_coarse*p_fine];
+    /// let mut interp_c_to_f : Vec<f64> = vec![0.; p_coarse * p_fine];
     /// {
     ///   let mut coarse = ceed.vector(p_coarse);
     ///   let mut fine = ceed.vector(p_fine);
@@ -1141,7 +1143,7 @@ impl Operator {
     ///                        &coarse, &mut fine);
     ///     let array = fine.view();
     ///     for j in 0..p_fine {
-    ///       interp_c_to_f[j*p_coarse + i] = array[j];
+    ///       interp_c_to_f[j * p_coarse + i] = array[j];
     ///     }
     ///   }
     /// }
@@ -1217,11 +1219,11 @@ impl Operator {
     /// let p_coarse = 3;
     /// let p_fine = 5;
     /// let q = 6;
-    /// let ndofs_coarse = p_coarse*ne-ne+1;
-    /// let ndofs_fine = p_fine*ne-ne+1;
+    /// let ndofs_coarse = p_coarse * ne - ne + 1;
+    /// let ndofs_fine = p_fine * ne - ne + 1;
     ///
     /// // Vectors
-    /// let x_array = (0..ne+1).map(|i| 2.0 * i as f64 / ne as f64 - 1.0).collect::<Vec<f64>>();
+    /// let x_array = (0..ne + 1).map(|i| 2.0 * i as f64 / ne as f64 - 1.0).collect::<Vec<f64>>();
     /// let x = ceed.vector_from_slice(&x_array);
     /// let mut qdata = ceed.vector(ne*q);
     /// qdata.set_value(0.0);
@@ -1238,27 +1240,27 @@ impl Operator {
     ///
     /// // Restrictions
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
     ///
-    /// let mut indu_coarse : Vec<i32> = vec![0; p_coarse*ne];
+    /// let mut indu_coarse : Vec<i32> = vec![0; p_coarse * ne];
     /// for i in 0..ne {
     ///   for j in 0..p_coarse {
-    ///     indu_coarse[p_coarse*i+j] = (i+j) as i32;
+    ///     indu_coarse[p_coarse * i + j] = (i + j) as i32;
     ///   }
     /// }
     /// let ru_coarse = ceed.elem_restriction(ne, p_coarse, 1, 1, ndofs_coarse, MemType::Host, &indu_coarse);
     ///
-    /// let mut indu_fine : Vec<i32> = vec![0; p_fine*ne];
+    /// let mut indu_fine : Vec<i32> = vec![0; p_fine * ne];
     /// for i in 0..ne {
     ///   for j in 0..p_fine {
-    ///     indu_fine[p_fine*i+j] = (i+j) as i32;
+    ///     indu_fine[p_fine * i + j] = (i + j) as i32;
     ///   }
     /// }
     /// let ru_fine = ceed.elem_restriction(ne, p_fine, 1, 1, ndofs_fine, MemType::Host, &indu_fine);
@@ -1299,7 +1301,7 @@ impl Operator {
     ///                        &coarse, &mut fine);
     ///     let array = fine.view();
     ///     for j in 0..p_fine {
-    ///       interp_c_to_f[j*p_coarse + i] = array[j];
+    ///       interp_c_to_f[j * p_coarse + i] = array[j];
     ///     }
     ///   }
     /// }
@@ -1384,13 +1386,13 @@ impl CompositeOperator {
     /// let ne = 4;
     /// let p = 3;
     /// let q = 4;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
-    /// let mut qdata_mass = ceed.vector(ne*q);
+    /// let mut qdata_mass = ceed.vector(ne * q);
     /// qdata_mass.set_value(0.0);
-    /// let mut qdata_diff = ceed.vector(ne*q);
+    /// let mut qdata_diff = ceed.vector(ne * q);
     /// qdata_diff.set_value(0.0);
     /// let mut u = ceed.vector(ndofs);
     /// u.set_value(1.0);
@@ -1398,21 +1400,21 @@ impl CompositeOperator {
     /// v.set_value(0.0);
     ///
     /// // Restrictions
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
     /// let mut indu : Vec<i32> = vec![0; p*ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = i as i32;
-    ///   indu[p*i+1] = (i+1) as i32;
-    ///   indu[p*i+2] = (i+2) as i32;
+    ///   indu[p * i + 0] = i as i32;
+    ///   indu[p * i + 1] = (i + 1) as i32;
+    ///   indu[p * i + 2] = (i + 2) as i32;
     /// }
     /// let ru = ceed.elem_restriction(ne, 3, 1, 1, ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);
@@ -1472,13 +1474,13 @@ impl CompositeOperator {
     /// let ne = 4;
     /// let p = 3;
     /// let q = 4;
-    /// let ndofs = p*ne-ne+1;
+    /// let ndofs = p * ne - ne + 1;
     ///
     /// // Vectors
     /// let x = ceed.vector_from_slice(&[-1., -0.5, 0.0, 0.5, 1.0]);
-    /// let mut qdata_mass = ceed.vector(ne*q);
+    /// let mut qdata_mass = ceed.vector(ne * q);
     /// qdata_mass.set_value(0.0);
-    /// let mut qdata_diff = ceed.vector(ne*q);
+    /// let mut qdata_diff = ceed.vector(ne * q);
     /// qdata_diff.set_value(0.0);
     /// let mut u = ceed.vector(ndofs);
     /// u.set_value(1.0);
@@ -1486,21 +1488,21 @@ impl CompositeOperator {
     /// v.set_value(0.0);
     ///
     /// // Restrictions
-    /// let mut indx : Vec<i32> = vec![0; 2*ne];
+    /// let mut indx : Vec<i32> = vec![0; 2 * ne];
     /// for i in 0..ne {
-    ///   indx[2*i+0] = i as i32;
-    ///   indx[2*i+1] = (i+1) as i32;
+    ///   indx[2 * i + 0] = i as i32;
+    ///   indx[2 * i + 1] = (i + 1) as i32;
     /// }
-    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne+1, MemType::Host, &indx);
-    /// let mut indu : Vec<i32> = vec![0; p*ne];
+    /// let rx = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &indx);
+    /// let mut indu : Vec<i32> = vec![0; p * ne];
     /// for i in 0..ne {
-    ///   indu[p*i+0] = i as i32;
-    ///   indu[p*i+1] = (i+1) as i32;
-    ///   indu[p*i+2] = (i+2) as i32;
+    ///   indu[p * i + 0] = i as i32;
+    ///   indu[p * i + 1] = (i + 1) as i32;
+    ///   indu[p * i + 2] = (i + 2) as i32;
     /// }
     /// let ru = ceed.elem_restriction(ne, 3, 1, 1, ndofs, MemType::Host, &indu);
     /// let strides : [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q*ne, strides);
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides);
     ///
     /// // Bases
     /// let bx = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss);

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -104,7 +104,6 @@ impl Drop for QFunction {
         unsafe {
             bind_ceed::CeedQFunctionContextDestroy(&mut self.qf_ctx_ptr);
         }
-        drop(&mut self.qf_core);
     }
 }
 

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -332,7 +332,7 @@ impl QFunction {
     ///     .input("weights", 1, EvalMode::Weight)
     ///     .output("v", 1, EvalMode::Interp);
     ///
-    /// const Q : usize = 8;
+    /// const Q: usize = 8;
     /// let mut w = [0.; Q];
     /// let mut u = [0.; Q];
     /// let mut v = [0.; Q];
@@ -404,6 +404,16 @@ impl QFunction {
         unsafe {
             bind_ceed::CeedQFunctionAddInput(self.qf_core.ptr, name_c.as_ptr(), size, emode);
         }
+        /* Note: adding an input can change the pointer to self, resulting in bad ctx data */
+        unsafe {
+            bind_ceed::CeedQFunctionContextSetData(
+                self.qf_ctx_ptr,
+                crate::MemType::Host as bind_ceed::CeedMemType,
+                crate::CopyMode::UsePointer as bind_ceed::CeedCopyMode,
+                10, /* Note: size not relevant - CPU only approach */
+                &mut self as *mut _ as *mut ::std::os::raw::c_void,
+            );
+        }
         self
     }
 
@@ -445,6 +455,16 @@ impl QFunction {
         let emode = emode as bind_ceed::CeedEvalMode;
         unsafe {
             bind_ceed::CeedQFunctionAddOutput(self.qf_core.ptr, name_c.as_ptr(), size, emode);
+        }
+        /* Note: adding an output can change the pointer to self, resulting in bad ctx data */
+        unsafe {
+            bind_ceed::CeedQFunctionContextSetData(
+                self.qf_ctx_ptr,
+                crate::MemType::Host as bind_ceed::CeedMemType,
+                crate::CopyMode::UsePointer as bind_ceed::CeedCopyMode,
+                10, /* Note: size not relevant - CPU only approach */
+                &mut self as *mut _ as *mut ::std::os::raw::c_void,
+            );
         }
         self
     }

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -144,10 +144,10 @@ impl fmt::Display for QFunctionCore {
 ///
 /// let mut qf = ceed.q_function_interior(1, Box::new(user_f));
 ///
-/// qf.add_input("u", 1, EvalMode::Interp);
-/// qf.add_input("weights", 1, EvalMode::Weight);
+/// qf.input("u", 1, EvalMode::Interp);
+/// qf.input("weights", 1, EvalMode::Weight);
 ///
-/// qf.add_output("v", 1, EvalMode::Interp);
+/// qf.output("v", 1, EvalMode::Interp);
 ///
 /// println!("{}", qf);
 /// ```
@@ -331,10 +331,10 @@ impl QFunction {
     ///
     /// let mut qf = ceed.q_function_interior(1, Box::new(user_f));
     ///
-    /// qf.add_input("u", 1, EvalMode::Interp);
-    /// qf.add_input("weights", 1, EvalMode::Weight);
+    /// qf.input("u", 1, EvalMode::Interp);
+    /// qf.input("weights", 1, EvalMode::Weight);
     ///
-    /// qf.add_output("v", 1, EvalMode::Interp);
+    /// qf.output("v", 1, EvalMode::Interp);
     ///
     /// const Q : usize = 8;
     /// let mut w = [0.; Q];
@@ -397,10 +397,10 @@ impl QFunction {
     ///
     /// let mut qf = ceed.q_function_interior(1, Box::new(user_f));
     ///
-    /// qf.add_input("u", 1, EvalMode::Interp);
-    /// qf.add_input("weights", 1, EvalMode::Weight);
+    /// qf.input("u", 1, EvalMode::Interp);
+    /// qf.input("weights", 1, EvalMode::Weight);
     /// ```
-    pub fn add_input(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) {
+    pub fn input(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) {
         let name_c = CString::new(fieldname).expect("CString::new failed");
         self.trampoline_data.input_sizes[self.trampoline_data.number_inputs] = size;
         self.trampoline_data.number_inputs += 1;
@@ -439,9 +439,9 @@ impl QFunction {
     ///
     /// let mut qf = ceed.q_function_interior(1, Box::new(user_f));
     ///
-    /// qf.add_output("v", 1, EvalMode::Interp);
+    /// qf.output("v", 1, EvalMode::Interp);
     /// ```
-    pub fn add_output(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) {
+    pub fn output(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) {
         let name_c = CString::new(fieldname).expect("CString::new failed");
         self.trampoline_data.output_sizes[self.trampoline_data.number_outputs] = size;
         self.trampoline_data.number_outputs += 1;

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -332,9 +332,9 @@ impl QFunction {
     /// let mut v = [0.; Q];
     ///
     /// for i in 0..Q as usize {
-    ///   let x = 2.*(i as f64)/((Q as f64) - 1.) - 1.;
-    ///   u[i] = 2. + 3.*x + 5.*x*x;
-    ///   w[i] = 1. - x*x;
+    ///   let x = 2. * (i as f64)/((Q as f64) - 1.) - 1.;
+    ///   u[i] = 2. + 3. * x + 5. * x * x;
+    ///   w[i] = 1. - x * x;
     ///   v[i] = u[i] * w[i];
     /// }
     ///
@@ -349,10 +349,12 @@ impl QFunction {
     ///   vv = output.remove(0);
     /// }
     ///
-    /// let array = vv.view();
-    /// for i in 0..Q {
-    ///   assert_eq!(array[i], v[i], "Incorrect value in QFunction application");
-    /// }
+    /// vv.view()
+    ///     .iter()
+    ///     .zip(v.iter())
+    ///     .for_each(|(computed, actual)| {
+    ///         assert_eq!(*computed, *actual, "Incorrect value in QFunction application");
+    ///     });
     /// ```
     pub fn apply(&self, Q: i32, u: &[Vector], v: &[Vector]) {
         self.qf_core.apply(Q, u, v)
@@ -509,10 +511,12 @@ impl QFunctionByName {
     ///   vv = output.remove(0);
     /// }
     ///
-    /// let array = vv.view();
-    /// for i in 0..Q {
-    ///   assert_eq!(array[i], v[i], "Incorrect value in QFunction application");
-    /// }
+    /// vv.view()
+    ///     .iter()
+    ///     .zip(v.iter())
+    ///     .for_each(|(computed, actual)| {
+    ///         assert_eq!(*computed, *actual, "Incorrect value in QFunction application");
+    ///     });
     /// ```
     pub fn apply(&self, Q: i32, u: &[Vector], v: &[Vector]) {
         self.qf_core.apply(Q, u, v)

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -413,12 +413,7 @@ impl QFunction {
     /// qf.input("u", 1, EvalMode::Interp);
     /// qf.input("weights", 1, EvalMode::Weight);
     /// ```
-    pub fn input<'a>(
-        &'a mut self,
-        fieldname: &str,
-        size: i32,
-        emode: crate::EvalMode,
-    ) -> &'a mut Self {
+    pub fn input(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) -> &mut Self {
         let name_c = CString::new(fieldname).expect("CString::new failed");
         self.trampoline_data.input_sizes[self.trampoline_data.number_inputs] = size;
         self.trampoline_data.number_inputs += 1;
@@ -460,12 +455,7 @@ impl QFunction {
     ///
     /// qf.output("v", 1, EvalMode::Interp);
     /// ```
-    pub fn output<'a>(
-        &'a mut self,
-        fieldname: &str,
-        size: i32,
-        emode: crate::EvalMode,
-    ) -> &'a mut Self {
+    pub fn output(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) -> &mut Self {
         let name_c = CString::new(fieldname).expect("CString::new failed");
         self.trampoline_data.output_sizes[self.trampoline_data.number_outputs] = size;
         self.trampoline_data.number_outputs += 1;

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -17,6 +17,8 @@
 //! A Ceed QFunction represents the spatial terms of the point-wise functions
 //! describing the physics at the quadrature points.
 
+use std::pin::Pin;
+
 use crate::prelude::*;
 
 pub type QFunctionInputs<'a> = [&'a [f64]; MAX_QFUNCTION_FIELDS];
@@ -71,13 +73,13 @@ struct QFunctionTrampolineData {
     number_outputs: usize,
     input_sizes: [i32; MAX_QFUNCTION_FIELDS],
     output_sizes: [i32; MAX_QFUNCTION_FIELDS],
+    user_f: Box<QFunctionUserClosure>,
 }
 
 pub struct QFunction {
     qf_core: QFunctionCore,
     qf_ctx_ptr: bind_ceed::CeedQFunctionContext,
-    trampoline_data: QFunctionTrampolineData,
-    user_f: Box<QFunctionUserClosure>,
+    trampoline_data: Pin<Box<QFunctionTrampolineData>>,
 }
 
 pub struct QFunctionByName {
@@ -208,8 +210,7 @@ unsafe extern "C" fn trampoline(
     inputs: *const *const bind_ceed::CeedScalar,
     outputs: *const *mut bind_ceed::CeedScalar,
 ) -> ::std::os::raw::c_int {
-    let context = &mut *(ctx as *mut QFunction);
-    let trampoline_data = &context.trampoline_data;
+    let trampoline_data: Pin<&mut QFunctionTrampolineData> = std::mem::transmute(ctx);
 
     // Inputs
     let inputs_slice: &[*const bind_ceed::CeedScalar] =
@@ -239,7 +240,7 @@ unsafe extern "C" fn trampoline(
         .for_each(|(x, a)| *a = x);
 
     // User closure
-    (context.user_f)(inputs_array, outputs_array)
+    (trampoline_data.get_unchecked_mut().user_f)(inputs_array, outputs_array)
 }
 
 // -----------------------------------------------------------------------------
@@ -256,11 +257,14 @@ impl QFunction {
         let number_outputs = 0;
         let input_sizes = [0; MAX_QFUNCTION_FIELDS];
         let output_sizes = [0; MAX_QFUNCTION_FIELDS];
-        let trampoline_data = QFunctionTrampolineData {
-            number_inputs,
-            number_outputs,
-            input_sizes,
-            output_sizes,
+        let trampoline_data = unsafe {
+            Pin::new_unchecked(Box::new(QFunctionTrampolineData {
+                number_inputs,
+                number_outputs,
+                input_sizes,
+                output_sizes,
+                user_f,
+            }))
         };
 
         // Create QFunction
@@ -274,18 +278,6 @@ impl QFunction {
             )
         };
 
-        // Create QFunction context
-        let qf_ctx_ptr = std::ptr::null_mut();
-
-        // Create object
-        let qf_core = QFunctionCore { ptr };
-        let mut qf_self = Self {
-            qf_core,
-            qf_ctx_ptr,
-            trampoline_data,
-            user_f,
-        };
-
         // Set closure
         let mut qf_ctx_ptr = std::ptr::null_mut();
         unsafe {
@@ -294,13 +286,16 @@ impl QFunction {
                 qf_ctx_ptr,
                 crate::MemType::Host as bind_ceed::CeedMemType,
                 crate::CopyMode::UsePointer as bind_ceed::CeedCopyMode,
-                10, /* Note: size not relevant - CPU only approach */
-                &mut qf_self as *mut _ as *mut ::std::os::raw::c_void,
+                std::mem::size_of::<QFunctionTrampolineData>() as u64,
+                std::mem::transmute(trampoline_data.as_ref()),
             );
-            bind_ceed::CeedQFunctionSetContext(qf_self.qf_core.ptr, qf_ctx_ptr);
+            bind_ceed::CeedQFunctionSetContext(ptr, qf_ctx_ptr);
         }
-        qf_self.qf_ctx_ptr = qf_ctx_ptr;
-        qf_self
+        Self {
+            qf_core: QFunctionCore { ptr },
+            qf_ctx_ptr,
+            trampoline_data,
+        }
     }
 
     /// Apply the action of a QFunction
@@ -398,21 +393,12 @@ impl QFunction {
     /// ```
     pub fn input(mut self, fieldname: &str, size: i32, emode: crate::EvalMode) -> Self {
         let name_c = CString::new(fieldname).expect("CString::new failed");
-        self.trampoline_data.input_sizes[self.trampoline_data.number_inputs] = size;
+        let idx = self.trampoline_data.number_inputs;
+        self.trampoline_data.input_sizes[idx] = size;
         self.trampoline_data.number_inputs += 1;
         let emode = emode as bind_ceed::CeedEvalMode;
         unsafe {
             bind_ceed::CeedQFunctionAddInput(self.qf_core.ptr, name_c.as_ptr(), size, emode);
-        }
-        /* Note: adding an input can change the pointer to self, resulting in bad ctx data */
-        unsafe {
-            bind_ceed::CeedQFunctionContextSetData(
-                self.qf_ctx_ptr,
-                crate::MemType::Host as bind_ceed::CeedMemType,
-                crate::CopyMode::UsePointer as bind_ceed::CeedCopyMode,
-                10, /* Note: size not relevant - CPU only approach */
-                &mut self as *mut _ as *mut ::std::os::raw::c_void,
-            );
         }
         self
     }
@@ -450,21 +436,12 @@ impl QFunction {
     /// ```
     pub fn output(mut self, fieldname: &str, size: i32, emode: crate::EvalMode) -> Self {
         let name_c = CString::new(fieldname).expect("CString::new failed");
-        self.trampoline_data.output_sizes[self.trampoline_data.number_outputs] = size;
+        let idx = self.trampoline_data.number_outputs;
+        self.trampoline_data.output_sizes[idx] = size;
         self.trampoline_data.number_outputs += 1;
         let emode = emode as bind_ceed::CeedEvalMode;
         unsafe {
             bind_ceed::CeedQFunctionAddOutput(self.qf_core.ptr, name_c.as_ptr(), size, emode);
-        }
-        /* Note: adding an output can change the pointer to self, resulting in bad ctx data */
-        unsafe {
-            bind_ceed::CeedQFunctionContextSetData(
-                self.qf_ctx_ptr,
-                crate::MemType::Host as bind_ceed::CeedMemType,
-                crate::CopyMode::UsePointer as bind_ceed::CeedCopyMode,
-                10, /* Note: size not relevant - CPU only approach */
-                &mut self as *mut _ as *mut ::std::os::raw::c_void,
-            );
         }
         self
     }

--- a/rust/src/qfunction.rs
+++ b/rust/src/qfunction.rs
@@ -66,6 +66,7 @@ pub(crate) struct QFunctionCore {
     ptr: bind_ceed::CeedQFunction,
 }
 
+#[derive(Copy, Clone)]
 struct QFunctionTrampolineData {
     number_inputs: usize,
     number_outputs: usize,
@@ -142,12 +143,11 @@ impl fmt::Display for QFunctionCore {
 ///   0
 /// };
 ///
-/// let mut qf = ceed.q_function_interior(1, Box::new(user_f));
-///
-/// qf.input("u", 1, EvalMode::Interp);
-/// qf.input("weights", 1, EvalMode::Weight);
-///
-/// qf.output("v", 1, EvalMode::Interp);
+/// let qf = ceed.q_function_interior(1, Box::new(user_f))
+///     .input("u", 1, EvalMode::Interp)
+///     .input("weights", 1, EvalMode::Weight)
+///     .output("v", 1, EvalMode::Interp)
+///     .build();
 ///
 /// println!("{}", qf);
 /// ```
@@ -305,6 +305,20 @@ impl QFunction {
         qf_self
     }
 
+    pub fn build(&mut self) -> Self {
+        let dummy_f = |_: QFunctionInputs, _: QFunctionOutputs| 1;
+        let mut user_f = std::mem::replace(&mut self.user_f, Box::new(dummy_f));
+        std::mem::swap(&mut self.user_f, &mut user_f);
+        Self {
+            qf_core: QFunctionCore {
+                ptr: std::mem::replace(&mut self.qf_core.ptr, std::ptr::null_mut()),
+            },
+            qf_ctx_ptr: std::mem::replace(&mut self.qf_ctx_ptr, std::ptr::null_mut()),
+            trampoline_data: self.trampoline_data.clone(),
+            user_f: user_f,
+        }
+    }
+
     /// Apply the action of a QFunction
     ///
     /// * `Q`      - The number of quadrature points
@@ -329,12 +343,11 @@ impl QFunction {
     ///   0
     /// };
     ///
-    /// let mut qf = ceed.q_function_interior(1, Box::new(user_f));
-    ///
-    /// qf.input("u", 1, EvalMode::Interp);
-    /// qf.input("weights", 1, EvalMode::Weight);
-    ///
-    /// qf.output("v", 1, EvalMode::Interp);
+    /// let qf = ceed.q_function_interior(1, Box::new(user_f))
+    ///     .input("u", 1, EvalMode::Interp)
+    ///     .input("weights", 1, EvalMode::Weight)
+    ///     .output("v", 1, EvalMode::Interp)
+    ///     .build();
     ///
     /// const Q : usize = 8;
     /// let mut w = [0.; Q];
@@ -364,7 +377,7 @@ impl QFunction {
     ///   assert_eq!(array[i], v[i], "Incorrect value in QFunction application");
     /// }
     /// ```
-    pub fn apply(&mut self, Q: i32, u: &[Vector], v: &[Vector]) {
+    pub fn apply(&self, Q: i32, u: &[Vector], v: &[Vector]) {
         self.qf_core.apply(Q, u, v)
     }
 
@@ -400,7 +413,12 @@ impl QFunction {
     /// qf.input("u", 1, EvalMode::Interp);
     /// qf.input("weights", 1, EvalMode::Weight);
     /// ```
-    pub fn input(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) {
+    pub fn input<'a>(
+        &'a mut self,
+        fieldname: &str,
+        size: i32,
+        emode: crate::EvalMode,
+    ) -> &'a mut Self {
         let name_c = CString::new(fieldname).expect("CString::new failed");
         self.trampoline_data.input_sizes[self.trampoline_data.number_inputs] = size;
         self.trampoline_data.number_inputs += 1;
@@ -408,6 +426,7 @@ impl QFunction {
         unsafe {
             bind_ceed::CeedQFunctionAddInput(self.qf_core.ptr, name_c.as_ptr(), size, emode);
         }
+        self
     }
 
     /// Add a QFunction output
@@ -441,7 +460,12 @@ impl QFunction {
     ///
     /// qf.output("v", 1, EvalMode::Interp);
     /// ```
-    pub fn output(&mut self, fieldname: &str, size: i32, emode: crate::EvalMode) {
+    pub fn output<'a>(
+        &'a mut self,
+        fieldname: &str,
+        size: i32,
+        emode: crate::EvalMode,
+    ) -> &'a mut Self {
         let name_c = CString::new(fieldname).expect("CString::new failed");
         self.trampoline_data.output_sizes[self.trampoline_data.number_outputs] = size;
         self.trampoline_data.number_outputs += 1;
@@ -449,6 +473,7 @@ impl QFunction {
         unsafe {
             bind_ceed::CeedQFunctionAddOutput(self.qf_core.ptr, name_c.as_ptr(), size, emode);
         }
+        self
     }
 }
 

--- a/rust/src/vector.rs
+++ b/rust/src/vector.rs
@@ -213,10 +213,11 @@ impl Vector {
     /// let val = 42.0;
     /// vec.set_value(val);
     ///
-    /// let v = vec.view();
-    /// for i in 0..len {
-    ///   assert_eq!(v[i], val, "Value not set correctly");
-    /// }
+    /// vec.view()
+    ///     .iter()
+    ///     .for_each(|v| {
+    ///         assert_eq!(*v, val, "Value not set correctly");
+    ///     });
     /// ```
     pub fn set_value(&mut self, value: f64) {
         unsafe { bind_ceed::CeedVectorSetValue(self.ptr, value) };
@@ -234,10 +235,12 @@ impl Vector {
     /// let mut vec = ceed.vector(4);
     /// vec.set_slice(&[10., 11., 12., 13.]);
     ///
-    /// let v = vec.view();
-    /// for i in 0..4 {
-    ///   assert_eq!(v[i], 10. + i as f64, "Slice not set correctly");
-    /// }
+    /// vec.view()
+    ///     .iter()
+    ///     .enumerate()
+    ///     .for_each(|(i, v)| {
+    ///         assert_eq!(*v, 10. + i as f64, "Slice not set correctly");
+    ///     });
     /// ```
     pub fn set_slice(&mut self, slice: &[f64]) {
         assert_eq!(self.length(), slice.len());
@@ -266,10 +269,11 @@ impl Vector {
     /// vec.set_value(val);
     /// vec.sync(MemType::Host);
     ///
-    /// let v = vec.view();
-    /// for i in 0..len {
-    ///   assert_eq!(v[i], val, "Value not set correctly");
-    /// }
+    /// vec.view()
+    ///     .iter()
+    ///     .for_each(|v| {
+    ///         assert_eq!(*v, val, "Value not set correctly");
+    ///     });
     /// ```
     pub fn sync(&self, mtype: crate::MemType) {
         unsafe { bind_ceed::CeedVectorSyncArray(self.ptr, mtype as bind_ceed::CeedMemType) };


### PR DESCRIPTION
I removed `get_`, `add_`, and `set_`:
* `*.get_*()`
* `qfunction.add_input(...)`
* `qfunction.add_output(...)`
* `operator.set_field(...)`
* `operator.add_sub_operator(...)`

We still have
* `vector.set_value(42.)`
but it seems clearer to me than `vector.value(42.)`