### PR TITLE
ctx - define interface for updating ctx fields

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -19,6 +19,8 @@ for each release of libCEED.
 - Added {c:func}`CeedQFunctionGetKernelName`; refactored {c:func}`CeedQFunctionGetSourcePath` to exclude function kernel name.
 - Clarify documentation for {c:func}`CeedVectorTakeArray`; this function will error if {c:func}`CeedVectorSetArray` with `copy_mode == CEED_USE_POINTER` was not previously called for the corresponding `CeedMemType`.
 - Added {c:func}`CeedVectorGetArrayWrite` that allows access to uninitalized arrays; require initalized data for {c:func}`CeedVectorGetArray`.
+- Added {c:func}`CeedQFunctionContextRegisterDouble` and {c:func}`CeedQFunctionContextRegisterInt32` with {c:func}`CeedQFunctionContextSetDouble` and {c:func}`CeedQFunctionContextSetInt32` to facilitate easy updating of {ref}`CeedQFunctionContext` data by user defined field names.
+- Added {c:func}`CeedQFunctionContextGetFieldDescriptions` to retreive user defined descriptions of fields that are registered with `CeedQFunctionContextRegister*`.
 
 ### New features
 

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -29,6 +29,7 @@ for each release of libCEED.
 - Added support for JiT of QFunctions with `#include "relative/path/local-file.h"` statements for additional local files. Note that files included with `""` are searched relative to the current file first, then by compiler paths (as with `<>` includes). To use this feature, one should adhere to relative paths only, not compiler flags like `-I`, which the JiT will not be aware of.
 - Remove need to guard library headers in QFunction source for code generation backends.
 - `CeedDebugEnv()` macro created to provide debugging outputs when Ceed context is not present.
+- Added {c:func}`CeedStringAllocCopy` to reduce repeated code for copying strings internally.
 
 ### Maintainability
 

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -16,6 +16,7 @@
 
 #include <ceed/ceed.h>
 #include <ceed/backend.h>
+#include <stddef.h>
 #include <string.h>
 #include "ceed-identity.h"
 
@@ -24,6 +25,8 @@
 **/
 static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
                                       CeedQFunction qf) {
+  int ierr;
+
   // Check QFunction name
   const char *name = "Identity";
   if (strcmp(name, requested))
@@ -35,6 +38,18 @@ static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
 
   // QFunction fields 'input' and 'output' with requested emodes added
   //   by the library rather than being added here
+
+  // Context data
+  CeedQFunctionContext ctx;
+  IdentityCtx ctx_data = {.size = 1};
+  ierr = CeedQFunctionContextCreate(ceed, &ctx); CeedChk(ierr);
+  ierr = CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                     sizeof(ctx_data), (void *)&ctx_data);
+  CeedChk(ierr);
+  ierr = CeedQFunctionContextRegisterInt32(ctx, "size", offsetof(IdentityCtx,
+         size), "field size of identity QFunction"); CeedChk(ierr);
+  ierr = CeedQFunctionSetContext(qf, ctx); CeedChk(ierr);
+  ierr = CeedQFunctionContextDestroy(&ctx); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/gallery/identity/ceed-identity.h
+++ b/gallery/identity/ceed-identity.h
@@ -21,11 +21,16 @@
 #ifndef identity_h
 #define identity_h
 
