### PR TITLE
julia: pin JuliaFormatter to v0.12.0 because subminor versions are changing

### DIFF
--- a/julia/LibCEED.jl/.style/Project.toml
+++ b/julia/LibCEED.jl/.style/Project.toml
@@ -2,3 +2,6 @@
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
+
+[compat]
+JuliaFormatter = "= 0.12.0"


### PR DESCRIPTION
v0.12.0 to v0.12.2 changes some formatting, one in a peculiar way that
I expect will be reversed in a future version of JuliaFormatter. Since
subminor versions are causing a lot of noise, we'll pin for now.

Fix #690