### PR TITLE
ex - better namespacing of petsc ex headers

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -14,8 +14,8 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#ifndef navierstokes_h
-#define navierstokes_h
+#ifndef libceed_fluids_examples_navier_stokes_h
+#define libceed_fluids_examples_navier_stokes_h
 
 #include <ceed.h>
 #include <petscdm.h>
@@ -447,4 +447,5 @@ PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q);
 PetscErrorCode SetBCsFromICs_NS(DM dm, Vec Q, Vec Q_loc);
 
 // -----------------------------------------------------------------------------
-#endif
+
+#endif // libceed_fluids_examples_navier_stokes_h

--- a/examples/petsc/area.h
+++ b/examples/petsc/area.h
@@ -14,8 +14,8 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#ifndef area_h
-#define area_h
+#ifndef libceed_petsc_examples_area_h
+#define libceed_petsc_examples_area_h
 
 // -----------------------------------------------------------------------------
 // Command Line Options
@@ -25,4 +25,4 @@ static const char *const problem_types[] = {"cube", "sphere",
                                             "ProblemType", "AREA", NULL
                                            };
 
-#endif // area_h
+#endif // libceed_petsc_examples_area_h

--- a/examples/petsc/bps.h
+++ b/examples/petsc/bps.h
@@ -14,8 +14,8 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#ifndef bps_h
-#define bps_h
+#ifndef libceed_petsc_examples_bps_h
+#define libceed_petsc_examples_bps_h
 
 // -----------------------------------------------------------------------------
 // Command Line Options
@@ -38,4 +38,4 @@ static const char *const bp_types[] = {"bp1", "bp2", "bp3", "bp4", "bp5", "bp6",
                                        "BPType", "CEED_BP", 0
                                       };
 
-#endif // bps_h
+#endif // libceed_petsc_examples_bps_h

--- a/examples/petsc/bpssphere.h
+++ b/examples/petsc/bpssphere.h
@@ -14,8 +14,8 @@
 // software, applications, hardware, advanced system engineering and early
 // testbed platforms, in support of the nation's exascale computing imperative.
 
-#ifndef sphere_h
-#define sphere_h
+#ifndef libceed_petsc_examples_sphere_h
+#define libceed_petsc_examples_sphere_h
 
 // -----------------------------------------------------------------------------
 // Command Line Options
@@ -25,4 +25,4 @@ static const char *const bp_types[] = {"bp1", "bp2", "bp3", "bp4", "bp5", "bp6",
                                        "BPType", "CEED_BP", 0
                                       };
 
-#endif // sphere_h
+#endif // libceed_petsc_examples_sphere_h

--- a/examples/petsc/include/areaproblemdata.h
+++ b/examples/petsc/include/areaproblemdata.h
@@ -1,5 +1,5 @@
-#ifndef areaproblemdata_h
-#define areaproblemdata_h
+#ifndef libceed_petsc_examples_area_problem_data_h
+#define libceed_petsc_examples_area_problem_data_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -49,4 +49,4 @@ static BPData problem_options[6] = {
   }
 };
 
-#endif // areaproblemdata_h
+#endif // libceed_petsc_examples_area_problem_data_h

--- a/examples/petsc/include/bcfunctions.h
+++ b/examples/petsc/include/bcfunctions.h
@@ -1,5 +1,5 @@
-#ifndef bcfunctions_h
-#define bcfunctions_h
+#ifndef libceed_petsc_examples_bc_functions_h
+#define libceed_petsc_examples_bc_functions_h
 
 #include <petsc.h>
 
@@ -8,4 +8,4 @@ PetscErrorCode BCsDiff(PetscInt dim, PetscReal time, const PetscReal x[],
 PetscErrorCode BCsMass(PetscInt dim, PetscReal time, const PetscReal x[],
                        PetscInt num_comp_u, PetscScalar *u, void *ctx);
 
-#endif // bcfunctions_h
+#endif // libceed_petsc_examples_bc_functions_h

--- a/examples/petsc/include/bpsproblemdata.h
+++ b/examples/petsc/include/bpsproblemdata.h
@@ -1,5 +1,5 @@
-#ifndef bpsproblemdata_h
-#define bpsproblemdata_h
+#ifndef libceed_petsc_examples_bps_problem_data_h
+#define libceed_petsc_examples_bps_problem_data_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -144,4 +144,4 @@ BPData bp_options[6] = {
   }
 };
 
-#endif // bpsproblemdata_h
+#endif // libceed_petsc_examples_bps_problem_data_h

