### PR TITLE
Remove magic number 16

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -138,9 +138,9 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
 //------------------------------------------------------------------------------
 static int CeedOperatorSetup_Blocked(CeedOperator op) {
   int ierr;
-  bool setup_done;
-  ierr = CeedOperatorIsSetupDone(op, &setup_done); CeedChkBackend(ierr);
-  if (setup_done) return CEED_ERROR_SUCCESS;
+  bool is_setup_done;
+  ierr = CeedOperatorIsSetupDone(op, &is_setup_done); CeedChkBackend(ierr);
+  if (is_setup_done) return CEED_ERROR_SUCCESS;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChkBackend(ierr);
   CeedOperator_Blocked *impl;

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -167,11 +167,11 @@ static int CeedOperatorSetup_Blocked(CeedOperator op) {
   ierr = CeedCalloc(num_input_fields + num_output_fields, &impl->e_data);
   CeedChkBackend(ierr);
 
-  ierr = CeedCalloc(16, &impl->input_state); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->e_vecs_in); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->e_vecs_out); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->q_vecs_in); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->q_vecs_out); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->input_state); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_in); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_out); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_in); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_out); CeedChkBackend(ierr);
 
   impl->num_e_vecs_in = num_input_fields;
   impl->num_e_vecs_out = num_output_fields;

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -25,9 +25,9 @@
 // Setup Input/Output Fields
 //------------------------------------------------------------------------------
 static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
-    CeedOperator op, bool inOrOut, CeedElemRestriction *blk_restr,
-    CeedVector *full_evecs, CeedVector *e_vecs, CeedVector *q_vecs,
-    CeedInt start_e, CeedInt numfields, CeedInt Q) {
+    CeedOperator op, bool is_input, CeedElemRestriction *blk_restr,
+    CeedVector *e_vecs_full, CeedVector *e_vecs, CeedVector *q_vecs,
+    CeedInt start_e, CeedInt num_fields, CeedInt Q) {
   CeedInt dim, ierr, num_comp, size, P;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChkBackend(ierr);
@@ -35,21 +35,21 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
   CeedElemRestriction r;
   CeedOperatorField *op_fields;
   CeedQFunctionField *qf_fields;
-  if (inOrOut) {
-    ierr = CeedOperatorGetFields(op, NULL, NULL, NULL, &op_fields);
-    CeedChkBackend(ierr);
-    ierr = CeedQFunctionGetFields(qf, NULL, NULL, NULL, &qf_fields);
-    CeedChkBackend(ierr);
-  } else {
+  if (is_input) {
     ierr = CeedOperatorGetFields(op, NULL, &op_fields, NULL, NULL);
     CeedChkBackend(ierr);
     ierr = CeedQFunctionGetFields(qf, NULL, &qf_fields, NULL, NULL);
+    CeedChkBackend(ierr);
+  } else {
+    ierr = CeedOperatorGetFields(op, NULL, NULL, NULL, &op_fields);
+    CeedChkBackend(ierr);
+    ierr = CeedQFunctionGetFields(qf, NULL, NULL, NULL, &qf_fields);
     CeedChkBackend(ierr);
   }
   const CeedInt blk_size = 8;
 
   // Loop over fields
-  for (CeedInt i=0; i<numfields; i++) {
+  for (CeedInt i=0; i<num_fields; i++) {
     CeedEvalMode eval_mode;
     ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode);
     CeedChkBackend(ierr);
@@ -86,7 +86,7 @@ static int CeedOperatorSetupFields_Blocked(CeedQFunction qf,
         ierr = CeedElemRestrictionRestoreOffsets(r, &offsets); CeedChkBackend(ierr);
       }
       ierr = CeedElemRestrictionCreateVector(blk_restr[i+start_e], NULL,
-                                             &full_evecs[i+start_e]);
+                                             &e_vecs_full[i+start_e]);
       CeedChkBackend(ierr);
     }
 
@@ -162,28 +162,28 @@ static int CeedOperatorSetup_Blocked(CeedOperator op) {
   // Allocate
   ierr = CeedCalloc(num_input_fields + num_output_fields, &impl->blk_restr);
   CeedChkBackend(ierr);
-  ierr = CeedCalloc(num_input_fields + num_output_fields, &impl->e_vecs);
+  ierr = CeedCalloc(num_input_fields + num_output_fields, &impl->e_vecs_full);
   CeedChkBackend(ierr);
 
-  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->input_state); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->input_states); CeedChkBackend(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_in); CeedChkBackend(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_out); CeedChkBackend(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_in); CeedChkBackend(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_out); CeedChkBackend(ierr);
 
-  impl->num_e_vecs_in = num_input_fields;
-  impl->num_e_vecs_out = num_output_fields;
+  impl->num_inputs = num_input_fields;
+  impl->num_outputs = num_output_fields;
 
   // Set up infield and outfield pointer arrays
   // Infields
