### PR TITLE
Add OCCA backend warning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,8 @@ noether-rocm:
     - echo "-------------- OCCA ----------------" && make -C $OCCA_DIR info
 # libCEED
     - make configure HIP_DIR=/opt/rocm OPT='-O -march=native -ffp-contract=fast'
-#    Note: OCCA CPU backends currently disabled in CI
-    - BACKENDS_CPU=$(OCCA_DIR= make info-backends-all | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
+#    Note: OCCA backends currently disabled in CI
+    - BACKENDS_CPU=$(OCCA_DIR= make info-backends-all | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(OCCA_DIR= make info-backends | grep -o '/gpu[^ ]*')
     - echo "-------------- libCEED -------------" && make info
     - echo "-------------- BACKENDS_CPU---------" && echo $BACKENDS_CPU
     - echo "-------------- BACKENDS_GPU---------" && echo $BACKENDS_GPU

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,8 @@ noether-rocm:
     - echo "-------------- OCCA ----------------" && make -C $OCCA_DIR info
 # libCEED
     - make configure HIP_DIR=/opt/rocm OPT='-O -march=native -ffp-contract=fast'
-    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
+#    Note: OCCA CPU backends currently disabled in CI
+    - BACKENDS_CPU=$(OCCA_DIR= make info-backends-all | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
     - echo "-------------- libCEED -------------" && make info
     - echo "-------------- BACKENDS_CPU---------" && echo $BACKENDS_CPU
     - echo "-------------- BACKENDS_GPU---------" && echo $BACKENDS_GPU

--- a/Makefile
+++ b/Makefile
@@ -637,9 +637,6 @@ install : $(libceed) $(OBJDIR)/ceed.pc
 	$(INSTALL_DATA) $(OBJDIR)/ceed.pc "$(DESTDIR)$(pkgconfigdir)/"
 	$(INSTALL_DATA) include/ceed.h "$(DESTDIR)$(includedir)/"
 	$(INSTALL_DATA) include/ceedf.h "$(DESTDIR)$(includedir)/"
-	$(INSTALL_DATA) include/ceed-backend.h "$(DESTDIR)$(includedir)/"
-	$(INSTALL_DATA) include/ceed-hash.h "$(DESTDIR)$(includedir)/"
-	$(INSTALL_DATA) include/ceed-khash.h "$(DESTDIR)$(includedir)/"
 
 .PHONY : all cln clean doxygen doc lib install par print test tst prove prv prove-all junit examples style style-c style-py tidy info info-backends info-backends-all
 

--- a/backends/occa/ceed-occa.cpp
+++ b/backends/occa/ceed-occa.cpp
@@ -14,6 +14,8 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
+ #warning "libCEED OCCA backend is experimental; for best performance, use device native backends"
+
 #include <map>
 #include <vector>
 #include <occa.hpp>

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -14,6 +14,7 @@ for each release of libCEED.
 - Clarify and document conditions where `CeedQFunction` and `CeedOperator` become immutable and no further fields or suboperators can be added.
 - Add {c:func} `CeedOperatorLinearAssembleQFunctionBuildOrUpdate` to reduce object creation overhead in assembly of CeedOperator preconditioning ingredients.
 - Promote {c:func} `CeedOperatorCheckReady`to the public API to facilitate interactive interfaces.
+- Warning added when compiling OCCA backend to alert users that this backend is experimental.
 
 ### New features
 

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -15,6 +15,7 @@ for each release of libCEED.
 - Add {c:func} `CeedOperatorLinearAssembleQFunctionBuildOrUpdate` to reduce object creation overhead in assembly of CeedOperator preconditioning ingredients.
 - Promote {c:func} `CeedOperatorCheckReady`to the public API to facilitate interactive interfaces.
 - Warning added when compiling OCCA backend to alert users that this backend is experimental.
+- `ceed-backend.h`, `ceed-hash.h`, and `ceed-khash.h` removed. Users should use `ceed/backend.h`, `ceed/hash.h`, and `ceed/khash.h`.
 
 ### New features
 

--- a/include/ceed-backend.h
+++ b/include/ceed-backend.h
@@ -1,3 +1,0 @@
-#include <ceed/backend.h>
-
-#warning <ceed-backend.h> is deprecated and will be removed in libCEED v0.9; use <ceed/backend.h>

--- a/include/ceed-hash.h
+++ b/include/ceed-hash.h
@@ -1,3 +1,0 @@
-#include <ceed/hash.h>
-
-#warning <ceed-hash.h> is deprecated and will be removed in libCEED v0.9; use <ceed/hash.h>

--- a/include/ceed-khash.h
+++ b/include/ceed-khash.h
@@ -1,3 +1,0 @@
-#include <ceed/khash.h>
-
-#warning <ceed-khash.h> is deprecated and will be removed in libCEED v0.9; use <ceed/khash.h>


### PR DESCRIPTION
See #816, the OCCA backend is not receiving regular maintenance, is less feature complete than the other backends, and is less performant. This change alerts users that this backend is experimental.