### PR TITLE
Draft: rust doc: example documenting a method with math

### DIFF
--- a/rust/libceed/Cargo.toml
+++ b/rust/libceed/Cargo.toml
@@ -18,7 +18,10 @@ categories = ["science"]
 
 [dependencies]
 libceed-sys = { version = "0.9", path = "../libceed-sys" }
-katexit = "0.1.1"
+katexit = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.2"
+
+[package.metadata.docs.rs]
+features = ["katexit"]

--- a/rust/libceed/Cargo.toml
+++ b/rust/libceed/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["science"]
 
 [dependencies]
 libceed-sys = { version = "0.9", path = "../libceed-sys" }
+katexit = "0.1.1"
 
 [dev-dependencies]
 version-sync = "0.9.2"

--- a/rust/libceed/README.md
+++ b/rust/libceed/README.md
@@ -3,14 +3,9 @@
 [![GitHub Actions](https://github.com/CEED/libCEED/actions/workflows/rust-test-with-style.yml/badge.svg)](https://github.com/CEED/libCEED/actions/workflows/rust-test-with-style.yml)
 [![Documentation](https://docs.rs/libceed/badge.svg)](https://docs.rs/libceed)
 
-This crate provides an interface to [libCEED](https://libceed.readthedocs.io),
-which is a performance-portable library for extensible element-based
-discretization for partial differential equations and related computational
-problems. The formulation is algebraic and intended to be lightweight and easy
-to incorporate in higher level abstractions. See the [libCEED user
-manual](https://libceed.readthedocs.io) for details on [interface
-concepts](https://libceed.readthedocs.io/en/latest/libCEEDapi/) and extensive
-examples.
+This crate provides an interface to [libCEED](https://libceed.readthedocs.io), which is a performance-portable library for extensible element-based discretization for partial differential equations and related computational problems.
+The formulation is algebraic and intended to be lightweight and easy to incorporate in higher level abstractions.
+See the [libCEED user manual](https://libceed.readthedocs.io) for details on [interface concepts](https://libceed.readthedocs.io/en/latest/libCEEDapi/) and extensive examples.
 
 ![libCEED operator decomposition](https://libceed.readthedocs.io/en/latest/_images/libCEED.png)
 
@@ -40,22 +35,26 @@ fn main() -> libceed::Result<()> {
 }
 ```
 
-This crate provides modules for each object, but they are usually created from
-the `Ceed` object as with the vector above. The resource string passed to
-`Ceed::init` is used to identify the "backend", which includes algorithmic
-strategies and hardware such as NVIDIA and AMD GPUs. See the [libCEED
-documentation](https://libceed.readthedocs.io/en/latest/gettingstarted/#backends)
-for more information on available backends.
+This crate provides modules for each object, but they are usually created from the `Ceed` object as with the vector above.
+The resource string passed to `Ceed::init` is used to identify the "backend", which includes algorithmic strategies and hardware such as NVIDIA and AMD GPUs.
+See the [libCEED documentation](https://libceed.readthedocs.io/en/latest/gettingstarted/#backends) for more information on available backends.
 
 ## Examples
 
-Examples of libCEED can be found in the [libCEED repository](https://github.com/CEED/libCEED) under the
-`examples/rust` directory.
+Examples of libCEED can be found in the [libCEED repository](https://github.com/CEED/libCEED) under the `examples/rust` directory.
+
+## Documentation
+
+This crate uses `katexit` to render equations in the documentation.
+To build the [documentation](https://docs.rs/libceed) locally with `katexit` enabled, use
+
+```bash
+cargo doc --features=katexit
+```
 
 ## License: BSD-2-Clause
 
 ## Contributing
 
-The `libceed` crate is developed within the [libCEED
-repository](https://github.com/CEED/libCEED). See the [contributing
-guidelines](https://libceed.readthedocs.io/en/latest/CONTRIBUTING/) for details.
+The `libceed` crate is developed within the [libCEED repository](https://github.com/CEED/libCEED).
+See the [contributing guidelines](https://libceed.readthedocs.io/en/latest/CONTRIBUTING/) for details.

--- a/rust/libceed/README.md
+++ b/rust/libceed/README.md
@@ -1,5 +1,8 @@
 # libceed: efficient, extensible discretization
 
+[![GitHub Actions](https://github.com/CEED/libCEED/actions/workflows/rust-test-with-style.yml/badge.svg)](https://github.com/CEED/libCEED/actions/workflows/rust-test-with-style.yml)
+[![Documentation](https://docs.rs/libceed/badge.svg)](https://docs.rs/libceed)
+
 This crate provides an interface to [libCEED](https://libceed.readthedocs.io),
 which is a performance-portable library for extensible element-based
 discretization for partial differential equations and related computational

--- a/rust/libceed/src/basis.rs
+++ b/rust/libceed/src/basis.rs
@@ -20,7 +20,7 @@
 use crate::prelude::*;
 
 // -----------------------------------------------------------------------------
-// CeedBasis option
+// Basis option
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub enum BasisOpt<'a> {
@@ -89,7 +89,7 @@ impl<'a> BasisOpt<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedBasis context wrapper
+// Basis context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub struct Basis<'a> {
@@ -340,7 +340,7 @@ impl<'a> Basis<'a> {
         self.check_error(ierr)
     }
 
-    /// Returns the dimension for given CeedBasis
+    /// Returns the dimension for given Basis
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -360,7 +360,7 @@ impl<'a> Basis<'a> {
         usize::try_from(dim).unwrap()
     }
 
-    /// Returns number of components for given CeedBasis
+    /// Returns number of components for given Basis
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -380,7 +380,7 @@ impl<'a> Basis<'a> {
         usize::try_from(ncomp).unwrap()
     }
 
-    /// Returns total number of nodes (in dim dimensions) of a CeedBasis
+    /// Returns total number of nodes (in dim dimensions) of a Basis
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -401,7 +401,7 @@ impl<'a> Basis<'a> {
     }
 
     /// Returns total number of quadrature points (in dim dimensions) of a
-    /// CeedBasis
+    /// Basis
     ///
     /// ```
     /// # use libceed::prelude::*;

--- a/rust/libceed/src/elem_restriction.rs
+++ b/rust/libceed/src/elem_restriction.rs
@@ -20,7 +20,7 @@
 use crate::prelude::*;
 
 // -----------------------------------------------------------------------------
-// CeedElemRestriction option
+// ElemRestriction option
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub enum ElemRestrictionOpt<'a> {
@@ -102,7 +102,7 @@ impl<'a> ElemRestrictionOpt<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedElemRestriction context wrapper
+// ElemRestriction context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub struct ElemRestriction<'a> {

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -714,7 +714,12 @@ impl Ceed {
         )
     }
 
+    #[cfg_attr(doc, katexit::katexit)]
     /// Returns a CeedQFunction for evaluating interior (volumetric) terms
+    ///
+    /// $$
+    /// v^T F(u) \sim \int_\Omega v^T f_0(u, \nabla u) + (\nabla v)^T f_1(u, \nabla u)
+    /// $$
     ///
     /// # arguments
     ///

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -21,6 +21,7 @@
 // -----------------------------------------------------------------------------
 #![allow(non_snake_case)]
 
+#[cfg_attr(feature = "katexit", katexit::katexit)]
 // -----------------------------------------------------------------------------
 // Crate prelude
 // -----------------------------------------------------------------------------
@@ -230,8 +231,7 @@ impl Clone for Ceed {
     /// let ceed = libceed::Ceed::init("/cpu/self/ref/serial");
     /// let ceed_clone = ceed.clone();
     ///
-    /// println!("{}", ceed);
-    /// println!("{}", ceed_clone);
+    /// println!(" original:{} \n clone:{}", ceed, ceed_clone);
     /// ```
     fn clone(&self) -> Self {
         let mut ptr_clone = std::ptr::null_mut();
@@ -407,7 +407,10 @@ impl Ceed {
         Vector::from_slice(self, slice)
     }
 
-    /// Returns an ElemRestriction
+    /// Returns an ElemRestriction, $\mathcal{E}$, which extracts the degrees of
+    ///   freedom for each element from the local vector into the element vector
+    ///   or assembles contributions from each element in the element vector to
+    ///   the local vector
     ///
     /// # arguments
     ///
@@ -458,7 +461,8 @@ impl Ceed {
         )
     }
 
-    /// Returns an ElemRestriction
+    /// Returns an ElemRestriction, $\mathcal{E}$, from an local vector to
+    ///   an element vector where data can be indexed from the `strides` array
     ///
     /// # arguments
     ///
@@ -466,10 +470,6 @@ impl Ceed {
     /// * `elemsize`   - Size (number of "nodes") per element
     /// * `ncomp`      - Number of field components per interpolation node (1
     ///                    for scalar fields)
-    /// * `compstride` - Stride between components for the same Lvector "node".
-    ///                    Data for node `i`, component `j`, element `k` can be
-    ///                    found in the Lvector at index
-    ///                    `offsets[i + k*elemsize] + j*compstride`.
     /// * `lsize`      - The size of the Lvector. This vector may be larger
     ///   than the elements and fields given by this restriction.
     /// * `strides`   - Array for strides between `[nodes, components, elements]`.
@@ -500,7 +500,7 @@ impl Ceed {
         ElemRestriction::create_strided(self, nelem, elemsize, ncomp, lsize, strides)
     }
 
-    /// Returns a tensor-product Basis
+    /// Returns an $H^1$ tensor-product Basis
     ///
     /// # arguments
     ///
@@ -554,7 +554,7 @@ impl Ceed {
         )
     }
 
-    /// Returns a tensor-product Lagrange Basis
+    /// Returns an $H^1$ Lagrange tensor-product Basis
     ///
     /// # arguments
     ///
@@ -585,7 +585,7 @@ impl Ceed {
         Basis::create_tensor_H1_Lagrange(self, dim, ncomp, P, Q, qmode)
     }
 
-    /// Returns a tensor-product Basis
+    /// Returns an $H-1$ Basis
     ///
     /// # arguments
     ///
@@ -716,7 +716,6 @@ impl Ceed {
         )
     }
 
-    #[cfg_attr(feature = "katexit", katexit::katexit)]
     /// Returns a QFunction for evaluating interior (volumetric) terms
     ///   of a weak form corresponding to the $L^2$ inner product
     ///
@@ -760,7 +759,7 @@ impl Ceed {
     }
 
     /// Returns a QFunction for evaluating interior (volumetric) terms
-    /// created by name
+    ///   created by name
     ///
     /// # arguments
     ///
@@ -779,8 +778,8 @@ impl Ceed {
     }
 
     /// Returns an Operator and associate a QFunction. A Basis and
-    /// ElemRestriction can be associated with QFunction fields via
-    /// set_field().
+    ///   ElemRestriction can be associated with QFunction fields via
+    ///   set_field().
     ///
     /// # arguments
     ///

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -153,6 +153,8 @@ impl EvalMode {
 // -----------------------------------------------------------------------------
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// libCEED error messages - returning an Error without painc!ing indicates
+///   the function call failed but the data is not corrupted
 #[derive(Debug)]
 pub struct Error {
     pub message: String,

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -368,7 +368,7 @@ impl Ceed {
         c_str.to_string_lossy().to_string()
     }
 
-    /// Returns a CeedVector of the specified length (does not allocate memory)
+    /// Returns a Vector of the specified length (does not allocate memory)
     ///
     /// # arguments
     ///
@@ -405,7 +405,7 @@ impl Ceed {
         Vector::from_slice(self, slice)
     }
 
-    /// Returns a ElemRestriction
+    /// Returns an ElemRestriction
     ///
     /// # arguments
     ///
@@ -456,7 +456,7 @@ impl Ceed {
         )
     }
 
-    /// Returns a ElemRestriction
+    /// Returns an ElemRestriction
     ///
     /// # arguments
     ///
@@ -498,7 +498,7 @@ impl Ceed {
         ElemRestriction::create_strided(self, nelem, elemsize, ncomp, lsize, strides)
     }
 
-    /// Returns a tensor-product basis
+    /// Returns a tensor-product Basis
     ///
     /// # arguments
     ///
@@ -552,7 +552,7 @@ impl Ceed {
         )
     }
 
-    /// Returns a tensor-product Lagrange basis
+    /// Returns a tensor-product Lagrange Basis
     ///
     /// # arguments
     ///
@@ -583,7 +583,7 @@ impl Ceed {
         Basis::create_tensor_H1_Lagrange(self, dim, ncomp, P, Q, qmode)
     }
 
-    /// Returns a tensor-product basis
+    /// Returns a tensor-product Basis
     ///
     /// # arguments
     ///
@@ -715,17 +715,21 @@ impl Ceed {
     }
 
     #[cfg_attr(feature = "katexit", katexit::katexit)]
-    /// Returns a CeedQFunction for evaluating interior (volumetric) terms
+    /// Returns a QFunction for evaluating interior (volumetric) terms
+    ///   of a weak form corresponding to the $L^2$ inner product
     ///
     /// $$
-    /// v^T F(u) \sim \int_\Omega v^T f_0(u, \nabla u) + (\nabla v)^T f_1(u, \nabla u)
+    /// \langle v, F(u) \rangle = \int_\Omega v \cdot f_0 \left( u, \nabla u \right) + \left( \nabla v \right) : f_1 \left( u, \nabla u \right),
     /// $$
+    ///
+    /// where $v \cdot f_0$ represents contraction over fields and $\nabla v : f_1$
+    ///   represents contraction over both fields and spatial dimensions.
     ///
     /// # arguments
     ///
     /// * `vlength` - Vector length. Caller must ensure that number of
     ///                 quadrature points is a multiple of vlength.
-    /// * `f`       - Boxed closure to evaluate action at quadrature points.
+    /// * `f`       - Boxed closure to evaluate weak form at quadrature points.
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -753,8 +757,12 @@ impl Ceed {
         QFunction::create(self, vlength, f)
     }
 
-    /// Returns a CeedQFunction for evaluating interior (volumetric) terms
+    /// Returns a QFunction for evaluating interior (volumetric) terms
     /// created by name
+    ///
+    /// # arguments
+    ///
+    /// * `name` - name of QFunction from libCEED gallery
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -768,9 +776,11 @@ impl Ceed {
         QFunctionByName::create(self, name)
     }
 
-    /// Returns a Operator and associate a QFunction. A Basis and
-    /// ElemRestriction can be   associated with QFunction fields with
+    /// Returns an Operator and associate a QFunction. A Basis and
+    /// ElemRestriction can be associated with QFunction fields via
     /// set_field().
+    ///
+    /// # arguments
     ///
     /// * `qf`   - QFunction defining the action of the operator at quadrature
     ///              points

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -714,7 +714,7 @@ impl Ceed {
         )
     }
 
-    #[cfg_attr(doc, katexit::katexit)]
+    #[cfg_attr(feature = "katexit", katexit::katexit)]
     /// Returns a CeedQFunction for evaluating interior (volumetric) terms
     ///
     /// $$

--- a/rust/libceed/src/lib.rs
+++ b/rust/libceed/src/lib.rs
@@ -21,7 +21,6 @@
 // -----------------------------------------------------------------------------
 #![allow(non_snake_case)]
 
-#[cfg_attr(feature = "katexit", katexit::katexit)]
 // -----------------------------------------------------------------------------
 // Crate prelude
 // -----------------------------------------------------------------------------
@@ -270,6 +269,7 @@ static REGISTER: Once = Once::new();
 // Object constructors
 // -----------------------------------------------------------------------------
 impl Ceed {
+    #[cfg_attr(feature = "katexit", katexit::katexit)]
     /// Returns a Ceed context initialized with the specified resource
     ///
     /// # arguments

--- a/rust/libceed/src/operator.rs
+++ b/rust/libceed/src/operator.rs
@@ -21,7 +21,7 @@
 use crate::prelude::*;
 
 // -----------------------------------------------------------------------------
-// CeedOperator Field context wrapper
+// Operator Field context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub struct OperatorField<'a> {
@@ -275,7 +275,7 @@ impl<'a> OperatorField<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedOperator context wrapper
+// Operator context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub(crate) struct OperatorCore<'a> {

--- a/rust/libceed/src/qfunction.rs
+++ b/rust/libceed/src/qfunction.rs
@@ -25,7 +25,7 @@ pub type QFunctionInputs<'a> = [&'a [crate::Scalar]; MAX_QFUNCTION_FIELDS];
 pub type QFunctionOutputs<'a> = [&'a mut [crate::Scalar]; MAX_QFUNCTION_FIELDS];
 
 // -----------------------------------------------------------------------------
-// CeedQFunction Field context wrapper
+// QFunction Field context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub struct QFunctionField<'a> {
@@ -119,7 +119,7 @@ impl<'a> QFunctionField<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedQFunction option
+// QFunction option
 // -----------------------------------------------------------------------------
 pub enum QFunctionOpt<'a> {
     SomeQFunction(&'a QFunction<'a>),
@@ -328,7 +328,7 @@ impl<'a> QFunctionOpt<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedQFunction context wrapper
+// QFunction context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub(crate) struct QFunctionCore<'a> {

--- a/rust/libceed/src/vector.rs
+++ b/rust/libceed/src/vector.rs
@@ -25,7 +25,7 @@ use std::{
 use crate::prelude::*;
 
 // -----------------------------------------------------------------------------
-// CeedVector option
+// Vector option
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub enum VectorOpt<'a> {
@@ -131,7 +131,7 @@ impl<'a> VectorOpt<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedVector borrowed slice wrapper
+// Vector borrowed slice wrapper
 // -----------------------------------------------------------------------------
 pub struct VectorSliceWrapper<'a> {
     pub(crate) vector: crate::Vector<'a>,
@@ -184,7 +184,7 @@ impl<'a> VectorSliceWrapper<'a> {
 }
 
 // -----------------------------------------------------------------------------
-// CeedVector context wrapper
+// Vector context wrapper
 // -----------------------------------------------------------------------------
 #[derive(Debug)]
 pub struct Vector<'a> {
@@ -338,7 +338,7 @@ impl<'a> Vector<'a> {
         crate::check_error(ptr, ierr)
     }
 
-    /// Returns the length of a CeedVector
+    /// Returns the length of a Vector
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -357,7 +357,7 @@ impl<'a> Vector<'a> {
         usize::try_from(n).unwrap()
     }
 
-    /// Returns the length of a CeedVector
+    /// Returns the length of a Vector
     ///
     /// ```
     /// # use libceed::prelude::*;
@@ -372,7 +372,7 @@ impl<'a> Vector<'a> {
         self.length()
     }
 
-    /// Set the CeedVector to a constant value
+    /// Set the Vector to a constant value
     ///
     /// # arguments
     ///
@@ -487,7 +487,7 @@ impl<'a> Vector<'a> {
         crate::VectorSliceWrapper::from_vector_and_slice_mut(self, slice)
     }
 
-    /// Sync the CeedVector to a specified memtype
+    /// Sync the Vector to a specified memtype
     ///
     /// # arguments
     ///
@@ -559,7 +559,7 @@ impl<'a> Vector<'a> {
         VectorViewMut::new(self)
     }
 
-    /// Return the norm of a CeedVector
+    /// Return the norm of a Vector
     ///
     /// # arguments
     ///
@@ -591,7 +591,7 @@ impl<'a> Vector<'a> {
         Ok(res)
     }
 
-    /// Compute x = alpha x for a CeedVector
+    /// Compute x = alpha x for a Vector
     ///
     /// # arguments
     ///
@@ -617,7 +617,7 @@ impl<'a> Vector<'a> {
         Ok(self)
     }
 
-    /// Compute y = alpha x + y for a pair of CeedVectors
+    /// Compute y = alpha x + y for a pair of Vectors
     ///
     /// # arguments
     ///
@@ -645,7 +645,7 @@ impl<'a> Vector<'a> {
         Ok(self)
     }
 
-    /// Compute the pointwise multiplication w = x .* y for CeedVectors
+    /// Compute the pointwise multiplication w = x .* y for Vectors
     ///
     /// # arguments
     ///
@@ -674,7 +674,7 @@ impl<'a> Vector<'a> {
         Ok(self)
     }
 
-    /// Compute the pointwise multiplication w = w .* x for CeedVectors
+    /// Compute the pointwise multiplication w = w .* x for Vectors
     ///
     /// # arguments
     ///
@@ -701,7 +701,7 @@ impl<'a> Vector<'a> {
         Ok(self)
     }
 
-    /// Compute the pointwise multiplication w = w .* w for a CeedVector
+    /// Compute the pointwise multiplication w = w .* w for a Vector
     ///
     /// ```
     /// # use libceed::prelude::*;


### PR DESCRIPTION
Cc: issue #695

@jeremylt This renders nicely. I haven't experimented further and I don't know off-hand how to make the dependency only apply to documentation, but not normal builds.
![image](https://user-images.githubusercontent.com/3303/149458525-cde02f85-ac5d-4752-80d4-0a8a440c8d50.png)