-  ierr = CeedOperatorSetupFields_Blocked(qf, op, 0, impl->blk_restr,
-                                         impl->e_vecs, impl->e_vecs_in,
+  ierr = CeedOperatorSetupFields_Blocked(qf, op, true, impl->blk_restr,
+                                         impl->e_vecs_full, impl->e_vecs_in,
                                          impl->q_vecs_in, 0,
                                          num_input_fields, Q);
   CeedChkBackend(ierr);
   // Outfields
-  ierr = CeedOperatorSetupFields_Blocked(qf, op, 1, impl->blk_restr,
-                                         impl->e_vecs, impl->e_vecs_out,
+  ierr = CeedOperatorSetupFields_Blocked(qf, op, false, impl->blk_restr,
+                                         impl->e_vecs_full, impl->e_vecs_out,
                                          impl->q_vecs_out, num_input_fields,
                                          num_output_fields, Q);
   CeedChkBackend(ierr);
@@ -218,7 +218,7 @@ static int CeedOperatorSetup_Blocked(CeedOperator op) {
 //------------------------------------------------------------------------------
 static inline int CeedOperatorSetupInputs_Blocked(CeedInt num_input_fields,
     CeedQFunctionField *qf_input_fields, CeedOperatorField *op_input_fields,
-    CeedVector in_vec, bool skip_active, CeedScalar *e_data[2*CEED_FIELD_MAX],
+    CeedVector in_vec, bool skip_active, CeedScalar *e_data_full[2*CEED_FIELD_MAX],
     CeedOperator_Blocked *impl, CeedRequest *request) {
   CeedInt ierr;
   CeedEvalMode eval_mode;
@@ -242,15 +242,15 @@ static inline int CeedOperatorSetupInputs_Blocked(CeedInt num_input_fields,
     } else {
       // Restrict
       ierr = CeedVectorGetState(vec, &state); CeedChkBackend(ierr);
-      if (state != impl->input_state[i] || vec == in_vec) {
+      if (state != impl->input_states[i] || vec == in_vec) {
         ierr = CeedElemRestrictionApply(impl->blk_restr[i], CEED_NOTRANSPOSE,
-                                        vec, impl->e_vecs[i], request);
+                                        vec, impl->e_vecs_full[i], request);
         CeedChkBackend(ierr);
-        impl->input_state[i] = state;
+        impl->input_states[i] = state;
       }
       // Get evec
-      ierr = CeedVectorGetArrayRead(impl->e_vecs[i], CEED_MEM_HOST,
-                                    (const CeedScalar **) &e_data[i]);
+      ierr = CeedVectorGetArrayRead(impl->e_vecs_full[i], CEED_MEM_HOST,
+                                    (const CeedScalar **) &e_data_full[i]);
       CeedChkBackend(ierr);
     }
   }
@@ -263,7 +263,7 @@ static inline int CeedOperatorSetupInputs_Blocked(CeedInt num_input_fields,
 static inline int CeedOperatorInputBasis_Blocked(CeedInt e, CeedInt Q,
     CeedQFunctionField *qf_input_fields, CeedOperatorField *op_input_fields,
     CeedInt num_input_fields, CeedInt blk_size, bool skip_active,
-    CeedScalar *e_data[2*CEED_FIELD_MAX], CeedOperator_Blocked *impl) {
+    CeedScalar *e_data_full[2*CEED_FIELD_MAX], CeedOperator_Blocked *impl) {
   CeedInt ierr;
   CeedInt dim, elem_size, size;
   CeedElemRestriction elem_restr;
@@ -293,14 +293,14 @@ static inline int CeedOperatorInputBasis_Blocked(CeedInt e, CeedInt Q,
     switch(eval_mode) {
     case CEED_EVAL_NONE:
       ierr = CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST,
-                                CEED_USE_POINTER, &e_data[i][e*Q*size]);
+                                CEED_USE_POINTER, &e_data_full[i][e*Q*size]);
       CeedChkBackend(ierr);
       break;
     case CEED_EVAL_INTERP:
       ierr = CeedOperatorFieldGetBasis(op_input_fields[i], &basis);
       CeedChkBackend(ierr);
       ierr = CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST,
-                                CEED_USE_POINTER, &e_data[i][e*elem_size*size]);
+                                CEED_USE_POINTER, &e_data_full[i][e*elem_size*size]);
       CeedChkBackend(ierr);
       ierr = CeedBasisApply(basis, blk_size, CEED_NOTRANSPOSE,
                             CEED_EVAL_INTERP, impl->e_vecs_in[i],
@@ -311,7 +311,7 @@ static inline int CeedOperatorInputBasis_Blocked(CeedInt e, CeedInt Q,
       CeedChkBackend(ierr);
       ierr = CeedBasisGetDimension(basis, &dim); CeedChkBackend(ierr);
       ierr = CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST,
-                                CEED_USE_POINTER, &e_data[i][e*elem_size*size/dim]);
+                                CEED_USE_POINTER, &e_data_full[i][e*elem_size*size/dim]);
       CeedChkBackend(ierr);
       ierr = CeedBasisApply(basis, blk_size, CEED_NOTRANSPOSE,
                             CEED_EVAL_GRAD, impl->e_vecs_in[i],
@@ -341,7 +341,7 @@ static inline int CeedOperatorInputBasis_Blocked(CeedInt e, CeedInt Q,
 static inline int CeedOperatorOutputBasis_Blocked(CeedInt e, CeedInt Q,
     CeedQFunctionField *qf_output_fields, CeedOperatorField *op_output_fields,
     CeedInt blk_size, CeedInt num_input_fields, CeedInt num_output_fields,
-    CeedOperator op, CeedScalar *e_data[2*CEED_FIELD_MAX],
+    CeedOperator op, CeedScalar *e_data_full[2*CEED_FIELD_MAX],
     CeedOperator_Blocked *impl) {
   CeedInt ierr;
   CeedInt dim, elem_size, size;
@@ -367,7 +367,7 @@ static inline int CeedOperatorOutputBasis_Blocked(CeedInt e, CeedInt Q,
       ierr = CeedOperatorFieldGetBasis(op_output_fields[i], &basis);
       CeedChkBackend(ierr);
       ierr = CeedVectorSetArray(impl->e_vecs_out[i], CEED_MEM_HOST,
-                                CEED_USE_POINTER, &e_data[i + num_input_fields][e*elem_size*size]);
+                                CEED_USE_POINTER, &e_data_full[i + num_input_fields][e*elem_size*size]);
       CeedChkBackend(ierr);
       ierr = CeedBasisApply(basis, blk_size, CEED_TRANSPOSE,
                             CEED_EVAL_INTERP, impl->q_vecs_out[i],
@@ -378,7 +378,7 @@ static inline int CeedOperatorOutputBasis_Blocked(CeedInt e, CeedInt Q,
       CeedChkBackend(ierr);
       ierr = CeedBasisGetDimension(basis, &dim); CeedChkBackend(ierr);
       ierr = CeedVectorSetArray(impl->e_vecs_out[i], CEED_MEM_HOST,
-                                CEED_USE_POINTER, &e_data[i + num_input_fields][e*elem_size*size/dim]);
+                                CEED_USE_POINTER, &e_data_full[i + num_input_fields][e*elem_size*size/dim]);
       CeedChkBackend(ierr);
       ierr = CeedBasisApply(basis, blk_size, CEED_TRANSPOSE,
                             CEED_EVAL_GRAD, impl->q_vecs_out[i],
@@ -410,7 +410,7 @@ static inline int CeedOperatorOutputBasis_Blocked(CeedInt e, CeedInt Q,
 //------------------------------------------------------------------------------
 static inline int CeedOperatorRestoreInputs_Blocked(CeedInt num_input_fields,
     CeedQFunctionField *qf_input_fields, CeedOperatorField *op_input_fields,
-    bool skip_active, CeedScalar *e_data[2*CEED_FIELD_MAX],
+    bool skip_active, CeedScalar *e_data_full[2*CEED_FIELD_MAX],
     CeedOperator_Blocked *impl) {
   CeedInt ierr;
   CeedEvalMode eval_mode;
@@ -428,8 +428,8 @@ static inline int CeedOperatorRestoreInputs_Blocked(CeedInt num_input_fields,
     CeedChkBackend(ierr);
     if (eval_mode == CEED_EVAL_WEIGHT) { // Skip
     } else {
-      ierr = CeedVectorRestoreArrayRead(impl->e_vecs[i],
-                                        (const CeedScalar **) &e_data[i]);
+      ierr = CeedVectorRestoreArrayRead(impl->e_vecs_full[i],
+                                        (const CeedScalar **) &e_data_full[i]);
       CeedChkBackend(ierr);
     }
   }
@@ -462,7 +462,7 @@ static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector in_vec,
   CeedChkBackend(ierr);
   CeedEvalMode eval_mode;
   CeedVector vec;
-  CeedScalar *e_data[2*CEED_FIELD_MAX] = {0};
+  CeedScalar *e_data_full[2*CEED_FIELD_MAX] = {0};
 
   // Setup
   ierr = CeedOperatorSetup_Blocked(op); CeedChkBackend(ierr);
@@ -470,21 +470,21 @@ static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector in_vec,
   // Restriction only operator
   if (impl->is_identity_restr_op) {
     ierr = CeedElemRestrictionApply(impl->blk_restr[0], CEED_NOTRANSPOSE, in_vec,
-                                    impl->e_vecs[0], request); CeedChkBackend(ierr);
+                                    impl->e_vecs_full[0], request); CeedChkBackend(ierr);
     ierr = CeedElemRestrictionApply(impl->blk_restr[1], CEED_TRANSPOSE,
-                                    impl->e_vecs[0], out_vec, request); CeedChkBackend(ierr);
+                                    impl->e_vecs_full[0], out_vec, request); CeedChkBackend(ierr);
     return CEED_ERROR_SUCCESS;
   }
 
   // Input Evecs and Restriction
   ierr = CeedOperatorSetupInputs_Blocked(num_input_fields, qf_input_fields,
-                                         op_input_fields, in_vec, false, e_data,
+                                         op_input_fields, in_vec, false, e_data_full,
                                          impl, request); CeedChkBackend(ierr);
 
   // Output Evecs
   for (CeedInt i=0; i<num_output_fields; i++) {
-    ierr = CeedVectorGetArray(impl->e_vecs[i+impl->num_e_vecs_in], CEED_MEM_HOST,
-                              &e_data[i + num_input_fields]); CeedChkBackend(ierr);
+    ierr = CeedVectorGetArray(impl->e_vecs_full[i+impl->num_inputs], CEED_MEM_HOST,
+                              &e_data_full[i + num_input_fields]); CeedChkBackend(ierr);
   }
 
   // Loop through elements
@@ -497,14 +497,14 @@ static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector in_vec,
         ierr = CeedQFunctionFieldGetSize(qf_output_fields[i], &size);
         CeedChkBackend(ierr);
         ierr = CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_HOST,
-                                  CEED_USE_POINTER, &e_data[i + num_input_fields][e*Q*size]);
+                                  CEED_USE_POINTER, &e_data_full[i + num_input_fields][e*Q*size]);
         CeedChkBackend(ierr);
       }
     }
 
     // Input basis apply
     ierr = CeedOperatorInputBasis_Blocked(e, Q, qf_input_fields, op_input_fields,
-                                          num_input_fields, blk_size, false, e_data,
+                                          num_input_fields, blk_size, false, e_data_full,
                                           impl); CeedChkBackend(ierr);
 
     // Q function
@@ -516,15 +516,15 @@ static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector in_vec,
     // Output basis apply
     ierr = CeedOperatorOutputBasis_Blocked(e, Q, qf_output_fields, op_output_fields,
                                            blk_size, num_input_fields,
-                                           num_output_fields, op, e_data, impl);
+                                           num_output_fields, op, e_data_full, impl);
     CeedChkBackend(ierr);
   }
 
   // Output restriction
   for (CeedInt i=0; i<num_output_fields; i++) {
     // Restore evec
-    ierr = CeedVectorRestoreArray(impl->e_vecs[i+impl->num_e_vecs_in],
-                                  &e_data[i + num_input_fields]); CeedChkBackend(ierr);
+    ierr = CeedVectorRestoreArray(impl->e_vecs_full[i+impl->num_inputs],
+                                  &e_data_full[i + num_input_fields]); CeedChkBackend(ierr);
     // Get output vector
     ierr = CeedOperatorFieldGetVector(op_output_fields[i], &vec);
     CeedChkBackend(ierr);
@@ -532,15 +532,15 @@ static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector in_vec,
     if (vec == CEED_VECTOR_ACTIVE)
       vec = out_vec;
     // Restrict
-    ierr = CeedElemRestrictionApply(impl->blk_restr[i+impl->num_e_vecs_in],
-                                    CEED_TRANSPOSE, impl->e_vecs[i+impl->num_e_vecs_in],
+    ierr = CeedElemRestrictionApply(impl->blk_restr[i+impl->num_inputs],
+                                    CEED_TRANSPOSE, impl->e_vecs_full[i+impl->num_inputs],
                                     vec, request); CeedChkBackend(ierr);
 
   }
 
   // Restore input arrays
   ierr = CeedOperatorRestoreInputs_Blocked(num_input_fields, qf_input_fields,
-         op_input_fields, false, e_data, impl); CeedChkBackend(ierr);
+         op_input_fields, false, e_data_full, impl); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -569,14 +569,14 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
   ierr = CeedQFunctionGetFields(qf, NULL, &qf_input_fields, NULL,
                                 &qf_output_fields);
   CeedChkBackend(ierr);
-  CeedVector vec, lvec = impl->qf_lvec;
-  CeedInt num_active_in = impl->qf_num_active_in,
-          num_active_out = impl->qf_num_active_out;
+  CeedVector vec, l_vec = impl->qf_l_vec;
+  CeedInt num_active_in = impl->num_active_in,
+          num_active_out = impl->num_active_out;
   CeedVector *active_in = impl->qf_active_in;
   CeedScalar *a, *tmp;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChkBackend(ierr);
-  CeedScalar *e_data[2*CEED_FIELD_MAX] = {0};
+  CeedScalar *e_data_full[2*CEED_FIELD_MAX] = {0};
 
   // Setup
   ierr = CeedOperatorSetup_Blocked(op); CeedChkBackend(ierr);
@@ -590,7 +590,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
 
   // Input Evecs and Restriction
   ierr = CeedOperatorSetupInputs_Blocked(num_input_fields, qf_input_fields,
-                                         op_input_fields, NULL, true, e_data,
+                                         op_input_fields, NULL, true, e_data_full,
                                          impl, request); CeedChkBackend(ierr);
 
   // Count number of active input fields
@@ -618,7 +618,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
         ierr = CeedVectorRestoreArray(impl->q_vecs_in[i], &tmp); CeedChkBackend(ierr);
       }
     }
