### PR TITLE
rust - fix ex3 and ex4 for new vector access protections

### DIFF
--- a/examples/rust/ex3-vector-volume/src/main.rs
+++ b/examples/rust/ex3-vector-volume/src/main.rs
@@ -258,6 +258,7 @@ fn example_3(options: opt::Opt) -> libceed::Result<()> {
     let mut v = ceed.vector(solution_size)?;
 
     // Initialize u with component index
+    u.set_value(0.0)?;
     for c in 0..ncomp_u {
         let q = solution_size / ncomp_u;
         u.view_mut()?.iter_mut().skip(c * q).take(q).for_each(|u| {

--- a/examples/rust/ex4-vector-surface/src/main.rs
+++ b/examples/rust/ex4-vector-surface/src/main.rs
@@ -346,6 +346,7 @@ fn example_4(options: opt::Opt) -> libceed::Result<()> {
 
     // Initialize u with sum of node coordinates
     let coords = mesh_coords.view()?;
+    u.set_value(0.0)?;
     for c in 0..ncomp_u {
         let q = solution_size / ncomp_u;
         u.view_mut()?


### PR DESCRIPTION
This call to `.set_value()` allocates a backing array in the `libceed::Vector`. Without it, `.view_mut()` (or `.view()`) errors, because it calls `GetArray` (or `GetArrayRead`).