### PR TITLE
WIP: Solids-GivensBC

### DIFF
--- a/examples/solids/README.rst
+++ b/examples/solids/README.rst
@@ -42,7 +42,8 @@ The elasticity min-app is controlled via command-line options, the following of 
      - `Poisson's ratio <https://en.wikipedia.org/wiki/Poisson%27s_ratio>`_, :math:`\nu < 0.5`
 
    * - :code:`-bc_clamp [int list]`
-     - List of face sets on which to displace by :code:`-bc_clamp_[facenumber]_translate [x,y,z]` and/or :code:`bc_clamp_[facenumber]_rotate [rx,ry,rz,theta]`
+     - List of face sets on which to displace by :code:`-bc_clamp_[facenumber]_translate [x,y,z]` and/or :code:`bc_clamp_[facenumber]_rotate [rx,ry,rz,c_0,c_1]`
+                                                                                                                   
 
 Note: The default for a clamped face is zero displacement. All displacement is with respect to the initial configuration.
 
@@ -68,7 +69,17 @@ With the sidesets defined in the figure, we provide here an example of a minimal
 
 In this example, we set the left boundary, face set :math:`999`, to zero displacement and the right boundary, face set :math:`998`, to displace :math:`0` in the :math:`x` direction, :math:`-0.5` in the :math:`y`, and :math:`1` in the :math:`z`.
 
-As an alternative to specifying a mesh with :code:`-mesh`, the user may use a DMPlex box mesh by specifying :code:`-dm_plex_box_faces [int list]`, :code:`-dm_plex_box_upper [real list]`, and :code:`-dm_plex_box_lower [real list]`.
+As an alternative to specifying a mesh with :code:`-mesh`, the user may use a DMPlex box mesh by specifying :code:`-dm_plex_box_faces [int list]`, :code:`-dm_plex_box_upper [real list]`, and :code:`-dm_plex_box_lower [real list]`. 
+
+As an alternative example exploiting :code:`-dm_plex_box_faces`, we consider a :code:`4 x 4 x 4` mesh where essential (Drichlet) boundary condition is placed on all sides. Sides 1 through 6 are rotated around :math:`x`-axis::
+
+   ./elasticity -problem hyperFS -E 1 -nu 0.3 -num_steps 40 -snes_linesearch_type cp -dm_plex_box_faces 4,4,4 -bc_clamp 1,2,3,4,5,6 -bc_clamp_1_rotate 0,0,1,0,.3 -bc_clamp_2_rotate 0,0,1,0,.3 -bc_clamp_3_rotate 0,0,1,0,.3 -bc_clamp_4_rotate 0,0,1,0,.3 -bc_clamp_5_rotate 0,0,1,0,.3 -bc_clamp_6_rotate 0,0,1,0,.3   
+
+.. note::
+
+   If the coordinates for a particular side of a mesh are zero along the axis of rotation, it may appear that particular side is clamped zero.
+
+On each boundary node, the rotation magnitude is computed: :code:`theta = (c_0 + c_1 * cx) * loadIncrement` where :code:`cx = kx * x + ky * y + kz * z`, with :code:`kx`, :code:`ky`, :code:`kz` are normalized values.
 
 The command line options just shown are the minimum requirements to run the mini-app, but additional options may also be set as follows
 

--- a/examples/solids/elasticity.c
+++ b/examples/solids/elasticity.c
@@ -844,7 +844,7 @@ int main(int argc, char **argv) {
 
     // -- Output
     ierr = PetscPrintf(comm,
-                       "    Strain Energy                      : %e\n",
+                       "    Strain Energy                      : %.12e\n",
                        energy); CHKERRQ(ierr);
   }
 