-    impl->qf_num_active_in = num_active_in;
+    impl->num_active_in = num_active_in;
     impl->qf_active_in = active_in;
   }
 
@@ -635,7 +635,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
         num_active_out += size;
       }
     }
-    impl->qf_num_active_out = num_active_out;
+    impl->num_active_out = num_active_out;
   }
 
   // Check sizes
@@ -647,12 +647,12 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
   // LCOV_EXCL_STOP
 
   // Setup Lvec
-  if (!lvec) {
+  if (!l_vec) {
     ierr = CeedVectorCreate(ceed, num_blks*blk_size*Q*num_active_in*num_active_out,
-                            &lvec); CeedChkBackend(ierr);
-    impl->qf_lvec = lvec;
+                            &l_vec); CeedChkBackend(ierr);
+    impl->qf_l_vec = l_vec;
   }
-  ierr = CeedVectorGetArray(lvec, CEED_MEM_HOST, &a); CeedChkBackend(ierr);
+  ierr = CeedVectorGetArray(l_vec, CEED_MEM_HOST, &a); CeedChkBackend(ierr);
 
   // Build objects if needed
   CeedInt strides[3] = {1, Q, num_active_in *num_active_out*Q};
@@ -671,7 +671,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
   for (CeedInt e=0; e<num_blks*blk_size; e+=blk_size) {
     // Input basis apply
     ierr = CeedOperatorInputBasis_Blocked(e, Q, qf_input_fields, op_input_fields,
-                                          num_input_fields, blk_size, true, e_data,
+                                          num_input_fields, blk_size, true, e_data_full,
                                           impl); CeedChkBackend(ierr);
 
     // Assemble QFunction
@@ -716,10 +716,10 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
 
   // Restore input arrays
   ierr = CeedOperatorRestoreInputs_Blocked(num_input_fields, qf_input_fields,
-         op_input_fields, true, e_data, impl); CeedChkBackend(ierr);
+         op_input_fields, true, e_data_full, impl); CeedChkBackend(ierr);
 
   // Output blocked restriction
