### PR TITLE
vec/ctx - make backend restore function optional

### DIFF
--- a/backends/avx/ceed-avx-tensor-f32.c
+++ b/backends/avx/ceed-avx-tensor-f32.c
@@ -298,13 +298,6 @@ static int CeedTensorContractApply_Avx(CeedTensorContract contract, CeedInt A,
 }
 
 //------------------------------------------------------------------------------
-// Tensor Contract Destroy
-//------------------------------------------------------------------------------
-static int CeedTensorContractDestroy_Avx(CeedTensorContract contract) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
 int CeedTensorContractCreate_f32_Avx(CeedBasis basis,
@@ -315,8 +308,6 @@ int CeedTensorContractCreate_f32_Avx(CeedBasis basis,
 
   ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Apply",
                                 CeedTensorContractApply_Avx); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Destroy",
-                                CeedTensorContractDestroy_Avx); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/avx/ceed-avx-tensor-f64.c
+++ b/backends/avx/ceed-avx-tensor-f64.c
@@ -298,13 +298,6 @@ static int CeedTensorContractApply_Avx(CeedTensorContract contract, CeedInt A,
 }
 
 //------------------------------------------------------------------------------
-// Tensor Contract Destroy
-//------------------------------------------------------------------------------
-static int CeedTensorContractDestroy_Avx(CeedTensorContract contract) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
 int CeedTensorContractCreate_f64_Avx(CeedBasis basis,
@@ -315,8 +308,6 @@ int CeedTensorContractCreate_f64_Avx(CeedBasis basis,
 
   ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Apply",
                                 CeedTensorContractApply_Avx); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Destroy",
-                                CeedTensorContractDestroy_Avx); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
@@ -352,14 +352,6 @@ static int CeedQFunctionContextGetData_Cuda(const CeedQFunctionContext ctx,
 }
 
 //------------------------------------------------------------------------------
-// Restore data obtained using CeedQFunctionContextGetData()
-//------------------------------------------------------------------------------
-static int CeedQFunctionContextRestoreData_Cuda(
-  const CeedQFunctionContext ctx) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Destroy the user context
 //------------------------------------------------------------------------------
 static int CeedQFunctionContextDestroy_Cuda(const CeedQFunctionContext ctx) {
@@ -398,9 +390,6 @@ int CeedQFunctionContextCreate_Cuda(CeedQFunctionContext ctx) {
                                 CeedQFunctionContextTakeData_Cuda); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "GetData",
                                 CeedQFunctionContextGetData_Cuda); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "RestoreData",
-                                CeedQFunctionContextRestoreData_Cuda);
-  CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "Destroy",
                                 CeedQFunctionContextDestroy_Cuda); CeedChkBackend(ierr);
 

--- a/backends/cuda-ref/ceed-cuda-vector.c
+++ b/backends/cuda-ref/ceed-cuda-vector.c
@@ -496,20 +496,6 @@ static int CeedVectorGetArrayWrite_Cuda(const CeedVector vec,
 }
 
 //------------------------------------------------------------------------------
-// Restore an array obtained using CeedVectorGetArrayRead()
-//------------------------------------------------------------------------------
-static int CeedVectorRestoreArrayRead_Cuda(const CeedVector vec) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
-// Restore an array obtained using CeedVectorGetArray()
-//------------------------------------------------------------------------------
-static int CeedVectorRestoreArray_Cuda(const CeedVector vec) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Get the norm of a CeedVector
 //------------------------------------------------------------------------------
 static int CeedVectorNorm_Cuda(CeedVector vec, CeedNormType type,
@@ -786,10 +772,6 @@ int CeedVectorCreate_Cuda(CeedInt n, CeedVector vec) {
                                 CeedVectorGetArrayRead_Cuda); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "GetArrayWrite",
                                 CeedVectorGetArrayWrite_Cuda); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Vector", vec, "RestoreArray",
-                                CeedVectorRestoreArray_Cuda); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Vector", vec, "RestoreArrayRead",
-                                CeedVectorRestoreArrayRead_Cuda); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "Norm",
                                 CeedVectorNorm_Cuda); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "Reciprocal",

--- a/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
+++ b/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
@@ -352,13 +352,6 @@ static int CeedQFunctionContextGetData_Hip(const CeedQFunctionContext ctx,
 }
 
 //------------------------------------------------------------------------------
-// Restore data obtained using CeedQFunctionContextGetData()
-//------------------------------------------------------------------------------
-static int CeedQFunctionContextRestoreData_Hip(const CeedQFunctionContext ctx) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Destroy the user context
 //------------------------------------------------------------------------------
 static int CeedQFunctionContextDestroy_Hip(const CeedQFunctionContext ctx) {
@@ -397,8 +390,6 @@ int CeedQFunctionContextCreate_Hip(CeedQFunctionContext ctx) {
                                 CeedQFunctionContextTakeData_Hip); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "GetData",
                                 CeedQFunctionContextGetData_Hip); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "RestoreData",
