### PR TITLE
Copy Ceed Object References

### DIFF
--- a/.github/workflows/rust-test-with-style.yml
+++ b/.github/workflows/rust-test-with-style.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        compiler: [gcc-10]
+        compiler: [clang]
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        compiler: [gcc-9]
+        compiler: [clang]
 
     runs-on: ${{ matrix.os }}
 

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -306,17 +306,6 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem,
 }
 
 //------------------------------------------------------------------------------
-// Basis Destroy Non-Tensor
-//------------------------------------------------------------------------------
-static int CeedBasisDestroyNonTensor_Ref(CeedBasis basis) {
-  int ierr;
-  CeedTensorContract contract;
-  ierr = CeedBasisGetTensorContract(basis, &contract); CeedChkBackend(ierr);
-  ierr = CeedTensorContractDestroy(&contract); CeedChkBackend(ierr);
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Basis Create Non-Tensor
 //------------------------------------------------------------------------------
 int CeedBasisCreateH1_Ref(CeedElemTopology topo, CeedInt dim,
@@ -334,12 +323,10 @@ int CeedBasisCreateH1_Ref(CeedElemTopology topo, CeedInt dim,
   ierr = CeedGetParent(ceed, &parent); CeedChkBackend(ierr);
   CeedTensorContract contract;
   ierr = CeedTensorContractCreate(parent, basis, &contract); CeedChkBackend(ierr);
-  ierr = CeedBasisSetTensorContract(basis, &contract); CeedChkBackend(ierr);
+  ierr = CeedBasisSetTensorContract(basis, contract); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
                                 CeedBasisApply_Ref); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Destroy",
-                                CeedBasisDestroyNonTensor_Ref); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -349,9 +336,6 @@ int CeedBasisCreateH1_Ref(CeedElemTopology topo, CeedInt dim,
 //------------------------------------------------------------------------------
 static int CeedBasisDestroyTensor_Ref(CeedBasis basis) {
   int ierr;
-  CeedTensorContract contract;
-  ierr = CeedBasisGetTensorContract(basis, &contract); CeedChkBackend(ierr);
-  ierr = CeedTensorContractDestroy(&contract); CeedChkBackend(ierr);
 
   CeedBasis_Ref *impl;
   ierr = CeedBasisGetData(basis, &impl); CeedChkBackend(ierr);
@@ -398,7 +382,7 @@ int CeedBasisCreateTensorH1_Ref(CeedInt dim, CeedInt P_1d,
   ierr = CeedGetParent(ceed, &parent); CeedChkBackend(ierr);
   CeedTensorContract contract;
   ierr = CeedTensorContractCreate(parent, basis, &contract); CeedChkBackend(ierr);
-  ierr = CeedBasisSetTensorContract(basis, &contract); CeedChkBackend(ierr);
+  ierr = CeedBasisSetTensorContract(basis, contract); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Basis", basis, "Apply",
                                 CeedBasisApply_Ref); CeedChkBackend(ierr);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -93,12 +93,14 @@ CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
                                        const char *func_name, int (*f)());
 CEED_EXTERN int CeedGetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedSetData(Ceed ceed, void *data);
+CEED_EXTERN int CeedIncrementRefCounter(Ceed ceed);
 
 CEED_EXTERN int CeedVectorGetCeed(CeedVector vec, Ceed *ceed);
 CEED_EXTERN int CeedVectorGetState(CeedVector vec, uint64_t *state);
 CEED_EXTERN int CeedVectorAddReference(CeedVector vec);
 CEED_EXTERN int CeedVectorGetData(CeedVector vec, void *data);
 CEED_EXTERN int CeedVectorSetData(CeedVector vec, void *data);
+CEED_EXTERN int CeedVectorIncrementRefCounter(CeedVector vec);
 
 CEED_EXTERN int CeedElemRestrictionGetCeed(CeedElemRestriction rstr,
     Ceed *ceed);
@@ -120,6 +122,7 @@ CEED_EXTERN int CeedElemRestrictionGetData(CeedElemRestriction rstr,
     void *data);
 CEED_EXTERN int CeedElemRestrictionSetData(CeedElemRestriction rstr,
     void *data);
+CEED_EXTERN int CeedElemRestrictionIncrementRefCounter(CeedElemRestriction rstr);
 
 CEED_EXTERN int CeedBasisGetCollocatedGrad(CeedBasis basis,
     CeedScalar *colo_grad_1d);
@@ -130,6 +133,7 @@ CEED_EXTERN int CeedBasisGetCeed(CeedBasis basis, Ceed *ceed);
 CEED_EXTERN int CeedBasisIsTensor(CeedBasis basis, bool *is_tensor);
 CEED_EXTERN int CeedBasisGetData(CeedBasis basis, void *data);
 CEED_EXTERN int CeedBasisSetData(CeedBasis basis, void *data);
+CEED_EXTERN int CeedBasisIncrementRefCounter(CeedBasis basis);
 
 CEED_EXTERN int CeedBasisGetTopologyDimension(CeedElemTopology topo,
     CeedInt *dim);
@@ -137,7 +141,7 @@ CEED_EXTERN int CeedBasisGetTopologyDimension(CeedElemTopology topo,
 CEED_EXTERN int CeedBasisGetTensorContract(CeedBasis basis,
     CeedTensorContract *contract);
 CEED_EXTERN int CeedBasisSetTensorContract(CeedBasis basis,
-    CeedTensorContract *contract);
+    CeedTensorContract contract);
 CEED_EXTERN int CeedTensorContractCreate(Ceed ceed, CeedBasis basis,
     CeedTensorContract *contract);
 CEED_EXTERN int CeedTensorContractApply(CeedTensorContract contract, CeedInt A,
@@ -153,6 +157,7 @@ CEED_EXTERN int CeedTensorContractGetData(CeedTensorContract contract,
     void *data);
 CEED_EXTERN int CeedTensorContractSetData(CeedTensorContract contract,
     void *data);
+CEED_EXTERN int CeedTensorContractIncrementRefCounter(CeedTensorContract contract);
 CEED_EXTERN int CeedTensorContractDestroy(CeedTensorContract *contract);
 
 CEED_EXTERN int CeedQFunctionRegister(const char *, const char *, CeedInt,
@@ -174,6 +179,7 @@ CEED_EXTERN int CeedQFunctionGetInnerContext(CeedQFunction qf,
 CEED_EXTERN int CeedQFunctionIsIdentity(CeedQFunction qf, bool *is_identity);
 CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void *data);
 CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void *data);
+CEED_EXTERN int CeedQFunctionIncrementRefCounter(CeedQFunction qf);
 CEED_EXTERN int CeedQFunctionGetFields(CeedQFunction qf,
                                        CeedQFunctionField **input_fields,
                                        CeedQFunctionField **output_fields);
@@ -194,6 +200,7 @@ CEED_EXTERN int CeedQFunctionContextGetBackendData(CeedQFunctionContext ctx,
     void *data);
 CEED_EXTERN int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx,
     void *data);
+CEED_EXTERN int CeedQFunctionContextIncrementRefCounter(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem);
@@ -208,6 +215,7 @@ CEED_EXTERN int CeedOperatorGetSubList(CeedOperator op,
                                        CeedOperator **sub_operators);
 CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void *data);
 CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void *data);