-  ierr = CeedVectorRestoreArray(lvec, &a); CeedChkBackend(ierr);
+  ierr = CeedVectorRestoreArray(l_vec, &a); CeedChkBackend(ierr);
   ierr = CeedVectorSetValue(*assembled, 0.0); CeedChkBackend(ierr);
   CeedElemRestriction blk_rstr = impl->qf_blk_rstr;
   if (!impl->qf_blk_rstr) {
@@ -728,7 +728,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(
            strides, &blk_rstr); CeedChkBackend(ierr);
     impl->qf_blk_rstr = blk_rstr;
   }
-  ierr = CeedElemRestrictionApply(blk_rstr, CEED_TRANSPOSE, lvec, *assembled,
+  ierr = CeedElemRestrictionApply(blk_rstr, CEED_TRANSPOSE, l_vec, *assembled,
                                   request); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
@@ -760,22 +760,22 @@ static int CeedOperatorDestroy_Blocked(CeedOperator op) {
   CeedOperator_Blocked *impl;
   ierr = CeedOperatorGetData(op, &impl); CeedChkBackend(ierr);
 
-  for (CeedInt i=0; i<impl->num_e_vecs_in+impl->num_e_vecs_out; i++) {
+  for (CeedInt i=0; i<impl->num_inputs+impl->num_outputs; i++) {
     ierr = CeedElemRestrictionDestroy(&impl->blk_restr[i]); CeedChkBackend(ierr);
-    ierr = CeedVectorDestroy(&impl->e_vecs[i]); CeedChkBackend(ierr);
+    ierr = CeedVectorDestroy(&impl->e_vecs_full[i]); CeedChkBackend(ierr);
   }
   ierr = CeedFree(&impl->blk_restr); CeedChkBackend(ierr);
-  ierr = CeedFree(&impl->e_vecs); CeedChkBackend(ierr);
-  ierr = CeedFree(&impl->input_state); CeedChkBackend(ierr);
+  ierr = CeedFree(&impl->e_vecs_full); CeedChkBackend(ierr);
+  ierr = CeedFree(&impl->input_states); CeedChkBackend(ierr);
 
-  for (CeedInt i=0; i<impl->num_e_vecs_in; i++) {
+  for (CeedInt i=0; i<impl->num_inputs; i++) {
     ierr = CeedVectorDestroy(&impl->e_vecs_in[i]); CeedChkBackend(ierr);
     ierr = CeedVectorDestroy(&impl->q_vecs_in[i]); CeedChkBackend(ierr);
   }
   ierr = CeedFree(&impl->e_vecs_in); CeedChkBackend(ierr);
   ierr = CeedFree(&impl->q_vecs_in); CeedChkBackend(ierr);
 
-  for (CeedInt i=0; i<impl->num_e_vecs_out; i++) {
+  for (CeedInt i=0; i<impl->num_outputs; i++) {
     ierr = CeedVectorDestroy(&impl->e_vecs_out[i]); CeedChkBackend(ierr);
     ierr = CeedVectorDestroy(&impl->q_vecs_out[i]); CeedChkBackend(ierr);
   }
@@ -783,11 +783,11 @@ static int CeedOperatorDestroy_Blocked(CeedOperator op) {
   ierr = CeedFree(&impl->q_vecs_out); CeedChkBackend(ierr);
 
   // QFunction assembly data
-  for (CeedInt i=0; i<impl->qf_num_active_in; i++) {
+  for (CeedInt i=0; i<impl->num_active_in; i++) {
     ierr = CeedVectorDestroy(&impl->qf_active_in[i]); CeedChkBackend(ierr);
   }
   ierr = CeedFree(&impl->qf_active_in); CeedChkBackend(ierr);
-  ierr = CeedVectorDestroy(&impl->qf_lvec); CeedChkBackend(ierr);
+  ierr = CeedVectorDestroy(&impl->qf_l_vec); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionDestroy(&impl->qf_blk_rstr); CeedChkBackend(ierr);
 
   ierr = CeedFree(&impl); CeedChkBackend(ierr);

--- a/backends/blocked/ceed-blocked.h
+++ b/backends/blocked/ceed-blocked.h
@@ -29,17 +29,16 @@ typedef struct {
 typedef struct {
   bool is_identity_qf, is_identity_restr_op;
   CeedElemRestriction *blk_restr; /* Blocked versions of restrictions */
-  CeedVector *e_vecs;      /* All E-vectors, inputs followed by outputs */
-  uint64_t *input_state;   /* State counter of inputs */
-  CeedVector *e_vecs_in;   /* Input E-vectors needed to apply operator */
-  CeedVector *e_vecs_out;  /* Output E-vectors needed to apply operator */
-  CeedVector *q_vecs_in;   /* Input Q-vectors needed to apply operator */
-  CeedVector *q_vecs_out;  /* Output Q-vectors needed to apply operator */
-  CeedInt    num_e_vecs_in;
-  CeedInt    num_e_vecs_out;
-  CeedInt    qf_num_active_in, qf_num_active_out;
+  CeedVector *e_vecs_full; /* Full E-vectors, inputs followed by outputs */
+  uint64_t *input_states;  /* State counter of inputs */
+  CeedVector *e_vecs_in;   /* Element block input E-vectors  */
+  CeedVector *e_vecs_out;  /* Element block output E-vectors */
+  CeedVector *q_vecs_in;   /* Element block input Q-vectors  */
+  CeedVector *q_vecs_out;  /* Element block output Q-vectors */
+  CeedInt    num_inputs, num_outputs;
+  CeedInt    num_active_in, num_active_out;
   CeedVector *qf_active_in;
-  CeedVector qf_lvec;
+  CeedVector qf_l_vec;
   CeedElemRestriction qf_blk_rstr;
 } CeedOperator_Blocked;
 

--- a/backends/blocked/ceed-blocked.h
+++ b/backends/blocked/ceed-blocked.h
@@ -28,15 +28,13 @@ typedef struct {
 
 typedef struct {
   bool is_identity_qf, is_identity_restr_op;
-  CeedElemRestriction *blk_restr; /// Blocked versions of restrictions
-  CeedVector
-  *e_vecs;   /// E-vectors needed to apply operator (input followed by outputs)
-  CeedScalar **e_data;
-  uint64_t *input_state;  /// State counter of inputs
-  CeedVector *e_vecs_in;   /// Input E-vectors needed to apply operator
-  CeedVector *e_vecs_out;  /// Output E-vectors needed to apply operator
-  CeedVector *q_vecs_in;   /// Input Q-vectors needed to apply operator
-  CeedVector *q_vecs_out;  /// Output Q-vectors needed to apply operator
+  CeedElemRestriction *blk_restr; /* Blocked versions of restrictions */
+  CeedVector *e_vecs;      /* All E-vectors, inputs followed by outputs */
+  uint64_t *input_state;   /* State counter of inputs */
+  CeedVector *e_vecs_in;   /* Input E-vectors needed to apply operator */
+  CeedVector *e_vecs_out;  /* Output E-vectors needed to apply operator */
+  CeedVector *q_vecs_in;   /* Input Q-vectors needed to apply operator */
+  CeedVector *q_vecs_out;  /* Output Q-vectors needed to apply operator */
   CeedInt    num_e_vecs_in;
   CeedInt    num_e_vecs_out;
   CeedInt    qf_num_active_in, qf_num_active_out;

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -137,7 +137,7 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector invec,
   ierr = CeedQFunctionGetFields(qf, NULL, &qfinputfields, NULL, &qfoutputfields);
   CeedChkBackend(ierr);
   CeedEvalMode emode;
-  CeedVector vec, outvecs[16] = {};
+  CeedVector vec, outvecs[CEED_FIELD_MAX] = {};
 
   // Creation of the operator
   ierr = CeedCudaGenOperatorBuild(op); CeedChkBackend(ierr);

--- a/backends/cuda-gen/ceed-cuda-gen.h
+++ b/backends/cuda-gen/ceed-cuda-gen.h
@@ -22,8 +22,8 @@
 #include <cuda.h>
 #include "../cuda/ceed-cuda.h"
 
-typedef struct { const CeedScalar *in[16]; CeedScalar *out[16]; } CudaFields;
-typedef struct { CeedInt *in[16]; CeedInt *out[16]; } CudaFieldsInt;
+typedef struct { const CeedScalar *in[CEED_FIELD_MAX]; CeedScalar *out[CEED_FIELD_MAX]; } CudaFields;
+typedef struct { CeedInt *in[CEED_FIELD_MAX]; CeedInt *out[CEED_FIELD_MAX]; } CudaFieldsInt;
 
 typedef struct {
   CeedInt dim;

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -36,7 +36,6 @@ static int CeedOperatorDestroy_Cuda(CeedOperator op) {
     ierr = CeedVectorDestroy(&impl->evecs[i]); CeedChkBackend(ierr);
   }
   ierr = CeedFree(&impl->evecs); CeedChkBackend(ierr);
-  ierr = CeedFree(&impl->edata); CeedChkBackend(ierr);
 
   for (CeedInt i = 0; i < impl->numein; i++) {
     ierr = CeedVectorDestroy(&impl->qvecsin[i]); CeedChkBackend(ierr);
@@ -218,8 +217,6 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
   // Allocate
   ierr = CeedCalloc(numinputfields + numoutputfields, &impl->evecs);
   CeedChkBackend(ierr);
-  ierr = CeedCalloc(numinputfields + numoutputfields, &impl->edata);
-  CeedChkBackend(ierr);
 
   ierr = CeedCalloc(CEED_FIELD_MAX, &impl->qvecsin); CeedChkBackend(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &impl->qvecsout); CeedChkBackend(ierr);
@@ -248,8 +245,8 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
 //------------------------------------------------------------------------------
 static inline int CeedOperatorSetupInputs_Cuda(CeedInt numinputfields,
     CeedQFunctionField *qfinputfields, CeedOperatorField *opinputfields,
-    CeedVector invec, const bool skipactive, CeedOperator_Cuda *impl,
-    CeedRequest *request) {
+    CeedVector invec, const bool skipactive, CeedScalar *edata[2*CEED_FIELD_MAX],
+    CeedOperator_Cuda *impl, CeedRequest *request) {
   CeedInt ierr;
   CeedEvalMode emode;
   CeedVector vec;
@@ -280,14 +277,14 @@ static inline int CeedOperatorSetupInputs_Cuda(CeedInt numinputfields,
       if (!impl->evecs[i]) {
         // No restriction for this field; read data directly from vec.
         ierr = CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE,
-                                      (const CeedScalar **) &impl->edata[i]);
+                                      (const CeedScalar **) &edata[i]);
         CeedChkBackend(ierr);
       } else {
         ierr = CeedElemRestrictionApply(Erestrict, CEED_NOTRANSPOSE, vec,
                                         impl->evecs[i], request); CeedChkBackend(ierr);
         // Get evec
         ierr = CeedVectorGetArrayRead(impl->evecs[i], CEED_MEM_DEVICE,
-                                      (const CeedScalar **) &impl->edata[i]);
+                                      (const CeedScalar **) &edata[i]);
         CeedChkBackend(ierr);
       }
     }
@@ -300,7 +297,8 @@ static inline int CeedOperatorSetupInputs_Cuda(CeedInt numinputfields,
 //------------------------------------------------------------------------------
 static inline int CeedOperatorInputBasis_Cuda(CeedInt numelements,
     CeedQFunctionField *qfinputfields, CeedOperatorField *opinputfields,
-    CeedInt numinputfields, const bool skipactive, CeedOperator_Cuda *impl) {
+    CeedInt numinputfields, const bool skipactive,
+    CeedScalar *edata[2*CEED_FIELD_MAX],CeedOperator_Cuda *impl) {
   CeedInt ierr;
   CeedInt elemsize, size;
   CeedElemRestriction Erestrict;
@@ -327,8 +325,7 @@ static inline int CeedOperatorInputBasis_Cuda(CeedInt numelements,
     switch (emode) {
     case CEED_EVAL_NONE:
       ierr = CeedVectorSetArray(impl->qvecsin[i], CEED_MEM_DEVICE,
-                                CEED_USE_POINTER,
-                                impl->edata[i]); CeedChkBackend(ierr);
+                                CEED_USE_POINTER, edata[i]); CeedChkBackend(ierr);
       break;
     case CEED_EVAL_INTERP:
       ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis);
@@ -360,7 +357,8 @@ static inline int CeedOperatorInputBasis_Cuda(CeedInt numelements,
 //------------------------------------------------------------------------------
 static inline int CeedOperatorRestoreInputs_Cuda(CeedInt numinputfields,
     CeedQFunctionField *qfinputfields, CeedOperatorField *opinputfields,
-    const bool skipactive, CeedOperator_Cuda *impl) {
+    const bool skipactive, CeedScalar *edata[2*CEED_FIELD_MAX],
+    CeedOperator_Cuda *impl) {
   CeedInt ierr;
   CeedEvalMode emode;
   CeedVector vec;
@@ -379,11 +377,11 @@ static inline int CeedOperatorRestoreInputs_Cuda(CeedInt numinputfields,
       if (!impl->evecs[i]) {  // This was a skiprestrict case
         ierr = CeedOperatorFieldGetVector(opinputfields[i], &vec); CeedChkBackend(ierr);
         ierr = CeedVectorRestoreArrayRead(vec,
-                                          (const CeedScalar **)&impl->edata[i]);
+                                          (const CeedScalar **)&edata[i]);
         CeedChkBackend(ierr);
       } else {
         ierr = CeedVectorRestoreArrayRead(impl->evecs[i],
-                                          (const CeedScalar **) &impl->edata[i]);
+                                          (const CeedScalar **) &edata[i]);
         CeedChkBackend(ierr);
       }
     }
@@ -416,18 +414,19 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
   CeedVector vec;
   CeedBasis basis;
   CeedElemRestriction Erestrict;
+  CeedScalar *edata[2*CEED_FIELD_MAX] = {0};
 
   // Setup
   ierr = CeedOperatorSetup_Cuda(op); CeedChkBackend(ierr);
 
   // Input Evecs and Restriction
   ierr = CeedOperatorSetupInputs_Cuda(numinputfields, qfinputfields,
-                                      opinputfields, invec, false, impl,
-                                      request); CeedChkBackend(ierr);
+                                      opinputfields, invec, false, edata,
+                                      impl, request); CeedChkBackend(ierr);
 
   // Input basis apply if needed
   ierr = CeedOperatorInputBasis_Cuda(numelements, qfinputfields, opinputfields,
-                                     numinputfields, false, impl);
+                                     numinputfields, false, edata, impl);
   CeedChkBackend(ierr);
 
   // Output pointers, as necessary
@@ -437,10 +436,9 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
     if (emode == CEED_EVAL_NONE) {
       // Set the output Q-Vector to use the E-Vector data directly.
       ierr = CeedVectorGetArray(impl->evecs[i + impl->numein], CEED_MEM_DEVICE,
-                                &impl->edata[i + numinputfields]); CeedChkBackend(ierr);
+                                &edata[i + numinputfields]); CeedChkBackend(ierr);
       ierr = CeedVectorSetArray(impl->qvecsout[i], CEED_MEM_DEVICE,
-                                CEED_USE_POINTER,
-                                impl->edata[i + numinputfields]);
+                                CEED_USE_POINTER, edata[i + numinputfields]);
       CeedChkBackend(ierr);
     }
   }
@@ -501,7 +499,7 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
     CeedChkBackend(ierr);
     if (emode == CEED_EVAL_NONE) {
       ierr = CeedVectorRestoreArray(impl->evecs[i+impl->numein],
-                                    &impl->edata[i + numinputfields]);
+                                    &edata[i + numinputfields]);
       CeedChkBackend(ierr);
     }
     // Get output vector
@@ -521,7 +519,7 @@ static int CeedOperatorApplyAdd_Cuda(CeedOperator op, CeedVector invec,
 
   // Restore input arrays
   ierr = CeedOperatorRestoreInputs_Cuda(numinputfields, qfinputfields,
-                                        opinputfields, false, impl);
+                                        opinputfields, false, edata, impl);
   CeedChkBackend(ierr);
   return CEED_ERROR_SUCCESS;
 }
@@ -557,6 +555,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op,
   ierr = CeedGetOperatorFallbackParentCeed(ceed, &ceedparent);
   CeedChkBackend(ierr);
   ceedparent = ceedparent ? ceedparent : ceed;
+  CeedScalar *edata[2*CEED_FIELD_MAX];
 
   // Setup
   ierr = CeedOperatorSetup_Cuda(op); CeedChkBackend(ierr);
@@ -572,8 +571,8 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op,
 
   // Input Evecs and Restriction
   ierr = CeedOperatorSetupInputs_Cuda(numinputfields, qfinputfields,
-                                      opinputfields, NULL, true, impl, request);
-  CeedChkBackend(ierr);
+                                      opinputfields, NULL, true, edata,
+                                      impl, request); CeedChkBackend(ierr);
 
   // Count number of active input fields
   if (!numactivein) {
@@ -644,7 +643,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op,
 
   // Input basis apply
   ierr = CeedOperatorInputBasis_Cuda(numelements, qfinputfields, opinputfields,
-                                     numinputfields, true, impl);
+                                     numinputfields, true, edata, impl);
   CeedChkBackend(ierr);
 
   // Assemble QFunction
@@ -688,7 +687,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op,
 
   // Restore input arrays
   ierr = CeedOperatorRestoreInputs_Cuda(numinputfields, qfinputfields,
-                                        opinputfields, true, impl);
+                                        opinputfields, true, edata, impl);
   CeedChkBackend(ierr);
 
   // Restore output

--- a/backends/cuda/ceed-cuda-operator.c
+++ b/backends/cuda/ceed-cuda-operator.c
@@ -221,8 +221,8 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
   ierr = CeedCalloc(numinputfields + numoutputfields, &impl->edata);
   CeedChkBackend(ierr);
 
-  ierr = CeedCalloc(16, &impl->qvecsin); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->qvecsout); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->qvecsin); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->qvecsout); CeedChkBackend(ierr);
 
   impl->numein = numinputfields; impl->numeout = numoutputfields;
 

