### PR TITLE
Modify errmsg handling related to CeedErrorStore

### DIFF
--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -850,6 +850,10 @@ int CeedDestroy(Ceed *ceed) {
 
 // LCOV_EXCL_START
 const char *CeedErrorFormat(Ceed ceed, const char *format, va_list *args) {
+  if (ceed->parent)
+    return CeedErrorFormat(ceed->parent, format, args);
+  if (ceed->opfallbackparent)
+    return CeedErrorFormat(ceed->opfallbackparent, format, args);
   vsnprintf(ceed->errmsg, CEED_MAX_RESOURCE_LEN, format, *args);
   return ceed->errmsg;
 }
@@ -995,6 +999,10 @@ int CeedSetErrorHandler(Ceed ceed,
   @ref Developer
 **/
 int CeedGetErrorMessage(Ceed ceed, const char **errmsg) {
+  if (ceed->parent)
+    return CeedGetErrorMessage(ceed->parent, errmsg);
+  if (ceed->opfallbackparent)
+    return CeedGetErrorMessage(ceed->opfallbackparent, errmsg);
   *errmsg = ceed->errmsg;
   return 0;
 }
@@ -1011,6 +1019,10 @@ int CeedGetErrorMessage(Ceed ceed, const char **errmsg) {
   @ref Developer
 **/
 int CeedResetErrorMessage(Ceed ceed, const char **errmsg) {
+  if (ceed->parent)
+    return CeedResetErrorMessage(ceed->parent, errmsg);
+  if (ceed->opfallbackparent)
+    return CeedResetErrorMessage(ceed->opfallbackparent, errmsg);
   *errmsg = NULL;
   memcpy(ceed->errmsg, "No error message stored", 24);
   return 0;


### PR DESCRIPTION
Currently, `CeedErrorStore` puts its message in the top-level `Ceed` object by following parents up the tree. However, `CeedGetErrorMessage` simply gets its own error message without going up the tree, so it may return a different error message from the one put with `CeedErrorStore` even if they are both called with the same `Ceed` object.

This PR modifies `CeedErrorFormat`, `CeedGetErrorMessage`, `CeedResetErrorMessage` to act more consistently with `CeedErrorStore`.

I discovered this behavior when trying to write a error handling wrapper in MFEM, see https://github.com/mfem/mfem/pull/1763 .