### PR TITLE
Update device ID selection for HIP/CUDA/MAGMA backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -265,6 +265,11 @@ Currently, each MAGMA library installation is only built for either CUDA or HIP.
 set of libCEED backends (``/gpu/cuda/magma/*`` or ``/gpu/hip/magma/*``) will automatically be built
 for the version of the MAGMA library found in ``MAGMA_DIR``.
 
+Users can specify a device for all CUDA, HIP, and MAGMA backends through adding `:device_id=#` 
+after the resource name.  For example:
+
+ - `/gpu/cuda/gen:device_id=1`
+ 
 The ``/*/occa`` backends rely upon the `OCCA <http://github.com/libocca/occa>`_ package to provide
 cross platform performance. To enable the OCCA backend, the environment variable ``OCCA_DIR`` must point
 to the top-level OCCA directory, with the OCCA library located in the ``${OCCA_DIR}/lib`` (By default,

--- a/backends/cuda-gen/ceed-cuda-gen.c
+++ b/backends/cuda-gen/ceed-cuda-gen.c
@@ -32,14 +32,14 @@ static int CeedInit_Cuda_gen(const char *resource, Ceed ceed) {
                      "Cuda backend cannot use resource: %s", resource);
   // LCOV_EXCL_STOP
 
-  Ceed ceedshared;
-  CeedInit("/gpu/cuda/shared", &ceedshared);
-  ierr = CeedSetDelegate(ceed, ceedshared); CeedChkBackend(ierr);
-
-  Ceed_Cuda_gen *data;
+  Ceed_Cuda *data;
   ierr = CeedCalloc(1, &data); CeedChkBackend(ierr);
   ierr = CeedSetData(ceed, data); CeedChkBackend(ierr);
   ierr = CeedCudaInit(ceed, resource, nrc); CeedChkBackend(ierr);
+
+  Ceed ceedshared;
+  CeedInit("/gpu/cuda/shared", &ceedshared);
+  ierr = CeedSetDelegate(ceed, ceedshared); CeedChkBackend(ierr);
 
   const char fallbackresource[] = "/gpu/cuda/ref";
   ierr = CeedSetOperatorFallbackResource(ceed, fallbackresource);

--- a/backends/cuda-gen/ceed-cuda-gen.h
+++ b/backends/cuda-gen/ceed-cuda-gen.h
@@ -44,10 +44,6 @@ typedef struct {
   void *d_c;
 } CeedQFunction_Cuda_gen;
 
-typedef struct {
-  Ceed_Cuda base;
-} Ceed_Cuda_gen;
-
 CEED_INTERN int CeedQFunctionCreate_Cuda_gen(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Cuda_gen(CeedOperator op);

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -773,7 +773,7 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt nelem,
   int ierr;
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChkBackend(ierr);
-  Ceed_Cuda_shared *ceed_Cuda;
+  Ceed_Cuda *ceed_Cuda;
   CeedGetData(ceed, &ceed_Cuda); CeedChkBackend(ierr);
   CeedBasis_Cuda_shared *data;
   CeedBasisGetData(basis, &data); CeedChkBackend(ierr);

--- a/backends/cuda-shared/ceed-cuda-shared.c
+++ b/backends/cuda-shared/ceed-cuda-shared.c
@@ -16,7 +16,6 @@
 
 #include <ceed/ceed.h>
 #include <ceed/backend.h>
-#include <stdbool.h>
 #include <string.h>
 #include "ceed-cuda-shared.h"
 #include "../cuda/ceed-cuda.h"
@@ -34,14 +33,14 @@ static int CeedInit_Cuda_shared(const char *resource, Ceed ceed) {
   // LCOV_EXCL_STOP
   ierr = CeedSetDeterministic(ceed, true); CeedChk(ierr);
 
-  Ceed ceedref;
-  CeedInit("/gpu/cuda/ref", &ceedref);
-  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
-
-  Ceed_Cuda_shared *data;
+  Ceed_Cuda *data;
   ierr = CeedCalloc(1, &data); CeedChk(ierr);
   ierr = CeedSetData(ceed, data); CeedChk(ierr);
   ierr = CeedCudaInit(ceed, resource, nrc); CeedChk(ierr);
+
+  Ceed ceedref;
+  CeedInit("/gpu/cuda/ref", &ceedref);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChk(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
                                 CeedBasisCreateTensorH1_Cuda_shared);

--- a/backends/cuda-shared/ceed-cuda-shared.h
+++ b/backends/cuda-shared/ceed-cuda-shared.h
@@ -35,10 +35,6 @@ typedef struct {
   CeedScalar *c_G;
 } CeedBasis_Cuda_shared;
 
-typedef struct {
-  Ceed_Cuda base;
-} Ceed_Cuda_shared;
-
 CEED_INTERN int CeedBasisCreateTensorH1_Cuda_shared(CeedInt dim, CeedInt P1d,
     CeedInt Q1d, const CeedScalar *interp1d, const CeedScalar *grad1d,
     const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);

--- a/backends/hip-gen/ceed-hip-gen.c
+++ b/backends/hip-gen/ceed-hip-gen.c
@@ -32,14 +32,14 @@ static int CeedInit_Hip_gen(const char *resource, Ceed ceed) {
                      "Hip backend cannot use resource: %s", resource);
   // LCOV_EXCL_STOP
 
-  Ceed ceedshared;
-  CeedInit("/gpu/hip/shared", &ceedshared);
-  ierr = CeedSetDelegate(ceed, ceedshared); CeedChkBackend(ierr);
-
-  Ceed_Hip_gen *data;
+  Ceed_Hip *data;
   ierr = CeedCalloc(1, &data); CeedChkBackend(ierr);
   ierr = CeedSetData(ceed, data); CeedChkBackend(ierr);
   ierr = CeedHipInit(ceed, resource, nrc); CeedChkBackend(ierr);
+
+  Ceed ceedshared;
+  CeedInit("/gpu/hip/shared", &ceedshared);
+  ierr = CeedSetDelegate(ceed, ceedshared); CeedChkBackend(ierr);
 
   const char fallbackresource[] = "/gpu/hip/ref";
   ierr = CeedSetOperatorFallbackResource(ceed, fallbackresource);

--- a/backends/hip-gen/ceed-hip-gen.h
+++ b/backends/hip-gen/ceed-hip-gen.h
@@ -44,10 +44,6 @@ typedef struct {
   void *d_c;
 } CeedQFunction_Hip_gen;
 
-typedef struct {
-  Ceed_Hip base;
-} Ceed_Hip_gen;
-
 CEED_INTERN int CeedQFunctionCreate_Hip_gen(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Hip_gen(CeedOperator op);

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -859,7 +859,7 @@ int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt nelem,
   int ierr;
   Ceed ceed;
   ierr = CeedBasisGetCeed(basis, &ceed); CeedChkBackend(ierr);
-  Ceed_Hip_shared *ceed_Hip;
+  Ceed_Hip *ceed_Hip;
   CeedGetData(ceed, &ceed_Hip); CeedChkBackend(ierr);
   CeedBasis_Hip_shared *data;
   CeedBasisGetData(basis, &data); CeedChkBackend(ierr);

--- a/backends/hip-shared/ceed-hip-shared.c
+++ b/backends/hip-shared/ceed-hip-shared.c
@@ -34,14 +34,14 @@ static int CeedInit_Hip_shared(const char *resource, Ceed ceed) {
   // LCOV_EXCL_STOP
   ierr = CeedSetDeterministic(ceed, true); CeedChkBackend(ierr);
 
-  Ceed ceedref;
-  CeedInit("/gpu/hip/ref", &ceedref);
-  ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
-
-  Ceed_Hip_shared *data;
+  Ceed_Hip *data;
   ierr = CeedCalloc(1, &data); CeedChkBackend(ierr);
   ierr = CeedSetData(ceed, data); CeedChkBackend(ierr);
   ierr = CeedHipInit(ceed, resource, nrc); CeedChkBackend(ierr);
+
+  Ceed ceedref;
+  CeedInit("/gpu/hip/ref", &ceedref);
+  ierr = CeedSetDelegate(ceed, ceedref); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "BasisCreateTensorH1",
                                 CeedBasisCreateTensorH1_Hip_shared);

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -34,10 +34,6 @@ typedef struct {
   CeedScalar *d_qweight1d;
 } CeedBasis_Hip_shared;
 
-typedef struct {
-  Ceed_Hip base;
-} Ceed_Hip_shared;
-
 CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P1d,
     CeedInt Q1d, const CeedScalar *interp1d, const CeedScalar *grad1d,
     const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);

--- a/backends/magma/ceed-magma-det.c
+++ b/backends/magma/ceed-magma-det.c
@@ -16,17 +16,37 @@
 
 #include <ceed/ceed.h>
 #include <ceed/backend.h>
+#include <string.h>
+#include <stdlib.h>
 #include "ceed-magma.h"
 
 CEED_INTERN int CeedInit_Magma_Det(const char *resource, Ceed ceed) {
   int ierr;
-  if (strcmp(resource, "/gpu/cuda/magma/det")
-      && strcmp(resource, "/gpu/hip/magma/det"))
+  const int nrc = 18; // number of characters in resource
+  if (strncmp(resource, "/gpu/cuda/magma/det", nrc)
+      && strncmp(resource, "/gpu/hip/magma/det", nrc))
     // LCOV_EXCL_START
     return CeedError(ceed, CEED_ERROR_BACKEND,
                      "Magma backend cannot use resource: %s", resource);
   // LCOV_EXCL_STOP
   ierr = CeedSetDeterministic(ceed, true); CeedChkBackend(ierr);
+
+  Ceed_Magma *data;
+  ierr = CeedCalloc(sizeof(Ceed_Magma), &data); CeedChkBackend(ierr);
+  ierr = CeedSetData(ceed, data); CeedChkBackend(ierr);
+
+  // get/set device ID
+  const char *device_spec = strstr(resource, ":device_id=");
+  const int deviceID = (device_spec) ? atoi(device_spec+11) : -1;
+
+  int currentDeviceID;
+  magma_getdevice(&currentDeviceID);
+  if (deviceID >= 0 && currentDeviceID != deviceID) {
+    magma_setdevice(deviceID);
+    currentDeviceID = deviceID;
+  }
+  // create a queue that uses the null stream
+  data->device = currentDeviceID;
 
   // Create reference CEED that implementation will be dispatched
   //   through unless overridden

--- a/backends/magma/ceed-magma-restriction.c
+++ b/backends/magma/ceed-magma-restriction.c
@@ -16,6 +16,7 @@
 
 #include <ceed/ceed.h>
 #include <ceed/backend.h>
+#include <string.h>
 #include "ceed-magma.h"
 
 static int CeedElemRestrictionApply_Magma(CeedElemRestriction r,


### PR DESCRIPTION
This PR fixes the device ID selection for the CUDA/HIP backends while retaining the option to use `/gpu/cuda` or `/gpu/hip` as shortcuts for the best backends (currently chooses `gen`).   It also adds the ability to set the device ID for the MAGMA backends. 

The device ID string was chosen to match that of the OCCA backends, i.e., `:device_id=#`.  An example full resource string would be `/gpu/hip/shared:device_id=1`.  

Other minor changes include:
 - Change some headers to fix compiler warnings
 - Remove the backend data structs for the `shared` and `gen` backends, and have those backends use the base `Ceed_Hip` or `Ceed_Cuda` structs.  (Previously, the `shared` and `gen` structs only contained a `Ceed_Hip` or `Ceed_Cuda` pointer called `base`, but nothing was ever accessed through `base` and the CUDA/HIP `Init` functions only ever assumed they were given the base struct directly.)

Resolves #709