+typedef struct {
+  CeedInt size;
+} IdentityCtx;
+
 CEED_QFUNCTION(Identity)(void *ctx, const CeedInt Q,
                          const CeedScalar *const *in,
                          CeedScalar *const *out) {
   // Ctx holds field size
-  const CeedInt size = *(CeedInt *)ctx;
+  IdentityCtx identity_ctx = *(IdentityCtx *)ctx;
+  const CeedInt size = identity_ctx.size;
 
   // in[0] is input, size (Q*size)
   const CeedScalar *input = in[0];

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -273,7 +273,7 @@ struct CeedQFunctionContext_private {
 /// Struct to handle the context data to use the Fortran QFunction stub
 /// @ingroup CeedQFunction
 struct CeedFortranContext_private {
-  CeedQFunctionContext innerctx;
+  CeedQFunctionContext inner_ctx;
   void (*f)(void *ctx, int *nq,
             const CeedScalar *u,const CeedScalar *u1,
             const CeedScalar *u2,const CeedScalar *u3,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -262,6 +262,9 @@ struct CeedQFunctionContext_private {
   int (*GetData)(CeedQFunctionContext, CeedMemType, void *);
   int (*RestoreData)(CeedQFunctionContext);
   int (*Destroy)(CeedQFunctionContext);
+  CeedInt num_fields;
+  CeedInt max_fields;
+  CeedQFunctionContextFieldDescription *field_descriptions;
   uint64_t state;
   size_t ctx_size;
   void *data;

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -87,6 +87,7 @@ typedef struct CeedTensorContract_private *CeedTensorContract;
 CEED_INTERN int CeedMallocArray(size_t n, size_t unit, void *p);
 CEED_INTERN int CeedCallocArray(size_t n, size_t unit, void *p);
 CEED_INTERN int CeedReallocArray(size_t n, size_t unit, void *p);
+CEED_INTERN int CeedStringAllocCopy(const char *source, char **copy);
 CEED_INTERN int CeedFree(void *p);
 
 #define CeedChk(ierr) do { int ierr_ = ierr; if (ierr_) return ierr_; } while (0)

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -767,15 +767,15 @@ static int CeedQFunctionFortranStub(void *ctx, int nq,
                                     const CeedScalar *const *u,
                                     CeedScalar *const *v) {
   CeedFortranContext fctx = ctx;
-  CeedQFunctionContext innerctx = fctx->innerctx;
+  CeedQFunctionContext inner_ctx = fctx->inner_ctx;
   int ierr;
 
   CeedScalar *ctx_ = NULL;
   // Note: Device backends are generating their own kernels from
   //         single source files, so only Host backends need to
   //         use this Fortran stub.
-  if (innerctx) {
-    ierr = CeedQFunctionContextGetData(innerctx, CEED_MEM_HOST, &ctx_);
+  if (inner_ctx) {
+    ierr = CeedQFunctionContextGetData(inner_ctx, CEED_MEM_HOST, &ctx_);
     CeedChk(ierr);
   }
 
@@ -784,8 +784,8 @@ static int CeedQFunctionFortranStub(void *ctx, int nq,
           v[0],v[1],v[2],v[3],v[4],v[5],v[6],v[7],v[8],v[9],
           v[10],v[11],v[12],v[13],v[14],v[15],&ierr);
 
-  if (innerctx) {
-    ierr = CeedQFunctionContextRestoreData(innerctx, (void *)&ctx_);
+  if (inner_ctx) {
+    ierr = CeedQFunctionContextRestoreData(inner_ctx, (void *)&ctx_);
     CeedChk(ierr);
   }
 
@@ -832,7 +832,7 @@ void fCeedQFunctionCreateInterior(int *ceed, int *vec_length,
   CeedFortranContext fctxdata;
   *err = CeedCalloc(1, &fctxdata);
   if (*err) return;
-  fctxdata->f = f; fctxdata->innerctx = NULL;
+  fctxdata->f = f; fctxdata->inner_ctx = NULL;
   CeedQFunctionContext fctx;
   *err = CeedQFunctionContextCreate(Ceed_dict[*ceed], &fctx);
   if (*err) return;
@@ -920,7 +920,7 @@ void fCeedQFunctionSetContext(int *qf, int *ctx, int *err) {
   CeedFortranContext fctxdata;
   *err = CeedQFunctionContextGetData(fctx, CEED_MEM_HOST, &fctxdata);
   if (*err) return;
-  fctxdata->innerctx = ctx_;
+  fctxdata->inner_ctx = ctx_;
   *err = CeedQFunctionContextRestoreData(fctx, (void **)&fctxdata);
 }
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -704,11 +704,8 @@ found:
   }
 
   op->num_fields += 1;
-  size_t len = strlen(field_name);
-  char *tmp;
-  ierr = CeedCalloc(len+1, &tmp); CeedChk(ierr);
-  memcpy(tmp, field_name, len+1);
-  (*op_field)->field_name = tmp;
+  ierr = CeedStringAllocCopy(field_name, (char **)&(*op_field)->field_name);
+  CeedChk(ierr);
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -114,9 +114,9 @@ int CeedQFunctionRegister(const char *name, const char *source,
 **/
 static int CeedQFunctionFieldSet(CeedQFunctionField *f,const char *field_name,
                                  CeedInt size, CeedEvalMode eval_mode) {
+  int ierr;
   size_t len = strlen(field_name);
   char *tmp;
-  int ierr;
 
   ierr = CeedCalloc(1, f); CeedChk(ierr);
   ierr = CeedCalloc(len+1, &tmp); CeedChk(ierr);

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -322,7 +322,7 @@ int CeedQFunctionGetInnerContext(CeedQFunction qf, CeedQFunctionContext *ctx) {
     CeedFortranContext fortran_ctx = NULL;
     ierr = CeedQFunctionContextGetData(qf->ctx, CEED_MEM_HOST, &fortran_ctx);
     CeedChk(ierr);
-    *ctx = fortran_ctx->innerctx;
+    *ctx = fortran_ctx->inner_ctx;
     ierr = CeedQFunctionContextRestoreData(qf->ctx, (void *)&fortran_ctx);
     CeedChk(ierr);
   } else {

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -112,16 +112,13 @@ int CeedQFunctionRegister(const char *name, const char *source,
 
   @ref Developer
 **/
-static int CeedQFunctionFieldSet(CeedQFunctionField *f,const char *field_name,
+static int CeedQFunctionFieldSet(CeedQFunctionField *f, const char *field_name,
                                  CeedInt size, CeedEvalMode eval_mode) {
   int ierr;
-  size_t len = strlen(field_name);
-  char *tmp;
 
   ierr = CeedCalloc(1, f); CeedChk(ierr);
-  ierr = CeedCalloc(len+1, &tmp); CeedChk(ierr);
-  memcpy(tmp, field_name, len+1);
-  (*f)->field_name = tmp;
+  ierr = CeedStringAllocCopy(field_name, (char **)&(*f)->field_name);
+  CeedChk(ierr);
   (*f)->size = size;
   (*f)->eval_mode = eval_mode;
   return CEED_ERROR_SUCCESS;
@@ -489,8 +486,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length,
 int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
                                       CeedQFunction *qf) {
   int ierr;
-  size_t match_len = 0, match_idx = UINT_MAX;
-  char *name_copy;
+  size_t match_len = 0, match_index = UINT_MAX;
 
   ierr = CeedQFunctionRegisterAll(); CeedChk(ierr);
   // Find matching backend
@@ -502,7 +498,7 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
     for (n = 0; curr_name[n] && curr_name[n] == name[n]; n++) {}
     if (n > match_len) {
       match_len = n;
-      match_idx = i;
+      match_index = i;
     }
   }
   if (!match_len)
@@ -512,19 +508,16 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed,  const char *name,
 
   // Create QFunction
   ierr = CeedQFunctionCreateInterior(ceed,
-                                     gallery_qfunctions[match_idx].vec_length,
-                                     gallery_qfunctions[match_idx].f,
-                                     gallery_qfunctions[match_idx].source, qf);
+                                     gallery_qfunctions[match_index].vec_length,
+                                     gallery_qfunctions[match_index].f,
+                                     gallery_qfunctions[match_index].source, qf);
   CeedChk(ierr);
 
   // QFunction specific setup
-  ierr = gallery_qfunctions[match_idx].init(ceed, name, *qf); CeedChk(ierr);
+  ierr = gallery_qfunctions[match_index].init(ceed, name, *qf); CeedChk(ierr);
 
   // Copy name
-  size_t slen = strlen(name) + 1;
-  ierr = CeedMalloc(slen, &name_copy); CeedChk(ierr);
-  memcpy(name_copy, name, slen);
-  (*qf)->gallery_name = name_copy;
+  ierr = CeedStringAllocCopy(name, (char **)&(*qf)->gallery_name); CeedChk(ierr);
   (*qf)->is_gallery = true;
   return CEED_ERROR_SUCCESS;
 }

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -558,16 +558,11 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode in_mode,
   ierr = CeedQFunctionAddOutput(*qf, "output", size, out_mode); CeedChk(ierr);
 
   (*qf)->is_identity = true;
-  CeedInt *size_data;
-  ierr = CeedCalloc(1, &size_data); CeedChk(ierr);
-  size_data[0] = size;
+
   CeedQFunctionContext ctx;
-  ierr = CeedQFunctionContextCreate(ceed, &ctx); CeedChk(ierr);
-  ierr = CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_OWN_POINTER,
-                                     sizeof(*size_data), (void *)size_data);
-  CeedChk(ierr);
-  ierr = CeedQFunctionSetContext(*qf, ctx); CeedChk(ierr);
-  ierr = CeedQFunctionContextDestroy(&ctx); CeedChk(ierr);
+  ierr = CeedQFunctionGetContext(*qf, &ctx); CeedChk(ierr);
+  ierr = CeedQFunctionContextSetInt32(ctx, "size", size); CeedChk(ierr);
+
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -19,9 +19,149 @@
 #include <ceed-impl.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 /// @file
 /// Implementation of public CeedQFunctionContext interfaces
+
+/// ----------------------------------------------------------------------------
+/// CeedQFunctionContext Library Internal Functions
+/// ----------------------------------------------------------------------------
+/// @addtogroup CeedQFunctionDeveloper
+/// @{
+
+/**
+  @brief Get index for QFunctionContext field
+
+  @param ctx         CeedQFunctionContext
+  @param field_name  Name of field
+  @param field_index Index of field, or -1 if field is not registered
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Developer
+**/
+int CeedQFunctionContextGetFieldIndex(CeedQFunctionContext ctx,
+                                      const char *field_name, CeedInt *field_index) {
+  *field_index = -1;
+  for (CeedInt i=0; i<ctx->num_fields; i++)
+    if (!strcmp(ctx->field_descriptions[i].name, field_name))
+      *field_index = i;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Common function for registering QFunctionContext fields
+
+  @param ctx               CeedQFunctionContext
+  @param field_name        Name of field to register
+  @param field_offset      Offset of field to register
+  @param field_description Description of field, or NULL for none
+  @param field_type        Field data type, such as double or int32
+  @param field_size        Size of field, in bytes
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Developer
+**/
+int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx,
+                                        const char *field_name, size_t field_offset,
+                                        const char *field_description,
+                                        CeedContextFieldType field_type,
+                                        size_t field_size) {
+  int ierr;
+
+  // Check for duplicate
+  CeedInt field_index = -1;
+  ierr = CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index);
+  CeedChk(ierr);
+  if (field_index != -1)
+    // LCOV_EXCL_START
+    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
+                     "QFunctionContext field with name \"%s\" already registered",
+                     field_name);
+  // LCOV_EXCL_STOP
+
+  // Allocate space for field data
+  if (ctx->num_fields == 0) {
+    ierr = CeedCalloc(1, &ctx->field_descriptions); CeedChk(ierr);
+    ctx->max_fields = 1;
+  } else if (ctx->num_fields == ctx->max_fields) {
+    ierr = CeedRealloc(2*ctx->max_fields, &ctx->field_descriptions);
+    CeedChk(ierr);
+    ctx->max_fields *= 2;
+  }
+
+  // Copy field data
+  {
+    size_t len = strlen(field_name);
+    char *tmp;
+    ierr = CeedCalloc(len + 1, &tmp); CeedChk(ierr);
+    memcpy(tmp, field_name, len+1);
+    ctx->field_descriptions[ctx->num_fields].name = tmp;
+  }
+  {
+    size_t len = strlen(field_description);
+    char *tmp;
+    ierr = CeedCalloc(len + 1, &tmp); CeedChk(ierr);
+    memcpy(tmp, field_description, len+1);
+    ctx->field_descriptions[ctx->num_fields].description = tmp;
+  }
+  ctx->field_descriptions[ctx->num_fields].type = field_type;
+  ctx->field_descriptions[ctx->num_fields].offset = field_offset;
+  ctx->field_descriptions[ctx->num_fields].size = field_size;
+  ctx->num_fields++;
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set QFunctionContext field holding a double precision value
+
+  @param ctx        CeedQFunctionContext
+  @param field_name Name of field to set
+  @param field_type Type of field to set
+  @param value      Value to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
+                                   const char *field_name,
+                                   CeedContextFieldType field_type, void *value) {
+  int ierr;
+
+  // Check field index
+  CeedInt field_index = -1;
+  ierr = CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index);
+  CeedChk(ierr);
+  if (field_index == -1)
+    // LCOV_EXCL_START
+    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
+                     "QFunctionContext field with name \"%s\" not registered",
+                     field_name);
+  // LCOV_EXCL_STOP
+
+  if (ctx->field_descriptions[field_index].type != field_type)
+    // LCOV_EXCL_START
+    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
+                     "QFunctionContext field with name \"%s\" registered as %s, "
+                     "not registered as %s", field_name,
+                     CeedContextFieldTypes[ctx->field_descriptions[field_index].type],
+                     CeedContextFieldTypes[field_type]);
+  // LCOV_EXCL_STOP
+
+  char *data;
+  ierr = CeedQFunctionContextGetData(ctx, CEED_MEM_HOST, &data); CeedChk(ierr);
+  memcpy(&data[ctx->field_descriptions[field_index].offset], value,
+         ctx->field_descriptions[field_index].size);
+  ierr = CeedQFunctionContextRestoreData(ctx, &data); CeedChk(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/// @}
 
 /// ----------------------------------------------------------------------------
 /// CeedQFunctionContext Backend API
@@ -400,6 +540,98 @@ int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
+  @brief Register QFunctionContext a field holding a double precision value
+
+  @param ctx               CeedQFunctionContext
+  @param field_name        Name of field to register
+  @param field_offset      Offset of field to register
+  @param field_description Description of field, or NULL for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx,
+                                       const char *field_name, size_t field_offset,
+                                       const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset,
+         field_description, CEED_CONTEXT_FIELD_DOUBLE, sizeof(double));
+}
+
+/**
+  @brief Register QFunctionContext a field holding a int32 value
+
+  @param ctx               CeedQFunctionContext
+  @param field_name        Name of field to register
+  @param field_offset      Offset of field to register
+  @param field_description Description of field, or NULL for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx,
+                                      const char *field_name, size_t field_offset,
+                                      const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset,
+         field_description, CEED_CONTEXT_FIELD_INT32, sizeof(int));
+}
+
+/**
+  @brief Get descriptions for registered QFunctionContext fields
+
+  @param ctx                     CeedQFunctionContext
+  @param[out] field_descriptions Variable to hold array of field descriptions
+  @param[out] num_fields         Length of field descriptions array
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextGetFieldDescriptions(CeedQFunctionContext ctx,
+    const CeedQFunctionContextFieldDescription **field_descriptions,
+    CeedInt *num_fields) {
+  *field_descriptions = ctx->field_descriptions;
+  *num_fields = ctx->num_fields;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set QFunctionContext field holding a double precision value
+
+  @param ctx        CeedQFunctionContext
+  @param field_name Name of field to register
+  @param value      Value to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
+                                  const char *field_name, double value) {
+  return CeedQFunctionContextSetGeneric(ctx, field_name,
+                                        CEED_CONTEXT_FIELD_DOUBLE,
+                                        &value);
+}
+
+/**
+  @brief Set QFunctionContext field holding a int32 value
+
+  @param ctx        CeedQFunctionContext
+  @param field_name Name of field to set
+  @param value      Value to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
+                                 const char *field_name, int value) {
+  return CeedQFunctionContextSetGeneric(ctx, field_name, CEED_CONTEXT_FIELD_INT32,
+                                        &value);
+}
+
+/**
   @brief Get data size for a Context
 
   @param ctx            CeedQFunctionContext
@@ -457,8 +689,14 @@ int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx) {
   if ((*ctx)->Destroy) {
     ierr = (*ctx)->Destroy(*ctx); CeedChk(ierr);
   }
+  for (CeedInt i=0; i<(*ctx)->num_fields; i++) {
+    ierr = CeedFree(&(*ctx)->field_descriptions[i].name); CeedChk(ierr);
+    ierr = CeedFree(&(*ctx)->field_descriptions[i].description); CeedChk(ierr);
+  }
+  ierr = CeedFree(&(*ctx)->field_descriptions); CeedChk(ierr);
   ierr = CeedDestroy(&(*ctx)->ceed); CeedChk(ierr);
   ierr = CeedFree(ctx); CeedChk(ierr);
+
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -93,25 +93,16 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx,
   }
 
   // Copy field data
-  {
-    size_t len = strlen(field_name);
-    char *tmp;
-    ierr = CeedCalloc(len + 1, &tmp); CeedChk(ierr);
-    memcpy(tmp, field_name, len+1);
-    ctx->field_descriptions[ctx->num_fields].name = tmp;
-  }
-  {
-    size_t len = strlen(field_description);
-    char *tmp;
-    ierr = CeedCalloc(len + 1, &tmp); CeedChk(ierr);
-    memcpy(tmp, field_description, len+1);
-    ctx->field_descriptions[ctx->num_fields].description = tmp;
-  }
+  ierr = CeedStringAllocCopy(field_name,
+                             (char **)&ctx->field_descriptions[ctx->num_fields].name);
+  CeedChk(ierr);
+  ierr = CeedStringAllocCopy(field_description,
+                             (char **)&ctx->field_descriptions[ctx->num_fields].description);
+  CeedChk(ierr);
   ctx->field_descriptions[ctx->num_fields].type = field_type;
   ctx->field_descriptions[ctx->num_fields].offset = field_offset;
   ctx->field_descriptions[ctx->num_fields].size = field_size;
   ctx->num_fields++;
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -157,7 +148,6 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
   memcpy(&data[ctx->field_descriptions[field_index].offset], value,
          ctx->field_descriptions[field_index].size);
   ierr = CeedQFunctionContextRestoreData(ctx, &data); CeedChk(ierr);
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-types.c
+++ b/interface/ceed-types.c
@@ -69,3 +69,8 @@ const char *const CeedElemTopologies[] = {
   [CEED_PRISM] = "prism",
   [CEED_HEX] = "hexahedron",
 };
+
+const char *const CeedContextFieldTypes[] = {
+  [CEED_CONTEXT_FIELD_DOUBLE] = "double",
+  [CEED_CONTEXT_FIELD_INT32] = "int32",
+};

--- a/tests/t407-qfunction.c
+++ b/tests/t407-qfunction.c
@@ -1,0 +1,65 @@
+/// @file
+/// Test registering and setting QFunctionContext fields
+/// \test Test registering and setting QFunctionContext fields
+#include <ceed.h>
+#include <stddef.h>
+#include <string.h>
+
+typedef struct {
+  double time;
+  int count;
+} TestContext;
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedQFunctionContext ctx;
+  TestContext ctx_data = {
+    .time = 1.0,
+    .count = 42
+  };
+
+  CeedInit(argv[1], &ceed);
+
+  CeedQFunctionContextCreate(ceed, &ctx);
+  CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_USE_POINTER,
+                              sizeof(TestContext), &ctx_data);
+
+  CeedQFunctionContextRegisterDouble(ctx, "time", offsetof(TestContext, time),
+                                     "current time");
+  CeedQFunctionContextRegisterInt32(ctx, "count", offsetof(TestContext, count),
+                                    "some sort of counter");
+
+  const CeedQFunctionContextFieldDescription *field_descriptions;
+  CeedInt num_fields;
+  CeedQFunctionContextGetFieldDescriptions(ctx, &field_descriptions, &num_fields);
+  if (num_fields != 2)
+    // LCOV_EXCL_START
+    printf("Incorrect number of fields set: %d != 2", num_fields);
+  // LCOV_EXCL_STOP
+  if (strcmp(field_descriptions[0].name, "time"))
+    // LCOV_EXCL_START
+    printf("Incorrect context field description for time: \"%s\" != \"time\"",
+           field_descriptions[0].name);
+  // LCOV_EXCL_STOP
+  if (strcmp(field_descriptions[1].name, "count"))
+    // LCOV_EXCL_START
+    printf("Incorrect context field description for time: \"%s\" != \"count\"",
+           field_descriptions[1].name);
+  // LCOV_EXCL_STOP
+
+  CeedQFunctionContextSetDouble(ctx, "time", 2.0);
+  if (ctx_data.time != 2.0)
+    // LCOV_EXCL_START
+    printf("Incorrect context data for time: %f != 2.0", ctx_data.time);
+  // LCOV_EXCL_STOP
+
+  CeedQFunctionContextSetInt32(ctx, "count", 43);
+  if (ctx_data.count != 43)
+    // LCOV_EXCL_START
+    printf("Incorrect context data for time: %d != 43", ctx_data.count);
+  // LCOV_EXCL_STOP
+
+  CeedQFunctionContextDestroy(&ctx);
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
If we like this interface, I can add functionality pretty quickly/easily in this PR, but I'd like to get some feedback on the API first.

The idea is that we can write code like this:

```C
CeedOperatorGetQFunction(op, &qf);
CeedQFunctionGetContext(qf, &ctx);
CeedQFunctionContextSetField(ctx, "time", t /* given to us by some solver */);
```

@karenlstengel, this would greatly simplify what you need to do for the TS IFunction.