--- a/examples/solids/elasticity.h
+++ b/examples/solids/elasticity.h
@@ -122,7 +122,9 @@ struct AppCtx_private {
   PetscInt      numIncrements;                        // Number of steps
   PetscInt      bcClampCount;
   PetscInt      bcClampFaces[16];
-  PetscScalar   bcClampMax[16][7];
+  // [translation; 3] [rotation axis; 3] [rotation magnitude c_0, c_1]
+  // The rotations are (c_0 + c_1 s) \pi, where s = x · axis
+  PetscScalar   bcClampMax[16][8];
   PetscInt      bcTractionCount;
   PetscInt      bcTractionFaces[16];
   PetscScalar   bcTractionVector[16][3];

--- a/examples/solids/index.rst
+++ b/examples/solids/index.rst
@@ -470,4 +470,3 @@ That is, given the linearization point :math:`\bm F` and solution increment :mat
    In the case where complete linearization is preferred, note the symmetry :math:`\mathsf C_{IJKL} = \mathsf C_{KLIJ}` evident in :math:numref:`eq-neo-hookean-incremental-stress-index`, thus :math:`\mathsf C` can be stored as a symmetric :math:`6\times 6` matrix, which has 21 unique entries.
    Along with 6 entries for :math:`\bm S`, this totals 27 entries of overhead compared to computing everything from :math:`\bm F`.
    This compares with 13 entries of overhead for direct storage of :math:`\{ \bm S, \bm C^{-1}, \log J \}`, which is sufficient for the Neo-Hookean model to avoid all but matrix products.
-

--- a/examples/solids/src/boundary.c
+++ b/examples/solids/src/boundary.c
@@ -60,19 +60,19 @@ PetscErrorCode BCClamp(PetscInt dim, PetscReal loadIncrement,
 
   PetscFunctionBeginUser;
   PetscScalar
-  // translation vector
+  // Translation vector
   lx = clampMax[0]*loadIncrement,
   ly = clampMax[1]*loadIncrement,
   lz = clampMax[2]*loadIncrement,
-  // normalized rotation axis
+  // Normalized rotation axis
   kx = clampMax[3],
   ky = clampMax[4],
   kz = clampMax[5],
-  // rotation polynomial
+  // Rotation polynomial
   c_0 = clampMax[6] * M_PI,
   c_1 = clampMax[7] * M_PI,
   cx = kx * x + ky * y + kz * z,
-  // rotation magnitude
+  // Rotation magnitude
   theta = (c_0 + c_1 * cx) * loadIncrement;
   PetscScalar c = cos(theta), s = sin(theta);
 

--- a/examples/solids/src/boundary.c
+++ b/examples/solids/src/boundary.c
@@ -59,16 +59,25 @@ PetscErrorCode BCClamp(PetscInt dim, PetscReal loadIncrement,
   PetscScalar (*clampMax) = (PetscScalar(*))ctx;
 
   PetscFunctionBeginUser;
-
-  PetscScalar lx = clampMax[0]*loadIncrement, ly = clampMax[1]*loadIncrement,
-              lz = clampMax[2]*loadIncrement,
-              theta = clampMax[6]*M_PI*loadIncrement,
-              kx = clampMax[3], ky = clampMax[4], kz = clampMax[5];
+  PetscScalar
+  // translation vector
+  lx = clampMax[0]*loadIncrement,
+  ly = clampMax[1]*loadIncrement,
+  lz = clampMax[2]*loadIncrement,
+  // normalized rotation axis
+  kx = clampMax[3],
+  ky = clampMax[4],
+  kz = clampMax[5],
+  // rotation polynomial
+  c_0 = clampMax[6] * M_PI,
+  c_1 = clampMax[7] * M_PI,
+  cx = kx * x + ky * y + kz * z,
+  // rotation magnitude
+  theta = (c_0 + c_1 * cx) * loadIncrement;
   PetscScalar c = cos(theta), s = sin(theta);
 
   u[0] = lx + s*(-kz*y + ky*z) + (1-c)*(-(ky*ky+kz*kz)*x + kx*ky*y + kx*kz*z);
   u[1] = ly + s*(kz*x + -kx*z) + (1-c)*(kx*ky*x + -(kx*kx+kz*kz)*y + ky*kz*z);
   u[2] = lz + s*(-ky*x + kx*y) + (1-c)*(kx*kz*x + ky*kz*y + -(kx*kx+ky*ky)*z);
-
   PetscFunctionReturn(0);
 };

--- a/examples/solids/src/cloptions.c
+++ b/examples/solids/src/cloptions.c
@@ -95,7 +95,9 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx appCtx) {
   for (PetscInt i = 0; i < appCtx->bcClampCount; i++) {
     // Translation vector
     char optionName[25];
-    for (PetscInt j = 0; j < 7; j++)
+    const size_t nclamp_params = sizeof(appCtx->bcClampMax[0])/sizeof(
+                                   appCtx->bcClampMax[0][0]);
+    for (PetscInt j = 0; j < nclamp_params; j++)
       appCtx->bcClampMax[i][j] = 0.;
 
     snprintf(optionName, sizeof optionName, "-bc_clamp_%d_translate",
@@ -107,7 +109,7 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx appCtx) {
     CHKERRQ(ierr);
 
     // Rotation vector
-    maxn = 4;
+    maxn = 5;
     snprintf(optionName, sizeof optionName, "-bc_clamp_%d_rotate",
              appCtx->bcClampFaces[i]);
     ierr = PetscOptionsScalarArray(optionName,


### PR DESCRIPTION
It appears it works with degree 1 but not with higher orders.

How to run
degree 1: 

`./elasticity -problem hyperFS -mesh ./meshes/test.exo -degree 1 -nu 0.3 -E 6.9e10 -bc_clamp 999,998,997,996,995,994 -bc_clamp_999_givens 1,0,0,0.174533 -bc_clamp_998_givens 1,0,0,0.174533 -bc_clamp_997_givens 1,0,0,0.174533 -bc_clamp_996_givens 1,0,0,0.174533 -bc_clamp_995_givens 1,0,0,0.174533 -bc_clamp_994_givens 1,0,0,0.174533 -num_steps 10 -snes_linesearch_type cp -snes_rtol 1e-7`

degree 2 and above diverges:

`./elasticity -problem hyperFS -mesh ./meshes/test.exo -degree 2 -nu 0.3 -E 6.9e10 -bc_clamp 999,998,997,996,995,994 -bc_clamp_999_givens 1,0,0,0.174533 -bc_clamp_998_givens 1,0,0,0.174533 -bc_clamp_997_givens 1,0,0,0.174533 -bc_clamp_996_givens 1,0,0,0.174533 -bc_clamp_995_givens 1,0,0,0.174533 -bc_clamp_994_givens 1,0,0,0.174533 -num_steps 10 -snes_linesearch_type cp -snes_rtol 1e-7`