### PR TITLE
Full assembly of CeedOperator

### DIFF
--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -36,7 +36,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
   // Create reference CEED that implementation will be dispatched
   //   through unless overridden
   Ceed ceedref;
-  CeedInit("/cpu/self/ref/serial", &ceedref);
+  CeedInit("/cpu/self/ref/blocked", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",

--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -36,7 +36,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
   // Create reference CEED that implementation will be dispatched
   //   through unless overridden
   Ceed ceedref;
-  CeedInit("/cpu/self/ref/blocked", &ceedref);
+  CeedInit("/cpu/self/opt/blocked", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",

--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -36,7 +36,7 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
   // Create reference CEED that implementation will be dispatched
   //   through unless overridden
   Ceed ceedref;
-  CeedInit("/cpu/self/opt/blocked", &ceedref);
+  CeedInit("/cpu/self/ref/serial", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",

--- a/backends/avx/ceed-avx-serial.c
+++ b/backends/avx/ceed-avx-serial.c
@@ -39,7 +39,6 @@ static int CeedInit_Avx(const char *resource, Ceed ceed) {
   CeedInit("/cpu/self/opt/serial", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
-
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "TensorContractCreate",
                                 CeedTensorContractCreate_Avx); CeedChkBackend(ierr);
   return CEED_ERROR_SUCCESS;

--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -39,6 +39,11 @@ CEED_INTERN int CeedInit_Blocked(const char *resource, Ceed ceed) {
   CeedInit("/cpu/self/ref/serial", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
+  // Set fallback CEED resource for advanced operator functionality
+  const char fallbackresource[] = "/cpu/self/ref/serial";
+  ierr = CeedSetOperatorFallbackResource(ceed, fallbackresource);
+  CeedChkBackend(ierr);
+
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",
                                 CeedOperatorCreate_Blocked); CeedChkBackend(ierr);
 

--- a/backends/opt/ceed-opt-blocked.c
+++ b/backends/opt/ceed-opt-blocked.c
@@ -51,6 +51,11 @@ static int CeedInit_Opt_Blocked(const char *resource, Ceed ceed) {
   CeedInit("/cpu/self/ref/serial", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
+  // Set fallback CEED resource for advanced operator functionality
+  const char fallbackresource[] = "/cpu/self/ref/serial";
+  ierr = CeedSetOperatorFallbackResource(ceed, fallbackresource);
+  CeedChkBackend(ierr);
+
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "Destroy",
                                 CeedDestroy_Opt); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",

--- a/backends/opt/ceed-opt-serial.c
+++ b/backends/opt/ceed-opt-serial.c
@@ -51,6 +51,11 @@ static int CeedInit_Opt_Serial(const char *resource, Ceed ceed) {
   CeedInit("/cpu/self/ref/serial", &ceedref);
   ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
+  // Set fallback CEED resource for advanced operator functionality
+  const char fallbackresource[] = "/cpu/self/ref/serial";
+  ierr = CeedSetOperatorFallbackResource(ceed, fallbackresource);
+  CeedChkBackend(ierr);
+
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "Destroy",
                                 CeedDestroy_Opt); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "OperatorCreate",

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -299,6 +299,8 @@ struct CeedOperator_private {
                                           CeedRequest *);
   int (*LinearAssembleAddPointBlockDiagonal)(CeedOperator, CeedVector,
       CeedRequest *);
+  int (*LinearAssembleSymbolic)(CeedOperator, CeedInt *, CeedInt **, CeedInt **);
+  int (*LinearAssemble)(CeedOperator, CeedVector);
   int (*CreateFDMElementInverse)(CeedOperator, CeedOperator *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -205,10 +205,6 @@ struct CeedBasis_private {
   void *data;                  /* place for the backend to store any data */
 };
 
-int CeedMatrixMultiply(Ceed ceed, const CeedScalar *matA,
-                       const CeedScalar *matB, CeedScalar *matC, CeedInt m,
-                       CeedInt n, CeedInt kk);
-
 struct CeedTensorContract_private {
   Ceed ceed;
   int (*Apply)(CeedTensorContract, CeedInt, CeedInt, CeedInt, CeedInt,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -205,6 +205,10 @@ struct CeedBasis_private {
   void *data;                  /* place for the backend to store any data */
 };
 
+int CeedMatrixMultiply(Ceed ceed, const CeedScalar *matA,
+                       const CeedScalar *matB, CeedScalar *matC, CeedInt m,
+                       CeedInt n, CeedInt kk);
+
 struct CeedTensorContract_private {
   Ceed ceed;
   int (*Apply)(CeedTensorContract, CeedInt, CeedInt, CeedInt, CeedInt,

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -594,6 +594,8 @@ CEED_EXTERN int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op,
     CeedVector assembled, CeedRequest *request);
 CEED_EXTERN int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op,
     CeedVector assembled, CeedRequest *request);
+CEED_EXTERN int CeedOperatorLinearFullAssemble(CeedOperator op,
+    CeedInt *nentries, CeedInt **rows, CeedInt **cols, CeedScalar **vals);
 CEED_EXTERN int CeedOperatorMultigridLevelCreate(CeedOperator opFine,
     CeedVector PMultFine, CeedElemRestriction rstrCoarse, CeedBasis basisCoarse,
     CeedOperator *opCoarse, CeedOperator *opProlong, CeedOperator *opRestrict);

--- a/include/ceed.h
+++ b/include/ceed.h
@@ -594,8 +594,9 @@ CEED_EXTERN int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op,
     CeedVector assembled, CeedRequest *request);
 CEED_EXTERN int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op,
     CeedVector assembled, CeedRequest *request);
-CEED_EXTERN int CeedOperatorLinearFullAssemble(CeedOperator op,
-    CeedInt *nentries, CeedInt **rows, CeedInt **cols, CeedScalar **vals);
+CEED_EXTERN int CeedOperatorLinearAssembleSymbolic(CeedOperator op,
+    CeedInt *nentries, CeedInt **rows, CeedInt **cols);
+CEED_EXTERN int CeedOperatorLinearAssemble(CeedOperator op, CeedVector values);
 CEED_EXTERN int CeedOperatorMultigridLevelCreate(CeedOperator opFine,
     CeedVector PMultFine, CeedElemRestriction rstrCoarse, CeedBasis basisCoarse,
     CeedOperator *opCoarse, CeedOperator *opProlong, CeedOperator *opRestrict);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -319,11 +319,11 @@ static int CeedOperatorGetActiveElemRestriction(CeedOperator op,
     int ierr;
     Ceed ceed;
     ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
-    return CeedError(ceed, 1,
+    return CeedError(ceed, CEED_ERROR_INCOMPLETE,
                      "No active ElemRestriction found!");
     // LCOV_EXCL_STOP
   }
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1327,7 +1327,8 @@ int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset,
   Ceed ceed = op->ceed;
   if (op->composite) {
     // LCOV_EXCL_START
-    return CeedError(ceed, 1, "Not suitable for composite operator");
+    return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
+                     "Composite operator not supported");
     // LCOV_EXCL_STOP
   }
 
@@ -1388,12 +1389,12 @@ int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset,
   }
   if (count != local_nentries)
     // LCOV_EXCL_START
-    return CeedError(ceed, 1, "Bad calculation of entries!");
+    return CeedError(ceed, CEED_ERROR_MAJOR, "Error computing assembled entries");
   // LCOV_EXCL_STOP
   ierr = CeedVectorRestoreArrayRead(elem_dof, &elem_dof_a); CeedChk(ierr);
   ierr = CeedVectorDestroy(&elem_dof); CeedChk(ierr);
 
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1409,7 +1410,8 @@ int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   Ceed ceed = op->ceed;;
   if (op->composite) {
     // LCOV_EXCL_START
-    return CeedError(ceed, 1, "Not suitable for composite operator");
+    return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
+                     "Composite operator not supported");
     // LCOV_EXCL_STOP
   }
 
@@ -1571,7 +1573,7 @@ int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
                   gradin[(din*nqpts+q) * elemsize + n];
               } else {
                 // LCOV_EXCL_START
-                return CeedError(ceed, 1, "Not implemented!");
+                return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Not implemented!");
                 // LCOV_EXCL_STOP
               }
             }
@@ -1586,7 +1588,7 @@ int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
                   gradin[(dout*nqpts+q) * elemsize + n];
               } else {
                 // LCOV_EXCL_START
-                return CeedError(ceed, 1, "Not implemented!");
+                return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Not implemented!");
                 // LCOV_EXCL_STOP
               }
             }
@@ -1630,7 +1632,7 @@ int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   }
   if (count != local_nentries)
     // LCOV_EXCL_START