--- a/examples/petsc/include/libceedsetup.h
+++ b/examples/petsc/include/libceedsetup.h
@@ -1,5 +1,5 @@
-#ifndef libceedsetup_h
-#define libceedsetup_h
+#ifndef libceed_petsc_examples_setup_h
+#define libceed_petsc_examples_setup_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -18,4 +18,4 @@ PetscErrorCode CeedLevelTransferSetup(Ceed ceed, CeedInt num_levels,
                                       CeedInt num_comp_u, CeedData *data, CeedInt *leveldegrees,
                                       CeedQFunction qf_restrict, CeedQFunction qf_prolong);
 
-#endif // libceedsetup_h
+#endif // libceed_petsc_examples_setup_h

--- a/examples/petsc/include/matops.h
+++ b/examples/petsc/include/matops.h
@@ -1,5 +1,5 @@
-#ifndef matops_h
-#define matops_h
+#ifndef libceed_petsc_examples_matops_h
+#define libceed_petsc_examples_matops_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -16,4 +16,4 @@ PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y);
 PetscErrorCode ComputeErrorMax(UserO user, CeedOperator op_error,
                                Vec X, CeedVector target, PetscReal *max_error);
 
-#endif // matops_h
+#endif // libceed_petsc_examples_matops_h

--- a/examples/petsc/include/petscutils.h
+++ b/examples/petsc/include/petscutils.h
@@ -1,5 +1,5 @@
-#ifndef ceed_petscutils_h
-#define ceed_petscutils_h
+#ifndef libceed_petsc_examples_utils_h
+#define libceed_petsc_examples_utils_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -18,4 +18,4 @@ PetscErrorCode SetupDMByDegree(DM dm, PetscInt degree, PetscInt num_comp_u,
 PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height,
     DMLabel domain_label, CeedInt value, CeedElemRestriction *elem_restr);
 
-#endif // petscutils_h
+#endif // libceed_petsc_examples_utils_h

--- a/examples/petsc/include/petscversion.h
+++ b/examples/petsc/include/petscversion.h
@@ -1,5 +1,5 @@
-#ifndef ceed_petscversion_h
-#define ceed_petscversion_h
+#ifndef libceed_petsc_examples_version_h
+#define libceed_petsc_examples_version_h
 
 #if PETSC_VERSION_LT(3,17,0)
 #error "PETSc v3.17 or later is required"

--- a/examples/petsc/include/sphereproblemdata.h
+++ b/examples/petsc/include/sphereproblemdata.h
@@ -1,5 +1,5 @@
-#ifndef sphereproblemdata_h
-#define sphereproblemdata_h
+#ifndef libceed_petsc_examples_sphere_problem_data_h
+#define libceed_petsc_examples_sphere_problem_data_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -131,4 +131,4 @@ static BPData bp_options[6] = {
   }
 };
 
-#endif // sphereproblemdata_h
+#endif // libceed_petsc_examples_sphere_problem_data_h

--- a/examples/petsc/include/structs.h
+++ b/examples/petsc/include/structs.h
@@ -1,5 +1,5 @@
-#ifndef structs_h
-#define structs_h
+#ifndef libceed_petsc_examples_structs_h
+#define libceed_petsc_examples_structs_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -57,4 +57,4 @@ typedef struct {
                             PetscInt, PetscScalar *, void *);
 } BPData;
 
-#endif // structs_h
+#endif // libceed_petsc_examples_structs_h

--- a/examples/solids/elasticity.h
+++ b/examples/solids/elasticity.h
@@ -1,5 +1,5 @@
-#ifndef setup_h
-#define setup_h
+#ifndef libceed_solids_examples_setup_h
+#define libceed_solids_examples_setup_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -21,4 +21,4 @@
 #error "PETSc v3.17 or later is required"
 #endif
 
-#endif // setup_h
+#endif // libceed_solids_examples_setup_h

--- a/examples/solids/include/boundary.h
+++ b/examples/solids/include/boundary.h
@@ -1,5 +1,5 @@
-#ifndef boundary_h
-#define boundary_h
+#ifndef libceed_solids_examples_boundary_h
+#define libceed_solids_examples_boundary_h
 
 #include <petsc.h>
 
@@ -26,4 +26,4 @@ PetscErrorCode BCClamp(PetscInt dim, PetscReal load_increment,
                        const PetscReal coords[], PetscInt num_comp_u,
                        PetscScalar *u, void *ctx);
 