--- a/backends/cuda/ceed-cuda.h
+++ b/backends/cuda/ceed-cuda.h
@@ -104,8 +104,8 @@ typedef struct {
 // We use a struct to avoid having to memCpy the array of pointers
 // __global__ copies by value the struct.
 typedef struct {
-  const CeedScalar *inputs[16];
-  CeedScalar *outputs[16];
+  const CeedScalar *inputs[CEED_FIELD_MAX];
+  CeedScalar *outputs[CEED_FIELD_MAX];
 } Fields_Cuda;
 
 typedef struct {

--- a/backends/cuda/ceed-cuda.h
+++ b/backends/cuda/ceed-cuda.h
@@ -159,9 +159,7 @@ typedef struct {
 } CeedOperatorDiag_Cuda;
 
 typedef struct {
-  CeedVector
-  *evecs;   // E-vectors needed to apply operator (input followed by outputs)
-  CeedScalar **edata;
+  CeedVector *evecs;   // E-vectors, inputs followed by outputs
   CeedVector *qvecsin;    // Input Q-vectors needed to apply operator
   CeedVector *qvecsout;   // Output Q-vectors needed to apply operator
   CeedInt    numein;

--- a/backends/hip-gen/ceed-hip-gen.h
+++ b/backends/hip-gen/ceed-hip-gen.h
@@ -22,8 +22,8 @@
 #include <hip/hip_runtime.h>
 #include "../hip/ceed-hip.h"
 
-typedef struct { const CeedScalar *in[16]; CeedScalar *out[16]; } HipFields;
-typedef struct { CeedInt *in[16]; CeedInt *out[16]; } HipFieldsInt;
+typedef struct { const CeedScalar *in[CEED_FIELD_MAX]; CeedScalar *out[CEED_FIELD_MAX]; } HipFields;
+typedef struct { CeedInt *in[CEED_FIELD_MAX]; CeedInt *out[CEED_FIELD_MAX]; } HipFieldsInt;
 
 typedef struct {
   CeedInt dim;

--- a/backends/hip/ceed-hip-operator.c
+++ b/backends/hip/ceed-hip-operator.c
@@ -220,8 +220,8 @@ static int CeedOperatorSetup_Hip(CeedOperator op) {
   ierr = CeedCalloc(numinputfields + numoutputfields, &impl->edata);
   CeedChkBackend(ierr);
 
-  ierr = CeedCalloc(16, &impl->qvecsin); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->qvecsout); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->qvecsin); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->qvecsout); CeedChkBackend(ierr);
 
   impl->numein = numinputfields; impl->numeout = numoutputfields;
 

--- a/backends/hip/ceed-hip.h
+++ b/backends/hip/ceed-hip.h
@@ -95,8 +95,8 @@ typedef struct {
 // We use a struct to avoid having to memCpy the array of pointers
 // __global__ copies by value the struct.
 typedef struct {
-  const CeedScalar *inputs[16];
-  CeedScalar *outputs[16];
+  const CeedScalar *inputs[CEED_FIELD_MAX];
+  CeedScalar *outputs[CEED_FIELD_MAX];
 } Fields_Hip;
 
 typedef struct {

--- a/backends/hip/ceed-hip.h
+++ b/backends/hip/ceed-hip.h
@@ -150,9 +150,7 @@ typedef struct {
 } CeedOperatorDiag_Hip;
 
 typedef struct {
-  CeedVector
-  *evecs;   // E-vectors needed to apply operator (input followed by outputs)
-  CeedScalar **edata;
+  CeedVector *evecs;   // E-vectors, inputs followed by outputs
   CeedVector *qvecsin;    // Input Q-vectors needed to apply operator
   CeedVector *qvecsout;   // Output Q-vectors needed to apply operator
   CeedInt    numein;

--- a/backends/memcheck/ceed-memcheck-qfunction.c
+++ b/backends/memcheck/ceed-memcheck-qfunction.c
@@ -94,8 +94,8 @@ int CeedQFunctionCreate_Memcheck(CeedQFunction qf) {
 
   CeedQFunction_Memcheck *impl;
   ierr = CeedCalloc(1, &impl); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->inputs); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->outputs); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->inputs); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->outputs); CeedChkBackend(ierr);
   ierr = CeedQFunctionSetData(qf, impl); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "QFunction", qf, "Apply",

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -174,11 +174,11 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
   ierr = CeedCalloc(num_input_fields + num_output_fields, &impl->e_data);
   CeedChkBackend(ierr);
 
-  ierr = CeedCalloc(16, &impl->input_state); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->e_vecs_in); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->e_vecs_out); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->q_vecs_in); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->q_vecs_out); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->input_state); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_in); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_out); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_in); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_out); CeedChkBackend(ierr);
 
   impl->num_e_vecs_in = num_input_fields;
   impl->num_e_vecs_out = num_output_fields;

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -142,9 +142,9 @@ static int CeedOperatorSetupFields_Opt(CeedQFunction qf, CeedOperator op,
 //------------------------------------------------------------------------------
 static int CeedOperatorSetup_Opt(CeedOperator op) {
   int ierr;
-  bool setup_done;
-  ierr = CeedOperatorIsSetupDone(op, &setup_done); CeedChkBackend(ierr);
-  if (setup_done) return CEED_ERROR_SUCCESS;
+  bool is_setup_done;
+  ierr = CeedOperatorIsSetupDone(op, &is_setup_done); CeedChkBackend(ierr);
+  if (is_setup_done) return CEED_ERROR_SUCCESS;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChkBackend(ierr);
   Ceed_Opt *ceed_impl;

--- a/backends/opt/ceed-opt.h
+++ b/backends/opt/ceed-opt.h
@@ -33,17 +33,16 @@ typedef struct {
 typedef struct {
   bool is_identity_qf, is_identity_restr_op;
   CeedElemRestriction *blk_restr; /* Blocked versions of restrictions */
-  CeedVector *e_vecs;      /* All, E-vectors, inputs followed by outputs */
-  uint64_t *input_state;   /* State counter of inputs */
-  CeedVector *e_vecs_in;   /* Input E-vectors needed to apply operator */
-  CeedVector *e_vecs_out;  /* Output E-vectors needed to apply operator */
-  CeedVector *q_vecs_in;   /* Input Q-vectors needed to apply operator */
-  CeedVector *q_vecs_out;  /* Output Q-vectors needed to apply operator */
-  CeedInt    num_e_vecs_in;
-  CeedInt    num_e_vecs_out;
-  CeedInt    qf_num_active_in, qf_num_active_out;
+  CeedVector *e_vecs_full; /* Full E-vectors, inputs followed by outputs */
+  uint64_t *input_states;  /* State counter of inputs */
+  CeedVector *e_vecs_in;   /* Element block input E-vectors  */
+  CeedVector *e_vecs_out;  /* Element block output E-vectors */
+  CeedVector *q_vecs_in;   /* Element block input Q-vectors  */
+  CeedVector *q_vecs_out;  /* Element block output Q-vectors */
+  CeedInt    num_inputs,num_outputs;
+  CeedInt    num_active_in, num_active_out;
   CeedVector *qf_active_in;
-  CeedVector qf_lvec;
+  CeedVector qf_l_vec;
   CeedElemRestriction qf_blk_rstr;
 } CeedOperator_Opt;
 

--- a/backends/opt/ceed-opt.h
+++ b/backends/opt/ceed-opt.h
@@ -33,9 +33,7 @@ typedef struct {
 typedef struct {
   bool is_identity_qf, is_identity_restr_op;
   CeedElemRestriction *blk_restr; /* Blocked versions of restrictions */
-  CeedVector
-  *e_vecs;   /* E-vectors needed to apply operator (input followed by outputs) */
-  CeedScalar **e_data;
+  CeedVector *e_vecs;      /* All, E-vectors, inputs followed by outputs */
   uint64_t *input_state;   /* State counter of inputs */
   CeedVector *e_vecs_in;   /* Input E-vectors needed to apply operator */
   CeedVector *e_vecs_out;  /* Output E-vectors needed to apply operator */

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -104,9 +104,9 @@ static int CeedOperatorSetupFields_Ref(CeedQFunction qf, CeedOperator op,
 //------------------------------------------------------------------------------/*
 static int CeedOperatorSetup_Ref(CeedOperator op) {
   int ierr;
-  bool setup_done;
-  ierr = CeedOperatorIsSetupDone(op, &setup_done); CeedChkBackend(ierr);
-  if (setup_done) return CEED_ERROR_SUCCESS;
+  bool is_setup_done;
+  ierr = CeedOperatorIsSetupDone(op, &is_setup_done); CeedChkBackend(ierr);
+  if (is_setup_done) return CEED_ERROR_SUCCESS;
   Ceed ceed;
   ierr = CeedOperatorGetCeed(op, &ceed); CeedChkBackend(ierr);
   CeedOperator_Ref *impl;

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -131,11 +131,11 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
   ierr = CeedCalloc(num_input_fields + num_output_fields, &impl->e_data);
   CeedChkBackend(ierr);
 
-  ierr = CeedCalloc(16, &impl->input_state); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->e_vecs_in); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->e_vecs_out); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->q_vecs_in); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->q_vecs_out); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->input_state); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_in); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->e_vecs_out); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_in); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_out); CeedChkBackend(ierr);
 
   impl->num_e_vecs_in = num_input_fields;
   impl->num_e_vecs_out = num_output_fields;

