### PR TITLE
Update GPU arch argument for hiprtc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ forced by setting the environment variable ``MKL=1``.
 The ``/gpu/cuda/*`` backends provide GPU performance strictly using CUDA.
 
 The ``/gpu/hip/*`` backends provide GPU performance strictly using HIP. They are based on
-the ``/gpu/cuda/*`` backends.  ROCm version 3.5 or newer is required.
+the ``/gpu/cuda/*`` backends.  ROCm version 3.6 or newer is required.
 
 The ``/gpu/*/magma/*`` backends rely upon the `MAGMA <https://bitbucket.org/icl/magma>`_ package.
 To enable the MAGMA backends, the environment variable ``MAGMA_DIR`` must point to the top-level

--- a/backends/hip/ceed-hip-compile.cpp
+++ b/backends/hip/ceed-hip-compile.cpp
@@ -73,8 +73,7 @@ int CeedCompileHip(Ceed ceed, const char *source, hipModule_t *module,
   ierr = CeedGetData(ceed, (void **)&ceed_data); CeedChkBackend(ierr);
   CeedChk_Hip(ceed, hipGetDeviceProperties(&prop, ceed_data->deviceId));
   char buff[optslen];
-  std::string gfxName = "gfx" + std::to_string(prop.gcnArch);
-  std::string archArg = "--gpu-architecture="  + gfxName;
+  std::string archArg = "--gpu-architecture="  + std::string(prop.gcnArchName);
   snprintf(buff, optslen, "%s", archArg.c_str());
   opts[1] = buff;
 


### PR DESCRIPTION
Use `gcnArchName` instead of `gcnArch` for the `--gpu-architecture` argument of `hiprtc`. 
This change is required for ROCm 4.2, but is compatible with >= 3.6 (the README was updated from 3.5 to 3.6).

Thanks to @moes1 for figuring this out!