### PR TITLE
QFContext - create labels for registered fields

### DIFF
--- a/doc/sphinx/source/.gitignore
+++ b/doc/sphinx/source/.gitignore
@@ -1,0 +1,1 @@
+README.md

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -46,8 +46,9 @@ static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested,
   ierr = CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES,
                                      sizeof(ctx_data), (void *)&ctx_data);
   CeedChk(ierr);
-  ierr = CeedQFunctionContextRegisterInt32(ctx, "size", offsetof(IdentityCtx,
-         size), "field size of identity QFunction"); CeedChk(ierr);
+  ierr = CeedQFunctionContextRegisterInt32(ctx, "size",
+         offsetof(IdentityCtx, size), 1, "field size of identity QFunction");
+  CeedChk(ierr);
   ierr = CeedQFunctionSetContext(qf, ctx); CeedChk(ierr);
   ierr = CeedQFunctionContextDestroy(&ctx); CeedChk(ierr);
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -274,7 +274,7 @@ struct CeedQFunctionContext_private {
   int (*Destroy)(CeedQFunctionContext);
   CeedInt num_fields;
   CeedInt max_fields;
-  CeedQFunctionContextFieldDescription *field_descriptions;
+  CeedContextFieldLabel *field_labels;
   uint64_t state;
   size_t ctx_size;
   void *data;
@@ -301,6 +301,16 @@ struct CeedFortranContext_private {
             CeedScalar *v15, int *err);
 };
 typedef struct CeedFortranContext_private *CeedFortranContext;
+
+struct CeedContextFieldLabel_private {
+  const char *name;
+  const char *description;
+  CeedContextFieldType type;
+  size_t size;
+  size_t offset;
+  CeedInt num_sub_labels;
+  CeedContextFieldLabel *sub_labels;
+};
 
 struct CeedOperatorField_private {
   CeedElemRestriction elem_restr; /* Restriction from L-vector */
@@ -355,6 +365,9 @@ struct CeedOperator_private {
   CeedOperator *sub_operators;
   CeedInt num_suboperators;
   void *data;
+  CeedInt num_context_labels;
+  CeedInt max_context_labels;
+  CeedContextFieldLabel *context_labels;
 };
 
 #endif

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -307,6 +307,7 @@ struct CeedContextFieldLabel_private {
   const char *description;
   CeedContextFieldType type;
   size_t size;
+  size_t num_values;
   size_t offset;
   CeedInt num_sub_labels;
   CeedContextFieldLabel *sub_labels;

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -241,9 +241,8 @@ CEED_EXTERN int CeedQFunctionContextGetBackendData(CeedQFunctionContext ctx,
 CEED_EXTERN int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx,
     void *data);
 CEED_EXTERN int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
-                                   const char *field_name,
-                                   CeedContextFieldType field_type,
-                                   bool *is_set, void *value);
+                                   CeedContextFieldLabel field_label,
+                                   CeedContextFieldType field_type, void *value);
 CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -169,6 +169,9 @@ typedef struct CeedOperatorField_private *CeedOperatorField;
 /// Handle for object describing context data for CeedQFunctions
 /// @ingroup CeedQFunctionUser
 typedef struct CeedQFunctionContext_private *CeedQFunctionContext;
+/// Handle for object describing registered fields for CeedQFunctionContext
+/// @ingroup CeedQFunctionUser
+typedef struct CeedContextFieldLabel_private *CeedContextFieldLabel;
 /// Handle for object describing FE-type operators acting on vectors
 ///
 /// Given an element restriction \f$E\f$, basis evaluator \f$B\f$, and
@@ -634,16 +637,6 @@ typedef enum {
 } CeedContextFieldType;
 CEED_EXTERN const char *const CeedContextFieldTypes[];
 
-/// Handle for object describing CeedQFunctionContext fields
-/// @ingroup CeedQFunction
-typedef struct {
-  const char *name;
-  const char *description;
-  CeedContextFieldType type;
-  size_t size;
-  size_t offset;
-} CeedQFunctionContextFieldDescription;
-
 CEED_EXTERN int CeedQFunctionContextCreate(Ceed ceed,
     CeedQFunctionContext *ctx);
 CEED_EXTERN int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx,
@@ -660,12 +653,14 @@ CEED_EXTERN int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx,
     const char *field_name, size_t field_offset, const char *field_description);
 CEED_EXTERN int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx,
     const char *field_name, size_t field_offset, const char *field_description);
-CEED_EXTERN int CeedQFunctionContextGetFieldDescriptions(CeedQFunctionContext ctx,
-    const CeedQFunctionContextFieldDescription **field_descriptions, CeedInt *num_fields);
+CEED_EXTERN int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
+    const char *field_name, CeedContextFieldLabel *field_label);
+CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
+    const CeedContextFieldLabel **field_labels, CeedInt *num_fields);
 CEED_EXTERN int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
-    const char *field_name, double value);
+    CeedContextFieldLabel field_label, double value);
 CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
-    const char *field_name, int value);
+    CeedContextFieldLabel field_label, int value);
 CEED_EXTERN int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx,
     size_t *ctx_size);
 CEED_EXTERN int CeedQFunctionContextView(CeedQFunctionContext ctx,
@@ -722,10 +717,12 @@ CEED_EXTERN int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem);
 CEED_EXTERN int CeedOperatorGetNumQuadraturePoints(CeedOperator op,
     CeedInt *num_qpts);
-CEED_EXTERN int CeedOperatorContextSetDouble(CeedOperator op, const char *field_name,
-    double value);
-CEED_EXTERN int CeedOperatorContextSetInt32(CeedOperator op, const char *field_name,
-    int value);
+CEED_EXTERN int CeedOperatorContextGetFieldLabel(CeedOperator op,
+    const char *field_name, CeedContextFieldLabel *field_label);
+CEED_EXTERN int CeedOperatorContextSetDouble(CeedOperator op,
+    CeedContextFieldLabel field_label, double value);
+CEED_EXTERN int CeedOperatorContextSetInt32(CeedOperator op,
+    CeedContextFieldLabel field_label, int value);
 CEED_EXTERN int CeedOperatorApply(CeedOperator op, CeedVector in,
                                   CeedVector out, CeedRequest *request);
 CEED_EXTERN int CeedOperatorApplyAdd(CeedOperator op, CeedVector in,

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -657,6 +657,9 @@ CEED_EXTERN int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
     const char *field_name, CeedContextFieldLabel *field_label);
 CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
     const CeedContextFieldLabel **field_labels, CeedInt *num_fields);
+CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label,
+    const char **field_name, const char **field_description,
+    CeedContextFieldType *field_type);
 CEED_EXTERN int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
     CeedContextFieldLabel field_label, double value);
 CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -631,9 +631,9 @@ CEED_EXTERN int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field,
 /// @ingroup CeedQFunction
 typedef enum {
   /// Double precision value
-  CEED_CONTEXT_FIELD_DOUBLE,
+  CEED_CONTEXT_FIELD_DOUBLE = 1,
   /// 32 bit integer value
-  CEED_CONTEXT_FIELD_INT32
+  CEED_CONTEXT_FIELD_INT32  = 2,
 } CeedContextFieldType;
 CEED_EXTERN const char *const CeedContextFieldTypes[];
 
@@ -650,20 +650,22 @@ CEED_EXTERN int CeedQFunctionContextGetData(CeedQFunctionContext ctx,
 CEED_EXTERN int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx,
     void *data);
 CEED_EXTERN int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx,
-    const char *field_name, size_t field_offset, const char *field_description);
+    const char *field_name, size_t field_offset, size_t num_values,
+    const char *field_description);
 CEED_EXTERN int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx,
-    const char *field_name, size_t field_offset, const char *field_description);
+    const char *field_name, size_t field_offset, size_t num_values,
+    const char *field_description);
 CEED_EXTERN int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
     const char *field_name, CeedContextFieldLabel *field_label);
 CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
     const CeedContextFieldLabel **field_labels, CeedInt *num_fields);
 CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label,
-    const char **field_name, const char **field_description,
+    const char **field_name, const char **field_description, size_t *num_values,
     CeedContextFieldType *field_type);
 CEED_EXTERN int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
-    CeedContextFieldLabel field_label, double value);
+    CeedContextFieldLabel field_label, double *values);
 CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
-    CeedContextFieldLabel field_label, int value);
+    CeedContextFieldLabel field_label, int *values);
 CEED_EXTERN int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx,
     size_t *ctx_size);
 CEED_EXTERN int CeedQFunctionContextView(CeedQFunctionContext ctx,
@@ -723,9 +725,9 @@ CEED_EXTERN int CeedOperatorGetNumQuadraturePoints(CeedOperator op,
 CEED_EXTERN int CeedOperatorContextGetFieldLabel(CeedOperator op,
     const char *field_name, CeedContextFieldLabel *field_label);
 CEED_EXTERN int CeedOperatorContextSetDouble(CeedOperator op,
-    CeedContextFieldLabel field_label, double value);
+    CeedContextFieldLabel field_label, double *values);
 CEED_EXTERN int CeedOperatorContextSetInt32(CeedOperator op,
-    CeedContextFieldLabel field_label, int value);
+    CeedContextFieldLabel field_label, int *values);
 CEED_EXTERN int CeedOperatorApply(CeedOperator op, CeedVector in,
                                   CeedVector out, CeedRequest *request);
 CEED_EXTERN int CeedOperatorApplyAdd(CeedOperator op, CeedVector in,

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1142,6 +1142,31 @@ int CeedOperatorContextGetFieldLabel(CeedOperator op,
           new_field_label->sub_labels[i] = new_field_label_i;
           new_field_label->name = new_field_label_i->name;
           new_field_label->description = new_field_label_i->description;
+          if (new_field_label->type &&
+              new_field_label->type != new_field_label_i->type) {
+            // LCOV_EXCL_START
+            ierr = CeedFree(&new_field_label); CeedChk(ierr);
+            return CeedError(op->ceed, CEED_ERROR_INCOMPATIBLE,
+                             "Incompatible field types on sub-operator contexts. "
+                             "%s != %s",
+                             CeedContextFieldTypes[new_field_label->type],
+                             CeedContextFieldTypes[new_field_label_i->type]);
+            // LCOV_EXCL_STOP
+          } else {
+            new_field_label->type = new_field_label_i->type;
+          }
+          if (new_field_label->num_values != 0 &&
+              new_field_label->num_values != new_field_label_i->num_values) {
+            // LCOV_EXCL_START
+            ierr = CeedFree(&new_field_label); CeedChk(ierr);
+            return CeedError(op->ceed, CEED_ERROR_INCOMPATIBLE,
+                             "Incompatible field number of values on sub-operator"
+                             " contexts. %ld != %ld",
+                             new_field_label->num_values, new_field_label_i->num_values);
+            // LCOV_EXCL_STOP
+          } else {
+            new_field_label->num_values = new_field_label_i->num_values;
+          }
         }
       }
     }