--- a/backends/ref/ceed-ref-qfunction.c
+++ b/backends/ref/ceed-ref-qfunction.c
@@ -91,8 +91,8 @@ int CeedQFunctionCreate_Ref(CeedQFunction qf) {
 
   CeedQFunction_Ref *impl;
   ierr = CeedCalloc(1, &impl); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->inputs); CeedChkBackend(ierr);
-  ierr = CeedCalloc(16, &impl->outputs); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->inputs); CeedChkBackend(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &impl->outputs); CeedChkBackend(ierr);
   ierr = CeedQFunctionSetData(qf, impl); CeedChkBackend(ierr);
 
   ierr = CeedSetBackendFunction(ceed, "QFunction", qf, "Apply",

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -53,9 +53,7 @@ typedef struct {
 
 typedef struct {
   bool is_identity_qf, is_identity_restr_op;
-  CeedVector
-  *e_vecs;   /* E-vectors needed to apply operator (input followed by outputs) */
-  CeedScalar **e_data;
+  CeedVector *e_vecs;      /* All E-vectors, inputs followed by outputs */
   uint64_t *input_state;   /* State counter of inputs */
   CeedVector *e_vecs_in;   /* Input E-vectors needed to apply operator */
   CeedVector *e_vecs_out;  /* Output E-vectors needed to apply operator */

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -53,15 +53,14 @@ typedef struct {
 
 typedef struct {
   bool is_identity_qf, is_identity_restr_op;
-  CeedVector *e_vecs;      /* All E-vectors, inputs followed by outputs */
-  uint64_t *input_state;   /* State counter of inputs */
-  CeedVector *e_vecs_in;   /* Input E-vectors needed to apply operator */
-  CeedVector *e_vecs_out;  /* Output E-vectors needed to apply operator */
-  CeedVector *q_vecs_in;   /* Input Q-vectors needed to apply operator */
-  CeedVector *q_vecs_out;  /* Output Q-vectors needed to apply operator */
-  CeedInt    num_e_vecs_in;
-  CeedInt    num_e_vecs_out;
-  CeedInt    qf_num_active_in, qf_num_active_out;
+  CeedVector *e_vecs_full; /* Full E-vectors, inputs followed by outputs */
+  uint64_t *input_states;  /* State counter of inputs */
+  CeedVector *e_vecs_in;   /* Single element input E-vectors  */
+  CeedVector *e_vecs_out;  /* Single element output E-vectors */
+  CeedVector *q_vecs_in;   /* Single element input Q-vectors  */
+  CeedVector *q_vecs_out;  /* Single element output Q-vectors */
+  CeedInt    num_inputs, num_outputs;
+  CeedInt    num_active_in, num_active_out;
   CeedVector *qf_active_in;
 } CeedOperator_Ref;
 

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -23,8 +23,8 @@
 #include <stdint.h>
 
 typedef struct {
-  CeedScalar *collograd1d;
-  bool collo_interp;
+  CeedScalar *collo_grad_1d;
+  bool has_collo_interp;
 } CeedBasis_Ref;
 
 typedef struct {
@@ -43,7 +43,6 @@ typedef struct {
 typedef struct {
   const CeedScalar **inputs;
   CeedScalar **outputs;
-  bool setup_done;
 } CeedQFunction_Ref;
 
 typedef struct {

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -30,6 +30,7 @@ for each release of libCEED.
 
 - Refactored preconditioner support internally to facilitate future development and improve GPU completeness/test coverage.
 - `Include-what-you-use` makefile target added as `make iwyu`.
+- Create backend constant `CEED_FIELD_MAX` to reduce magic numbers in codebase.
 
 (v0-9)=
 

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -30,6 +30,7 @@
 #define CEED_MAX_BACKEND_PRIORITY UINT_MAX
 #define CEED_ALIGN 64
 #define CEED_COMPOSITE_MAX 16
+#define CEED_FIELD_MAX 16
 
 /**
   @ingroup Ceed

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -936,7 +936,7 @@ void fCeedQFunctionApply(int *qf, int *Q,
                          int *v12, int *v13, int *v14, int *v15, int *err) {
   CeedQFunction qf_ = CeedQFunction_dict[*qf];
   CeedVector *in;
-  *err = CeedCalloc(16, &in);
+  *err = CeedCalloc(CEED_FIELD_MAX, &in);
   if (*err) return;
   in[0] = *u==FORTRAN_NULL?NULL:CeedVector_dict[*u];
   in[1] = *u1==FORTRAN_NULL?NULL:CeedVector_dict[*u1];
@@ -955,7 +955,7 @@ void fCeedQFunctionApply(int *qf, int *Q,
   in[14] = *u14==FORTRAN_NULL?NULL:CeedVector_dict[*u14];
   in[15] = *u15==FORTRAN_NULL?NULL:CeedVector_dict[*u15];
   CeedVector *out;
-  *err = CeedCalloc(16, &out);
+  *err = CeedCalloc(CEED_FIELD_MAX, &out);
   if (*err) return;
   out[0] = *v==FORTRAN_NULL?NULL:CeedVector_dict[*v];
   out[1] = *v1==FORTRAN_NULL?NULL:CeedVector_dict[*v1];

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -514,8 +514,8 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
     (*op)->dqfT = dqfT;
     ierr = CeedQFunctionReference(dqfT); CeedChk(ierr);
   }
-  ierr = CeedCalloc(16, &(*op)->input_fields); CeedChk(ierr);
-  ierr = CeedCalloc(16, &(*op)->output_fields); CeedChk(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &(*op)->input_fields); CeedChk(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &(*op)->output_fields); CeedChk(ierr);
   ierr = ceed->OperatorCreate(*op); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
 }
@@ -548,7 +548,7 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
   (*op)->ceed = ceed;
   ierr = CeedReference(ceed); CeedChk(ierr);
   (*op)->is_composite = true;
-  ierr = CeedCalloc(16, &(*op)->sub_operators); CeedChk(ierr);
+  ierr = CeedCalloc(CEED_COMPOSITE_MAX, &(*op)->sub_operators); CeedChk(ierr);
 
   if (ceed->CompositeOperatorCreate) {
     ierr = ceed->CompositeOperatorCreate(*op); CeedChk(ierr);

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -468,8 +468,8 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length,
     strncpy(source_copy, source, source_len);
     (*qf)->source_path = source_copy;
   }
-  ierr = CeedCalloc(16, &(*qf)->input_fields); CeedChk(ierr);
-  ierr = CeedCalloc(16, &(*qf)->output_fields); CeedChk(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &(*qf)->input_fields); CeedChk(ierr);
+  ierr = CeedCalloc(CEED_FIELD_MAX, &(*qf)->output_fields); CeedChk(ierr);
   ierr = ceed->QFunctionCreate(*qf); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
 }


### PR DESCRIPTION
This removes the use of the magic number 16 as the maximum number of input or output fields for a QFunction/Operator and instead declares the value as a constant.

I then use this value to [finally] remove the `e_data` array from my pre-vector-access-control hack in the CPU operator data.