### PR TITLE
Allow number of quad points per element to be set for Op

### DIFF
--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -205,7 +205,7 @@ CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 CEED_EXTERN int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem);
 CEED_EXTERN int CeedOperatorGetNumQuadraturePoints(CeedOperator op,
-    CeedInt *numqpts);
+    CeedInt *num_qpts);
 CEED_EXTERN int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args);
 CEED_EXTERN int CeedOperatorIsSetupDone(CeedOperator op, bool *is_setup_done);
 CEED_EXTERN int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -624,6 +624,7 @@ CEED_EXTERN int CeedOperatorMultigridLevelCreateH1(CeedOperator op_fine,
     CeedOperator *op_prolong, CeedOperator *op_restrict);
 CEED_EXTERN int CeedOperatorCreateFDMElementInverse(CeedOperator op,
     CeedOperator *fdm_inv, CeedRequest *request);
+CEED_EXTERN int CeedOperatorSetNumQuadraturePoints(CeedOperator op, CeedInt num_qpts);
 CEED_EXTERN int CeedOperatorView(CeedOperator op, FILE *stream);
 CEED_EXTERN int CeedOperatorApply(CeedOperator op, CeedVector in,
                                   CeedVector out, CeedRequest *request);


### PR DESCRIPTION
I found a use case for all collocated bases - restricting into the broken space for BDDC. In order to make that work though, we need to be able to set the number of "quadrature points" per element. See also #750