-    return CeedError(ceed, 1, "Bad calculation of entries!");
+    return CeedError(ceed, CEED_ERROR_MAJOR, "Error computing entries");
   // LCOV_EXCL_STOP
   ierr = CeedVectorRestoreArray(values, &vals); CeedChk(ierr);
 
@@ -1640,7 +1642,7 @@ int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   ierr = CeedFree(&emodein); CeedChk(ierr);
   ierr = CeedFree(&emodeout); CeedChk(ierr);
 
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1653,7 +1655,8 @@ int CeedSingleOperatorAssemblyCountEntries(CeedOperator op, CeedInt *nentries) {
 
   if (op->composite) {
     // LCOV_EXCL_START
-    return CeedError(op->ceed, 1, "Not implemented for composite operator");
+    return CeedError(op->ceed, CEED_ERROR_UNSUPPORTED,
+                     "Composite operator not supported");
     // LCOV_EXCL_STOP
   }
   ierr = CeedOperatorGetActiveElemRestriction(op, &rstr); CeedChk(ierr);
@@ -1662,7 +1665,7 @@ int CeedSingleOperatorAssemblyCountEntries(CeedOperator op, CeedInt *nentries) {
   ierr = CeedElemRestrictionGetNumComponents(rstr, &ncomp); CeedChk(ierr);
   *nentries = elemsize*ncomp * elemsize*ncomp * nelem;
 
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1743,7 +1746,7 @@ int CeedOperatorLinearAssembleSymbolic(CeedOperator op,
     CeedChk(ierr);
   }
 
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1800,7 +1803,7 @@ int CeedOperatorLinearAssemble(CeedOperator op, CeedVector values) {
     ierr = CeedSingleOperatorAssemble(op, offset, values); CeedChk(ierr);
   }
 
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1064,8 +1064,7 @@ int CeedCompositeOperatorAddSub(CeedOperator compositeop, CeedOperator subop) {
   if (!compositeop->composite)
     // LCOV_EXCL_START
     return CeedError(compositeop->ceed, CEED_ERROR_MINOR,
-                     "CeedOperator is not a composite "
-                     "operator");
+                     "CeedOperator is not a composite operator");
   // LCOV_EXCL_STOP
 
   if (compositeop->numsub == CEED_COMPOSITE_MAX)

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1163,7 +1163,8 @@ int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled,
       ierr = CeedOperatorCreateFallback(op); CeedChk(ierr);
     }
     // Assemble
-    return CeedOperatorLinearAssembleAddDiagonal(op, assembled, request);
+    return CeedOperatorLinearAssembleAddDiagonal(op->opfallback, assembled,
+           request);
   }
 }
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1694,27 +1694,17 @@ int CeedOperatorLinearAssembleSymbolic(CeedOperator op,
   bool isComposite;
   ierr = CeedOperatorCheckReady(op->ceed, op); CeedChk(ierr);
 
-  // Use backend version, if available
+  // Use backend or fallback version, if available
   if (op->LinearAssembleSymbolic) {
     return op->LinearAssembleSymbolic(op, nentries, rows, cols);
   } else {
-    // Check for valid fallback resource
-    const char *resource, *fallbackresource;
-    ierr = CeedGetResource(op->ceed, &resource); CeedChk(ierr);
-    ierr = CeedGetOperatorFallbackResource(op->ceed, &fallbackresource);
-    if (strcmp(fallbackresource, "") && strcmp(resource, fallbackresource)) {
-      // Fallback to reference Ceed
-      if (!op->opfallback) {
-        ierr = CeedOperatorCreateFallback(op); CeedChk(ierr);
-      }
-      if (op->opfallback->LinearAssembleSymbolic) {
-        return op->opfallback->LinearAssembleSymbolic(
-                 op->opfallback, nentries, rows, cols);
-      }
+    if (op->opfallback && op->opfallback->LinearAssembleSymbolic) {
+      return op->opfallback->LinearAssembleSymbolic(
+               op->opfallback, nentries, rows, cols);
     }
   }
 
-  // if fallback resource is not valid, or if it does not provide
+  // if neither backend nor fallback resource proivdes
   // LinearAssembleSymbolic, continue with interface-level implementation
 
   // count entries and allocate rows, cols arrays
@@ -1780,26 +1770,16 @@ int CeedOperatorLinearAssemble(CeedOperator op, CeedVector values) {
   CeedOperator *suboperators;
   ierr = CeedOperatorCheckReady(op->ceed, op); CeedChk(ierr);
 
-  // Use backend version, if available
+  // Use backend or fallback version, if available
   if (op->LinearAssemble) {
     return op->LinearAssemble(op, values);
   } else {
-    // Check for valid fallback resource
-    const char *resource, *fallbackresource;
-    ierr = CeedGetResource(op->ceed, &resource); CeedChk(ierr);
-    ierr = CeedGetOperatorFallbackResource(op->ceed, &fallbackresource);
-    if (strcmp(fallbackresource, "") && strcmp(resource, fallbackresource)) {
-      // Fallback to reference Ceed
-      if (!op->opfallback) {
-        ierr = CeedOperatorCreateFallback(op); CeedChk(ierr);
-      }
-      if (op->opfallback->LinearAssemble) {
-        return op->opfallback->LinearAssemble(op->opfallback, values);
-      }
+    if (op->opfallback && op->opfallback->LinearAssemble) {
+      return op->opfallback->LinearAssemble(op->opfallback, values);
     }
   }
 
-  // if fallback resource is not valid, or if it does not provide
+  // if neither backend nor fallback resource provides
   // LinearAssemble, continue with interface-level implementation
 
   bool isComposite;

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1163,7 +1163,7 @@ int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled,
       ierr = CeedOperatorCreateFallback(op); CeedChk(ierr);
     }
     // Assemble
-    return CeedOperatorLinearAssembleAddDiagonal(op->opfallback, assembled,
+    return CeedOperatorLinearAssembleDiagonal(op->opfallback, assembled,
            request);
   }
 }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -694,6 +694,8 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleAddDiagonal),
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssemblePointBlockDiagonal),
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleAddPointBlockDiagonal),
+    CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSymbolic),
+    CEED_FTABLE_ENTRY(CeedOperator, LinearAssemble),
     CEED_FTABLE_ENTRY(CeedOperator, CreateFDMElementInverse),
     CEED_FTABLE_ENTRY(CeedOperator, Apply),
     CEED_FTABLE_ENTRY(CeedOperator, ApplyComposite),

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -710,7 +710,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
   memcpy((*ceed)->foffsets, foffsets, sizeof(foffsets));
 
   // Set fallback for advanced CeedOperator functions
