### PR TITLE
[OCCA] Update array methods and remove OCCA internal methods

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ noether-rocm:
       cd ..
       && export OCCA_VERSION=occa-1.1.1 OCCA_OPENCL_ENABLED=0
       && { [[ -d $OCCA_VERSION ]] || { git clone --depth 1 --branch main https://github.com/libocca/occa.git $OCCA_VERSION && make -C $OCCA_VERSION -j$(nproc); }; }
-      && (cd $OCCA_VERSION && git reset --hard origin/main)
+      && (cd $OCCA_VERSION; git fetch; git reset --hard origin/main)
       && make -C $OCCA_VERSION info
       && export OCCA_DIR=$PWD/$OCCA_VERSION
       && cd libCEED

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ noether-rocm:
       cd ..
       && export OCCA_VERSION=occa-1.1.1 OCCA_OPENCL_ENABLED=0
       && { [[ -d $OCCA_VERSION ]] || { git clone --depth 1 --branch main https://github.com/libocca/occa.git $OCCA_VERSION && make -C $OCCA_VERSION -j$(nproc); }; }
-      && (cd $OCCA_VERSION; git fetch; git reset --hard origin/main)
+      && (cd $OCCA_VERSION; git fetch; git reset --hard origin/main; make clean; make -j$(nproc);)
       && make -C $OCCA_VERSION info
       && export OCCA_DIR=$PWD/$OCCA_VERSION
       && cd libCEED

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,11 +16,12 @@ noether-rocm:
     - export PETSC_DIR=/projects/jed/petsc PETSC_ARCH=mpich-hip-g && git -C $PETSC_DIR describe && make -C $PETSC_DIR info
 # LIBXSMM v1.16.1
     - cd .. && export XSMM_VERSION=libxsmm-1.16.1 && { [[ -d $XSMM_VERSION ]] || { git clone --depth 1 --branch 1.16.1 https://github.com/hfp/libxsmm.git $XSMM_VERSION && make -C $XSMM_VERSION -j$(nproc); }; } && git -C $XSMM_VERSION describe --tags && export XSMM_DIR=$PWD/$XSMM_VERSION && cd libCEED
-# OCCA v1.1.1 (Note: Change main -> v1.1.1)
+# OCCA v1.1.1 (Note, change before setting the PR for review: main -> v1.1.1, remove git pull step)
     - >
       cd ..
       && export OCCA_VERSION=occa-1.1.1 OCCA_OPENCL_ENABLED=0
       && { [[ -d $OCCA_VERSION ]] || { git clone --depth 1 --branch main https://github.com/libocca/occa.git $OCCA_VERSION && make -C $OCCA_VERSION -j$(nproc); }; }
+      && (cd $OCCA_VERSION && git reset --hard origin/main)
       && make -C $OCCA_VERSION info
       && export OCCA_DIR=$PWD/$OCCA_VERSION
       && cd libCEED

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,14 @@ noether-rocm:
     - export PETSC_DIR=/projects/jed/petsc PETSC_ARCH=mpich-hip-g && git -C $PETSC_DIR describe && make -C $PETSC_DIR info
 # LIBXSMM v1.16.1
     - cd .. && export XSMM_VERSION=libxsmm-1.16.1 && { [[ -d $XSMM_VERSION ]] || { git clone --depth 1 --branch 1.16.1 https://github.com/hfp/libxsmm.git $XSMM_VERSION && make -C $XSMM_VERSION -j$(nproc); }; } && git -C $XSMM_VERSION describe --tags && export XSMM_DIR=$PWD/$XSMM_VERSION && cd libCEED
-# OCCA v1.1.0
-    - cd .. && export OCCA_VERSION=occa-1.1.0 OCCA_OPENCL_ENABLED=0 && { [[ -d $OCCA_VERSION ]] || { git clone --depth 1 --branch v1.1.0 https://github.com/libocca/occa.git $OCCA_VERSION && make -C $OCCA_VERSION -j$(nproc); }; } && make -C $OCCA_VERSION info && export OCCA_DIR=$PWD/$OCCA_VERSION && cd libCEED
+# OCCA v1.1.1 (Note: Change main -> v1.1.1)
+    - >
+      cd ..
+      && export OCCA_VERSION=occa-1.1.1 OCCA_OPENCL_ENABLED=0
+      && { [[ -d $OCCA_VERSION ]] || { git clone --depth 1 --branch main https://github.com/libocca/occa.git $OCCA_VERSION && make -C $OCCA_VERSION -j$(nproc); }; }
+      && make -C $OCCA_VERSION info
+      && export OCCA_DIR=$PWD/$OCCA_VERSION
+      && cd libCEED
 # libCEED
     - make info
     - make -j$(nproc)

--- a/backends/occa/ceed-occa-cpu-operator.cpp
+++ b/backends/occa/ceed-occa-cpu-operator.cpp
@@ -205,8 +205,8 @@ namespace ceed {
       }
     }
 
-    ::occa::properties CpuOperator::getKernelProps() {
-      ::occa::properties props = qfunction->getKernelProps(ceedQ);
+    ::occa::json CpuOperator::getKernelProps() {
+      ::occa::json props = qfunction->getKernelProps(ceedQ);
 
       props["defines/OCCA_Q"] = ceedQ;
 

--- a/backends/occa/ceed-occa-cpu-operator.hpp
+++ b/backends/occa/ceed-occa-cpu-operator.hpp
@@ -71,7 +71,7 @@ namespace ceed {
                                       SimplexBasis &basis);
 
       // Set props for a given field
-      ::occa::properties getKernelProps();
+      ::occa::json getKernelProps();
 
       void applyAdd(Vector *in, Vector *out);
 

--- a/backends/occa/ceed-occa-elem-restriction.cpp
+++ b/backends/occa/ceed-occa-elem-restriction.cpp
@@ -181,7 +181,7 @@ namespace ceed {
     }
 
     void ElemRestriction::setupKernelBuilders() {
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/CeedInt"]    = ::occa::dtype::get<CeedInt>().name();
       kernelProps["defines/CeedScalar"] = ::occa::dtype::get<CeedScalar>().name();
 
@@ -292,7 +292,7 @@ namespace ceed {
                                Vector &v) {
       const bool rIsTransposed = (rTransposeMode != CEED_NOTRANSPOSE);
 
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/USER_STRIDES"]    = StrideType::USER_STRIDES;
       kernelProps["defines/NOT_STRIDED"]     = StrideType::NOT_STRIDED;
       kernelProps["defines/BACKEND_STRIDES"] = StrideType::BACKEND_STRIDES;

--- a/backends/occa/ceed-occa-elem-restriction.cpp
+++ b/backends/occa/ceed-occa-elem-restriction.cpp
@@ -14,6 +14,7 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
+#include <cstring>
 #include <map>
 
 #include "./ceed-occa-elem-restriction.hpp"
@@ -79,7 +80,11 @@ namespace ceed {
 
     void ElemRestriction::setupFromDeviceMemory(CeedCopyMode copyMode,
                                                 const CeedInt *indices_d) {
-      ::occa::memory deviceIndices = arrayToMemory(indices_d);
+      const CeedInt entries = ceedElementCount * ceedElementSize;
+
+      ::occa::memory deviceIndices = (
+        getDevice().wrapMemory<CeedInt>(indices_d, entries)
+      );
 
       freeIndices = (copyMode == CEED_OWN_POINTER);
 
@@ -334,7 +339,7 @@ namespace ceed {
           return 0;
         }
         case CEED_MEM_DEVICE: {
-          *offsets = memoryToArray<CeedInt>(indices);
+          *offsets = indices.ptr<CeedInt>();
           return 0;
         }
       }

--- a/backends/occa/ceed-occa-qfunction.cpp
+++ b/backends/occa/ceed-occa-qfunction.cpp
@@ -15,6 +15,7 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 
 #include <sstream>
+#include <string>
 
 #include "ceed-occa-qfunction.hpp"
 #include "ceed-occa-qfunctioncontext.hpp"
@@ -141,8 +142,8 @@ namespace ceed {
       // Set and define in for the q point
       for (int i = 0; i < args.inputCount(); ++i) {
         const CeedInt fieldSize = args.getQfInput(i).size;
-        const std::string qIn_i = "qIn" + ::occa::toString(i);
-        const std::string in_i = "in" + ::occa::toString(i);
+        const std::string qIn_i = "qIn" + std::to_string(i);
+        const std::string in_i = "in" + std::to_string(i);
 
         ss << "    CeedScalar " << qIn_i << "[" << fieldSize << "];"              << std::endl
            << "    in[" << i << "] = " << qIn_i << ";"                            << std::endl
@@ -155,7 +156,7 @@ namespace ceed {
       // Set out for the q point
       for (int i = 0; i < args.outputCount(); ++i) {
         const CeedInt fieldSize = args.getQfOutput(i).size;
-        const std::string qOut_i = "qOut" + ::occa::toString(i);
+        const std::string qOut_i = "qOut" + std::to_string(i);
 
         ss << "    CeedScalar " << qOut_i << "[" << fieldSize << "];"             << std::endl
            << "    out[" << i << "] = " << qOut_i << ";"                          << std::endl;
@@ -166,8 +167,8 @@ namespace ceed {
       // Copy out for the q point
       for (int i = 0; i < args.outputCount(); ++i) {
         const CeedInt fieldSize = args.getQfOutput(i).size;
-        const std::string qOut_i = "qOut" + ::occa::toString(i);
-        const std::string out_i = "out" + ::occa::toString(i);
+        const std::string qOut_i = "qOut" + std::to_string(i);
+        const std::string out_i = "out" + std::to_string(i);
 
         ss << "    for (int qi = 0; qi < " << fieldSize << "; ++qi) {"           << std::endl
            << "      " << out_i << "[q + (OCCA_Q * qi)] = " << qOut_i << "[qi];" << std::endl
@@ -191,7 +192,7 @@ namespace ceed {
       for (CeedInt i = 0; i < args.inputCount(); i++) {
         Vector *u = Vector::from(U[i]);
         if (!u) {
-          return ceedError("Incorrect qFunction input field: U[" + ::occa::toString(i) + "]");
+          return ceedError("Incorrect qFunction input field: U[" + std::to_string(i) + "]");
         }
         qFunctionKernel.pushArg(u->getConstKernelArg());
       }
@@ -199,7 +200,7 @@ namespace ceed {
       for (CeedInt i = 0; i < args.outputCount(); i++) {
         Vector *v = Vector::from(V[i]);
         if (!v) {
-          return ceedError("Incorrect qFunction output field: V[" + ::occa::toString(i) + "]");
+          return ceedError("Incorrect qFunction output field: V[" + std::to_string(i) + "]");
         }
         qFunctionKernel.pushArg(v->getKernelArg());
       }

--- a/backends/occa/ceed-occa-qfunction.cpp
+++ b/backends/occa/ceed-occa-qfunction.cpp
@@ -74,8 +74,8 @@ namespace ceed {
       return QFunction::from(qf);
     }
 
-    ::occa::properties QFunction::getKernelProps(const CeedInt Q) {
-      ::occa::properties props;
+    ::occa::json QFunction::getKernelProps(const CeedInt Q) {
+      ::occa::json props;
 
       // Types
       props["defines/CeedInt"] = ::occa::dtype::get<CeedInt>().name();
@@ -99,7 +99,7 @@ namespace ceed {
     int QFunction::buildKernel(const CeedInt Q) {
       // TODO: Store a kernel per Q
       if (!qFunctionKernel.isInitialized()) {
-        ::occa::properties props = getKernelProps(Q);
+        ::occa::json props = getKernelProps(Q);
 
         // Properties only used in the QFunction kernel source
         props["defines/OCCA_Q"] = Q;

--- a/backends/occa/ceed-occa-qfunction.hpp
+++ b/backends/occa/ceed-occa-qfunction.hpp
@@ -40,7 +40,7 @@ namespace ceed {
       static QFunction* from(CeedQFunction qf);
       static QFunction* from(CeedOperator op);
 
-      ::occa::properties getKernelProps(const CeedInt Q);
+      ::occa::json getKernelProps(const CeedInt Q);
 
       int buildKernel(const CeedInt Q);
       std::string getKernelSource(const std::string &kernelName,

--- a/backends/occa/ceed-occa-qfunctioncontext.cpp
+++ b/backends/occa/ceed-occa-qfunctioncontext.cpp
@@ -14,8 +14,9 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#include "ceed-occa-qfunctioncontext.hpp"
+#include <cstring>
 
+#include "ceed-occa-qfunctioncontext.hpp"
 
 namespace ceed {
   namespace occa {

--- a/backends/occa/ceed-occa-qfunctioncontext.hpp
+++ b/backends/occa/ceed-occa-qfunctioncontext.hpp
@@ -47,8 +47,8 @@ namespace ceed {
         return mem;
       }
 
-      void* memoryToData(::occa::memory &memory) {
-        return memory.getModeMemory();
+      void* memoryToData(::occa::memory &mem) {
+        return mem.getModeMemory();
       }
 
       void resizeCtx(const size_t ctxSize_);

--- a/backends/occa/ceed-occa-simplex-basis.cpp
+++ b/backends/occa/ceed-occa-simplex-basis.cpp
@@ -63,7 +63,7 @@ namespace ceed {
         kernelSource += occa_simplex_basis_cpu_kernel_source;
       }
 
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/CeedInt"]    = ::occa::dtype::get<CeedInt>().name();
       kernelProps["defines/CeedScalar"] = ::occa::dtype::get<CeedScalar>().name();
       kernelProps["defines/DIM"] = dim;
@@ -164,7 +164,7 @@ namespace ceed {
 
     ::occa::kernel SimplexBasis::buildCpuEvalKernel(::occa::kernelBuilder &kernelBuilder,
                                                     const bool transpose) {
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/TRANSPOSE"] = transpose;
 
       return kernelBuilder.build(getDevice(), kernelProps);
@@ -172,7 +172,7 @@ namespace ceed {
 
     ::occa::kernel SimplexBasis::buildGpuEvalKernel(::occa::kernelBuilder &kernelBuilder,
                                                     const bool transpose) {
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/TRANSPOSE"]          = transpose;
       kernelProps["defines/ELEMENTS_PER_BLOCK"] = Q <= 1024 ? (1024 / Q) : 1;
 

--- a/backends/occa/ceed-occa-tensor-basis.cpp
+++ b/backends/occa/ceed-occa-tensor-basis.cpp
@@ -90,7 +90,7 @@ namespace ceed {
         kernelSource += cpuKernelSources[dim - 1];
       }
 
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/CeedInt"]    = ::occa::dtype::get<CeedInt>().name();
       kernelProps["defines/CeedScalar"] = ::occa::dtype::get<CeedScalar>().name();
       kernelProps["defines/Q1D"] = Q1D;
@@ -233,7 +233,7 @@ namespace ceed {
 
     ::occa::kernel TensorBasis::buildCpuEvalKernel(::occa::kernelBuilder &kernelBuilder,
                                                    const bool transpose) {
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/TRANSPOSE"] = transpose;
 
       return kernelBuilder.build(getDevice(), kernelProps);
@@ -243,7 +243,7 @@ namespace ceed {
                                                    const bool transpose,
                                                    const int elementsPerBlock) {
 
-      ::occa::properties kernelProps;
+      ::occa::json kernelProps;
       kernelProps["defines/TRANSPOSE"]          = transpose;
       kernelProps["defines/MAX_PQ"]             = Q1D > P1D ? Q1D : P1D;
       kernelProps["defines/ELEMENTS_PER_BLOCK"] = elementsPerBlock;

--- a/backends/occa/ceed-occa-types.hpp
+++ b/backends/occa/ceed-occa-types.hpp
@@ -20,6 +20,9 @@
 #include <ceed-backend.h>
 #include <occa.hpp>
 
+// Uses occa::kernelBuilder
+#include <occa/experimental.hpp>
+
 #define CeedOccaFromChk(ierr)                   \
   do {                                          \
     if (ierr) {                                 \

--- a/backends/occa/ceed-occa-vector.cpp
+++ b/backends/occa/ceed-occa-vector.cpp
@@ -14,6 +14,8 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
+#include <cstring>
+
 #include "ceed-occa-vector.hpp"
 
 
@@ -92,6 +94,10 @@ namespace ceed {
       }
     }
 
+    ::occa::memory Vector::arrayToMemory(CeedScalar *array) {
+      return getDevice().wrapMemory<CeedScalar>(array, length);
+    }
+
     int Vector::setValue(CeedScalar value) {
       // Prioritize keeping data in the device
       if (syncState & SyncState::device) {
@@ -141,7 +147,7 @@ namespace ceed {
             setCurrentHostBufferIfNeeded();
             currentMemory.copyFrom(currentHostBuffer);
           }
-          *array = memoryToArray<CeedScalar>(currentMemory);
+          *array = currentMemory.ptr<CeedScalar>();
           memory = ::occa::null;
           currentMemory = ::occa::null;
 
@@ -224,7 +230,7 @@ namespace ceed {
             currentMemory.copyFrom(currentHostBuffer);
           }
           syncState = SyncState::device;
-          *array = memoryToArray<CeedScalar>(currentMemory);
+          *array = currentMemory.ptr<CeedScalar>();
           return 0;
       }
       return ceedError("Invalid CeedMemType passed");

--- a/backends/occa/ceed-occa-vector.hpp
+++ b/backends/occa/ceed-occa-vector.hpp
@@ -22,20 +22,6 @@
 
 namespace ceed {
   namespace occa {
-    template <class TM>
-    ::occa::memory arrayToMemory(const TM *array) {
-      if (array) {
-        ::occa::memory mem((::occa::modeMemory_t*) array);
-        return mem.as(::occa::dtype::get<TM>());
-      }
-      return ::occa::null;
-    }
-
-    template <class TM>
-    TM* memoryToArray(::occa::memory &memory) {
-      return (TM*) memory.getModeMemory();
-    }
-
     class Vector : public CeedObject {
      public:
       // Owned resources
@@ -70,6 +56,8 @@ namespace ceed {
       void setCurrentHostBufferIfNeeded();
 
       void freeHostBuffer();
+
+      ::occa::memory arrayToMemory(CeedScalar *array);
 
       int setValue(CeedScalar value);
 

--- a/backends/occa/ceed-occa.cpp
+++ b/backends/occa/ceed-occa.cpp
@@ -257,18 +257,11 @@ namespace ceed {
         return CeedError(ceed, 1, "(OCCA) Backend cannot use resource: %s", c_resource);
       }
 
-      std::string devicePropsStr = "{\n";
-      StringMap::const_iterator it;
-      for (it = query.begin(); it != query.end(); ++it) {
-        devicePropsStr += "  \"";
-        devicePropsStr += it->first;
-        devicePropsStr += "\": ";
-        devicePropsStr += it->second;
-        devicePropsStr += ",\n";
+      ::occa::json deviceProps;
+      for (auto &kv : query) {
+        deviceProps[kv.first] = kv.second;
       }
-      devicePropsStr += '}';
 
-      ::occa::json deviceProps(devicePropsStr);
       setDefaultProps(deviceProps, mode);
 
       ceed::occa::Context *context = new Context(::occa::device(deviceProps));

--- a/backends/occa/ceed-occa.cpp
+++ b/backends/occa/ceed-occa.cpp
@@ -211,7 +211,7 @@ namespace ceed {
       return 0;
     }
 
-    void setDefaultProps(::occa::properties &deviceProps,
+    void setDefaultProps(::occa::json &deviceProps,
                          const std::string &defaultMode) {
       std::string mode;
       if (deviceProps.has("mode")) {
@@ -268,7 +268,7 @@ namespace ceed {
       }
       devicePropsStr += '}';
 
-      ::occa::properties deviceProps(devicePropsStr);
+      ::occa::json deviceProps(devicePropsStr);
       setDefaultProps(deviceProps, mode);
 
       ceed::occa::Context *context = new Context(::occa::device(deviceProps));

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -121,8 +121,6 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm,
       const char *resolved;
       CeedGetResource(ceed, &resolved);
       if (strstr(resolved, "/gpu/cuda")) vectype = VECCUDA;
-      else if (strstr(resolved, "/gpu/hip/occa"))
-        vectype = VECSTANDARD; // https://github.com/CEED/libCEED/issues/678
       else if (strstr(resolved, "/gpu/hip")) vectype = VECHIP;
       else vectype = VECSTANDARD;
     }

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -503,8 +503,6 @@ int main(int argc, char **argv) {
     const char *resolved;
     CeedGetResource(ceed, &resolved);
     if (strstr(resolved, "/gpu/cuda")) default_vectype = VECCUDA;
-    else if (strstr(resolved, "/gpu/hip/occa"))
-      default_vectype = VECSTANDARD; // https://github.com/CEED/libCEED/issues/678
     else if (strstr(resolved, "/gpu/hip")) default_vectype = VECHIP;
     else default_vectype = VECSTANDARD;
   }

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -156,8 +156,6 @@ int main(int argc, char **argv) {
     const char *resolved;
     CeedGetResource(ceed, &resolved);
     if (strstr(resolved, "/gpu/cuda")) vectype = VECCUDA;
-    else if (strstr(resolved, "/gpu/hip/occa"))
-      vectype = VECSTANDARD; // https://github.com/CEED/libCEED/issues/678
     else if (strstr(resolved, "/gpu/hip")) vectype = VECHIP;
     else vectype = VECSTANDARD;
   }


### PR DESCRIPTION
## Description

- Replaces the array getter/setter methods to use the `occa::memory::ptr()` and `occa::device::wrapMemory` methods
- Removes use of OCCA internal methods

:warning: **Before merging, I need to make sure I change the following** :warning:
- [ ] Git branch from `main` -> `v1.1.1`
- [ ] The cache update step 
  - `&& (cd $OCCA_VERSION && git reset --hard origin/main)`