### PR TITLE
Add version macros and CeedGetVersion() [fix #697]

### DIFF
--- a/doc/sphinx/source/api/Ceed.rst
+++ b/doc/sphinx/source/api/Ceed.rst
@@ -23,6 +23,8 @@ Macros
 .. doxygendefine:: CeedPragmaSIMD
    :project: libCEED
 
+.. doxygendefine:: CEED_VERSION_GE
+   :project: libCEED
 
 Typedefs and Enumerations
 --------------------------------------

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -192,6 +192,41 @@ CEED_EXTERN int CeedSetErrorHandler(Ceed ceed,
 CEED_EXTERN int CeedGetErrorMessage(Ceed, const char **errmsg);
 CEED_EXTERN int CeedResetErrorMessage(Ceed, const char **errmsg);
 
+/// libCEED library version numbering
+/// @ingroup Ceed
+#define CEED_VERSION_MAJOR 0
+#define CEED_VERSION_MINOR 7
+#define CEED_VERSION_PATCH 0
+#define CEED_VERSION_RELEASE false
+
+/// Compile-time check that the the current library version is at least as
+/// recent as the specified version. This macro is typically used in
+/// @code
+/// #if CEED_VERSION_GE(0, 8, 0)
+///   code path that needs at least 0.8.0
+/// #else
+///   fallback code for older versions
+/// #endif
+/// @endcode
+///
+/// A non-release version always compares as positive infinity.
+///
+/// @param major   Major version
+/// @param minor   Minor version
+/// @param patch   Patch (subminor) version
+///
+/// @ingroup Ceed
+/// @sa CeedGetVersion()
+#define CEED_VERSION_GE(major, minor, patch)                                   \
+  (!CEED_VERSION_RELEASE ||                                                    \
+   (CEED_VERSION_MAJOR > major ||                                              \
+    (CEED_VERSION_MAJOR == major &&                                            \
+     (CEED_VERSION_MINOR > minor ||                                            \
+      (CEED_VERSION_MINOR == minor && CEED_VERSION_PATCH >= patch)))))
+
+CEED_EXTERN int CeedGetVersion(int *major, int *minor, int *patch,
+                               bool *release);
+
 /// Specify memory type
 ///
 /// Many Ceed interfaces take or return pointers to memory.  This enum is used to

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1015,4 +1015,29 @@ int CeedResetErrorMessage(Ceed ceed, const char **errmsg) {
   return 0;
 }
 
+/**
+  @brief Get libCEED library version info
+
+  libCEED version numbers have the form major.minor.patch. Non-release versions
+  may contain unstable interfaces.
+
+  @param[out] major    Major version of the library
+  @param[out] minor    Minor version of the library
+  @param[out] patch    Patch (subminor) version of the library
+  @param[out] release  True for releases; false for development branches.
+
+  The caller may pass NULL for any arguments that are not needed.
+
+  @sa CEED_VERSION_GE()
+
+  @ref Developer
+*/
+int CeedGetVersion(int *major, int *minor, int *patch, bool *release) {
+  if (major) *major = CEED_VERSION_MAJOR;
+  if (minor) *minor = CEED_VERSION_MINOR;
+  if (patch) *patch = CEED_VERSION_PATCH;
+  if (release) *release = CEED_VERSION_RELEASE;
+  return 0;
+}
+
 /// @}

--- a/tests/t000-ceed.c
+++ b/tests/t000-ceed.c
@@ -6,6 +6,16 @@
 int main(int argc, char **argv) {
   Ceed ceed;
 
+  {
+    int major, minor, patch;
+    CeedGetVersion(&major, &minor, &patch, NULL);
+    if (!CEED_VERSION_GE(major, minor, patch)) {
+      // LCOV_EXCL_START
+      printf("Library version mismatch %d.%d.%d\n", major, minor, patch);
+      // LCOV_EXCL_STOP
+    }
+  }
+
   CeedInit(argv[1], &ceed);
   CeedDestroy(&ceed);
 


### PR DESCRIPTION
If this is deemed sufficient, I can add support for `CeedGetVersion()` from the other language bindings.