### PR TITLE
Update Rust Github Action

### DIFF
--- a/.github/workflows/rust-test-with-style.yml
+++ b/.github/workflows/rust-test-with-style.yml
@@ -27,7 +27,6 @@ jobs:
         CC: ${{ matrix.compiler }}
         FC: gfortran-9
       with:
-        version: '0.16.0'
         args: '--run-types Doctests Tests --exclude-files backends/* gallery/* include/* interface/*'
     - name: Codecov upload
       uses: codecov/codecov-action@v1.0.2


### PR DESCRIPTION
Bugfix allows us to use latest cargo tarpaulin again https://github.com/xd009642/tarpaulin/issues/747

A v0.19 should be coming soon, and we'll get that when it drops with this change