-                                CeedQFunctionContextRestoreData_Hip); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "Destroy",
                                 CeedQFunctionContextDestroy_Hip); CeedChkBackend(ierr);
 

--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -494,20 +494,6 @@ static int CeedVectorGetArrayWrite_Hip(const CeedVector vec,
 }
 
 //------------------------------------------------------------------------------
-// Restore an array obtained using CeedVectorGetArrayRead()
-//------------------------------------------------------------------------------
-static int CeedVectorRestoreArrayRead_Hip(const CeedVector vec) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
-// Restore an array obtained using CeedVectorGetArray()
-//------------------------------------------------------------------------------
-static int CeedVectorRestoreArray_Hip(const CeedVector vec) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Get the norm of a CeedVector
 //------------------------------------------------------------------------------
 static int CeedVectorNorm_Hip(CeedVector vec, CeedNormType type,
@@ -783,10 +769,6 @@ int CeedVectorCreate_Hip(CeedInt n, CeedVector vec) {
                                 CeedVectorGetArrayRead_Hip); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "GetArrayWrite",
                                 CeedVectorGetArrayWrite_Hip); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Vector", vec, "RestoreArray",
-                                CeedVectorRestoreArray_Hip); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "Vector", vec, "RestoreArrayRead",
-                                CeedVectorRestoreArrayRead_Hip); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "Norm",
                                 CeedVectorNorm_Hip); CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Vector", vec, "Reciprocal",

--- a/backends/opt/ceed-opt-tensor.c
+++ b/backends/opt/ceed-opt-tensor.c
@@ -65,13 +65,6 @@ static int CeedTensorContractApply_Opt(CeedTensorContract contract, CeedInt A,
 }
 
 //------------------------------------------------------------------------------
-// Tensor Contract Destroy
-//------------------------------------------------------------------------------
-static int CeedTensorContractDestroy_Opt(CeedTensorContract contract) {
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
 int CeedTensorContractCreate_Opt(CeedBasis basis, CeedTensorContract contract) {
@@ -81,8 +74,6 @@ int CeedTensorContractCreate_Opt(CeedBasis basis, CeedTensorContract contract) {
 
   ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Apply",
                                 CeedTensorContractApply_Opt); CeedChkBackend(ierr);
-  ierr = CeedSetBackendFunction(ceed, "TensorContract", contract, "Destroy",
-                                CeedTensorContractDestroy_Opt); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -511,12 +511,6 @@ int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type,
 int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
   int ierr;
 
-  if (!ctx->RestoreData)
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
-                     "Backend does not support RestoreData");
-  // LCOV_EXCL_STOP
-
   if (ctx->state % 2 != 1)
     // LCOV_EXCL_START
     return CeedError(ctx->ceed, 1,
@@ -524,7 +518,9 @@ int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
                      "access was not granted");
   // LCOV_EXCL_STOP
 
-  ierr = ctx->RestoreData(ctx); CeedChk(ierr);
+  if (ctx->RestoreData) {
+    ierr = ctx->RestoreData(ctx); CeedChk(ierr);
+  }
   *(void **)data = NULL;
   ctx->state += 1;
   return CEED_ERROR_SUCCESS;

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -564,18 +564,13 @@ int CeedVectorGetArrayWrite(CeedVector vec, CeedMemType mem_type,
 int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
   int ierr;
 
-  if (!vec->RestoreArray)
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED,
-                     "Backend does not support RestoreArray");
-  // LCOV_EXCL_STOP
-
   if (vec->state % 2 != 1)
     return CeedError(vec->ceed, CEED_ERROR_ACCESS,
                      "Cannot restore CeedVector array access, "
                      "access was not granted");
-
-  ierr = vec->RestoreArray(vec); CeedChk(ierr);
+  if (vec->RestoreArray) {
+    ierr = vec->RestoreArray(vec); CeedChk(ierr);
+  }
   *array = NULL;
   vec->state += 1;
   return CEED_ERROR_SUCCESS;
@@ -594,12 +589,6 @@ int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
 int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
   int ierr;
 
-  if (!vec->RestoreArrayRead)
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED,
-                     "Backend does not support RestoreArrayRead");
-  // LCOV_EXCL_STOP
-
   if (vec->num_readers == 0)
     // LCOV_EXCL_START
     return CeedError(vec->ceed, CEED_ERROR_ACCESS,
@@ -607,7 +596,9 @@ int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
                      "access was not granted");
   // LCOV_EXCL_STOP
 
-  ierr = vec->RestoreArrayRead(vec); CeedChk(ierr);
+  if (vec->RestoreArrayRead) {
+    ierr = vec->RestoreArrayRead(vec); CeedChk(ierr);
+  }
   *array = NULL;
   vec->num_readers--;
   return CEED_ERROR_SUCCESS;


### PR DESCRIPTION
Really, we should just let the backend opt out of specialized restoring logic.