### PR TITLE
doc - fix minor spacing bug in release notes

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -9,14 +9,14 @@ for each release of libCEED.
 
 ### Interface changes
 
-- Update {c:func} `CeedQFunctionGetFields` and {c:func} `CeedOperatorGetFields` to include number of fields.
+- Update {c:func}`CeedQFunctionGetFields` and {c:func}`CeedOperatorGetFields` to include number of fields.
 - Promote to the public API: QFunction and Operator field objects, `CeedQFunctionField` and `CeedOperatorField`, and associated getters, {c:func}`CeedQFunctionGetFields`; {c:func}`CeedQFunctionFieldGetName`; {c:func}`CeedQFunctionFieldGetSize`; {c:func}`CeedQFunctionFieldGetEvalMode`; {c:func}`CeedOperatorGetFields`; {c:func}`CeedOperatorFieldGetElemRestriction`; {c:func}`CeedOperatorFieldGetBasis`; and {c:func}`CeedOperatorFieldGetVector`.
 - Clarify and document conditions where `CeedQFunction` and `CeedOperator` become immutable and no further fields or suboperators can be added.
-- Add {c:func} `CeedOperatorLinearAssembleQFunctionBuildOrUpdate` to reduce object creation overhead in assembly of CeedOperator preconditioning ingredients.
-- Promote {c:func} `CeedOperatorCheckReady`to the public API to facilitate interactive interfaces.
+- Add {c:func}`CeedOperatorLinearAssembleQFunctionBuildOrUpdate` to reduce object creation overhead in assembly of CeedOperator preconditioning ingredients.
+- Promote {c:func}`CeedOperatorCheckReady`to the public API to facilitate interactive interfaces.
 - Warning added when compiling OCCA backend to alert users that this backend is experimental.
 - `ceed-backend.h`, `ceed-hash.h`, and `ceed-khash.h` removed. Users should use `ceed/backend.h`, `ceed/hash.h`, and `ceed/khash.h`.
-- Added {c:func} `CeedQFunctionGetKernelName`; refactored {c:func} `CeedQFunctionGetSourcePath` to exclude function kernel name.
+- Added {c:func}`CeedQFunctionGetKernelName`; refactored {c:func}`CeedQFunctionGetSourcePath` to exclude function kernel name.
 
 ### New features
 


### PR DESCRIPTION
Anyone can review - this fixes a small bug in the release notes that prevents correct rendering.

Before:
![image](https://user-images.githubusercontent.com/25011573/142485556-980115e2-50a5-49c6-b316-15391a23059e.png)

After:
![image](https://user-images.githubusercontent.com/25011573/142486040-836efacb-eee9-42e6-872f-4e8c17e6684c.png)