+CEED_EXTERN int CeedOperatorIncrementRefCounter(CeedOperator op);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
 CEED_EXTERN int CeedOperatorGetFields(CeedOperator op,

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -93,14 +93,14 @@ CEED_EXTERN int CeedSetBackendFunction(Ceed ceed,
                                        const char *func_name, int (*f)());
 CEED_EXTERN int CeedGetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedSetData(Ceed ceed, void *data);
-CEED_EXTERN int CeedIncrementRefCounter(Ceed ceed);
+CEED_EXTERN int CeedReference(Ceed ceed);
 
 CEED_EXTERN int CeedVectorGetCeed(CeedVector vec, Ceed *ceed);
 CEED_EXTERN int CeedVectorGetState(CeedVector vec, uint64_t *state);
 CEED_EXTERN int CeedVectorAddReference(CeedVector vec);
 CEED_EXTERN int CeedVectorGetData(CeedVector vec, void *data);
 CEED_EXTERN int CeedVectorSetData(CeedVector vec, void *data);
-CEED_EXTERN int CeedVectorIncrementRefCounter(CeedVector vec);
+CEED_EXTERN int CeedVectorReference(CeedVector vec);
 
 CEED_EXTERN int CeedElemRestrictionGetCeed(CeedElemRestriction rstr,
     Ceed *ceed);
@@ -122,7 +122,7 @@ CEED_EXTERN int CeedElemRestrictionGetData(CeedElemRestriction rstr,
     void *data);
 CEED_EXTERN int CeedElemRestrictionSetData(CeedElemRestriction rstr,
     void *data);
-CEED_EXTERN int CeedElemRestrictionIncrementRefCounter(CeedElemRestriction rstr);
+CEED_EXTERN int CeedElemRestrictionReference(CeedElemRestriction rstr);
 
 CEED_EXTERN int CeedBasisGetCollocatedGrad(CeedBasis basis,
     CeedScalar *colo_grad_1d);
@@ -133,7 +133,7 @@ CEED_EXTERN int CeedBasisGetCeed(CeedBasis basis, Ceed *ceed);
 CEED_EXTERN int CeedBasisIsTensor(CeedBasis basis, bool *is_tensor);
 CEED_EXTERN int CeedBasisGetData(CeedBasis basis, void *data);
 CEED_EXTERN int CeedBasisSetData(CeedBasis basis, void *data);
-CEED_EXTERN int CeedBasisIncrementRefCounter(CeedBasis basis);
+CEED_EXTERN int CeedBasisReference(CeedBasis basis);
 
 CEED_EXTERN int CeedBasisGetTopologyDimension(CeedElemTopology topo,
     CeedInt *dim);
@@ -157,7 +157,7 @@ CEED_EXTERN int CeedTensorContractGetData(CeedTensorContract contract,
     void *data);
 CEED_EXTERN int CeedTensorContractSetData(CeedTensorContract contract,
     void *data);
-CEED_EXTERN int CeedTensorContractIncrementRefCounter(CeedTensorContract contract);
+CEED_EXTERN int CeedTensorContractReference(CeedTensorContract contract);
 CEED_EXTERN int CeedTensorContractDestroy(CeedTensorContract *contract);
 
 CEED_EXTERN int CeedQFunctionRegister(const char *, const char *, CeedInt,
@@ -179,7 +179,7 @@ CEED_EXTERN int CeedQFunctionGetInnerContext(CeedQFunction qf,
 CEED_EXTERN int CeedQFunctionIsIdentity(CeedQFunction qf, bool *is_identity);
 CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void *data);
 CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void *data);
-CEED_EXTERN int CeedQFunctionIncrementRefCounter(CeedQFunction qf);
+CEED_EXTERN int CeedQFunctionReference(CeedQFunction qf);
 CEED_EXTERN int CeedQFunctionGetFields(CeedQFunction qf,
                                        CeedQFunctionField **input_fields,
                                        CeedQFunctionField **output_fields);
@@ -200,7 +200,7 @@ CEED_EXTERN int CeedQFunctionContextGetBackendData(CeedQFunctionContext ctx,
     void *data);
 CEED_EXTERN int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx,
     void *data);
