### PR TITLE
rust - looser lifetime restrictions

### DIFF
--- a/rust/libceed/src/basis.rs
+++ b/rust/libceed/src/basis.rs
@@ -144,7 +144,7 @@ impl<'a> fmt::Display for Basis<'a> {
 impl<'a> Basis<'a> {
     // Constructors
     pub fn create_tensor_H1(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         dim: usize,
         ncomp: usize,
         P1d: usize,
@@ -183,7 +183,7 @@ impl<'a> Basis<'a> {
     }
 
     pub fn create_tensor_H1_Lagrange(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         dim: usize,
         ncomp: usize,
         P: usize,
@@ -209,7 +209,7 @@ impl<'a> Basis<'a> {
     }
 
     pub fn create_H1(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         topo: crate::ElemTopology,
         ncomp: usize,
         nnodes: usize,

--- a/rust/libceed/src/elem_restriction.rs
+++ b/rust/libceed/src/elem_restriction.rs
@@ -163,7 +163,7 @@ impl<'a> fmt::Display for ElemRestriction<'a> {
 impl<'a> ElemRestriction<'a> {
     // Constructors
     pub fn create(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         nelem: usize,
         elemsize: usize,
         ncomp: usize,
@@ -203,7 +203,7 @@ impl<'a> ElemRestriction<'a> {
     }
 
     pub fn create_strided(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         nelem: usize,
         elemsize: usize,
         ncomp: usize,
@@ -265,7 +265,7 @@ impl<'a> ElemRestriction<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_lvector(&self) -> crate::Result<Vector> {
+    pub fn create_lvector<'b>(&self) -> crate::Result<Vector<'b>> {
         let mut ptr_lvector = std::ptr::null_mut();
         let null = std::ptr::null_mut() as *mut _;
         let ierr =
@@ -294,7 +294,7 @@ impl<'a> ElemRestriction<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_evector(&self) -> crate::Result<Vector> {
+    pub fn create_evector<'b>(&self) -> crate::Result<Vector<'b>> {
         let mut ptr_evector = std::ptr::null_mut();
         let null = std::ptr::null_mut() as *mut _;
         let ierr =
@@ -324,7 +324,7 @@ impl<'a> ElemRestriction<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_vectors(&self) -> crate::Result<(Vector, Vector)> {
+    pub fn create_vectors<'b, 'c>(&self) -> crate::Result<(Vector<'b>, Vector<'c>)> {
         let mut ptr_lvector = std::ptr::null_mut();
         let mut ptr_evector = std::ptr::null_mut();
         let ierr = unsafe {

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -361,7 +361,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn vector(&self, n: usize) -> Result<Vector> {
+    pub fn vector<'a>(&self, n: usize) -> Result<Vector<'a>> {
         Vector::create(self, n)
     }
 
@@ -380,7 +380,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn vector_from_slice(&self, slice: &[crate::Scalar]) -> Result<Vector> {
+    pub fn vector_from_slice<'a>(&self, slice: &[crate::Scalar]) -> Result<Vector<'a>> {
         Vector::from_slice(self, slice)
     }
 
@@ -420,7 +420,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn elem_restriction(
+    pub fn elem_restriction<'a>(
         &self,
         nelem: usize,
         elemsize: usize,
@@ -429,7 +429,7 @@ impl Ceed {
         lsize: usize,
         mtype: MemType,
         offsets: &[i32],
-    ) -> Result<ElemRestriction> {
+    ) -> Result<ElemRestriction<'a>> {
         ElemRestriction::create(
             self, nelem, elemsize, ncomp, compstride, lsize, mtype, offsets,
         )
@@ -466,14 +466,14 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn strided_elem_restriction(
+    pub fn strided_elem_restriction<'a>(
         &self,
         nelem: usize,
         elemsize: usize,
         ncomp: usize,
         lsize: usize,
         strides: [i32; 3],
-    ) -> Result<ElemRestriction> {
+    ) -> Result<ElemRestriction<'a>> {
         ElemRestriction::create_strided(self, nelem, elemsize, ncomp, lsize, strides)
     }
 
@@ -515,7 +515,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn basis_tensor_H1(
+    pub fn basis_tensor_H1<'a>(
         &self,
         dim: usize,
         ncomp: usize,
@@ -525,7 +525,7 @@ impl Ceed {
         grad1d: &[crate::Scalar],
         qref1d: &[crate::Scalar],
         qweight1d: &[crate::Scalar],
-    ) -> Result<Basis> {
+    ) -> Result<Basis<'a>> {
         Basis::create_tensor_H1(
             self, dim, ncomp, P1d, Q1d, interp1d, grad1d, qref1d, qweight1d,
         )
@@ -551,14 +551,14 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn basis_tensor_H1_Lagrange(
+    pub fn basis_tensor_H1_Lagrange<'a>(
         &self,
         dim: usize,
         ncomp: usize,
         P: usize,
         Q: usize,
         qmode: QuadMode,
-    ) -> Result<Basis> {
+    ) -> Result<Basis<'a>> {
         Basis::create_tensor_H1_Lagrange(self, dim, ncomp, P, Q, qmode)
     }
 
@@ -677,7 +677,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn basis_H1(
+    pub fn basis_H1<'a>(
         &self,
         topo: ElemTopology,
         ncomp: usize,
@@ -687,7 +687,7 @@ impl Ceed {
         grad: &[crate::Scalar],
         qref: &[crate::Scalar],
         qweight: &[crate::Scalar],
-    ) -> Result<Basis> {
+    ) -> Result<Basis<'a>> {
         Basis::create_H1(
             self, topo, ncomp, nnodes, nqpts, interp, grad, qref, qweight,
         )
@@ -719,11 +719,11 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn q_function_interior(
+    pub fn q_function_interior<'a>(
         &self,
         vlength: usize,
         f: Box<qfunction::QFunctionUserClosure>,
-    ) -> Result<QFunction> {
+    ) -> Result<QFunction<'a>> {
         QFunction::create(self, vlength, f)
     }
 
@@ -738,7 +738,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn q_function_interior_by_name(&self, name: &str) -> Result<QFunctionByName> {
+    pub fn q_function_interior_by_name<'a>(&self, name: &str) -> Result<QFunctionByName<'a>> {
         QFunctionByName::create(self, name)
     }
 
@@ -762,12 +762,12 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn operator<'b>(
+    pub fn operator<'a, 'b>(
         &self,
         qf: impl Into<QFunctionOpt<'b>>,
         dqf: impl Into<QFunctionOpt<'b>>,
         dqfT: impl Into<QFunctionOpt<'b>>,
-    ) -> Result<Operator> {
+    ) -> Result<Operator<'a>> {
         Operator::create(self, qf, dqf, dqfT)
     }
 
@@ -781,7 +781,7 @@ impl Ceed {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn composite_operator(&self) -> Result<CompositeOperator> {
+    pub fn composite_operator<'a>(&self) -> Result<CompositeOperator<'a>> {
         CompositeOperator::create(self)
     }
 }

--- a/rust/libceed/src/operator.rs
+++ b/rust/libceed/src/operator.rs
@@ -514,7 +514,7 @@ impl<'a> OperatorCore<'a> {
 impl<'a> Operator<'a> {
     // Constructor
     pub fn create<'b>(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         qf: impl Into<QFunctionOpt<'b>>,
         dqf: impl Into<QFunctionOpt<'b>>,
         dqfT: impl Into<QFunctionOpt<'b>>,
@@ -1617,12 +1617,12 @@ impl<'a> Operator<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_multigrid_level(
+    pub fn create_multigrid_level<'b>(
         &self,
         p_mult_fine: &Vector,
         rstr_coarse: &ElemRestriction,
         basis_coarse: &Basis,
-    ) -> crate::Result<(Operator, Operator, Operator)> {
+    ) -> crate::Result<(Operator<'b>, Operator<'b>, Operator<'b>)> {
         let mut ptr_coarse = std::ptr::null_mut();
         let mut ptr_prolong = std::ptr::null_mut();
         let mut ptr_restrict = std::ptr::null_mut();
@@ -1806,13 +1806,13 @@ impl<'a> Operator<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_multigrid_level_tensor_H1(
+    pub fn create_multigrid_level_tensor_H1<'b>(
         &self,
         p_mult_fine: &Vector,
         rstr_coarse: &ElemRestriction,
         basis_coarse: &Basis,
         interpCtoF: &Vec<Scalar>,
-    ) -> crate::Result<(Operator, Operator, Operator)> {
+    ) -> crate::Result<(Operator<'b>, Operator<'b>, Operator<'b>)> {
         let mut ptr_coarse = std::ptr::null_mut();
         let mut ptr_prolong = std::ptr::null_mut();
         let mut ptr_restrict = std::ptr::null_mut();
@@ -1997,13 +1997,13 @@ impl<'a> Operator<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn create_multigrid_level_H1(
+    pub fn create_multigrid_level_H1<'b>(
         &self,
         p_mult_fine: &Vector,
         rstr_coarse: &ElemRestriction,
         basis_coarse: &Basis,
         interpCtoF: &[Scalar],
-    ) -> crate::Result<(Operator, Operator, Operator)> {
+    ) -> crate::Result<(Operator<'b>, Operator<'b>, Operator<'b>)> {
         let mut ptr_coarse = std::ptr::null_mut();
         let mut ptr_prolong = std::ptr::null_mut();
         let mut ptr_restrict = std::ptr::null_mut();
@@ -2032,7 +2032,7 @@ impl<'a> Operator<'a> {
 // -----------------------------------------------------------------------------
 impl<'a> CompositeOperator<'a> {
     // Constructor
-    pub fn create(ceed: &'a crate::Ceed) -> crate::Result<Self> {
+    pub fn create(ceed: &crate::Ceed) -> crate::Result<Self> {
         let mut ptr = std::ptr::null_mut();
         let ierr = unsafe { bind_ceed::CeedCompositeOperatorCreate(ceed.ptr, &mut ptr) };
         ceed.check_error(ierr)?;

--- a/rust/libceed/src/qfunction.rs
+++ b/rust/libceed/src/qfunction.rs
@@ -583,7 +583,7 @@ unsafe extern "C" fn trampoline(
 impl<'a> QFunction<'a> {
     // Constructor
     pub fn create(
-        ceed: &'a crate::Ceed,
+        ceed: &crate::Ceed,
         vlength: usize,
         user_f: Box<QFunctionUserClosure>,
     ) -> crate::Result<Self> {
@@ -877,7 +877,7 @@ impl<'a> QFunction<'a> {
 // -----------------------------------------------------------------------------
 impl<'a> QFunctionByName<'a> {
     // Constructor
-    pub fn create(ceed: &'a crate::Ceed, name: &str) -> crate::Result<Self> {
+    pub fn create(ceed: &crate::Ceed, name: &str) -> crate::Result<Self> {
         let name_c = CString::new(name).expect("CString::new failed");
         let mut ptr = std::ptr::null_mut();
         let ierr = unsafe {

--- a/rust/libceed/src/vector.rs
+++ b/rust/libceed/src/vector.rs
@@ -253,7 +253,7 @@ impl<'a> fmt::Display for Vector<'a> {
 // -----------------------------------------------------------------------------
 impl<'a> Vector<'a> {
     // Constructors
-    pub fn create(ceed: &'a crate::Ceed, n: usize) -> crate::Result<Self> {
+    pub fn create(ceed: &crate::Ceed, n: usize) -> crate::Result<Self> {
         let n = i32::try_from(n).unwrap();
         let mut ptr = std::ptr::null_mut();
         let ierr = unsafe { bind_ceed::CeedVectorCreate(ceed.ptr, n, &mut ptr) };
@@ -293,7 +293,7 @@ impl<'a> Vector<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_slice(ceed: &'a crate::Ceed, v: &[crate::Scalar]) -> crate::Result<Self> {
+    pub fn from_slice(ceed: &crate::Ceed, v: &[crate::Scalar]) -> crate::Result<Self> {
         let mut x = Self::create(ceed, v.len())?;
         x.set_slice(v)?;
         Ok(x)
@@ -316,7 +316,7 @@ impl<'a> Vector<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_array(ceed: &'a crate::Ceed, v: &mut [crate::Scalar]) -> crate::Result<Self> {
+    pub fn from_array(ceed: &crate::Ceed, v: &mut [crate::Scalar]) -> crate::Result<Self> {
         let x = Self::create(ceed, v.len())?;
         let (host, user_pointer) = (
             crate::MemType::Host as bind_ceed::CeedMemType,


### PR DESCRIPTION
I was getting some strange behavior where the lifetimes for the `ceed` and any objects it created were strangely interlinked. This removes those entanglements.