### PR TITLE
Check Release Notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,20 @@
+name: Release Notes
+
+on:
+  push:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Environment setup
+      uses: actions/checkout@v2
+    - name: Check release notes
+      run: |
+        git fetch origin main
+        git diff origin/main --exit-code include/ceed/* && ! git diff origin/main --exit-code doc/sphinx/source/releasenotes.rst

--- a/doc/sphinx/source/releasenotes.rst
+++ b/doc/sphinx/source/releasenotes.rst
@@ -18,12 +18,15 @@ New features
 ^^^^^^^^^^^^
 
 * Add :c:func:`CeedVectorAXPY` and :c:func:`CeedVectorPointwiseMult` as a convenience for stand-alone testing and internal use.
+* Add `CEED_QFUNCTION_HELPER` macro to properly annotate QFunction helper functions for code generation backends.
 
 Performance improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Examples
 ^^^^^^^^
+
+* Solid mechanics mini-app updated to explore the performance impacts of various formulations in the initial and current configuration.
 
 Deprecated backends
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It seems that GitHub actions forgot to implement a proper 'warn on failure' type mode
https://github.com/actions/toolkit/issues/399

This test should generate a hard failure if we forget to update the release notes.