### PR TITLE
Disable autodetection of HIP and CUDA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ noether-rocm:
 # OCCA v1.1.0
     - cd .. && export OCCA_VERSION=occa-1.1.0 OCCA_OPENCL_ENABLED=0 && { [[ -d $OCCA_VERSION ]] || { git clone --depth 1 --branch v1.1.0 https://github.com/libocca/occa.git $OCCA_VERSION && make -C $OCCA_VERSION -j$(nproc); }; } && make -C $OCCA_VERSION info && export OCCA_DIR=$PWD/$OCCA_VERSION && cd libCEED
 # libCEED
-    - make info
+    - make configure HIP_DIR=/opt/rocm OPT='-O -march=native -ffp-contract=fast'
     - BACKENDS_CPU=$(make info-backends | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
     - make -j$NPROC_CPU
     - echo '[{"subject":"/","metrics":[{"name":"Transfer Size (KB)","value":"19.5","desiredSize":"smaller"},{"name":"Speed Index","value":0,"desiredSize":"smaller"},{"name":"Total Score","value":92,"desiredSize":"larger"},{"name":"Requests","value":4,"desiredSize":"smaller"}]}]' > performance.json

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,13 @@ OCCA_DIR ?= ../occa
 
 # env variable MAGMA_DIR can be used too
 MAGMA_DIR ?= ../magma
-# If CUDA_DIR is not set, check for nvcc, or resort to /usr/local/cuda
-CUDA_DIR  ?= $(or $(patsubst %/,%,$(dir $(patsubst %/,%,$(dir \
-               $(shell which nvcc 2> /dev/null))))),/usr/local/cuda)
+
+# Often /opt/cuda or /usr/local/cuda, but sometimes present on machines that don't support HIP
+CUDA_DIR  ?=
 CUDA_ARCH ?= 
-HIP_DIR ?= /opt/rocm
+
+# Often /opt/rocm, but sometimes present on machines that don't support HIP
+HIP_DIR ?=
 HIP_ARCH ?=
 
 # Check for PETSc in ../petsc

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,15 @@ or::
 if your compiler does not support gcc-style options, if you are cross
 compiling, etc.
 
+To enable CUDA support, add ``CUDA_DIR=/opt/cuda`` or an appropriate directory
+to your ``make`` invocation. To enable HIP support, add ``HIP_DIR=/opt/rocm`` or
+an appropriate directory. To store these or other arguments as defaults for
+future invocations of ``make``, use::
+
+    make configure CUDA_DIR=/usr/local/cuda HIP_DIR=/opt/rocm OPT='-O3 -march=znver2'
+
+which stores these variables in ``config.mk``.
+
 Additional Language Interfaces
 ----------------------------------------
 


### PR DESCRIPTION
Some machines, especially HPC machines with shared filesystems (e.g., at
LLNL) have CUDA and/or HIP compilation stacks despite no such devices.
Autodetection produces confusing errors in such environments, so we
disable them and require explicitly setting CUDA_DIR and/or HIP_DIR to
locate them (picked up automatically from the environment if present).
Document this behavior.

Reported-by: Natalie Beams <nbeams@icl.utk.edu>