-#endif //boundary_h
+#endif // libceed_solids_examples_boundary_h

--- a/examples/solids/include/cl-options.h
+++ b/examples/solids/include/cl-options.h
@@ -1,5 +1,5 @@
-#ifndef cloptions_h
-#define cloptions_h
+#ifndef libceed_solids_examples_cl_options_h
+#define libceed_solids_examples_cl_options_h
 
 #include <petsc.h>
 #include "../include/structs.h"
@@ -7,4 +7,4 @@
 // Process general command line options
 PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx);
 
-#endif // cloptions_h
+#endif // libceed_solids_examples_cl_options_h

--- a/examples/solids/include/matops.h
+++ b/examples/solids/include/matops.h
@@ -1,5 +1,5 @@
-#ifndef matops_h
-#define matops_h
+#ifndef libceed_solids_examples_matops_h
+#define libceed_solids_examples_matops_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -34,4 +34,4 @@ PetscErrorCode ComputeStrainEnergy(DM dm_energy, UserMult user,
 // this function checks to see if the computed energy is close enough to reference file energy.
 PetscErrorCode RegressionTests_solids(AppCtx app_ctx, PetscReal energy);
 
-#endif // matopts_h
+#endif // libceed_solids_examples_matopts_h

--- a/examples/solids/include/misc.h
+++ b/examples/solids/include/misc.h
@@ -1,5 +1,5 @@
-#ifndef misc_h
-#define misc_h
+#ifndef libceed_solids_examples_misc_h
+#define libceed_solids_examples_misc_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -42,4 +42,4 @@ PetscErrorCode ViewDiagnosticQuantities(MPI_Comm comm, DM dm_U,
 // -----------------------------------------------------------------------------
 PetscErrorCode RegressionTests_solids(AppCtx app_ctx, PetscReal energy);
 
-#endif // misc_h
+#endif // libceed_solids_examples_misc_h

--- a/examples/solids/include/setup-dm.h
+++ b/examples/solids/include/setup-dm.h
@@ -1,5 +1,5 @@
-#ifndef setupdm_h
-#define setupdm_h
+#ifndef libceed_solids_examples_setup_dm_h
+#define libceed_solids_examples_setup_dm_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -19,4 +19,4 @@ PetscErrorCode CreateDistributedDM(MPI_Comm comm, AppCtx app_ctx, DM *dm);
 PetscErrorCode SetupDMByDegree(DM dm, AppCtx app_ctx, PetscInt order,
                                PetscBool boundary, PetscInt num_comp_u);
 
-#endif // setupdm_h
+#endif // libceed_solids_examples_setup_dm_h

--- a/examples/solids/include/setup-libceed.h
+++ b/examples/solids/include/setup-libceed.h
@@ -1,5 +1,5 @@
-#ifndef setuplibceed_h
-#define setuplibceed_h
+#ifndef libceed_solids_examples_setup_libceed_h
+#define libceed_solids_examples_setup_libceed_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -43,4 +43,4 @@ PetscErrorCode SetupLibceedLevel(DM dm, Ceed ceed, AppCtx app_ctx,
                                  PetscInt U_loc_size, CeedVector fine_mult,
                                  CeedData *data);
 
-#endif // setuplibceed_h
+#endif // libceed_solids_examples_setup_libceed_h

--- a/examples/solids/include/structs.h
+++ b/examples/solids/include/structs.h
@@ -1,5 +1,5 @@
-#ifndef structs_h
-#define structs_h
+#ifndef libceed_solids_examples_structs_h
+#define libceed_solids_examples_structs_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -156,4 +156,4 @@ typedef struct {
   const char *const *field_names;
 } ProblemData;
 
-#endif // structs_h
+#endif // libceed_solids_examples_structs_h

--- a/examples/solids/include/utils.h
+++ b/examples/solids/include/utils.h
@@ -1,5 +1,5 @@
-#ifndef utils_h
-#define utils_h
+#ifndef libceed_solids_examples_utils_h
+#define libceed_solids_examples_utils_h
 
 #include <ceed.h>
 #include <petsc.h>
@@ -9,4 +9,4 @@ static inline CeedMemType MemTypeP2C(PetscMemType mem_type) {
   return PetscMemTypeDevice(mem_type) ? CEED_MEM_DEVICE : CEED_MEM_HOST;
 }
 
-#endif // utils_h
+#endif // libceed_solids_examples_utils_h


### PR DESCRIPTION
Do we want to add this more strict namespacing for these example header guards?