### PR TITLE
Docs: Tiny rewording in Intro

### DIFF
--- a/doc/sphinx/source/intro.rst
+++ b/doc/sphinx/source/intro.rst
@@ -5,7 +5,7 @@ Historically, conventional high-order finite element methods were rarely used fo
 industrial problems because the Jacobian rapidly loses sparsity as the order is
 increased, leading to unaffordable solve times and memory requirements
 :cite:`brown2010`. This effect typically limited the order of accuracy to at most
-quadratic, especially because they are computationally advantageous in terms of
+quadratic, especially because quadratic finite element formulations are computationally advantageous in terms of
 floating point operations (FLOPS) per degree of freedom (DOF)---see
 :numref:`fig-assembledVsmatrix-free`---, despite the fast convergence and favorable
 stability properties offered by higher order discretizations. Nowadays, high-order


### PR DESCRIPTION
Since this Introduction was mentioned lately in issue #756 , I was re-reading it and realized this sentence could have been improved. 
The use of the word `they` was a bit confusing in my opinion. 

 @jeremylt I just changed this sentence expanding its line, as recommended in #735 , although the original file had the older style (the max 80 char per line), but I wouldn't change the entire file style now. Do you agree?