### PR TITLE
[#808][OCCA] Avoid verifying objects in destructors

### DIFF
--- a/backends/occa/ceed-occa-basis.cpp
+++ b/backends/occa/ceed-occa-basis.cpp
@@ -27,19 +27,30 @@ namespace ceed {
 
     Basis::~Basis() {}
 
-    Basis* Basis::from(CeedBasis basis) {
+    Basis* Basis::getBasis(CeedBasis basis,
+                           const bool assertValid) {
       if (!basis) {
         return NULL;
       }
 
       int ierr;
-      Basis *basis_;
+      Basis *basis_ = NULL;
 
-      ierr = CeedBasisGetData(basis, &basis_); CeedOccaFromChk(ierr);
+      ierr = CeedBasisGetData(basis, &basis_);
+      if (assertValid) {
+        CeedOccaFromChk(ierr);
+      }
+
+      return basis_;
+    }
+
+    Basis* Basis::from(CeedBasis basis) {
+      Basis *basis_ = getBasis(basis);
       if (!basis_) {
         return NULL;
       }
 
+      int ierr;
       ierr = basis_->setCeedFields(basis); CeedOccaFromChk(ierr);
 
       return basis_;
@@ -86,7 +97,7 @@ namespace ceed {
     }
 
     int Basis::ceedDestroy(CeedBasis basis) {
-      delete Basis::from(basis);
+      delete getBasis(basis, false);
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/backends/occa/ceed-occa-basis.hpp
+++ b/backends/occa/ceed-occa-basis.hpp
@@ -36,6 +36,9 @@ namespace ceed {
 
       virtual ~Basis();
 
+      static Basis* getBasis(CeedBasis basis,
+                             const bool assertValid = true);
+
       static Basis* from(CeedBasis basis);
       static Basis* from(CeedOperatorField operatorField);
 

--- a/backends/occa/ceed-occa-elem-restriction.cpp
+++ b/backends/occa/ceed-occa-elem-restriction.cpp
@@ -194,17 +194,30 @@ namespace ceed {
       );
     }
 
-    ElemRestriction* ElemRestriction::from(CeedElemRestriction r) {
+    ElemRestriction* ElemRestriction::getElemRestriction(CeedElemRestriction r,
+                                                         const bool assertValid) {
       if (!r || r == CEED_ELEMRESTRICTION_NONE) {
         return NULL;
       }
 
       int ierr;
-      ElemRestriction *elemRestriction;
+      ElemRestriction *elemRestriction = NULL;
 
       ierr = CeedElemRestrictionGetData(r, (void**) &elemRestriction);
-      CeedOccaFromChk(ierr);
+      if (assertValid) {
+        CeedOccaFromChk(ierr);
+      }
 
+      return elemRestriction;
+    }
+
+    ElemRestriction* ElemRestriction::from(CeedElemRestriction r) {
+      ElemRestriction *elemRestriction = getElemRestriction(r);
+      if (!elemRestriction) {
+        return NULL;
+      }
+
+      int ierr;
       ierr = CeedElemRestrictionGetCeed(r, &elemRestriction->ceed);
       CeedOccaFromChk(ierr);
 
@@ -429,7 +442,7 @@ namespace ceed {
     }
 
     int ElemRestriction::ceedDestroy(CeedElemRestriction r) {
-      delete ElemRestriction::from(r);
+      delete getElemRestriction(r, false);
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/backends/occa/ceed-occa-elem-restriction.hpp
+++ b/backends/occa/ceed-occa-elem-restriction.hpp
@@ -76,6 +76,9 @@ namespace ceed {
 
       void setupKernelBuilders();
 
+      static ElemRestriction* getElemRestriction(CeedElemRestriction r,
+                                                 const bool assertValid = true);
+
       static ElemRestriction* from(CeedElemRestriction r);
       static ElemRestriction* from(CeedOperatorField operatorField);
       ElemRestriction* setupFrom(CeedElemRestriction r);

--- a/backends/occa/ceed-occa-operator.cpp
+++ b/backends/occa/ceed-occa-operator.cpp
@@ -31,15 +31,30 @@ namespace ceed {
 
     Operator::~Operator() {}
 
-    Operator* Operator::from(CeedOperator op) {
+    Operator* Operator::getOperator(CeedOperator op,
+                                    const bool assertValid) {
       if (!op) {
         return NULL;
       }
 
       int ierr;
-      Operator *operator_;
+      Operator *operator_ = NULL;
 
-      ierr = CeedOperatorGetData(op, (void**) &operator_); CeedOccaFromChk(ierr);
+      ierr = CeedOperatorGetData(op, (void**) &operator_);
+      if (assertValid) {
+        CeedOccaFromChk(ierr);
+      }
+
+      return operator_;
+    }
+
+    Operator* Operator::from(CeedOperator op) {
+      Operator *operator_ = getOperator(op);
+      if (!operator_) {
+        return NULL;
+      }
+
+      int ierr;
       ierr = CeedOperatorGetCeed(op, &operator_->ceed); CeedOccaFromChk(ierr);
 
       operator_->qfunction = QFunction::from(op);
@@ -154,7 +169,7 @@ namespace ceed {
     }
 
     int Operator::ceedDestroy(CeedOperator op) {
-      delete Operator::from(op);
+      delete getOperator(op, false);
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/backends/occa/ceed-occa-operator.hpp
+++ b/backends/occa/ceed-occa-operator.hpp
@@ -46,6 +46,9 @@ namespace ceed {
       Operator();
       virtual ~Operator();
 
+      static Operator* getOperator(CeedOperator op,
+                                   const bool assertValid = true);
+
       static Operator* from(CeedOperator op);
 
       bool isApplyingIdentityFunction();

--- a/backends/occa/ceed-occa-qfunction.cpp
+++ b/backends/occa/ceed-occa-qfunction.cpp
@@ -42,7 +42,7 @@ namespace ceed {
       ierr = CeedQFunctionGetData(qf, &qFunction);
       CeedOccaFromChk(ierr);
 
-      return qfunction;
+      return qFunction;
     }
 
     QFunction* QFunction::from(CeedQFunction qf) {

--- a/backends/occa/ceed-occa-qfunction.cpp
+++ b/backends/occa/ceed-occa-qfunction.cpp
@@ -30,17 +30,28 @@ namespace ceed {
       qFunctionName = source.substr(colonIndex + 1);
     }
 
-    QFunction* QFunction::from(CeedQFunction qf) {
+    QFunction* QFunction::getQFunction(CeedQFunction qf,
+                                       const bool assertValid) {
       if (!qf) {
         return NULL;
       }
 
       int ierr;
-      QFunction *qFunction;
+      QFunction *qFunction = NULL;
 
       ierr = CeedQFunctionGetData(qf, &qFunction);
       CeedOccaFromChk(ierr);
 
+      return qfunction;
+    }
+
+    QFunction* QFunction::from(CeedQFunction qf) {
+      QFunction *qFunction = getQFunction(qf);
+      if (!qFunction) {
+        return NULL;
+      }
+
+      int ierr;
       ierr = CeedQFunctionGetCeed(qf, &qFunction->ceed);
       CeedOccaFromChk(ierr);
 
@@ -252,7 +263,7 @@ namespace ceed {
     }
 
     int QFunction::ceedDestroy(CeedQFunction qf) {
-      delete QFunction::from(qf);
+      delete getQFunction(qf, false);
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/backends/occa/ceed-occa-qfunction.hpp
+++ b/backends/occa/ceed-occa-qfunction.hpp
@@ -36,6 +36,9 @@ namespace ceed {
 
       QFunction(const std::string &source);
 
+      static QFunction* getQFunction(CeedQFunction qf,
+                                     const bool assertValid = true);
+
       static QFunction* from(CeedQFunction qf);
       static QFunction* from(CeedOperator op);
 

--- a/backends/occa/ceed-occa-qfunctioncontext.cpp
+++ b/backends/occa/ceed-occa-qfunctioncontext.cpp
@@ -29,16 +29,30 @@ namespace ceed {
       freeHostCtxBuffer();
     }
 
-    QFunctionContext* QFunctionContext::from(CeedQFunctionContext ctx) {
+    QFunctionContext* QFunctionContext::getQFunctionContext(CeedQFunctionContext ctx,
+                                                            const bool assertValid) {
       if (!ctx) {
         return NULL;
       }
 
       int ierr;
-
       QFunctionContext *ctx_ = NULL;
-      ierr = CeedQFunctionContextGetBackendData(ctx, &ctx_); CeedOccaFromChk(ierr);
 
+      ierr = CeedQFunctionContextGetBackendData(ctx, &ctx_);
+      if (assertValid) {
+        CeedOccaFromChk(ierr);
+      }
+
+      return ctx_;
+    }
+
+    QFunctionContext* QFunctionContext::from(CeedQFunctionContext ctx) {
+      QFunctionContext *ctx_ = getQFunctionContext(ctx);
+      if (!ctx_) {
+        return NULL;
+      }
+
+      int ierr;
       ierr = CeedQFunctionContextGetContextSize(ctx, &ctx_->ctxSize);
       CeedOccaFromChk(ierr);
 
@@ -283,7 +297,7 @@ namespace ceed {
     }
 
     int QFunctionContext::ceedDestroy(CeedQFunctionContext ctx) {
-      delete QFunctionContext::from(ctx);
+      delete getQFunctionContext(ctx, false);
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/backends/occa/ceed-occa-qfunctioncontext.hpp
+++ b/backends/occa/ceed-occa-qfunctioncontext.hpp
@@ -39,6 +39,9 @@ namespace ceed {
 
       ~QFunctionContext();
 
+      static QFunctionContext* getQFunctionContext(CeedQFunctionContext ctx,
+                                                   const bool assertValid = true);
+
       static QFunctionContext* from(CeedQFunctionContext ctx);
 
       ::occa::memory dataToMemory(const void *data) {

--- a/backends/occa/ceed-occa-vector.cpp
+++ b/backends/occa/ceed-occa-vector.cpp
@@ -30,20 +30,32 @@ namespace ceed {
       freeHostBuffer();
     }
 
-    Vector* Vector::from(CeedVector vec) {
+    Vector* Vector::getVector(CeedVector vec,
+                              const bool assertValid) {
       if (!vec || vec == CEED_VECTOR_NONE) {
         return NULL;
       }
 
       int ierr;
-
       Vector *vector = NULL;
-      ierr = CeedVectorGetData(vec, &vector); CeedOccaFromChk(ierr);
 
-      if (vector != NULL) {
-        ierr = CeedVectorGetCeed(vec, &vector->ceed); CeedOccaFromChk(ierr);
-        ierr = CeedVectorGetLength(vec, &vector->length); CeedOccaFromChk(ierr);
+      ierr = CeedVectorGetData(vec, &vector);
+      if (assertValid) {
+        CeedOccaFromChk(ierr);
       }
+
+      return vector;
+    }
+
+    Vector* Vector::from(CeedVector vec) {
+      Vector *vector = getVector(vec);
+      if (!vector) {
+        return NULL;
+      }
+
+      int ierr;
+      ierr = CeedVectorGetCeed(vec, &vector->ceed); CeedOccaFromChk(ierr);
+      ierr = CeedVectorGetLength(vec, &vector->length); CeedOccaFromChk(ierr);
 
       return vector;
     }
@@ -408,7 +420,7 @@ namespace ceed {
     }
 
     int Vector::ceedDestroy(CeedVector vec) {
-      delete Vector::from(vec);
+      delete getVector(vec, false);
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/backends/occa/ceed-occa-vector.hpp
+++ b/backends/occa/ceed-occa-vector.hpp
@@ -54,6 +54,9 @@ namespace ceed {
 
       ~Vector();
 
+      static Vector* getVector(CeedVector vec,
+                               const bool assertValid = true);
+
       static Vector* from(CeedVector vec);
 
       void resize(const CeedInt length_);


### PR DESCRIPTION
## Description

Destructors can be called on partial objects. Avoid building the full object during the destructor

Should close #808