-CEED_EXTERN int CeedQFunctionContextIncrementRefCounter(CeedQFunctionContext ctx);
+CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem);
@@ -215,7 +215,7 @@ CEED_EXTERN int CeedOperatorGetSubList(CeedOperator op,
                                        CeedOperator **sub_operators);
 CEED_EXTERN int CeedOperatorGetData(CeedOperator op, void *data);
 CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void *data);
-CEED_EXTERN int CeedOperatorIncrementRefCounter(CeedOperator op);
+CEED_EXTERN int CeedOperatorReference(CeedOperator op);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
 CEED_EXTERN int CeedOperatorGetFields(CeedOperator op,

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -150,6 +150,7 @@ typedef struct CeedOperator_private *CeedOperator;
 
 CEED_EXTERN int CeedRegistryGetList(size_t *n, char ***const resources, CeedInt **array);
 CEED_EXTERN int CeedInit(const char *resource, Ceed *ceed);
+CEED_EXTERN int CeedReferenceCopy(Ceed ceed, Ceed *ceed_copy);
 CEED_EXTERN int CeedGetResource(Ceed ceed, const char **resource);
 CEED_EXTERN int CeedIsDeterministic(Ceed ceed, bool *is_deterministic);
 CEED_EXTERN int CeedView(Ceed ceed, FILE *stream);
@@ -304,6 +305,7 @@ typedef enum {
 CEED_EXTERN const char *const CeedCopyModes[];
 
 CEED_EXTERN int CeedVectorCreate(Ceed ceed, CeedInt len, CeedVector *vec);
+CEED_EXTERN int CeedVectorReferenceCopy(CeedVector vec, CeedVector *vec_copy);
 CEED_EXTERN int CeedVectorSetArray(CeedVector vec, CeedMemType mem_type,
                                    CeedCopyMode copy_mode, CeedScalar *array);
 CEED_EXTERN int CeedVectorSetValue(CeedVector vec, CeedScalar value);
@@ -386,6 +388,8 @@ CEED_EXTERN int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem,
 CEED_EXTERN int CeedElemRestrictionCreateBlockedStrided(Ceed ceed,
     CeedInt num_elem, CeedInt elem_size, CeedInt blk_size, CeedInt num_comp,
     CeedInt l_size, const CeedInt strides[3], CeedElemRestriction *rstr);
+CEED_EXTERN int CeedElemRestrictionReferenceCopy(CeedElemRestriction rstr,
+    CeedElemRestriction *rstr_copy);
 CEED_EXTERN int CeedElemRestrictionCreateVector(CeedElemRestriction rstr,
     CeedVector *lvec, CeedVector *evec);
 CEED_EXTERN int CeedElemRestrictionApply(CeedElemRestriction rstr,
@@ -489,6 +493,7 @@ CEED_EXTERN int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo,
                                   const CeedScalar *grad,
                                   const CeedScalar *q_ref,
                                   const CeedScalar *q_weights, CeedBasis *basis);
+CEED_EXTERN int CeedBasisReferenceCopy(CeedBasis basis, CeedBasis *basis_copy);
 CEED_EXTERN int CeedBasisView(CeedBasis basis, FILE *stream);
 CEED_EXTERN int CeedBasisApply(CeedBasis basis, CeedInt num_elem,
                                CeedTransposeMode t_mode,
@@ -554,6 +559,7 @@ CEED_EXTERN int CeedQFunctionCreateInteriorByName(Ceed ceed, const char *name,
     CeedQFunction *qf);
 CEED_EXTERN int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size,
     CeedEvalMode in_mode, CeedEvalMode out_mode, CeedQFunction *qf);
+CEED_EXTERN int CeedQFunctionReferenceCopy(CeedQFunction qf, CeedQFunction *qf_copy);
 CEED_EXTERN int CeedQFunctionAddInput(CeedQFunction qf, const char *field_name,
                                       CeedInt size, CeedEvalMode eval_mode);
 CEED_EXTERN int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name,
@@ -567,6 +573,8 @@ CEED_EXTERN int CeedQFunctionDestroy(CeedQFunction *qf);
 
 CEED_EXTERN int CeedQFunctionContextCreate(Ceed ceed,
     CeedQFunctionContext *ctx);
+CEED_EXTERN int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx,
+    CeedQFunctionContext *ctx_copy);
 CEED_EXTERN int CeedQFunctionContextSetData(CeedQFunctionContext ctx,
     CeedMemType mem_type, CeedCopyMode copy_mode, size_t size, void *data);
 CEED_EXTERN int CeedQFunctionContextGetData(CeedQFunctionContext ctx,
@@ -582,6 +590,7 @@ CEED_EXTERN int CeedOperatorCreate(Ceed ceed, CeedQFunction qf,
                                    CeedQFunction dqf, CeedQFunction dqfT,
                                    CeedOperator *op);
 CEED_EXTERN int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op);
+CEED_EXTERN int CeedOperatorReferenceCopy(CeedOperator op, CeedOperator *op_copy);
 CEED_EXTERN int CeedOperatorSetField(CeedOperator op, const char *field_name,
                                      CeedElemRestriction r, CeedBasis b,
                                      CeedVector v);

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -304,7 +304,7 @@ int CeedBasisSetData(CeedBasis basis, void *data) {
 
   @ref Backend
 **/
-int CeedBasisIncrementRefCounter(CeedBasis basis) {
+int CeedBasisReference(CeedBasis basis) {
   basis->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
@@ -352,7 +352,7 @@ int CeedBasisGetTensorContract(CeedBasis basis, CeedTensorContract *contract) {
 int CeedBasisSetTensorContract(CeedBasis basis, CeedTensorContract contract) {
   int ierr;
   basis->contract = contract;
-  ierr = CeedTensorContractIncrementRefCounter(contract); CeedChk(ierr);
+  ierr = CeedTensorContractReference(contract); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
 }
 
@@ -451,7 +451,7 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt num_comp,
 
   ierr = CeedCalloc(1, basis); CeedChk(ierr);
   (*basis)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*basis)->ref_count = 1;
   (*basis)->tensor_basis = 1;
   (*basis)->dim = dim;
@@ -612,7 +612,7 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp,
   ierr = CeedBasisGetTopologyDimension(topo, &dim); CeedChk(ierr);
 
   (*basis)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*basis)->ref_count = 1;
   (*basis)->tensor_basis = 0;
   (*basis)->dim = dim;
@@ -630,6 +630,30 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp,
   memcpy((*basis)->grad, grad, dim*Q*P*sizeof(grad[0]));
   ierr = ceed->BasisCreateH1(topo, dim, P, Q, interp, grad, q_ref,
                              q_weight, *basis); CeedChk(ierr);
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Copy the pointer to a CeedBasis. Both pointers should
+           be destroyed with `CeedBasisDestroy()`;
+           Note: If `*basis_copy` is non-NULL, then it is assumed that
+           `*basis_copy` is a pointer to a CeedBasis. This CeedBasis
+           will be destroyed if `*basis_copy` is the only
+           reference to this CeedBasis.
+
+  @param basis            CeedBasis to copy reference to
+  @param[out] basis_copy  Variable to store copied reference
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedBasisReferenceCopy(CeedBasis basis, CeedBasis *basis_copy) {
+  int ierr;
+
+  ierr = CeedBasisReference(basis); CeedChk(ierr);
+  ierr = CeedBasisDestroy(basis_copy); CeedChk(ierr);
+  *basis_copy = basis;
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -280,7 +280,7 @@ int CeedElemRestrictionSetData(CeedElemRestriction rstr, void *data) {
 
   @ref Backend
 **/
-int CeedElemRestrictionIncrementRefCounter(CeedElemRestriction rstr) {
+int CeedElemRestrictionReference(CeedElemRestriction rstr) {
   rstr->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
@@ -358,7 +358,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size,
 
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
   (*rstr)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -421,7 +421,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem,
 
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
   (*rstr)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -506,7 +506,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem,
                                elem_size); CeedChk(ierr);
 
   (*rstr)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -572,7 +572,7 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem,
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
 
   (*rstr)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -585,6 +585,31 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem,
     (*rstr)->strides[i] = strides[i];
   ierr = ceed->ElemRestrictionCreateBlocked(CEED_MEM_HOST, CEED_OWN_POINTER,
          NULL, *rstr); CeedChk(ierr);
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Copy the pointer to a CeedElemRestriction. Both pointers should
+           be destroyed with `CeedElemRestrictionDestroy()`;
+           Note: If `*rstr_copy` is non-NULL, then it is assumed that
+           `*rstr_copy` is a pointer to a CeedElemRestriction. This
+           CeedElemRestriction will be destroyed if `*rstr_copy` is the
+           only reference to this CeedElemRestriction.
+
+  @param rstr            CeedElemRestriction to copy reference to
+  @param[out] rstr_copy  Variable to store copied reference
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedElemRestrictionReferenceCopy(CeedElemRestriction rstr,
+                                     CeedElemRestriction *rstr_copy) {
+  int ierr;
+
+  ierr = CeedElemRestrictionReference(rstr); CeedChk(ierr);
+  ierr = CeedElemRestrictionDestroy(rstr_copy); CeedChk(ierr);
+  *rstr_copy = rstr;
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -271,6 +271,20 @@ int CeedElemRestrictionSetData(CeedElemRestriction rstr, void *data) {
   return CEED_ERROR_SUCCESS;
 }
 
+/**
+  @brief Increment the reference counter for a CeedElemRestriction
+
+  @param rstr  ElemRestriction to increment the reference counter
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedElemRestrictionIncrementRefCounter(CeedElemRestriction rstr) {
+  rstr->ref_count++;
+  return CEED_ERROR_SUCCESS;
+}
+
 /// @}
 
 /// @cond DOXYGEN_SKIP
@@ -344,7 +358,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size,
 
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
   (*rstr)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -407,7 +421,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem,
 
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
   (*rstr)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -492,7 +506,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem,
                                elem_size); CeedChk(ierr);
 
   (*rstr)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;
@@ -558,7 +572,7 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem,
   ierr = CeedCalloc(1, rstr); CeedChk(ierr);
 
   (*rstr)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*rstr)->ref_count = 1;
   (*rstr)->num_elem = num_elem;
   (*rstr)->elem_size = elem_size;

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -348,7 +348,7 @@ int CeedQFunctionSetData(CeedQFunction qf, void *data) {
 
   @ref Backend
 **/
-int CeedQFunctionIncrementRefCounter(CeedQFunction qf) {
+int CeedQFunctionReference(CeedQFunction qf) {
   qf->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
@@ -470,7 +470,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length,
 
   ierr = CeedCalloc(1, qf); CeedChk(ierr);
   (*qf)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*qf)->ref_count = 1;
   (*qf)->vec_length = vec_length;
   (*qf)->identity = 0;
@@ -589,6 +589,30 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode in_mode,
 }
 
 /**
+  @brief Copy the pointer to a CeedQFunction. Both pointers should
+           be destroyed with `CeedQFunctionDestroy()`;
+           Note: If `*qf_copy` is non-NULL, then it is assumed that
+           `*qf_copy` is a pointer to a CeedQFunction. This
+           CeedQFunction will be destroyed if `*qf_copy` is the only
+           reference to this CeedQFunction.
+
+  @param qf            CeedQFunction to copy reference to
+  @param[out] qf_copy  Variable to store copied reference
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionReferenceCopy(CeedQFunction qf, CeedQFunction *qf_copy) {
+  int ierr;
+
+  ierr = CeedQFunctionReference(qf); CeedChk(ierr);
+  ierr = CeedQFunctionDestroy(qf_copy); CeedChk(ierr);
+  *qf_copy = qf;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Add a CeedQFunction input
 
   @param qf          CeedQFunction
@@ -671,7 +695,7 @@ int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name,
 int CeedQFunctionSetContext(CeedQFunction qf, CeedQFunctionContext ctx) {
   int ierr;
   qf->ctx = ctx;
-  ierr = CeedQFunctionContextIncrementRefCounter(ctx); CeedChk(ierr);
+  ierr = CeedQFunctionContextReference(ctx); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -340,6 +340,20 @@ int CeedQFunctionSetData(CeedQFunction qf, void *data) {
 }
 
 /**
+  @brief Increment the reference counter for a CeedQFunction
+
+  @param qf  CeedQFunction to increment the reference counter
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionIncrementRefCounter(CeedQFunction qf) {
+  qf->ref_count++;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Get the CeedQFunctionFields of a CeedQFunction
 
   @param qf                  CeedQFunction
@@ -456,7 +470,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length,
 
   ierr = CeedCalloc(1, qf); CeedChk(ierr);
   (*qf)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*qf)->ref_count = 1;
   (*qf)->vec_length = vec_length;
   (*qf)->identity = 0;
@@ -655,8 +669,9 @@ int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name,
   @ref User
 **/
 int CeedQFunctionSetContext(CeedQFunction qf, CeedQFunctionContext ctx) {
+  int ierr;
   qf->ctx = ctx;
-  ctx->ref_count++;
+  ierr = CeedQFunctionContextIncrementRefCounter(ctx); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -105,6 +105,20 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
   return CEED_ERROR_SUCCESS;
 }
 
+/**
+  @brief Increment the reference counter for a CeedQFunctionContext
+
+  @param ctx  CeedQFunctionContext to increment the reference counter
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextIncrementRefCounter(CeedQFunctionContext ctx) {
+  ctx->ref_count++;
+  return CEED_ERROR_SUCCESS;
+}
+
 /// @}
 
 /// ----------------------------------------------------------------------------
@@ -143,7 +157,7 @@ int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
 
   ierr = CeedCalloc(1, ctx); CeedChk(ierr);
   (*ctx)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*ctx)->ref_count = 1;
   ierr = ceed->QFunctionContextCreate(*ctx); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -114,7 +114,7 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
 
   @ref Backend
 **/
-int CeedQFunctionContextIncrementRefCounter(CeedQFunctionContext ctx) {
+int CeedQFunctionContextReference(CeedQFunctionContext ctx) {
   ctx->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
@@ -157,9 +157,34 @@ int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
 
   ierr = CeedCalloc(1, ctx); CeedChk(ierr);
   (*ctx)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*ctx)->ref_count = 1;
   ierr = ceed->QFunctionContextCreate(*ctx); CeedChk(ierr);
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Copy the pointer to a CeedQFunctionContext. Both pointers should
+           be destroyed with `CeedQFunctionContextDestroy()`;
+           Note: If `*ctx_copy` is non-NULL, then it is assumed that
+           `*ctx_copy` is a pointer to a CeedQFunctionContext. This
+           CeedQFunctionContext will be destroyed if `*ctx_copy` is the
+           only reference to this CeedQFunctionContext.
+
+  @param ctx            CeedQFunctionContext to copy reference to
+  @param[out] ctx_copy  Variable to store copied reference
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx,
+                                      CeedQFunctionContext *ctx_copy) {
+  int ierr;
+
+  ierr = CeedQFunctionContextReference(ctx); CeedChk(ierr);
+  ierr = CeedQFunctionContextDestroy(ctx_copy); CeedChk(ierr);
+  *ctx_copy = ctx;
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -62,7 +62,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedBasis basis,
   ierr = CeedCalloc(1, contract); CeedChk(ierr);
 
   (*contract)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   ierr = ceed->TensorContractCreate(basis, *contract);
   CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
@@ -158,7 +158,7 @@ int CeedTensorContractSetData(CeedTensorContract contract, void *data) {
 
   @ref Backend
 **/
-int CeedTensorContractIncrementRefCounter(CeedTensorContract contract) {
+int CeedTensorContractReference(CeedTensorContract contract) {
   contract->ref_count++;
   return CEED_ERROR_SUCCESS;
 }

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -62,7 +62,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedBasis basis,
   ierr = CeedCalloc(1, contract); CeedChk(ierr);
 
   (*contract)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   ierr = ceed->TensorContractCreate(basis, *contract);
   CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
@@ -146,6 +146,20 @@ int CeedTensorContractGetData(CeedTensorContract contract, void *data) {
 **/
 int CeedTensorContractSetData(CeedTensorContract contract, void *data) {
   contract->data = data;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Increment the reference counter for a CeedTensorContract
+
+  @param contract  CeedTensorContract to increment the reference counter
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedTensorContractIncrementRefCounter(CeedTensorContract contract) {
+  contract->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -121,6 +121,20 @@ int CeedVectorSetData(CeedVector vec, void *data) {
   return CEED_ERROR_SUCCESS;
 }
 
+/**
+  @brief Increment the reference counter for a CeedVector
+
+  @param vec  CeedVector to increment the reference counter
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedVectorIncrementRefCounter(CeedVector vec) {
+  vec->ref_count++;
+  return CEED_ERROR_SUCCESS;
+}
+
 /// @}
 
 /// ----------------------------------------------------------------------------
@@ -160,7 +174,7 @@ int CeedVectorCreate(Ceed ceed, CeedInt length, CeedVector *vec) {
 
   ierr = CeedCalloc(1, vec); CeedChk(ierr);
   (*vec)->ceed = ceed;
-  ceed->ref_count++;
+  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
   (*vec)->ref_count = 1;
   (*vec)->length = length;
   (*vec)->state = 0;

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -130,7 +130,7 @@ int CeedVectorSetData(CeedVector vec, void *data) {
 
   @ref Backend
 **/
-int CeedVectorIncrementRefCounter(CeedVector vec) {
+int CeedVectorReference(CeedVector vec) {
   vec->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
@@ -174,11 +174,35 @@ int CeedVectorCreate(Ceed ceed, CeedInt length, CeedVector *vec) {
 
   ierr = CeedCalloc(1, vec); CeedChk(ierr);
   (*vec)->ceed = ceed;
-  ierr = CeedIncrementRefCounter(ceed); CeedChk(ierr);
+  ierr = CeedReference(ceed); CeedChk(ierr);
   (*vec)->ref_count = 1;
   (*vec)->length = length;
   (*vec)->state = 0;
   ierr = ceed->VectorCreate(length, *vec); CeedChk(ierr);
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Copy the pointer to a CeedVector. Both pointers should
+           be destroyed with `CeedVectorDestroy()`;
+           Note: If `*vec_copy` is non-NULL, then it is assumed that
+           `*vec_copy` is a pointer to a CeedVector. This
+           CeedVector will be destroyed if `*vec_copy` is the only
+           reference to this CeedVector.
+
+  @param vec            CeedVector to copy reference to
+  @param[out] vec_copy  Variable to store copied reference
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedVectorReferenceCopy(CeedVector vec, CeedVector *vec_copy) {
+  int ierr;
+
+  ierr = CeedVectorReference(vec); CeedChk(ierr);
+  ierr = CeedVectorDestroy(vec_copy); CeedChk(ierr);
+  *vec_copy = vec;
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -586,6 +586,20 @@ int CeedSetData(Ceed ceed, void *data) {
   return CEED_ERROR_SUCCESS;
 }
 
+/**
+  @brief Increment the reference counter for a Ceed context
+
+  @param ceed  Ceed context to increment the reference counter
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedIncrementRefCounter(Ceed ceed) {
+  ceed->ref_count++;
+  return CEED_ERROR_SUCCESS;
+}
+
 /// @}
 
 /// ----------------------------------------------------------------------------

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -595,7 +595,7 @@ int CeedSetData(Ceed ceed, void *data) {
 
   @ref Backend
 **/
-int CeedIncrementRefCounter(Ceed ceed) {
+int CeedReference(Ceed ceed) {
   ceed->ref_count++;
   return CEED_ERROR_SUCCESS;
 }
@@ -825,6 +825,30 @@ int CeedInit(const char *resource, Ceed *ceed) {
 }
 
 /**
+  @brief Copy the pointer to a Ceed context. Both pointers should
+           be destroyed with `CeedDestroy()`;
+           Note: If `*ceed_copy` is non-NULL, then it is assumed that
+           `*ceed_copy` is a pointer to a Ceed context. This Ceed
+           context will be destroyed if `*ceed_copy` is the only
+           reference to this Ceed context.
+
+  @param ceed            Ceed context to copy reference to
+  @param[out] ceed_copy  Variable to store copied reference
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedReferenceCopy(Ceed ceed, Ceed *ceed_copy) {
+  int ierr;
+
+  ierr = CeedReference(ceed); CeedChk(ierr);
+  ierr = CeedDestroy(ceed_copy); CeedChk(ierr);
+  *ceed_copy = ceed;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Get the full resource name for a Ceed context
 
   @param ceed           Ceed context to get resource name of
@@ -834,7 +858,6 @@ int CeedInit(const char *resource, Ceed *ceed) {
 
   @ref User
 **/
-
 int CeedGetResource(Ceed ceed, const char **resource) {
   *resource = (const char *)ceed->resource;
   return CEED_ERROR_SUCCESS;

--- a/tests/t009-ceed.c
+++ b/tests/t009-ceed.c
@@ -1,0 +1,25 @@
+/// @file
+/// Test creation, copying, and destruction of a CEED object
+/// \test Test creation, copying, and destruction of a CEED object
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed, ceed_2;
+
+  CeedInit(argv[1], &ceed);
+  CeedInit("/cpu/self/ref/serial", &ceed_2);
+
+  CeedReferenceCopy(ceed, &ceed_2); // This destroys the previous ceed_2
+  if (ceed != ceed_2)
+    // LCOV_EXCL_START
+    printf("Error copying Ceed reference.");
+  // LCOV_EXCL_STOP
+
+  CeedDestroy(&ceed);
+
+  CeedMemType type;
+  CeedGetPreferredMemType(ceed_2, &type); // Second reference still valid
+
+  CeedDestroy(&ceed_2); // Both references should be destroyed
+  return 0;
+}

--- a/tests/t120-vector.c
+++ b/tests/t120-vector.c
@@ -1,0 +1,30 @@
+/// @file
+/// Test creation, copying, and destroying of a vector
+/// \test Test creation, copying, and destroying of a vector
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedVector x, x_2;
+  CeedInt n;
+
+  CeedInit(argv[1], &ceed);
+
+  n = 10;
+  CeedVectorCreate(ceed, n, &x);
+  CeedVectorCreate(ceed, n+1, &x_2);
+
+  CeedVectorReferenceCopy(x, &x_2); // This destroys the previous x_2
+  CeedVectorDestroy(&x);
+
+  CeedInt len;
+  CeedVectorGetLength(x_2, &len); // Second reference still valid
+  if (len != n)
+    // LCOV_EXCL_START
+    printf("Error copying CeedVector reference.");
+  // LCOV_EXCL_STOP
+
+  CeedVectorDestroy(&x_2);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t216-elemrestriction.c
+++ b/tests/t216-elemrestriction.c
@@ -1,0 +1,36 @@
+/// @file
+/// Test creation, copying, and destruction of an element restriction
+/// \test Test creation, copying, and destruction of an element restriction
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedInt num_elem = 3, comp_stride = 1;
+  CeedInt ind[2*num_elem];
+  CeedElemRestriction r, r_2;
+
+  CeedInit(argv[1], &ceed);
+
+  for (CeedInt i=0; i<num_elem; i++) {
+    ind[2*i+0] = i;
+    ind[2*i+1] = i+1;
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, 2, 1, comp_stride, num_elem+1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, ind, &r);
+  CeedElemRestrictionCreate(ceed, num_elem, 2, 1, comp_stride+1, num_elem+1,
+                            CEED_MEM_HOST, CEED_USE_POINTER, ind, &r_2);
+
+  CeedElemRestrictionReferenceCopy(r, &r_2); // This destroys the previous r_2
+  CeedElemRestrictionDestroy(&r);
+
+  CeedInt comp_stride_2;
+  CeedElemRestrictionGetCompStride(r_2, &comp_stride_2);
+  if (comp_stride_2 != comp_stride)
+    // LCOV_EXCL_START
+    printf("Error copying CeedElemRestriction reference.");
+  // LCOV_EXCL_STOP
+
+  CeedElemRestrictionDestroy(&r_2);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t307-basis.c
+++ b/tests/t307-basis.c
@@ -1,0 +1,30 @@
+/// @file
+/// Test creation, copying, and distruction of a H1Lagrange basis
+/// \test Test creation, copying, and distruction of a H1Lagrange basis
+#include <ceed.h>
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedBasis b, b_2;
+  CeedInt P_1d = 4;
+
+  CeedInit(argv[1], &ceed);
+
+  CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, P_1d, 4, CEED_GAUSS_LOBATTO, &b);
+  CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, P_1d+1, 4, CEED_GAUSS_LOBATTO,
+                                  &b_2);
+
+  CeedBasisReferenceCopy(b, &b_2); // This destroys the previous b_2
+  CeedBasisDestroy(&b);
+
+  CeedInt P_1d_2;
+  CeedBasisGetNumNodes1D(b_2, &P_1d_2);
+  if (P_1d != P_1d_2)
+    // LCOV_EXCL_START
+    printf("Error copying CeedBasis reference.");
+  // LCOV_EXCL_STOP
+
+  CeedBasisDestroy(&b_2);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t403-qfunction.c
+++ b/tests/t403-qfunction.c
@@ -1,0 +1,38 @@
+/// @file
+/// Test creation, copying, and destruction for QFunction and QFunctionContext
+/// \test Test creation, copying, and destruction for QFunction and QFunctionContext
+#include <ceed.h>
+#include "t400-qfunction.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedQFunction qf, qf_2;
+  CeedQFunctionContext ctx, ctx_2;
+
+  CeedInit(argv[1], &ceed);
+
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf);
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_2);
+
+  CeedQFunctionReferenceCopy(qf, &qf_2); // This destroys the previous qf_2
+  if (qf != qf_2)
+    // LCOV_EXCL_START
+    printf("Error copying CeedQFunction reference.");
+  // LCOV_EXCL_STOP
+
+  CeedQFunctionContextCreate(ceed, &ctx);
+  CeedQFunctionContextCreate(ceed, &ctx_2);
+
+  CeedQFunctionContextReferenceCopy(ctx, &ctx_2);
+  if (ctx != ctx_2)
+    // LCOV_EXCL_START
+    printf("Error copying CeedQFunctionContext reference.");
+  // LCOV_EXCL_STOP
+
+  CeedQFunctionDestroy(&qf);
+  CeedQFunctionDestroy(&qf_2);
+  CeedQFunctionContextDestroy(&ctx);
+  CeedQFunctionContextDestroy(&ctx_2);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t508-operator.c
+++ b/tests/t508-operator.c
@@ -1,0 +1,36 @@
+/// @file
+/// Test creation, copying, and destruction for mass matrix operator
+/// \test Test creation, copying, and destruction for mass matrix operator
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include "t500-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedQFunction qf, qf_2;
+  CeedOperator op, op_2;
+
+  CeedInit(argv[1], &ceed);
+
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf);
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_2);
+  CeedOperatorCreate(ceed, qf, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op);
+  CeedOperatorCreate(ceed, qf_2, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_2);
+
+  CeedOperatorReferenceCopy(op, &op_2); // This destroys the previous op_2
+  if (op != op_2)
+    // LCOV_EXCL_START
+    printf("Error copying CeedOperator reference.");
+  // LCOV_EXCL_STOP
+
+  CeedQFunctionDestroy(&qf);
+  CeedQFunctionDestroy(&qf_2);
+  CeedOperatorDestroy(&op);
+  CeedOperatorDestroy(&op_2);
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
This adds reference copying to libCEED. This creates a second, separate reference to the same Ceed object that can (and should) be independently destroyed.

@knepley, I think this will address your segfault. @YohannDudouit, this might also be of interest for MFEM.