@@ -1178,7 +1203,7 @@ int CeedOperatorContextGetFieldLabel(CeedOperator op,
 
   @param op          CeedOperator
   @param field_label Label of field to register
-  @param value       Value to set
+  @param values      Values to set
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1186,9 +1211,9 @@ int CeedOperatorContextGetFieldLabel(CeedOperator op,
 **/
 int CeedOperatorContextSetDouble(CeedOperator op,
                                  CeedContextFieldLabel field_label,
-                                 double value) {
+                                 double *values) {
   return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_DOUBLE,
-                                       &value);
+                                       values);
 }
 
 /**
@@ -1198,7 +1223,7 @@ int CeedOperatorContextSetDouble(CeedOperator op,
 
   @param op          CeedOperator
   @param field_label Label of field to set
-  @param value       Value to set
+  @param values      Values to set
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1206,9 +1231,9 @@ int CeedOperatorContextSetDouble(CeedOperator op,
 **/
 int CeedOperatorContextSetInt32(CeedOperator op,
                                 CeedContextFieldLabel field_label,
-                                int value) {
+                                int *values) {
   return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_INT32,
-                                       &value);
+                                       values);
 }
 
 /**

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -272,37 +272,47 @@ int CeedOperatorGetActiveElemRestriction(CeedOperator op,
            that do not have a matching field of the same type or composite
            operators that do not have any field of a matching type.
 
-  @param op         CeedOperator
-  @param field_name Name of field to set
-  @param field_type Type of field to set
-  @param value      Value to set
+  @param op          CeedOperator
+  @param field_label Label of field to set
+  @param field_type  Type of field to set
+  @param value       Value to set
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 static int CeedOperatorContextSetGeneric(CeedOperator op,
-    const char *field_name, CeedContextFieldType field_type, void *value) {
+    CeedContextFieldLabel field_label, CeedContextFieldType field_type,
+    void *value) {
   int ierr;
-  bool is_set = false, is_composite = false;
 
+  if (!field_label)
+    // LCOV_EXCL_START
+    return CeedError(op->ceed, CEED_ERROR_UNSUPPORTED,
+                     "Invalid field label");
+  // LCOV_EXCL_STOP
+
+  bool is_composite = false;
   ierr = CeedOperatorIsComposite(op, &is_composite); CeedChk(ierr);
-
   if (is_composite) {
     CeedInt num_sub;
     CeedOperator *sub_operators;
 
     ierr = CeedOperatorGetNumSub(op, &num_sub); CeedChk(ierr);
     ierr = CeedOperatorGetSubList(op, &sub_operators); CeedChk(ierr);
+    if (num_sub != field_label->num_sub_labels)
+      // LCOV_EXCL_START
+      return CeedError(op->ceed, CEED_ERROR_UNSUPPORTED,
+                       "ContextLabel does not correspond to composite operator.\n"
+                       "Use CeedOperatorGetContextFieldLabel().");
+    // LCOV_EXCL_STOP
 
     for (CeedInt i = 0; i < num_sub; i++) {
       // Try every sub-operator, ok if some sub-operators do not have field
-      if (sub_operators[i]->qf->ctx) {
-        bool is_set_i = false;
-        ierr = CeedQFunctionContextSetGeneric(sub_operators[i]->qf->ctx, field_name,
-                                              field_type, &is_set_i, value);
-        CeedChk(ierr);
-        is_set = is_set || is_set_i;
+      if (field_label->sub_labels[i] && sub_operators[i]->qf->ctx) {
+        ierr = CeedQFunctionContextSetGeneric(sub_operators[i]->qf->ctx,
+                                              field_label->sub_labels[i],
+                                              field_type, value); CeedChk(ierr);
       }
     }
   } else {
@@ -312,16 +322,9 @@ static int CeedOperatorContextSetGeneric(CeedOperator op,
                        "QFunction does not have context data");
     // LCOV_EXCL_STOP
 
-    ierr = CeedQFunctionContextSetGeneric(op->qf->ctx, field_name,
-                                          field_type, &is_set, value); CeedChk(ierr);
+    ierr = CeedQFunctionContextSetGeneric(op->qf->ctx, field_label,
+                                          field_type, value); CeedChk(ierr);
   }
-
-  if (!is_set)
-    // LCOV_EXCL_START
-    return CeedError(op->ceed, CEED_ERROR_UNSUPPORTED,
-                     "QFunctionContext field with name \"%s\" not registered",
-                     field_name);
-  // LCOV_EXCL_STOP
 
   return CEED_ERROR_SUCCESS;
 }
@@ -1090,21 +1093,101 @@ int CeedOperatorGetNumQuadraturePoints(CeedOperator op, CeedInt *num_qpts) {
 }
 
 /**
-  @brief Set QFunctionContext field holding a double precision value.
-           For composite operators, the value is set in all
-           sub-operator QFunctionContexts that have a matching `field_name`.
+  @brief Get label for a registered QFunctionContext field, or `NULL` if no
+           field has been registered with this `field_name`.
 
-  @param op         CeedOperator
-  @param field_name Name of field to register
-  @param value      Value to set
+  @param[in] op            CeedOperator
+  @param[in] field_name    Name of field to retrieve label
+  @param[out] field_label  Variable to field label
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
-int CeedOperatorContextSetDouble(CeedOperator op, const char *field_name,
+int CeedOperatorContextGetFieldLabel(CeedOperator op,
+                                     const char *field_name,
+                                     CeedContextFieldLabel *field_label) {
+  int ierr;
+
+  bool is_composite;
+  ierr = CeedOperatorIsComposite(op, &is_composite); CeedChk(ierr);
+  if (is_composite) {
+    // Check if composite label already created
+    for (CeedInt i=0; i<op->num_context_labels; i++) {
+      if (!strcmp(op->context_labels[i]->name, field_name)) {
+        *field_label = op->context_labels[i];
+        return CEED_ERROR_SUCCESS;
+      }
+    }
+
+    // Create composite label if needed
+    CeedInt num_sub;
+    CeedOperator *sub_operators;
+    CeedContextFieldLabel new_field_label;
+
+    ierr = CeedCalloc(1, &new_field_label); CeedChk(ierr);
+    ierr = CeedOperatorGetNumSub(op, &num_sub); CeedChk(ierr);
+    ierr = CeedOperatorGetSubList(op, &sub_operators); CeedChk(ierr);
+    ierr = CeedCalloc(num_sub, &new_field_label->sub_labels); CeedChk(ierr);
+    new_field_label->num_sub_labels = num_sub;
+
+    bool label_found = false;
+    for (CeedInt i=0; i<num_sub; i++) {
+      if (sub_operators[i]->qf->ctx) {
+        CeedContextFieldLabel new_field_label_i;
+        ierr = CeedQFunctionContextGetFieldLabel(sub_operators[i]->qf->ctx, field_name,
+               &new_field_label_i); CeedChk(ierr);
+        if (new_field_label_i) {
+          label_found = true;
+          new_field_label->sub_labels[i] = new_field_label_i;
+          new_field_label->name = new_field_label_i->name;
+          new_field_label->description = new_field_label_i->description;
+        }
+      }
+    }
+    if (!label_found) {
+      // LCOV_EXCL_START
+      ierr = CeedFree(&new_field_label); CeedChk(ierr);
+      *field_label = NULL;
+      // LCOV_EXCL_STOP
+    } else {
+      // Move new composite label to operator
+      if (op->num_context_labels == 0) {
+        ierr = CeedCalloc(1, &op->context_labels); CeedChk(ierr);
+        op->max_context_labels = 1;
+      } else if (op->num_context_labels == op->max_context_labels) {
+        ierr = CeedRealloc(2*op->num_context_labels, &op->context_labels);
+        CeedChk(ierr);
+        op->max_context_labels *= 2;
+      }
+      op->context_labels[op->num_context_labels] = new_field_label;
+      *field_label = new_field_label;
+      op->num_context_labels++;
+    }
+
+    return CEED_ERROR_SUCCESS;
+  } else {
+    return CeedQFunctionContextGetFieldLabel(op->qf->ctx, field_name, field_label);
+  }
+}
+
+/**
+  @brief Set QFunctionContext field holding a double precision value.
+           For composite operators, the value is set in all
+           sub-operator QFunctionContexts that have a matching `field_name`.
+
+  @param op          CeedOperator
+  @param field_label Label of field to register
+  @param value       Value to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorContextSetDouble(CeedOperator op,
+                                 CeedContextFieldLabel field_label,
                                  double value) {
-  return CeedOperatorContextSetGeneric(op, field_name, CEED_CONTEXT_FIELD_DOUBLE,
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_DOUBLE,
                                        &value);
 }
 
@@ -1113,19 +1196,19 @@ int CeedOperatorContextSetDouble(CeedOperator op, const char *field_name,
            For composite operators, the value is set in all
            sub-operator QFunctionContexts that have a matching `field_name`.
 
-  @param op         CeedOperator
-  @param field_name Name of field to set
-  @param value      Value to set
+  @param op          CeedOperator
+  @param field_label Label of field to set
+  @param value       Value to set
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
-int CeedOperatorContextSetInt32(CeedOperator op, const char *field_name,
+int CeedOperatorContextSetInt32(CeedOperator op,
+                                CeedContextFieldLabel field_label,
                                 int value) {
-  return CeedOperatorContextSetGeneric(op, field_name, CEED_CONTEXT_FIELD_INT32,
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_INT32,
                                        &value);
-  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1270,7 +1353,7 @@ int CeedOperatorDestroy(CeedOperator *op) {
   }
   ierr = CeedDestroy(&(*op)->ceed); CeedChk(ierr);
   // Free fields
-  for (int i=0; i<(*op)->num_fields; i++)
+  for (CeedInt i=0; i<(*op)->num_fields; i++)
     if ((*op)->input_fields[i]) {
       if ((*op)->input_fields[i]->elem_restr != CEED_ELEMRESTRICTION_NONE) {
         ierr = CeedElemRestrictionDestroy(&(*op)->input_fields[i]->elem_restr);
@@ -1286,7 +1369,7 @@ int CeedOperatorDestroy(CeedOperator *op) {
       ierr = CeedFree(&(*op)->input_fields[i]->field_name); CeedChk(ierr);
       ierr = CeedFree(&(*op)->input_fields[i]); CeedChk(ierr);
     }
-  for (int i=0; i<(*op)->num_fields; i++)
+  for (CeedInt i=0; i<(*op)->num_fields; i++)
     if ((*op)->output_fields[i]) {
       ierr = CeedElemRestrictionDestroy(&(*op)->output_fields[i]->elem_restr);
       CeedChk(ierr);
@@ -1301,13 +1384,19 @@ int CeedOperatorDestroy(CeedOperator *op) {
       ierr = CeedFree(&(*op)->output_fields[i]); CeedChk(ierr);
     }
   // Destroy sub_operators
-  for (int i=0; i<(*op)->num_suboperators; i++)
+  for (CeedInt i=0; i<(*op)->num_suboperators; i++)
     if ((*op)->sub_operators[i]) {
       ierr = CeedOperatorDestroy(&(*op)->sub_operators[i]); CeedChk(ierr);
     }
   ierr = CeedQFunctionDestroy(&(*op)->qf); CeedChk(ierr);
   ierr = CeedQFunctionDestroy(&(*op)->dqf); CeedChk(ierr);
   ierr = CeedQFunctionDestroy(&(*op)->dqfT); CeedChk(ierr);
+  // Destroy any composite labels
+  for (CeedInt i=0; i<(*op)->num_context_labels; i++) {
+    ierr = CeedFree(&(*op)->context_labels[i]->sub_labels); CeedChk(ierr);
+    ierr = CeedFree(&(*op)->context_labels[i]); CeedChk(ierr);
+  }
+  ierr = CeedFree(&(*op)->context_labels); CeedChk(ierr);
 
   // Destroy fallback
   if ((*op)->op_fallback) {

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -557,7 +557,7 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode in_mode,
   ierr = CeedQFunctionGetContext(*qf, &ctx); CeedChk(ierr);
   ierr = CeedQFunctionContextGetFieldLabel(ctx, "size", &size_label);
   CeedChk(ierr);
-  ierr = CeedQFunctionContextSetInt32(ctx, size_label, size); CeedChk(ierr);
+  ierr = CeedQFunctionContextSetInt32(ctx, size_label, &size); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -553,8 +553,11 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode in_mode,
   (*qf)->is_identity = true;
 
   CeedQFunctionContext ctx;
+  CeedContextFieldLabel size_label;
   ierr = CeedQFunctionGetContext(*qf, &ctx); CeedChk(ierr);
-  ierr = CeedQFunctionContextSetInt32(ctx, "size", size); CeedChk(ierr);
+  ierr = CeedQFunctionContextGetFieldLabel(ctx, "size", &size_label);
+  CeedChk(ierr);
+  ierr = CeedQFunctionContextSetInt32(ctx, size_label, size); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -45,7 +45,7 @@ int CeedQFunctionContextGetFieldIndex(CeedQFunctionContext ctx,
                                       const char *field_name, CeedInt *field_index) {
   *field_index = -1;
   for (CeedInt i=0; i<ctx->num_fields; i++)
-    if (!strcmp(ctx->field_descriptions[i].name, field_name))
+    if (!strcmp(ctx->field_labels[i]->name, field_name))
       *field_index = i;
   return CEED_ERROR_SUCCESS;
 }
@@ -84,24 +84,25 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx,
 
   // Allocate space for field data
   if (ctx->num_fields == 0) {
-    ierr = CeedCalloc(1, &ctx->field_descriptions); CeedChk(ierr);
+    ierr = CeedCalloc(1, &ctx->field_labels); CeedChk(ierr);
     ctx->max_fields = 1;
   } else if (ctx->num_fields == ctx->max_fields) {
-    ierr = CeedRealloc(2*ctx->max_fields, &ctx->field_descriptions);
+    ierr = CeedRealloc(2*ctx->max_fields, &ctx->field_labels);
     CeedChk(ierr);
     ctx->max_fields *= 2;
   }
+  ierr = CeedCalloc(1, &ctx->field_labels[ctx->num_fields]); CeedChk(ierr);
 
   // Copy field data
   ierr = CeedStringAllocCopy(field_name,
-                             (char **)&ctx->field_descriptions[ctx->num_fields].name);
+                             (char **)&ctx->field_labels[ctx->num_fields]->name);
   CeedChk(ierr);
   ierr = CeedStringAllocCopy(field_description,
-                             (char **)&ctx->field_descriptions[ctx->num_fields].description);
+                             (char **)&ctx->field_labels[ctx->num_fields]->description);
   CeedChk(ierr);
-  ctx->field_descriptions[ctx->num_fields].type = field_type;
-  ctx->field_descriptions[ctx->num_fields].offset = field_offset;
-  ctx->field_descriptions[ctx->num_fields].size = field_size;
+  ctx->field_labels[ctx->num_fields]->type = field_type;
+  ctx->field_labels[ctx->num_fields]->offset = field_offset;
+  ctx->field_labels[ctx->num_fields]->size = field_size;
   ctx->num_fields++;
   return CEED_ERROR_SUCCESS;
 }
@@ -230,45 +231,35 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
 /**
   @brief Set QFunctionContext field
 
-  @param ctx        CeedQFunctionContext
-  @param field_name Name of field to set
-  @param field_type Type of field to set
-  @param is_set     Boolean flag if value was set
-  @param value      Value to set
+  @param ctx         CeedQFunctionContext
+  @param field_label Label of field to set
+  @param field_type  Type of field to set
+  @param value       Value to set
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
-                                   const char *field_name,
+                                   CeedContextFieldLabel field_label,
                                    CeedContextFieldType field_type,
-                                   bool *is_set, void *value) {
+                                   void *value) {
   int ierr;
 
-  // Check field index
-  *is_set = false;
-  CeedInt field_index = -1;
-  ierr = CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index);
-  CeedChk(ierr);
-  if (field_index == -1)
-    return CEED_ERROR_SUCCESS;
-
-  if (ctx->field_descriptions[field_index].type != field_type)
+  // Check field type
+  if (field_label->type != field_type)
     // LCOV_EXCL_START
     return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
                      "QFunctionContext field with name \"%s\" registered as %s, "
-                     "not registered as %s", field_name,
-                     CeedContextFieldTypes[ctx->field_descriptions[field_index].type],
+                     "not registered as %s", field_label->name,
+                     CeedContextFieldTypes[field_label->type],
                      CeedContextFieldTypes[field_type]);
   // LCOV_EXCL_STOP
 
   char *data;
   ierr = CeedQFunctionContextGetData(ctx, CEED_MEM_HOST, &data); CeedChk(ierr);
-  memcpy(&data[ctx->field_descriptions[field_index].offset], value,
-         ctx->field_descriptions[field_index].size);
+  memcpy(&data[field_label->offset], value, field_label->size);
   ierr = CeedQFunctionContextRestoreData(ctx, &data); CeedChk(ierr);
-  *is_set = true;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -565,49 +556,76 @@ int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx,
 }
 
 /**
-  @brief Get descriptions for registered QFunctionContext fields
+  @brief Get labels for all registered QFunctionContext fields
 
-  @param ctx                     CeedQFunctionContext
-  @param[out] field_descriptions Variable to hold array of field descriptions
-  @param[out] num_fields         Length of field descriptions array
+  @param ctx                CeedQFunctionContext
+  @param[out] field_labels  Variable to hold array of field labels
+  @param[out] num_fields    Length of field descriptions array
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
-int CeedQFunctionContextGetFieldDescriptions(CeedQFunctionContext ctx,
-    const CeedQFunctionContextFieldDescription **field_descriptions,
-    CeedInt *num_fields) {
-  *field_descriptions = ctx->field_descriptions;
+int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
+    const CeedContextFieldLabel **field_labels, CeedInt *num_fields) {
+  *field_labels = ctx->field_labels;
   *num_fields = ctx->num_fields;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get label for a registered QFunctionContext field, or `NULL` if no
+           field has been registered with this `field_name`
+
+  @param[in] ctx           CeedQFunctionContext
+  @param[in] field_name    Name of field to retrieve label
+  @param[out] field_label  Variable to field label
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
+                                      const char *field_name, CeedContextFieldLabel *field_label) {
+  int ierr;
+
+  CeedInt field_index;
+  ierr = CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index);
+  CeedChk(ierr);
+
+  if (field_index != -1) {
+    *field_label = ctx->field_labels[field_index];
+  } else {
+    *field_label = NULL;
+  }
+
   return CEED_ERROR_SUCCESS;
 }
 
 /**
   @brief Set QFunctionContext field holding a double precision value
 
-  @param ctx        CeedQFunctionContext
-  @param field_name Name of field to register
-  @param value      Value to set
+  @param ctx         CeedQFunctionContext
+  @param field_label Label for field to register
+  @param value       Value to set
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
-                                  const char *field_name, double value) {
+                                  CeedContextFieldLabel field_label, double value) {
   int ierr;
-  bool is_set = false;
 
-  ierr = CeedQFunctionContextSetGeneric(ctx, field_name,
-                                        CEED_CONTEXT_FIELD_DOUBLE,
-                                        &is_set, &value); CeedChk(ierr);
-  if (!is_set)
+  if (!field_label)
     // LCOV_EXCL_START
     return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
-                     "QFunctionContext field with name \"%s\" not registered",
-                     field_name);
+                     "Invalid field label");
   // LCOV_EXCL_STOP
+
+  ierr = CeedQFunctionContextSetGeneric(ctx, field_label,
+                                        CEED_CONTEXT_FIELD_DOUBLE,
+                                        &value); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -615,28 +633,27 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
 /**
   @brief Set QFunctionContext field holding an int32 value
 
-  @param ctx        CeedQFunctionContext
-  @param field_name Name of field to set
-  @param value      Value to set
+  @param ctx         CeedQFunctionContext
+  @param field_label Label for field to register
+  @param value       Value to set
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
-                                 const char *field_name, int value) {
+                                 CeedContextFieldLabel field_label, int value) {
   int ierr;
-  bool is_set = false;
 
-  ierr = CeedQFunctionContextSetGeneric(ctx, field_name,
-                                        CEED_CONTEXT_FIELD_INT32,
-                                        &is_set, &value); CeedChk(ierr);
-  if (!is_set)
+  if (!field_label)
     // LCOV_EXCL_START
     return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
-                     "QFunctionContext field with name \"%s\" not registered",
-                     field_name);
+                     "Invalid field label");
   // LCOV_EXCL_STOP
+
+  ierr = CeedQFunctionContextSetGeneric(ctx, field_label,
+                                        CEED_CONTEXT_FIELD_INT32,
+                                        &value); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -671,6 +688,13 @@ int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx,
 int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream) {
   fprintf(stream, "CeedQFunctionContext\n");
   fprintf(stream, "  Context Data Size: %ld\n", ctx->ctx_size);
+  for (CeedInt i = 0; i < ctx->num_fields; i++) {
+    // LCOV_EXCL_START
+    fprintf(stream, "  Labeled %s field: %s\n",
+            CeedContextFieldTypes[ctx->field_labels[i]->type],
+            ctx->field_labels[i]->name);
+    // LCOV_EXCL_STOP
+  }
   return CEED_ERROR_SUCCESS;
 }
 
@@ -700,10 +724,11 @@ int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx) {
     ierr = (*ctx)->Destroy(*ctx); CeedChk(ierr);
   }
   for (CeedInt i=0; i<(*ctx)->num_fields; i++) {
-    ierr = CeedFree(&(*ctx)->field_descriptions[i].name); CeedChk(ierr);
-    ierr = CeedFree(&(*ctx)->field_descriptions[i].description); CeedChk(ierr);
+    ierr = CeedFree(&(*ctx)->field_labels[i]->name); CeedChk(ierr);
+    ierr = CeedFree(&(*ctx)->field_labels[i]->description); CeedChk(ierr);
+    ierr = CeedFree(&(*ctx)->field_labels[i]); CeedChk(ierr);
   }
-  ierr = CeedFree(&(*ctx)->field_descriptions); CeedChk(ierr);
+  ierr = CeedFree(&(*ctx)->field_labels); CeedChk(ierr);
   ierr = CeedDestroy(&(*ctx)->ceed); CeedChk(ierr);
   ierr = CeedFree(ctx); CeedChk(ierr);
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -603,6 +603,28 @@ int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
 }
 
 /**
+  @brief Get the descriptive information about a CeedContextFieldLabel
+
+  @param[in] label              CeedContextFieldLabel
+  @param[out] field_name        Name of labeled field
+  @param[out] field_description Description of field, or NULL for none
+  @param[out] field_type        CeedContextFieldType
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label,
+                                        const char **field_name,
+                                        const char **field_description,
+                                        CeedContextFieldType *field_type) {
+  if (field_name) *field_name = label->name;
+  if (field_description) *field_description = label->description;
+  if (field_type) *field_type = label->type;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Set QFunctionContext field holding a double precision value
 
   @param ctx         CeedQFunctionContext

--- a/tests/t330-basis.c
+++ b/tests/t330-basis.c
@@ -16,10 +16,11 @@ int main(int argc, char **argv) {
   CeedInit(argv[1], &ceed);
 
   // Test skipped if using single precision
-  if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
+  if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32)
+    // LCOV_EXCL_START
     return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
                      "Test not implemented in single precision");
-  }
+  // LCOV_EXCL_STOP
 
   HdivBasisQuad(Q, q_ref, q_weights, interp, div, CEED_GAUSS);
   CeedBasisCreateHdiv(ceed, CEED_TOPOLOGY_QUAD, num_comp, P, num_qpts, interp,

--- a/tests/t330-basis.h
+++ b/tests/t330-basis.h
@@ -56,10 +56,12 @@ static void HdivBasisQuad(CeedInt Q, CeedScalar *q_ref, CeedScalar *q_weights,
   case CEED_GAUSS:
     CeedGaussQuadrature(Q, q_ref_1d, q_weight_1d);
     break;
+  // LCOV_EXCL_START
   case CEED_GAUSS_LOBATTO:
     CeedLobattoQuadrature(Q, q_ref_1d, q_weight_1d);
     break;
   }
+  // LCOV_EXCL_STOP
 
   // Divergence operator; Divergence of nodal basis for ref element
   CeedScalar D[8] = {0.25,0.25,0.25,0.25,0.25,0.25,0.25,0.25};

--- a/tests/t407-qfunction.c
+++ b/tests/t407-qfunction.c
@@ -13,6 +13,8 @@ typedef struct {
 int main(int argc, char **argv) {
   Ceed ceed;
   CeedQFunctionContext ctx;
+  CeedContextFieldLabel time_label, count_label;
+
   TestContext ctx_data = {
     .time = 1.0,
     .count = 42
@@ -29,31 +31,23 @@ int main(int argc, char **argv) {
   CeedQFunctionContextRegisterInt32(ctx, "count", offsetof(TestContext, count),
                                     "some sort of counter");
 
-  const CeedQFunctionContextFieldDescription *field_descriptions;
+  const CeedContextFieldLabel *field_labels;
   CeedInt num_fields;
-  CeedQFunctionContextGetFieldDescriptions(ctx, &field_descriptions, &num_fields);
+  CeedQFunctionContextGetAllFieldLabels(ctx, &field_labels, &num_fields);
   if (num_fields != 2)
     // LCOV_EXCL_START
     printf("Incorrect number of fields set: %d != 2", num_fields);
   // LCOV_EXCL_STOP
-  if (strcmp(field_descriptions[0].name, "time"))
-    // LCOV_EXCL_START
-    printf("Incorrect context field description for time: \"%s\" != \"time\"",
-           field_descriptions[0].name);
-  // LCOV_EXCL_STOP
-  if (strcmp(field_descriptions[1].name, "count"))
-    // LCOV_EXCL_START
-    printf("Incorrect context field description for time: \"%s\" != \"count\"",
-           field_descriptions[1].name);
-  // LCOV_EXCL_STOP
 
-  CeedQFunctionContextSetDouble(ctx, "time", 2.0);
+  CeedQFunctionContextGetFieldLabel(ctx, "time", &time_label);
+  CeedQFunctionContextSetDouble(ctx, time_label, 2.0);
   if (ctx_data.time != 2.0)
     // LCOV_EXCL_START
     printf("Incorrect context data for time: %f != 2.0", ctx_data.time);
   // LCOV_EXCL_STOP
 
-  CeedQFunctionContextSetInt32(ctx, "count", 43);
+  CeedQFunctionContextGetFieldLabel(ctx, "count", &count_label);
+  CeedQFunctionContextSetInt32(ctx, count_label, 43);
   if (ctx_data.count != 43)
     // LCOV_EXCL_START
     printf("Incorrect context data for count: %d != 43", ctx_data.count);

--- a/tests/t407-qfunction.c
+++ b/tests/t407-qfunction.c
@@ -38,6 +38,30 @@ int main(int argc, char **argv) {
     // LCOV_EXCL_START
     printf("Incorrect number of fields set: %d != 2", num_fields);
   // LCOV_EXCL_STOP
+  const char *name;
+  CeedContextFieldType type;
+  CeedContextFieldLabelGetDescription(field_labels[0], &name, NULL, &type);
+  if (strcmp(name, "time"))
+    // LCOV_EXCL_START
+    printf("Incorrect context field description for time: \"%s\" != \"time\"",
+           name);
+  // LCOV_EXCL_STOP
+  if (type != CEED_CONTEXT_FIELD_DOUBLE)
+    // LCOV_EXCL_START
+    printf("Incorrect context field type for time: \"%s\" != \"%s\"",
+           CeedContextFieldTypes[type], CeedContextFieldTypes[CEED_CONTEXT_FIELD_DOUBLE]);
+  // LCOV_EXCL_STOP
+  CeedContextFieldLabelGetDescription(field_labels[1], &name, NULL, &type);
+  if (strcmp(name, "count"))
+    // LCOV_EXCL_START
+    printf("Incorrect context field description for count: \"%s\" != \"count\"",
+           name);
+  // LCOV_EXCL_STOP
+  if (type != CEED_CONTEXT_FIELD_INT32)
+    // LCOV_EXCL_START
+    printf("Incorrect context field type for count: \"%s\" != \"%s\"",
+           CeedContextFieldTypes[type], CeedContextFieldTypes[CEED_CONTEXT_FIELD_INT32]);
+  // LCOV_EXCL_STOP
 
   CeedQFunctionContextGetFieldLabel(ctx, "time", &time_label);
   CeedQFunctionContextSetDouble(ctx, time_label, 2.0);

--- a/tests/t407-qfunction.c
+++ b/tests/t407-qfunction.c
@@ -7,7 +7,7 @@
 
 typedef struct {
   double time;
-  int count;
+  int count[2];
 } TestContext;
 
 int main(int argc, char **argv) {
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
 
   TestContext ctx_data = {
     .time = 1.0,
-    .count = 42
+    .count = {13, 42},
   };
 
   CeedInit(argv[1], &ceed);
@@ -27,54 +27,75 @@ int main(int argc, char **argv) {
                               sizeof(TestContext), &ctx_data);
 
   CeedQFunctionContextRegisterDouble(ctx, "time", offsetof(TestContext, time),
-                                     "current time");
+                                     1, "current time");
   CeedQFunctionContextRegisterInt32(ctx, "count", offsetof(TestContext, count),
-                                    "some sort of counter");
+                                    2, "some sort of counter");
 
   const CeedContextFieldLabel *field_labels;
   CeedInt num_fields;
   CeedQFunctionContextGetAllFieldLabels(ctx, &field_labels, &num_fields);
   if (num_fields != 2)
     // LCOV_EXCL_START
-    printf("Incorrect number of fields set: %d != 2", num_fields);
+    printf("Incorrect number of fields set: %d != 2\n", num_fields);
   // LCOV_EXCL_STOP
+
   const char *name;
+  size_t num_values;
   CeedContextFieldType type;
-  CeedContextFieldLabelGetDescription(field_labels[0], &name, NULL, &type);
+  CeedContextFieldLabelGetDescription(field_labels[0], &name, NULL, &num_values,
+                                      &type);
   if (strcmp(name, "time"))
     // LCOV_EXCL_START
-    printf("Incorrect context field description for time: \"%s\" != \"time\"",
+    printf("Incorrect context field description for time: \"%s\" != \"time\"\n",
            name);
+  // LCOV_EXCL_STOP
+  if (num_values != 1)
+    // LCOV_EXCL_START
+    printf("Incorrect context field number of values for time: \"%ld\" != 1\n",
+           num_values);
   // LCOV_EXCL_STOP
   if (type != CEED_CONTEXT_FIELD_DOUBLE)
     // LCOV_EXCL_START
-    printf("Incorrect context field type for time: \"%s\" != \"%s\"",
+    printf("Incorrect context field type for time: \"%s\" != \"%s\"\n",
            CeedContextFieldTypes[type], CeedContextFieldTypes[CEED_CONTEXT_FIELD_DOUBLE]);
   // LCOV_EXCL_STOP
-  CeedContextFieldLabelGetDescription(field_labels[1], &name, NULL, &type);
+
+  CeedContextFieldLabelGetDescription(field_labels[1], &name, NULL, &num_values,
+                                      &type);
   if (strcmp(name, "count"))
     // LCOV_EXCL_START
-    printf("Incorrect context field description for count: \"%s\" != \"count\"",
+    printf("Incorrect context field description for count: \"%s\" != \"count\"\n",
            name);
+  // LCOV_EXCL_STOP
+  if (num_values != 2)
+    // LCOV_EXCL_START
+    printf("Incorrect context field number of values for count: \"%ld\" != 2\n",
+           num_values);
   // LCOV_EXCL_STOP
   if (type != CEED_CONTEXT_FIELD_INT32)
     // LCOV_EXCL_START
-    printf("Incorrect context field type for count: \"%s\" != \"%s\"",
+    printf("Incorrect context field type for count: \"%s\" != \"%s\"\n",
            CeedContextFieldTypes[type], CeedContextFieldTypes[CEED_CONTEXT_FIELD_INT32]);
   // LCOV_EXCL_STOP
 
   CeedQFunctionContextGetFieldLabel(ctx, "time", &time_label);
-  CeedQFunctionContextSetDouble(ctx, time_label, 2.0);
+  double value_time = 2.0;
+  CeedQFunctionContextSetDouble(ctx, time_label, &value_time);
   if (ctx_data.time != 2.0)
     // LCOV_EXCL_START
-    printf("Incorrect context data for time: %f != 2.0", ctx_data.time);
+    printf("Incorrect context data for time: %f != 2.0\n", ctx_data.time);
   // LCOV_EXCL_STOP
 
   CeedQFunctionContextGetFieldLabel(ctx, "count", &count_label);
-  CeedQFunctionContextSetInt32(ctx, count_label, 43);
-  if (ctx_data.count != 43)
+  int values_count[2] = {14, 43};
+  CeedQFunctionContextSetInt32(ctx, count_label, (int *)&values_count);
+  if (ctx_data.count[0] != 14)
     // LCOV_EXCL_START
-    printf("Incorrect context data for count: %d != 43", ctx_data.count);
+    printf("Incorrect context data for count[0]: %d != 14\n", ctx_data.count[0]);
+  // LCOV_EXCL_STOP
+  if (ctx_data.count[1] != 43)
+    // LCOV_EXCL_START
+    printf("Incorrect context data for count[1]: %d != 43\n", ctx_data.count[1]);
   // LCOV_EXCL_STOP
 
   CeedQFunctionContextDestroy(&ctx);

--- a/tests/t525-operator.c
+++ b/tests/t525-operator.c
@@ -18,8 +18,10 @@ typedef struct {
 int main(int argc, char **argv) {
   Ceed ceed;
   CeedQFunctionContext qf_ctx_sub_1, qf_ctx_sub_2;
+  CeedContextFieldLabel count_label, other_label, time_label;
   CeedQFunction qf_sub_1, qf_sub_2;
   CeedOperator op_sub_1, op_sub_2, op_composite;
+
   TestContext1 ctx_data_1 = {
     .count = 42,
     .other = -3.0,
@@ -47,7 +49,8 @@ int main(int argc, char **argv) {
                      &op_sub_1);
 
   // Check setting field in operator
-  CeedOperatorContextSetInt32(op_sub_1, "count", 43);
+  CeedOperatorContextGetFieldLabel(op_sub_1, "count", &count_label);
+  CeedOperatorContextSetInt32(op_sub_1, count_label, 43);
   if (ctx_data_1.count != 43)
     // LCOV_EXCL_START
     printf("Incorrect context data for count: %d != 43", ctx_data_1.count);
@@ -74,14 +77,16 @@ int main(int argc, char **argv) {
   CeedCompositeOperatorAddSub(op_composite, op_sub_2);
 
   // Check setting field in context of single sub-operator for composite operator
-  CeedOperatorContextSetDouble(op_composite, "time", 2.0);
+  CeedOperatorContextGetFieldLabel(op_composite, "time", &time_label);
+  CeedOperatorContextSetDouble(op_composite, time_label, 2.0);
   if (ctx_data_2.time != 2.0)
     // LCOV_EXCL_START
     printf("Incorrect context data for time: %f != 2.0", ctx_data_2.time);
   // LCOV_EXCL_STOP
 
   // Check setting field in context of multiple sub-operators for composite operator
-  CeedOperatorContextSetDouble(op_composite, "other", 9000.);
+  CeedOperatorContextGetFieldLabel(op_composite, "other", &other_label);
+  CeedOperatorContextSetDouble(op_composite, other_label, 9000.);
   if (ctx_data_1.other != 9000.0)
     // LCOV_EXCL_START
     printf("Incorrect context data for other: %f != 2.0", ctx_data_1.other);

--- a/tests/t525-operator.c
+++ b/tests/t525-operator.c
@@ -92,6 +92,8 @@ int main(int argc, char **argv) {
 
   // Check setting field in context of multiple sub-operators for composite operator
   CeedOperatorContextGetFieldLabel(op_composite, "other", &other_label);
+  // No issue requesting same label twice
+  CeedOperatorContextGetFieldLabel(op_composite, "other", &other_label);
   double value_other = 9000.;
   CeedOperatorContextSetDouble(op_composite, other_label, &value_other);
   if (ctx_data_1.other != 9000.0)

--- a/tests/t525-operator.c
+++ b/tests/t525-operator.c
@@ -37,10 +37,12 @@ int main(int argc, char **argv) {
   CeedQFunctionContextCreate(ceed, &qf_ctx_sub_1);
   CeedQFunctionContextSetData(qf_ctx_sub_1, CEED_MEM_HOST, CEED_USE_POINTER,
                               sizeof(TestContext1), &ctx_data_1);
-  CeedQFunctionContextRegisterInt32(qf_ctx_sub_1, "count", offsetof(TestContext1,
-                                    count), "some sort of counter");
-  CeedQFunctionContextRegisterDouble(qf_ctx_sub_1, "other", offsetof(TestContext1,
-                                     other), "some other value");
+  CeedQFunctionContextRegisterInt32(qf_ctx_sub_1, "count",
+                                    offsetof(TestContext1, count),
+                                    1, "some sort of counter");
+  CeedQFunctionContextRegisterDouble(qf_ctx_sub_1, "other",
+                                     offsetof(TestContext1, other),
+                                     1, "some other value");
 
   CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_sub_1);
   CeedQFunctionSetContext(qf_sub_1, qf_ctx_sub_1);
@@ -50,7 +52,8 @@ int main(int argc, char **argv) {
 
   // Check setting field in operator
   CeedOperatorContextGetFieldLabel(op_sub_1, "count", &count_label);
-  CeedOperatorContextSetInt32(op_sub_1, count_label, 43);
+  int value_count = 43;
+  CeedOperatorContextSetInt32(op_sub_1, count_label, &value_count);
   if (ctx_data_1.count != 43)
     // LCOV_EXCL_START
     printf("Incorrect context data for count: %d != 43", ctx_data_1.count);
@@ -60,10 +63,12 @@ int main(int argc, char **argv) {
   CeedQFunctionContextCreate(ceed, &qf_ctx_sub_2);
   CeedQFunctionContextSetData(qf_ctx_sub_2, CEED_MEM_HOST, CEED_USE_POINTER,
                               sizeof(TestContext2), &ctx_data_2);
-  CeedQFunctionContextRegisterDouble(qf_ctx_sub_2, "time", offsetof(TestContext2,
-                                     time), "current time");
-  CeedQFunctionContextRegisterDouble(qf_ctx_sub_2, "other", offsetof(TestContext2,
-                                     other), "some other value");
+  CeedQFunctionContextRegisterDouble(qf_ctx_sub_2, "time",
+                                     offsetof(TestContext2, time),
+                                     1, "current time");
+  CeedQFunctionContextRegisterDouble(qf_ctx_sub_2, "other",
+                                     offsetof(TestContext2, other),
+                                     1, "some other value");
 
   CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_sub_2);
   CeedQFunctionSetContext(qf_sub_2, qf_ctx_sub_2);
@@ -78,7 +83,8 @@ int main(int argc, char **argv) {
 
   // Check setting field in context of single sub-operator for composite operator
   CeedOperatorContextGetFieldLabel(op_composite, "time", &time_label);
-  CeedOperatorContextSetDouble(op_composite, time_label, 2.0);
+  double value_time = 2.0;
+  CeedOperatorContextSetDouble(op_composite, time_label, &value_time);
   if (ctx_data_2.time != 2.0)
     // LCOV_EXCL_START
     printf("Incorrect context data for time: %f != 2.0", ctx_data_2.time);
@@ -86,7 +92,8 @@ int main(int argc, char **argv) {
 
   // Check setting field in context of multiple sub-operators for composite operator
   CeedOperatorContextGetFieldLabel(op_composite, "other", &other_label);
-  CeedOperatorContextSetDouble(op_composite, other_label, 9000.);
+  double value_other = 9000.;
+  CeedOperatorContextSetDouble(op_composite, other_label, &value_other);
   if (ctx_data_1.other != 9000.0)
     // LCOV_EXCL_START
     printf("Incorrect context data for other: %f != 2.0", ctx_data_1.other);


### PR DESCRIPTION
In Ratel we have code that generates an operator that may or may not have a particular named context field. This PR stops `Ceed*ContextSet*()` from failing when the field is not found. Now the function only fails if there is a field/type mismatch. The caller can consult the boolean `is_set` and decide if not finding the field is a problem.