-  const char fallbackresource[] = "/cpu/self/ref/serial";
+  const char fallbackresource[] = "";
   ierr = CeedSetOperatorFallbackResource(*ceed, fallbackresource);
   CeedChk(ierr);
 

--- a/tests/t560-operator.c
+++ b/tests/t560-operator.c
@@ -1,0 +1,161 @@
+/// @file
+/// Test full assembly of mass matrix operator
+/// \test Test full assembly of mass matrix operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t510-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu,
+                      Erestrictui;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup, qf_mass;
+  CeedOperator op_setup, op_mass;
+  CeedVector qdata, X, U, V;
+  CeedInt P = 3, Q = 4, dim = 2;
+  CeedInt nx = 3, ny = 2;
+  CeedInt nelem = nx * ny;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q*Q;
+  CeedInt indx[nelem*P*P];
+  CeedScalar assembled[ndofs*ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ndofs*ndofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<nx*2+1; i++)
+    for (CeedInt j=0; j<ny*2+1; j++) {
+      x[i+j*(nx*2+1)+0*ndofs] = (CeedScalar) i / (2*nx);
+      x[i+j*(nx*2+1)+1*ndofs] = (CeedScalar) j / (2*ny);
+    }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vector
+  CeedVectorCreate(ceed, nqpts, &qdata);
+
+  // Element Setup
+  for (CeedInt i=0; i<nelem; i++) {
+    CeedInt col, row, offset;
+    col = i % nx;
+    row = i / nx;
+    offset = col*(P-1) + row*(nx*2+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        indx[P*(P*i+k)+j] = offset + k*(nx*2+1) + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, P*P, dim, ndofs, dim*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
+
+  CeedElemRestrictionCreate(ceed, nelem, P*P, 1, 1, ndofs, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictu);
+  CeedInt stridesu[3] = {1, Q*Q, Q*Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts, stridesu,
+                                   &Erestrictui);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P, Q, CEED_GAUSS, &bu);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
+  CeedOperatorSetField(op_setup, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
+
+  // Fully assemble operator
+  for (int k=0; k<ndofs*ndofs; ++k) {
+    assembled[k] = 0.0;
+    assembledTrue[k] = 0.0;
+  }
+  CeedInt nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedScalar *vals;
+  CeedOperatorLinearFullAssemble(op_mass, &nentries, &rows, &cols,
+                                 &vals);
+  for (int k=0; k<nentries; ++k) {
+    assembled[rows[k]*ndofs + cols[k]] += vals[k];
+  }
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, ndofs, &V);
+  for (int i=0; i<ndofs; i++) {
+    // Set input
+    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+    u[i] = 1.0;
+    if (i)
+      u[i-1] = 0.0;
+    CeedVectorRestoreArray(U, &u);
+
+    // Compute entries for column i
+    CeedOperatorApply(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+    for (int k=0; k<ndofs; k++) {
+      assembledTrue[i*ndofs + k] = v[k];
+    }
+    CeedVectorRestoreArrayRead(V, &v);
+  }
+
+  // Check output
+  for (int i=0; i<ndofs; i++)
+    for (int j=0; j<ndofs; j++)
+      if (fabs(assembled[j*ndofs+i] - assembledTrue[j*ndofs+i]) > 1e-14)
+        // LCOV_EXCL_START
+        printf("[%d,%d] Error in assembly: %f != %f\n", i, j,
+               assembled[j*ndofs+i], assembledTrue[j*ndofs+i]);
+  // LCOV_EXCL_STOP
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  free(vals);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&qdata);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t560-operator.c
+++ b/tests/t560-operator.c
@@ -101,12 +101,16 @@ int main(int argc, char **argv) {
   CeedInt nentries;
   CeedInt *rows;
   CeedInt *cols;
-  CeedScalar *vals;
-  CeedOperatorLinearFullAssemble(op_mass, &nentries, &rows, &cols,
-                                 &vals);
+  CeedVector values;
+  CeedOperatorLinearAssembleSymbolic(op_mass, &nentries, &rows, &cols);
+  CeedVectorCreate(ceed, nentries, &values);
+  CeedOperatorLinearAssemble(op_mass, values);
+  const CeedScalar *vals;
+  CeedVectorGetArrayRead(values, CEED_MEM_HOST, &vals);
   for (int k=0; k<nentries; ++k) {
     assembled[rows[k]*ndofs + cols[k]] += vals[k];
   }
+  CeedVectorRestoreArrayRead(values, &vals);
 
   // Manually assemble operator
   CeedVectorCreate(ceed, ndofs, &U);
@@ -142,7 +146,7 @@ int main(int argc, char **argv) {
   // Cleanup
   free(rows);
   free(cols);
-  free(vals);
+  CeedVectorDestroy(&values);
   CeedQFunctionDestroy(&qf_setup);
   CeedQFunctionDestroy(&qf_mass);
   CeedOperatorDestroy(&op_setup);

--- a/tests/t561-operator.c
+++ b/tests/t561-operator.c
@@ -1,0 +1,169 @@
+/// @file
+/// Test full assembly of Poisson operator
+/// \test Test full assembly of Poisson operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t534-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu,
+                      Erestrictui, Erestrictqi;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup, qf_diff;
+  CeedOperator op_setup, op_diff;
+  CeedVector qdata, X, U, V;
+  CeedInt P = 3, Q = 4, dim = 2;
+  CeedInt nx = 3, ny = 2;
+  CeedInt nelem = nx * ny;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q*Q;
+  CeedInt indx[nelem*P*P];
+  CeedScalar assembled[ndofs*ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ndofs*ndofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<nx*2+1; i++)
+    for (CeedInt j=0; j<ny*2+1; j++) {
+      x[i+j*(nx*2+1)+0*ndofs] = (CeedScalar) i / (2*nx);
+      x[i+j*(nx*2+1)+1*ndofs] = (CeedScalar) j / (2*ny);
+    }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vector
+  CeedVectorCreate(ceed, nqpts*dim*(dim+1)/2, &qdata);
+
+  // Element Setup
+  for (CeedInt i=0; i<nelem; i++) {
+    CeedInt col, row, offset;
+    col = i % nx;
+    row = i / nx;
+    offset = col*(P-1) + row*(nx*2+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        indx[P*(P*i+k)+j] = offset + k*(nx*2+1) + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, P*P, dim, ndofs, dim*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
+
+  CeedElemRestrictionCreate(ceed, nelem, P*P, 1, 1, ndofs, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictu);
+  CeedInt stridesu[3] = {1, Q*Q, Q*Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts, stridesu,
+                                   &Erestrictui);
+
+  CeedInt stridesqd[3] = {1, Q*Q, Q *Q *dim *(dim+1)/2};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, dim*(dim+1)/2,
+                                   dim*(dim+1)/2*nqpts,
+                                   stridesqd, &Erestrictqi);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P, Q, CEED_GAUSS, &bu);
+
+  // QFunction - setup
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_setup, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+
+  // Operator - setup
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
+
+  // QFunction - apply
+  CeedQFunctionCreateInterior(ceed, 1, diff, diff_loc, &qf_diff);
+  CeedQFunctionAddInput(qf_diff, "du", dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_diff, "dv", dim, CEED_EVAL_GRAD);
+
+  // Operator - apply
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diff);
+  CeedOperatorSetField(op_diff, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "qdata", Erestrictqi, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_diff, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // Fully assemble operator
+  for (int k=0; k<ndofs*ndofs; ++k) {
+    assembled[k] = 0.0;
+    assembledTrue[k] = 0.0;
+  }
+  CeedInt nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedScalar *vals;
+  CeedOperatorLinearFullAssemble(op_diff, &nentries, &rows, &cols,
+                                 &vals);
+  for (int k=0; k<nentries; ++k) {
+    assembled[rows[k]*ndofs + cols[k]] += vals[k];
+  }
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, ndofs, &V);
+  for (int i=0; i<ndofs; i++) {
+    // Set input
+    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+    u[i] = 1.0;
+    if (i)
+      u[i-1] = 0.0;
+    CeedVectorRestoreArray(U, &u);
+
+    // Compute entries for column i
+    CeedOperatorApply(op_diff, U, V, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+    for (int k=0; k<ndofs; k++) {
+      assembledTrue[i*ndofs + k] = v[k];
+    }
+    CeedVectorRestoreArrayRead(V, &v);
+  }
+
+  // Check output
+  for (int i=0; i<ndofs; i++)
+    for (int j=0; j<ndofs; j++)
+      if (fabs(assembled[j*ndofs+i] - assembledTrue[j*ndofs+i]) > 1e-14)
+        // LCOV_EXCL_START
+        printf("[%d,%d] Error in assembly: %f != %f\n", i, j,
+               assembled[j*ndofs+i], assembledTrue[j*ndofs+i]);
+  // LCOV_EXCL_STOP
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  free(vals);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_diff);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_diff);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedElemRestrictionDestroy(&Erestrictqi);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&qdata);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t562-operator.c
+++ b/tests/t562-operator.c
@@ -1,0 +1,198 @@
+/// @file
+/// Test full assembly of mass and Poisson operator (see t535)
+/// \test Test full assembly of mass and Poisson operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t535-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu,
+                      Erestrictui, Erestrictqi;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup_mass, qf_setup_diff, qf_apply;
+  CeedOperator op_setup_mass, op_setup_diff, op_apply;
+  CeedVector qdata_mass, qdata_diff, X, U, V;
+  CeedInt P = 3, Q = 4, dim = 2;
+  CeedInt nx = 3, ny = 2;
+  CeedInt nelem = nx * ny;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q*Q;
+  CeedInt indx[nelem*P*P];
+  CeedScalar assembled[ndofs*ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ndofs*ndofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<nx*2+1; i++)
+    for (CeedInt j=0; j<ny*2+1; j++) {
+      x[i+j*(nx*2+1)+0*ndofs] = (CeedScalar) i / (2*nx);
+      x[i+j*(nx*2+1)+1*ndofs] = (CeedScalar) j / (2*ny);
+    }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vectors
+  CeedVectorCreate(ceed, nqpts, &qdata_mass);
+  CeedVectorCreate(ceed, nqpts*dim*(dim+1)/2, &qdata_diff);
+
+  // Element Setup
+  for (CeedInt i=0; i<nelem; i++) {
+    CeedInt col, row, offset;
+    col = i % nx;
+    row = i / nx;
+    offset = col*(P-1) + row*(nx*2+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        indx[P*(P*i+k)+j] = offset + k*(nx*2+1) + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, P*P, dim, ndofs, dim*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
+
+  CeedElemRestrictionCreate(ceed, nelem, P*P, 1, 1, ndofs, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictu);
+  CeedInt stridesu[3] = {1, Q*Q, Q*Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts, stridesu,
+                                   &Erestrictui);
+
+  CeedInt stridesqd[3] = {1, Q*Q, Q *Q *dim *(dim+1)/2};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, dim*(dim+1)/2,
+                                   dim*(dim+1)/2*nqpts,
+                                   stridesqd, &Erestrictqi);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P, Q, CEED_GAUSS, &bu);
+
+  // QFunction - setup mass
+  CeedQFunctionCreateInterior(ceed, 1, setup_mass, setup_mass_loc,
+                              &qf_setup_mass);
+  CeedQFunctionAddInput(qf_setup_mass, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup_mass, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_setup_mass, "qdata", 1, CEED_EVAL_NONE);
+
+  // Operator - setup mass
+  CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_mass);
+  CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_mass, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_mass, "qdata", Erestrictui,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // QFunction - setup diff
+  CeedQFunctionCreateInterior(ceed, 1, setup_diff, setup_diff_loc,
+                              &qf_setup_diff);
+  CeedQFunctionAddInput(qf_setup_diff, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup_diff, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_setup_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+
+  // Operator - setup diff
+  CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_diff);
+  CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_diff, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_diff, "qdata", Erestrictqi,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operators
+  CeedOperatorApply(op_setup_mass, X, qdata_mass, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup_diff, X, qdata_diff, CEED_REQUEST_IMMEDIATE);
+
+  // QFunction - apply
+  CeedQFunctionCreateInterior(ceed, 1, apply, apply_loc, &qf_apply);
+  CeedQFunctionAddInput(qf_apply, "du", dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_apply, "qdata_mass", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_apply, "qdata_diff", dim*(dim+1)/2, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_apply, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "v", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
+
+  // Operator - apply
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
+  CeedOperatorSetField(op_apply, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui,
+                       CEED_BASIS_COLLOCATED, qdata_mass);
+  CeedOperatorSetField(op_apply, "qdata_diff", Erestrictqi,
+                       CEED_BASIS_COLLOCATED, qdata_diff);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // Fully assemble operator
+  for (int k=0; k<ndofs*ndofs; ++k) {
+    assembled[k] = 0.0;
+    assembledTrue[k] = 0.0;
+  }
+  CeedInt nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedScalar *vals;
+  CeedOperatorLinearFullAssemble(op_apply, &nentries, &rows, &cols,
+                                 &vals);
+  for (int k=0; k<nentries; ++k) {
+    assembled[rows[k]*ndofs + cols[k]] += vals[k];
+  }
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, ndofs, &V);
+  for (int i=0; i<ndofs; i++) {
+    // Set input
+    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+    u[i] = 1.0;
+    if (i)
+      u[i-1] = 0.0;
+    CeedVectorRestoreArray(U, &u);
+
+    // Compute entries for column i
+    CeedOperatorApply(op_apply, U, V, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+    for (int k=0; k<ndofs; k++) {
+      assembledTrue[i*ndofs + k] = v[k];
+    }
+    CeedVectorRestoreArrayRead(V, &v);
+  }
+
+  // Check output
+  for (int i=0; i<ndofs; i++)
+    for (int j=0; j<ndofs; j++)
+      if (fabs(assembled[j*ndofs+i] - assembledTrue[j*ndofs+i]) > 1e-14)
+        // LCOV_EXCL_START
+        printf("[%d,%d] Error in assembly: %f != %f\n", i, j,
+               assembled[j*ndofs+i], assembledTrue[j*ndofs+i]);
+  // LCOV_EXCL_STOP
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  free(vals);
+  CeedQFunctionDestroy(&qf_setup_mass);
+  CeedQFunctionDestroy(&qf_setup_diff);
+  CeedQFunctionDestroy(&qf_apply);
+  CeedOperatorDestroy(&op_setup_mass);
+  CeedOperatorDestroy(&op_setup_diff);
+  CeedOperatorDestroy(&op_apply);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedElemRestrictionDestroy(&Erestrictqi);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&qdata_mass);
+  CeedVectorDestroy(&qdata_diff);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t563-operator.c
+++ b/tests/t563-operator.c
@@ -1,0 +1,215 @@
+/// @file
+/// Test full assembly of mass and Poisson operator (see t536)
+/// \test Test full assembly of mass and Poisson operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t320-basis.h"
+#include "t535-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu,
+                      Erestrictui, Erestrictqi;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup_mass, qf_setup_diff, qf_apply;
+  CeedOperator op_setup_mass, op_setup_diff, op_apply;
+  CeedVector qdata_mass, qdata_diff, X, U, V;
+  CeedInt nelem = 12, dim = 2, P = 6, Q = 4;
+  CeedInt nx = 3, ny = 2;
+  CeedInt row, col, offset;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q;
+  CeedInt indx[nelem*P*P];
+  CeedScalar assembled[ndofs*ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ndofs*ndofs];
+  CeedScalar qref[dim*Q], qweight[Q];
+  CeedScalar interp[P*Q], grad[dim*P*Q];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<ndofs; i++) {
+    x[i] = (1. / (nx*2)) * (CeedScalar) (i % (nx*2+1));
+    x[i+ndofs] = (1. / (ny*2)) * (CeedScalar) (i / (nx*2+1));
+  }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vectors
+  CeedVectorCreate(ceed, nqpts, &qdata_mass);
+  CeedVectorCreate(ceed, nqpts*dim*(dim+1)/2, &qdata_diff);
+
+  // Element Setup
+  for (CeedInt i=0; i<nelem/2; i++) {
+    col = i % nx;
+    row = i / nx;
+    offset = col*2 + row*(nx*2+1)*2;
+
+    indx[i*2*P +  0] =  2 + offset;
+    indx[i*2*P +  1] =  9 + offset;
+    indx[i*2*P +  2] = 16 + offset;
+    indx[i*2*P +  3] =  1 + offset;
+    indx[i*2*P +  4] =  8 + offset;
+    indx[i*2*P +  5] =  0 + offset;
+
+    indx[i*2*P +  6] = 14 + offset;
+    indx[i*2*P +  7] =  7 + offset;
+    indx[i*2*P +  8] =  0 + offset;
+    indx[i*2*P +  9] = 15 + offset;
+    indx[i*2*P + 10] =  8 + offset;
+    indx[i*2*P + 11] = 16 + offset;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, P, dim, ndofs, dim*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
+
+  CeedElemRestrictionCreate(ceed, nelem, P, 1, 1, ndofs, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictu);
+  CeedInt stridesu[3] = {1, Q, Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q, 1, nqpts, stridesu,
+                                   &Erestrictui);
+
+  CeedInt stridesqd[3] = {1, Q, Q *dim *(dim+1)/2};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q, dim*(dim+1)/2,
+                                   dim*(dim+1)/2*nqpts,
+                                   stridesqd, &Erestrictqi);
+
+  // Bases
+  buildmats(qref, qweight, interp, grad);
+  CeedBasisCreateH1(ceed, CEED_TRIANGLE, dim, P, Q, interp, grad, qref,
+                    qweight, &bx);
+
+  buildmats(qref, qweight, interp, grad);
+  CeedBasisCreateH1(ceed, CEED_TRIANGLE, 1, P, Q, interp, grad, qref,
+                    qweight, &bu);
+
+  // QFunction - setup mass
+  CeedQFunctionCreateInterior(ceed, 1, setup_mass, setup_mass_loc,
+                              &qf_setup_mass);
+  CeedQFunctionAddInput(qf_setup_mass, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup_mass, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_setup_mass, "qdata", 1, CEED_EVAL_NONE);
+
+  // Operator - setup mass
+  CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_mass);
+  CeedOperatorSetField(op_setup_mass, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_mass, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_mass, "qdata", Erestrictui,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // QFunction - setup diff
+  CeedQFunctionCreateInterior(ceed, 1, setup_diff, setup_diff_loc,
+                              &qf_setup_diff);
+  CeedQFunctionAddInput(qf_setup_diff, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_setup_diff, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_setup_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+
+  // Operator - setup diff
+  CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setup_diff);
+  CeedOperatorSetField(op_setup_diff, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_diff, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_diff, "qdata", Erestrictqi,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operators
+  CeedOperatorApply(op_setup_mass, X, qdata_mass, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup_diff, X, qdata_diff, CEED_REQUEST_IMMEDIATE);
+
+  // QFunction - apply
+  CeedQFunctionCreateInterior(ceed, 1, apply, apply_loc, &qf_apply);
+  CeedQFunctionAddInput(qf_apply, "du", dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_apply, "qdata_mass", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_apply, "qdata_diff", dim*(dim+1)/2, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_apply, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "v", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
+
+  // Operator - apply
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_apply);
+  CeedOperatorSetField(op_apply, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "qdata_mass", Erestrictui,
+                       CEED_BASIS_COLLOCATED, qdata_mass);
+  CeedOperatorSetField(op_apply, "qdata_diff", Erestrictqi,
+                       CEED_BASIS_COLLOCATED, qdata_diff);
+  CeedOperatorSetField(op_apply, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // Fully assemble operator
+  for (int k=0; k<ndofs*ndofs; ++k) {
+    assembled[k] = 0.0;
+    assembledTrue[k] = 0.0;
+  }
+  CeedInt nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedScalar *vals;
+  CeedOperatorLinearFullAssemble(op_apply, &nentries, &rows, &cols,
+                                 &vals);
+  for (int k=0; k<nentries; ++k) {
+    assembled[rows[k]*ndofs + cols[k]] += vals[k];
+  }
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, ndofs, &V);
+  for (int i=0; i<ndofs; i++) {
+    // Set input
+    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+    u[i] = 1.0;
+    if (i)
+      u[i-1] = 0.0;
+    CeedVectorRestoreArray(U, &u);
+
+    // Compute entries for column i
+    CeedOperatorApply(op_apply, U, V, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+    for (int k=0; k<ndofs; k++) {
+      assembledTrue[i*ndofs + k] = v[k];
+    }
+    CeedVectorRestoreArrayRead(V, &v);
+  }
+
+  // Check output
+  for (int i=0; i<ndofs; i++)
+    for (int j=0; j<ndofs; j++)
+      if (fabs(assembled[j*ndofs+i] - assembledTrue[j*ndofs+i]) > 1e-14)
+        // LCOV_EXCL_START
+        printf("[%d,%d] Error in assembly: %f != %f\n", i, j,
+               assembled[j*ndofs+i], assembledTrue[j*ndofs+i]);
+  // LCOV_EXCL_STOP
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  free(vals);
+  CeedQFunctionDestroy(&qf_setup_mass);
+  CeedQFunctionDestroy(&qf_setup_diff);
+  CeedQFunctionDestroy(&qf_apply);
+  CeedOperatorDestroy(&op_setup_mass);
+  CeedOperatorDestroy(&op_setup_diff);
+  CeedOperatorDestroy(&op_apply);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedElemRestrictionDestroy(&Erestrictqi);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&qdata_mass);
+  CeedVectorDestroy(&qdata_diff);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t563-operator.c
+++ b/tests/t563-operator.c
@@ -151,12 +151,16 @@ int main(int argc, char **argv) {
   CeedInt nentries;
   CeedInt *rows;
   CeedInt *cols;
-  CeedScalar *vals;
-  CeedOperatorLinearFullAssemble(op_apply, &nentries, &rows, &cols,
-                                 &vals);
+  CeedVector values;
+  CeedOperatorLinearAssembleSymbolic(op_apply, &nentries, &rows, &cols);
+  CeedVectorCreate(ceed, nentries, &values);
+  CeedOperatorLinearAssemble(op_apply, values);
+  const CeedScalar *vals;
+  CeedVectorGetArrayRead(values, CEED_MEM_HOST, &vals);
   for (int k=0; k<nentries; ++k) {
     assembled[rows[k]*ndofs + cols[k]] += vals[k];
   }
+  CeedVectorRestoreArrayRead(values, &vals);
 
   // Manually assemble operator
   CeedVectorCreate(ceed, ndofs, &U);
@@ -192,7 +196,7 @@ int main(int argc, char **argv) {
   // Cleanup
   free(rows);
   free(cols);
-  free(vals);
+  CeedVectorDestroy(&values);
   CeedQFunctionDestroy(&qf_setup_mass);
   CeedQFunctionDestroy(&qf_setup_diff);
   CeedQFunctionDestroy(&qf_apply);

--- a/tests/t564-operator.c
+++ b/tests/t564-operator.c
@@ -1,0 +1,165 @@
+/// @file
+/// Test assembly of mass matrix operator (multi-component) see t537
+/// \test Test assembly of mass matrix operator (multi-component)
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t537-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu,
+                      Erestrictui;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setup, qf_mass;
+  CeedOperator op_setup, op_mass;
+  CeedVector qdata, X, U, V;
+  CeedInt P = 3, Q = 4, dim = 2, ncomp = 2;
+  // CeedInt nx = 3, ny = 2;
+  CeedInt nx = 1, ny = 1;
+  CeedInt nelem = nx * ny;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q*Q;
+  CeedInt indx[nelem*P*P];
+  CeedScalar assembled[ncomp*ncomp*ndofs*ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ncomp*ncomp*ndofs*ndofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<nx*2+1; i++)
+    for (CeedInt j=0; j<ny*2+1; j++) {
+      x[i+j*(nx*2+1)+0*ndofs] = (CeedScalar) i / (2*nx);
+      x[i+j*(nx*2+1)+1*ndofs] = (CeedScalar) j / (2*ny);
+    }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vector
+  CeedVectorCreate(ceed, nqpts, &qdata);
+
+  // Element Setup
+  for (CeedInt i=0; i<nelem; i++) {
+    CeedInt col, row, offset;
+    col = i % nx;
+    row = i / nx;
+    offset = col*(P-1) + row*(nx*2+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        indx[P*(P*i+k)+j] = offset + k*(nx*2+1) + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, P*P, dim, ndofs, dim*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
+  CeedElemRestrictionCreate(ceed, nelem, P*P, ncomp, ndofs, ncomp*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictu);
+  CeedInt stridesu[3] = {1, Q*Q, Q*Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts, stridesu,
+                                   &Erestrictui);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, ncomp, P, Q, CEED_GAUSS, &bu);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "_weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", ncomp, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", ncomp, CEED_EVAL_INTERP);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
+  CeedOperatorSetField(op_setup, "_weight", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
+  CeedOperatorSetField(op_mass, "rho", Erestrictui, CEED_BASIS_COLLOCATED,
+                       qdata);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, X, qdata, CEED_REQUEST_IMMEDIATE);
+
+  // Fuly assemble operator
+  for (int k=0; k<ncomp*ncomp*ndofs*ndofs; ++k) {
+    assembled[k] = 0.0;
+    assembledTrue[k] = 0.0;
+  }
+  CeedInt nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedScalar *vals;
+  CeedOperatorLinearFullAssemble(op_mass, &nentries, &rows, &cols,
+                                 &vals);
+  for (int k=0; k<nentries; ++k) {
+    assembled[rows[k]*ncomp*ndofs + cols[k]] += vals[k];
+  }
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, ncomp*ndofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, ncomp*ndofs, &V);
+  CeedInt indOld = -1;
+  for (int j=0; j<ndofs*ncomp; j++) {
+    // Set input
+    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+    CeedInt ind = j;
+    u[ind] = 1.0;
+    if (ind > 0)
+      u[indOld] = 0.0;
+    indOld = ind;
+    CeedVectorRestoreArray(U, &u);
+
+    // Compute effect of DoF j
+    CeedOperatorApply(op_mass, U, V, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+    for (int k=0; k<ndofs*ncomp; k++) {
+      assembledTrue[j*ndofs*ncomp + k] = v[k];
+    }
+    CeedVectorRestoreArrayRead(V, &v);
+  }
+
+  // Check output
+  for (int i=0; i<ncomp*ndofs; i++)
+    for (int j=0; j<ncomp*ndofs; j++)
+      if (fabs(assembled[j*ndofs*ncomp+i] - assembledTrue[j*ndofs*ncomp+i]) > 1e-14)
+        // LCOV_EXCL_START
+        printf("[%d,%d] Error in assembly: %f != %f\n", i, j,
+               assembled[j*ndofs*ncomp+i], assembledTrue[j*ndofs*ncomp+i]);
+  // LCOV_EXCL_STOP
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  free(vals);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  // CeedVectorDestroy(&A);
+  CeedVectorDestroy(&qdata);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t565-operator.c
+++ b/tests/t565-operator.c
@@ -1,0 +1,202 @@
+/// @file
+/// Test full assembly of composite operator (see t538)
+/// \test Test full assembly of composite operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction Erestrictx, Erestrictu,
+                      Erestrictui, ErestrictqiMass, ErestrictqiDiff;
+  CeedBasis bx, bu;
+  CeedQFunction qf_setupMass, qf_mass, qf_setupDiff, qf_diff;
+  CeedOperator op_setupMass, op_mass, op_setupDiff, op_diff, op_apply;
+  CeedVector qdataMass, qdataDiff, X, U, V;
+  CeedInt P = 3, Q = 4, dim = 2;
+  CeedInt nx = 3, ny = 2;
+  CeedInt nelem = nx * ny;
+  CeedInt ndofs = (nx*2+1)*(ny*2+1), nqpts = nelem*Q*Q;
+  CeedInt indx[nelem*P*P];
+  CeedScalar assembled[ndofs*ndofs];
+  CeedScalar x[dim*ndofs], assembledTrue[ndofs*ndofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<nx*2+1; i++)
+    for (CeedInt j=0; j<ny*2+1; j++) {
+      x[i+j*(nx*2+1)+0*ndofs] = (CeedScalar) i / (2*nx);
+      x[i+j*(nx*2+1)+1*ndofs] = (CeedScalar) j / (2*ny);
+    }
+  CeedVectorCreate(ceed, dim*ndofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vectors
+  CeedVectorCreate(ceed, nqpts, &qdataMass);
+  CeedVectorCreate(ceed, nqpts*dim*(dim+1)/2, &qdataDiff);
+
+  // Element Setup
+  for (CeedInt i=0; i<nelem; i++) {
+    CeedInt col, row, offset;
+    col = i % nx;
+    row = i / nx;
+    offset = col*(P-1) + row*(nx*2+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        indx[P*(P*i+k)+j] = offset + k*(nx*2+1) + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, nelem, P*P, dim, ndofs, dim*ndofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, indx, &Erestrictx);
+
+  CeedElemRestrictionCreate(ceed, nelem, P*P, 1, 1, ndofs, CEED_MEM_HOST,
+                            CEED_USE_POINTER, indx, &Erestrictu);
+  CeedInt stridesu[3] = {1, Q*Q, Q*Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts, stridesu,
+                                   &Erestrictui);
+
+  CeedInt stridesqdMass[3] = {1, Q*Q, Q*Q};
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, 1, nqpts,
+                                   stridesqdMass, &ErestrictqiMass);
+  CeedInt stridesqdDiff[3] = {1, Q*Q, Q*Q*dim*(dim+1)/2}; /* *NOPAD* */
+  CeedElemRestrictionCreateStrided(ceed, nelem, Q*Q, dim*(dim+1)/2,
+                                   dim*(dim+1)/2*nqpts,
+                                   stridesqdDiff, &ErestrictqiDiff);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &bx);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P, Q, CEED_GAUSS, &bu);
+
+  // QFunction - setup mass
+  CeedQFunctionCreateInteriorByName(ceed, "Mass2DBuild", &qf_setupMass);
+
+  // Operator - setup mass
+  CeedOperatorCreate(ceed, qf_setupMass, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupMass);
+  CeedOperatorSetField(op_setupMass, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupMass, "weights", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupMass, "qdata", ErestrictqiMass,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // QFunction - setup diffusion
+  CeedQFunctionCreateInteriorByName(ceed, "Poisson2DBuild", &qf_setupDiff);
+
+  // Operator - setup diffusion
+  CeedOperatorCreate(ceed, qf_setupDiff, CEED_QFUNCTION_NONE,
+                     CEED_QFUNCTION_NONE, &op_setupDiff);
+  CeedOperatorSetField(op_setupDiff, "dx", Erestrictx, bx, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setupDiff, "weights", CEED_ELEMRESTRICTION_NONE, bx,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setupDiff, "qdata", ErestrictqiDiff,
+                       CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operators
+  CeedOperatorApply(op_setupMass, X, qdataMass, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setupDiff, X, qdataDiff, CEED_REQUEST_IMMEDIATE);
+
+  // QFunction - apply mass
+  CeedQFunctionCreateInteriorByName(ceed, "MassApply", &qf_mass);
+
+  // Operator - apply mass
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_mass);
+  CeedOperatorSetField(op_mass, "u", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "qdata", ErestrictqiMass, CEED_BASIS_COLLOCATED,
+                       qdataMass);
+  CeedOperatorSetField(op_mass, "v", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // QFunction - apply diff
+  CeedQFunctionCreateInteriorByName(ceed, "Poisson2DApply", &qf_diff);
+
+  // Operator - apply
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diff);
+  CeedOperatorSetField(op_diff, "du", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "qdata", ErestrictqiDiff, CEED_BASIS_COLLOCATED,
+                       qdataDiff);
+  CeedOperatorSetField(op_diff, "dv", Erestrictu, bu, CEED_VECTOR_ACTIVE);
+
+  // Composite operator
+  CeedCompositeOperatorCreate(ceed, &op_apply);
+  CeedCompositeOperatorAddSub(op_apply, op_mass);
+  CeedCompositeOperatorAddSub(op_apply, op_diff);
+
+  // Fully assemble operator
+  for (int k=0; k<ndofs*ndofs; ++k) {
+    assembled[k] = 0.0;
+    assembledTrue[k] = 0.0;
+  }
+  CeedInt nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedScalar *vals;
+  CeedOperatorLinearFullAssemble(op_apply, &nentries, &rows, &cols,
+                                 &vals);
+  for (int k=0; k<nentries; ++k) {
+    assembled[rows[k]*ndofs + cols[k]] += vals[k];
+  }
+
+  // Manually assemble diagonal
+  CeedVectorCreate(ceed, ndofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, ndofs, &V);
+  for (int i=0; i<ndofs; i++) {
+    // Set input
+    CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+    u[i] = 1.0;
+    if (i)
+      u[i-1] = 0.0;
+    CeedVectorRestoreArray(U, &u);
+
+    // Compute entries for column i
+    CeedOperatorApply(op_apply, U, V, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+    for (int k=0; k<ndofs; k++) {
+      assembledTrue[i*ndofs + k] = v[k];
+    }
+    CeedVectorRestoreArrayRead(V, &v);
+  }
+
+  // Check output
+  for (int i=0; i<ndofs; i++)
+    for (int j=0; j<ndofs; j++)
+      if (fabs(assembled[j*ndofs+i] - assembledTrue[j*ndofs+i]) > 1e-14)
+        // LCOV_EXCL_START
+        printf("[%d,%d] Error in assembly: %f != %f\n", i, j,
+               assembled[j*ndofs+i], assembledTrue[j*ndofs+i]);
+  // LCOV_EXCL_STOP
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  free(vals);
+  CeedQFunctionDestroy(&qf_setupMass);
+  CeedQFunctionDestroy(&qf_setupDiff);
+  CeedQFunctionDestroy(&qf_diff);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setupMass);
+  CeedOperatorDestroy(&op_setupDiff);
+  CeedOperatorDestroy(&op_mass);
+  CeedOperatorDestroy(&op_diff);
+  CeedOperatorDestroy(&op_apply);
+  CeedElemRestrictionDestroy(&Erestrictu);
+  CeedElemRestrictionDestroy(&Erestrictx);
+  CeedElemRestrictionDestroy(&Erestrictui);
+  CeedElemRestrictionDestroy(&ErestrictqiMass);
+  CeedElemRestrictionDestroy(&ErestrictqiDiff);
+  CeedBasisDestroy(&bu);
+  CeedBasisDestroy(&bx);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&qdataMass);
+  CeedVectorDestroy(&qdataDiff);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t565-operator.c
+++ b/tests/t565-operator.c
@@ -134,12 +134,16 @@ int main(int argc, char **argv) {
   CeedInt nentries;
   CeedInt *rows;
   CeedInt *cols;
-  CeedScalar *vals;
-  CeedOperatorLinearFullAssemble(op_apply, &nentries, &rows, &cols,
-                                 &vals);
+  CeedVector values;
+  CeedOperatorLinearAssembleSymbolic(op_apply, &nentries, &rows, &cols);
+  CeedVectorCreate(ceed, nentries, &values);
+  CeedOperatorLinearAssemble(op_apply, values);
+  const CeedScalar *vals;
+  CeedVectorGetArrayRead(values, CEED_MEM_HOST, &vals);
   for (int k=0; k<nentries; ++k) {
     assembled[rows[k]*ndofs + cols[k]] += vals[k];
   }
+  CeedVectorRestoreArrayRead(values, &vals);
 
   // Manually assemble diagonal
   CeedVectorCreate(ceed, ndofs, &U);
@@ -175,7 +179,7 @@ int main(int argc, char **argv) {
   // Cleanup
   free(rows);
   free(cols);
-  free(vals);
+  CeedVectorDestroy(&values);
   CeedQFunctionDestroy(&qf_setupMass);
   CeedQFunctionDestroy(&qf_setupDiff);
   CeedQFunctionDestroy(&qf_diff);


### PR DESCRIPTION
This PR introduces `CeedOperatorLinearFullAssemble()`, which is able to produce the full assembled matrix for fairly general `CeedOperator` objects. The output format is `(row, column, value)` triples which are intended to be added (not set) into whatever (probably sparse) matrix format the client code would like. This implementation is not intended to be very fast, and is a bad idea in general for high-order operators, but it may be useful in p-multigrid type algorithms where you may want to assemble and use traditional AMG when you get to low-order.

This also introduces tests `t560-operator.c` through `t565`, which correspond respectively to `t533` through `t538`. Note I have made no attempt to duplicate the Fortran versions of these tests, however.

I expect this will need some polishing and updating, but I've gotten about as far as I can with it by myself - I'm happy to do more but I may need some guidance from the libCEED experts.