### PR TITLE
Add CEED_QFUNCTION_JIT macro

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -815,6 +815,7 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
 
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
   code << "#define CEED_QFUNCTION_HELPER inline __device__\n";
+  code << "#define CEED_QFUNCTION_JIT 1\n";
   code << "#define CeedPragmaSIMD\n";
   code << "#define CEED_ERROR_SUCCESS 0\n\n";
 

--- a/backends/cuda/ceed-cuda-qfunction-load.cpp
+++ b/backends/cuda/ceed-cuda-qfunction-load.cpp
@@ -77,6 +77,7 @@ extern "C" int CeedCudaBuildQFunction(CeedQFunction qf) {
   // Defintions
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
   code << "#define CEED_QFUNCTION_HELPER inline __device__\n";
+  code << "#define CEED_QFUNCTION_JIT 1\n";
   code << "#define CeedPragmaSIMD\n";
   code << "#define CEED_ERROR_SUCCESS 0\n";
   code << "#define CEED_Q_VLA 1\n\n";

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -787,6 +787,7 @@ CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op) {
 
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
   code << "#define CEED_QFUNCTION_HELPER inline __device__ __forceinline__\n";
+  code << "#define CEED_QFUNCTION_JIT 1\n";
   code << "#define CeedPragmaSIMD\n";
   code << "#define CEED_ERROR_SUCCESS 0\n\n";
 

--- a/backends/hip/ceed-hip-qfunction-load.cpp
+++ b/backends/hip/ceed-hip-qfunction-load.cpp
@@ -74,6 +74,7 @@ extern "C" int CeedHipBuildQFunction(CeedQFunction qf) {
   // Defintions
   code << "\n#define CEED_QFUNCTION(name) inline __device__ int name\n";
   code << "#define CEED_QFUNCTION_HELPER inline __device__ __forceinline__\n";
+  code << "#define CEED_QFUNCTION_JIT 1\n";
   code << "#define CeedPragmaSIMD\n";
   code << "#define CEED_ERROR_SUCCESS 0\n";
   code << "#define CEED_Q_VLA 1\n\n";

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -20,6 +20,7 @@ for each release of libCEED.
 ### New features
 
 - `CeedScalar` can now be set as `float` or `double` at compile time.
+- Add `CEED_QFUNCTION_JIT` macro to simplfy logic for header inclusion in QFunction source for JiT.
 
 ### Maintainability
 

--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -20,7 +20,7 @@
 #ifndef advection_h
 #define advection_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/fluids/qfunctions/advection2d.h
+++ b/examples/fluids/qfunctions/advection2d.h
@@ -20,7 +20,7 @@
 #ifndef advection2d_h
 #define advection2d_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/fluids/qfunctions/densitycurrent.h
+++ b/examples/fluids/qfunctions/densitycurrent.h
@@ -24,7 +24,7 @@
 #ifndef densitycurrent_h
 #define densitycurrent_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/fluids/qfunctions/eulervortex.h
+++ b/examples/fluids/qfunctions/eulervortex.h
@@ -25,7 +25,7 @@
 #ifndef eulervortex_h
 #define eulervortex_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/fluids/qfunctions/mass.h
+++ b/examples/fluids/qfunctions/mass.h
@@ -20,7 +20,7 @@
 #ifndef mass_h
 #define mass_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/fluids/qfunctions/setupgeo.h
+++ b/examples/fluids/qfunctions/setupgeo.h
@@ -20,7 +20,7 @@
 #ifndef setup_geo_h
 #define setup_geo_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/fluids/qfunctions/setupgeo2d.h
+++ b/examples/fluids/qfunctions/setupgeo2d.h
@@ -20,7 +20,7 @@
 #ifndef setup_geo_2d_h
 #define setup_geo_2d_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/nek/bps/bps.h
+++ b/examples/nek/bps/bps.h
@@ -17,7 +17,7 @@
 #ifndef bps_h
 #define bps_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/area/areacube.h
+++ b/examples/petsc/qfunctions/area/areacube.h
@@ -20,7 +20,7 @@
 #ifndef areacube_h
 #define areacube_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/area/areasphere.h
+++ b/examples/petsc/qfunctions/area/areasphere.h
@@ -20,7 +20,7 @@
 #ifndef areasphere_h
 #define areasphere_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp1.h
+++ b/examples/petsc/qfunctions/bps/bp1.h
@@ -20,7 +20,7 @@
 #ifndef bp1_h
 #define bp1_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp1sphere.h
+++ b/examples/petsc/qfunctions/bps/bp1sphere.h
@@ -20,7 +20,7 @@
 #ifndef bp1sphere_h
 #define bp1sphere_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp2.h
+++ b/examples/petsc/qfunctions/bps/bp2.h
@@ -20,7 +20,7 @@
 #ifndef bp2_h
 #define bp2_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp2sphere.h
+++ b/examples/petsc/qfunctions/bps/bp2sphere.h
@@ -20,7 +20,7 @@
 #ifndef bp2sphere_h
 #define bp2sphere_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp3.h
+++ b/examples/petsc/qfunctions/bps/bp3.h
@@ -20,7 +20,7 @@
 #ifndef bp3_h
 #define bp3_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp3sphere.h
+++ b/examples/petsc/qfunctions/bps/bp3sphere.h
@@ -20,7 +20,7 @@
 #ifndef bp3sphere_h
 #define bp3sphere_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp4.h
+++ b/examples/petsc/qfunctions/bps/bp4.h
@@ -20,7 +20,7 @@
 #ifndef bp4_h
 #define bp4_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/petsc/qfunctions/bps/bp4sphere.h
+++ b/examples/petsc/qfunctions/bps/bp4sphere.h
@@ -20,7 +20,7 @@
 #ifndef bp4sphere_h
 #define bp4sphere_h
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/constant-force.h
+++ b/examples/solids/qfunctions/constant-force.h
@@ -20,7 +20,7 @@
 #ifndef CONSTANT_H
 #define CONSTANT_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/finite-strain-mooney-rivlin-initial-1.h
+++ b/examples/solids/qfunctions/finite-strain-mooney-rivlin-initial-1.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_FSInitialMR1_H
 #define ELAS_FSInitialMR1_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-current-1.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-current-1.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_FSCurrentNH1_H
 #define ELAS_FSCurrentNH1_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-current-2.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-current-2.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_FSCurrentNH2_H
 #define ELAS_FSCurrentNH2_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-initial-1.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-initial-1.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_FSInitialNH1_H
 #define ELAS_FSInitialNH1_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-initial-2.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-initial-2.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_FSInitialNH2_H
 #define ELAS_FSInitialNH2_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/linear.h
+++ b/examples/solids/qfunctions/linear.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_LINEAR_H
 #define ELAS_LINEAR_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/manufactured-force.h
+++ b/examples/solids/qfunctions/manufactured-force.h
@@ -20,7 +20,7 @@
 #ifndef MANUFACTURED_H
 #define MANUFACTURED_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/manufactured-true.h
+++ b/examples/solids/qfunctions/manufactured-true.h
@@ -20,7 +20,7 @@
 #ifndef MANUFACTURED_TRUE_H
 #define MANUFACTURED_TRUE_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/examples/solids/qfunctions/small-strain-neo-hookean.h
+++ b/examples/solids/qfunctions/small-strain-neo-hookean.h
@@ -20,7 +20,7 @@
 #ifndef ELAS_SS_NH_H
 #define ELAS_SS_NH_H
 
-#ifndef __CUDACC__
+#if !CEED_QFUNCTION_JIT
 #  include <math.h>
 #endif
 

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -82,6 +82,14 @@
 
 /**
   @ingroup CeedQFunction
+  This macro indicates if QFunction source is being JiT compiled.
+**/
+#ifndef CEED_QFUNCTION_JIT
+#define CEED_QFUNCTION_JIT 0
+#endif
+
+/**
+  @ingroup CeedQFunction
   Using VLA syntax to reshape User QFunction inputs and outputs can make
     user code more readable. VLA is a C99 feature that is not supported by
     the C++ dialect used by CUDA. This macro allows users to use the VLA


### PR DESCRIPTION
This PR adds the `CEED_QFUNCTION_JIT` macro to simplify the logic for header inclusion with QFunction sources. This is related to #822.