### PR TITLE
HIP: add atomics flag and more kernel launch bounds for performance improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ NVCCFLAGS ?= -ccbin $(CXX) -Xcompiler "$(OPT)" -Xcompiler -fPIC
 ifneq ($(CUDA_ARCH),)
   NVCCFLAGS += -arch=$(CUDA_ARCH)
 endif
-HIPCCFLAGS ?= $(filter-out $(OMP_SIMD_FLAG),$(OPT)) -fPIC
+HIPCCFLAGS ?= $(filter-out $(OMP_SIMD_FLAG),$(OPT)) -fPIC -munsafe-fp-atomics
 ifneq ($(HIP_ARCH),)
   HIPCCFLAGS += --amdgpu-target=$(HIP_ARCH)
 endif

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ forced by setting the environment variable `MKL=1`.
 The `/gpu/cuda/*` backends provide GPU performance strictly using CUDA.
 
 The `/gpu/hip/*` backends provide GPU performance strictly using HIP. They are based on
-the `/gpu/cuda/*` backends.  ROCm version 3.6 or newer is required.
+the `/gpu/cuda/*` backends.  ROCm version 4.2 or newer is required.
 
 The `/gpu/*/magma/*` backends rely upon the [MAGMA](https://bitbucket.org/icl/magma) package.
 To enable the MAGMA backends, the environment variable `MAGMA_DIR` must point to the top-level

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -26,6 +26,35 @@
 #include "../hip-shared/ceed-hip-shared.h"
 #include "../hip/ceed-hip-compile.h"
 
+
+//------------------------------------------------------------------------------
+// Calculate the block size used for launching the operator kernel 
+//------------------------------------------------------------------------------
+CEED_INTERN int BlockGridCalculate(const CeedInt dim, const CeedInt nelem,
+		                   const CeedInt P1d, const CeedInt Q1d,
+				   CeedInt *block_sizes) {
+  
+  const CeedInt thread1d = CeedIntMax(Q1d, P1d);
+  if (dim==1) {
+    CeedInt elemsPerBlock = 64*thread1d > 256? 256/thread1d : 64;
+    elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
+    block_sizes[0] = thread1d;
+    block_sizes[1] = 1;
+    block_sizes[2] = elemsPerBlock;
+  } else if (dim==2) {
+    const CeedInt elemsPerBlock = thread1d<4? 16 : 2;
+    block_sizes[0] = thread1d;
+    block_sizes[1] = thread1d;
+    block_sizes[2] = elemsPerBlock;
+  } else if (dim==3) {
+    const CeedInt elemsPerBlock = thread1d<6? 4 : (thread1d<8? 2 : 1);
+    block_sizes[0] = thread1d;
+    block_sizes[1] = thread1d;
+    block_sizes[2] = elemsPerBlock;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
 static const char *deviceFunctions = QUOTE(
 
 //------------------------------------------------------------------------------
@@ -858,7 +887,8 @@ CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op) {
 
   // Setup
   code << "\n// -----------------------------------------------------------------------------\n";
-  code << "\nextern \"C\" __global__ void "<<oper<<"(CeedInt nelem, void* ctx, HipFieldsInt indices, HipFields fields, HipFields B, HipFields G, CeedScalar* W) {\n";
+  code << "\nextern \"C\" __launch_bounds__(BLOCK_SIZE)\n";
+  code << "__global__ void "<<oper<<"(CeedInt nelem, void* ctx, HipFieldsInt indices, HipFields fields, HipFields B, HipFields G, CeedScalar* W) {\n";
   for (CeedInt i = 0; i < numinputfields; i++) {
     ierr = CeedQFunctionFieldGetEvalMode(qfinputfields[i], &emode);
     CeedChkBackend(ierr);
@@ -1360,8 +1390,12 @@ CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op) {
   CeedDebug256(ceed, 2, "Generated Operator Kernels:\n");
   CeedDebug(ceed, code.str().c_str());
 
-  ierr = CeedCompileHip(ceed, code.str().c_str(), &data->module, 1,
-                         "T1d", CeedIntMax(Q1d, data->maxP1d));
+  CeedInt block_sizes[3];
+  ierr = BlockGridCalculate(dim, numelements, data->maxP1d, Q1d, block_sizes); 
+  CeedChkBackend(ierr);
+  ierr = CeedCompileHip(ceed, code.str().c_str(), &data->module, 2,
+                         "T1d", block_sizes[0],
+			 "BLOCK_SIZE", block_sizes[0] * block_sizes[1] * block_sizes[2]);
   CeedChkBackend(ierr);
   ierr = CeedGetKernelHip(ceed, data->module, oper.c_str(), &data->op);
   CeedChkBackend(ierr);

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -30,9 +30,9 @@
 //------------------------------------------------------------------------------
 // Calculate the block size used for launching the operator kernel 
 //------------------------------------------------------------------------------
-CEED_INTERN int BlockGridCalculate(const CeedInt dim, const CeedInt nelem,
-		                   const CeedInt P1d, const CeedInt Q1d,
-				   CeedInt *block_sizes) {
+extern "C" int BlockGridCalculate_Hip_gen(const CeedInt dim, const CeedInt nelem,
+     	                                  const CeedInt P1d, const CeedInt Q1d,
+				          CeedInt *block_sizes) {
   
   const CeedInt thread1d = CeedIntMax(Q1d, P1d);
   if (dim==1) {
@@ -759,7 +759,7 @@ inline __device__ void weight3d(BackendData& data, const CeedScalar *qweight1d, 
 //------------------------------------------------------------------------------
 // Build singe operator kernel
 //------------------------------------------------------------------------------
-CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op) {
+extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
 
   using std::ostringstream;
   using std::string;
@@ -1391,7 +1391,7 @@ CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op) {
   CeedDebug(ceed, code.str().c_str());
 
   CeedInt block_sizes[3];
-  ierr = BlockGridCalculate(dim, numelements, data->maxP1d, Q1d, block_sizes); 
+  ierr = BlockGridCalculate_Hip_gen(dim, numelements, data->maxP1d, Q1d, block_sizes); 
   CeedChkBackend(ierr);
   ierr = CeedCompileHip(ceed, code.str().c_str(), &data->module, 2,
                          "T1d", block_sizes[0],

--- a/backends/hip-gen/ceed-hip-gen-operator-build.h
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.h
@@ -17,6 +17,9 @@
 #ifndef _ceed_hip_gen_operator_build_h
 #define _ceed_hip_gen_operator_build_h
 
+CEED_INTERN int BlockGridCalculate(const CeedInt dim, const CeedInt nelem,
+                                   const CeedInt P1d, const CeedInt Q1d,
+                                   CeedInt *block_sizes);
 CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op);
 
 #endif // _ceed_hip_gen_operator_build_h

--- a/backends/hip-gen/ceed-hip-gen-operator-build.h
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.h
@@ -17,9 +17,10 @@
 #ifndef _ceed_hip_gen_operator_build_h
 #define _ceed_hip_gen_operator_build_h
 
-CEED_INTERN int BlockGridCalculate(const CeedInt dim, const CeedInt nelem,
-                                   const CeedInt P1d, const CeedInt Q1d,
-                                   CeedInt *block_sizes);
+CEED_INTERN int BlockGridCalculate_Hip_gen(const CeedInt dim,
+    const CeedInt nelem,
+    const CeedInt P1d, const CeedInt Q1d,
+    CeedInt *block_sizes);
 CEED_INTERN int CeedHipGenOperatorBuild(CeedOperator op);
 
 #endif // _ceed_hip_gen_operator_build_h

--- a/backends/hip-gen/ceed-hip-gen-operator.c
+++ b/backends/hip-gen/ceed-hip-gen-operator.c
@@ -122,7 +122,7 @@ static int CeedOperatorApplyAdd_Hip_gen(CeedOperator op, CeedVector invec,
   const CeedInt P1d = data->maxP1d;
   const CeedInt thread1d = CeedIntMax(Q1d, P1d);
   CeedInt block_sizes[3];
-  ierr = BlockGridCalculate(dim, nelem, P1d, Q1d, block_sizes);
+  ierr = BlockGridCalculate_Hip_gen(dim, nelem, P1d, Q1d, block_sizes);
   CeedChkBackend(ierr);
   if (dim==1) {
     CeedInt grid = nelem/block_sizes[2] + ( (

--- a/backends/hip-gen/ceed-hip-gen-operator.c
+++ b/backends/hip-gen/ceed-hip-gen-operator.c
@@ -121,28 +121,33 @@ static int CeedOperatorApplyAdd_Hip_gen(CeedOperator op, CeedVector invec,
   const CeedInt Q1d = data->Q1d;
   const CeedInt P1d = data->maxP1d;
   const CeedInt thread1d = CeedIntMax(Q1d, P1d);
+  CeedInt block_sizes[3];
+  ierr = BlockGridCalculate(dim, nelem, P1d, Q1d, block_sizes);
+  CeedChkBackend(ierr);
   if (dim==1) {
-    CeedInt elemsPerBlock = 64*thread1d > 256? 256/thread1d : 64;
-    elemsPerBlock = elemsPerBlock>0?elemsPerBlock:1;
-    CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
-                                           ? 1 : 0 );
-    CeedInt sharedMem = elemsPerBlock*thread1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, thread1d, 1,
-                                     elemsPerBlock, sharedMem, opargs);
+    CeedInt grid = nelem/block_sizes[2] + ( (
+        nelem/block_sizes[2]*block_sizes[2]<nelem)
+                                            ? 1 : 0 );
+    CeedInt sharedMem = block_sizes[2]*thread1d*sizeof(CeedScalar);
+    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, block_sizes[0],
+                                     block_sizes[1],
+                                     block_sizes[2], sharedMem, opargs);
   } else if (dim==2) {
-    const CeedInt elemsPerBlock = thread1d<4? 16 : 2;
-    CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
-                                           ? 1 : 0 );
-    CeedInt sharedMem = elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, thread1d, thread1d,
-                                     elemsPerBlock, sharedMem, opargs);
+    CeedInt grid = nelem/block_sizes[2] + ( (
+        nelem/block_sizes[2]*block_sizes[2]<nelem)
+                                            ? 1 : 0 );
+    CeedInt sharedMem = block_sizes[2]*thread1d*thread1d*sizeof(CeedScalar);
+    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, block_sizes[0],
+                                     block_sizes[1],
+                                     block_sizes[2], sharedMem, opargs);
   } else if (dim==3) {
-    const CeedInt elemsPerBlock = thread1d<6? 4 : (thread1d<8? 2 : 1);
-    CeedInt grid = nelem/elemsPerBlock + ( (nelem/elemsPerBlock*elemsPerBlock<nelem)
-                                           ? 1 : 0 );
-    CeedInt sharedMem = elemsPerBlock*thread1d*thread1d*sizeof(CeedScalar);
-    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, thread1d, thread1d,
-                                     elemsPerBlock, sharedMem, opargs);
+    CeedInt grid = nelem/block_sizes[2] + ( (
+        nelem/block_sizes[2]*block_sizes[2]<nelem)
+                                            ? 1 : 0 );
+    CeedInt sharedMem = block_sizes[2]*thread1d*thread1d*sizeof(CeedScalar);
+    ierr = CeedRunKernelDimSharedHip(ceed, data->op, grid, block_sizes[0],
+                                     block_sizes[1],
+                                     block_sizes[2], sharedMem, opargs);
   }
   CeedChkBackend(ierr);
 

--- a/backends/hip/ceed-hip-compile.cpp
+++ b/backends/hip/ceed-hip-compile.cpp
@@ -57,7 +57,7 @@ int CeedCompileHip(Ceed ceed, const char *source, hipModule_t *module,
 
   // Macro definitions
   // Get kernel specific options, such as kernel constants
-  const int opts_size = 2;
+  const int opts_size = 3;
   const char *opts[opts_size];
   if (num_opts > 0) {
     va_list args;
@@ -90,6 +90,7 @@ int CeedCompileHip(Ceed ceed, const char *source, hipModule_t *module,
   CeedChk_Hip(ceed, hipGetDeviceProperties(&prop, ceed_data->device_id));
   std::string arch_arg = "--gpu-architecture="  + std::string(prop.gcnArchName);
   opts[1] = arch_arg.c_str();
+  opts[2] = "-munsafe-fp-atomics";
 
   // Add string source argument provided in call
   code << source;

--- a/backends/magma/ceed-magma-basis.c
+++ b/backends/magma/ceed-magma-basis.c
@@ -110,7 +110,7 @@ int CeedBasisApply_Magma(CeedBasis basis, CeedInt nelem,
                         impl->dinterp1d, tmode,
                         u, u_elstride, u_compstride,
                         v, v_elstride, v_compstride,
-                        nelem, data->basis_kernel_mode, data->maxthreads,
+                        nelem, data->basis_kernel_mode,
                         data->queue);
     if (ierr != 0) return CeedError(ceed, CEED_ERROR_BACKEND,
                                       "MAGMA: launch failure detected for magma_interp");
@@ -168,7 +168,7 @@ int CeedBasisApply_Magma(CeedBasis basis, CeedInt nelem,
                        impl->dinterp1d, impl->dgrad1d, tmode,
                        u, u_elstride, u_compstride, u_dimstride,
                        v, v_elstride, v_compstride, v_dimstride,
-                       nelem, data->basis_kernel_mode, data->maxthreads,
+                       nelem, data->basis_kernel_mode,
                        data->queue);
     if (ierr != 0) return CeedError(ceed, CEED_ERROR_BACKEND,
                                       "MAGMA: launch failure detected for magma_grad");
@@ -183,7 +183,7 @@ int CeedBasisApply_Magma(CeedBasis basis, CeedInt nelem,
     CeedInt Q = Q1d;
     int eldofssize = CeedIntPow(Q, dim);
     ierr = magma_weight(Q, dim, impl->dqweight1d, v, eldofssize, nelem,
-                        data->basis_kernel_mode, data->maxthreads, data->queue);
+                        data->basis_kernel_mode, data->queue);
     if (ierr != 0) return CeedError(ceed, CEED_ERROR_BACKEND,
                                       "MAGMA: launch failure detected for magma_weight");
   }

--- a/backends/magma/ceed-magma.c
+++ b/backends/magma/ceed-magma.c
@@ -52,11 +52,6 @@ static int CeedInit_Magma(const char *resource, Ceed ceed) {
   // kernel selection
   data->basis_kernel_mode = MAGMA_KERNEL_DIM_SPECIFIC;
 
-  // kernel max threads per thread-block
-  data->maxthreads[0] = 128;  // for 1D kernels
-  data->maxthreads[1] = 128;  // for 2D kernels
-  data->maxthreads[2] =  64;  // for 3D kernels
-
   // get/set device ID
   const char *device_spec = strstr(resource, ":device_id=");
   const int deviceID = (device_spec) ? atoi(device_spec+11) : -1;

--- a/backends/magma/ceed-magma.h
+++ b/backends/magma/ceed-magma.h
@@ -29,7 +29,6 @@ typedef enum {
 
 typedef struct {
   magma_kernel_mode_t basis_kernel_mode;
-  magma_int_t maxthreads[3];
   magma_device_t device;
   magma_queue_t queue;
 } Ceed_Magma;
@@ -75,21 +74,21 @@ CEED_INTERN {
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_interp_2d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_interp_3d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_interp_generic(magma_int_t P, magma_int_t Q,
                                    magma_int_t dim, magma_int_t ncomp,
@@ -106,42 +105,42 @@ CEED_INTERN {
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
-    magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_int_t *maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_queue_t queue);
 
   magma_int_t magma_grad_1d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dTinterp, const CeedScalar *dTgrad, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_gradn_2d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_gradt_2d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_gradn_3d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_gradt_3d(
     magma_int_t P, magma_int_t Q, magma_int_t ncomp,
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
     CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_grad_generic(
     magma_int_t P, magma_int_t Q, magma_int_t dim, magma_int_t ncomp,
@@ -155,22 +154,22 @@ CEED_INTERN {
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t u_elemstride, magma_int_t cstrdU, magma_int_t dstrdU,
     CeedScalar *dV, magma_int_t v_elemstride, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_int_t *maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_queue_t queue);
 
   magma_int_t magma_weight_1d(
     magma_int_t Q, const CeedScalar *dqweight1d,
     CeedScalar *dV, magma_int_t v_stride,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_weight_2d(
     magma_int_t Q, const CeedScalar *dqweight1d,
     CeedScalar *dV, magma_int_t v_stride,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_weight_3d(
     magma_int_t Q, const CeedScalar *dqweight1d,
     CeedScalar *dV, magma_int_t v_stride,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_queue_t queue);
 
   magma_int_t magma_weight_generic(
     magma_int_t Q, magma_int_t dim,
@@ -182,7 +181,7 @@ CEED_INTERN {
     magma_int_t Q, magma_int_t dim,
     const CeedScalar *dqweight1d,
     CeedScalar *dV, magma_int_t v_stride,
-    magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_int_t *maxthreads, magma_queue_t queue);
+    magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_queue_t queue);
 
   void magma_weight_nontensor(magma_int_t grid, magma_int_t threads, magma_int_t nelem,
                               magma_int_t Q,

--- a/backends/magma/kernels/common/elem_restriction.h
+++ b/backends/magma/kernels/common/elem_restriction.h
@@ -23,6 +23,7 @@
 #include "../cuda/atomics.cuh"
 #endif
 
+#define MAGMA_ERSTR_THREADS 256
 //////////////////////////////////////////////////////////////////////////////////////////
 // Fastest index listed first
 // i : related to nodes
@@ -31,7 +32,7 @@
 // Go from L-vector (du) to E-vector (dv):
 //
 // dv(i, e, c) = du( offsets(i, e) + compstride * c)  
-static __global__ void 
+static __launch_bounds__(MAGMA_ERSTR_THREADS) __global__ void 
 magma_readDofsOffset_kernel(const int NCOMP, const int compstride,
                             const int esize, const int nelem, int *offsets, 
                             const CeedScalar *du, CeedScalar *dv)
@@ -56,7 +57,7 @@ magma_readDofsOffset_kernel(const int NCOMP, const int compstride,
 //  to describe the L-vector layout
 //
 // dv(i, e, c) = du( i * strides[0] + c * strides[1] + e * strides[2] )  
-static __global__ void 
+static __launch_bounds__(MAGMA_ERSTR_THREADS) __global__ void 
 magma_readDofsStrided_kernel(const int NCOMP, const int esize, const int nelem,
                              const int *strides, const CeedScalar *du, CeedScalar *dv)
 {
@@ -80,7 +81,7 @@ magma_readDofsStrided_kernel(const int NCOMP, const int esize, const int nelem,
 //
 // dv(offsets(i, e) + compstride * c) = du(i, e, c)
 // Double precision version (calls magma_datomic_add)
-static __global__ void 
+static __launch_bounds__(MAGMA_ERSTR_THREADS) __global__ void 
 magma_writeDofsOffset_kernel_d(const int NCOMP, const int compstride,
                                const int esize, const int nelem, int *offsets, 
                                const double *du, double *dv)
@@ -123,7 +124,7 @@ magma_writeDofsOffset_kernel_s(const int NCOMP, const int compstride,
 //
 // dv( i * strides[0] + c * strides[1] + e * strides[2] ) = du(i, e, c) 
 // Double precision version (calls magma_datomic_add)
-static __global__ void 
+static __launch_bounds__(MAGMA_ERSTR_THREADS) __global__ void 
 magma_writeDofsStrided_kernel_d(const int NCOMP, const int esize, const int nelem,
                                 const int *strides, const double *du, double *dv)
 {

--- a/backends/magma/kernels/common/grad.h
+++ b/backends/magma/kernels/common/grad.h
@@ -23,8 +23,8 @@
 #include "grad_device.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename T, int DIM, int NCOMP, int P, int Q>
-static __global__ void
+template<typename T, int DIM, int NCOMP, int P, int Q, int MAXPQ>
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __global__ void
 magma_grad_1d_kernel(  
     const T *dTgrad, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, 
@@ -78,7 +78,7 @@ magma_grad_1d_kernel(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int NCOMP, int P, int Q, int MAXPQ>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __global__ void
 magma_gradn_2d_kernel(
     const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, const int dstrdU,  
@@ -140,7 +140,7 @@ magma_gradn_2d_kernel(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int NCOMP, int P, int Q, int MAXPQ>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __global__ void
 magma_gradt_2d_kernel(
     const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, const int dstrdU,  
@@ -206,7 +206,7 @@ magma_gradt_2d_kernel(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int NCOMP, int P, int Q, int MAXPQ>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ*MAXPQ, MAGMA_MAXTHREADS_3D)) __global__ void
 magma_gradn_3d_kernel(
     const T* dinterp1d, const T* dgrad1d, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, const int dstrdU,  
@@ -276,7 +276,7 @@ magma_gradn_3d_kernel(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int NCOMP, int P, int Q, int MAXPQ>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ*MAXPQ, MAGMA_MAXTHREADS_3D)) __global__ void
 magma_gradt_3d_kernel(
     const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, const int dstrdU,  

--- a/backends/magma/kernels/common/interp.h
+++ b/backends/magma/kernels/common/interp.h
@@ -23,8 +23,8 @@
 #include "interp_device.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////
-template<typename T, int DIM, int NCOMP, int P, int Q>
-static __global__ void
+template<typename T, int DIM, int NCOMP, int P, int Q, int MAXPQ>
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __global__ void
 magma_interp_1d_kernel(  
     const T *dT, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, 
@@ -79,7 +79,7 @@ magma_interp_1d_kernel(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int NCOMP, int P, int Q, int MAXPQ>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __global__ void
 magma_interp_2d_kernel(
     const T *dT, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, 
@@ -129,7 +129,7 @@ magma_interp_2d_kernel(
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int NCOMP, int P, int Q, int MAXPQ>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ*MAXPQ, MAGMA_MAXTHREADS_3D)) __global__ void
 magma_interp_3d_kernel(
     const T *dT, magma_trans_t transT,
     const T *dU, const int estrdU, const int cstrdU, 

--- a/backends/magma/kernels/common/magma_common_device.h
+++ b/backends/magma/kernels/common/magma_common_device.h
@@ -23,6 +23,16 @@
 #define MAGMA_DEVICE_SHARED(type, name) extern __shared__ type name[];
 #endif
 
+#define MAGMA_MAXTHREADS_1D 128
+#define MAGMA_MAXTHREADS_2D 128
+#define MAGMA_MAXTHREADS_3D 64
+// Define macro for determining number of threads in y-direction
+// for basis kernels
+#define MAGMA_BASIS_NTCOL(x, maxt) (((maxt) < (x)) ? 1 : ((maxt) / (x)))
+// Define macro for computing the total threads in a block
+// for use with __launch_bounds__()
+#define MAGMA_BASIS_BOUNDS(x, maxt) (x * MAGMA_BASIS_NTCOL(x, maxt))
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // init scalar to zero
 template<typename T>

--- a/backends/magma/kernels/common/weight.h
+++ b/backends/magma/kernels/common/weight.h
@@ -24,7 +24,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int Q>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(Q, MAGMA_MAXTHREADS_1D)) __global__ void
 magma_weight_1d_kernel(const T *dqweight1d, T *dV, const int v_stride, const int nelem)
 {
     MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
@@ -58,7 +58,7 @@ magma_weight_1d_kernel(const T *dqweight1d, T *dV, const int v_stride, const int
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int Q>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(Q, MAGMA_MAXTHREADS_2D)) __global__ void
 magma_weight_2d_kernel(const T *dqweight1d, T *dV, const int v_stride, const int nelem)
 {
     MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
@@ -94,7 +94,7 @@ magma_weight_2d_kernel(const T *dqweight1d, T *dV, const int v_stride, const int
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template<typename T, int Q>
-static __global__ void
+static __launch_bounds__(MAGMA_BASIS_BOUNDS(Q*Q, MAGMA_MAXTHREADS_3D)) __global__ void
 magma_weight_3d_kernel(const T *dqweight1d, T *dV, const int v_stride, const int nelem)
 {
     MAGMA_DEVICE_SHARED(CeedScalar, shared_data)

--- a/backends/magma/kernels/cuda/grad_1d.cu
+++ b/backends/magma/kernels/cuda/grad_1d.cu
@@ -24,14 +24,15 @@ magma_grad_1d_kernel_driver(
                 const T *dTgrad, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
-    magma_int_t nthreads = max(P, Q); 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    const int MAXPQ = maxpq(P,Q);
+    magma_int_t nthreads = MAXPQ; 
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_1D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * ntcol * (NCOMP * (1*P + 1*Q)); 
     shmem += sizeof(T) * (P*Q);    
@@ -40,7 +41,7 @@ magma_grad_1d_kernel_driver(
     #if CUDA_VERSION >= 9000
     cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (shmem <= shmem_max) {
-        cudaFuncSetAttribute(magma_grad_1d_kernel<T, 1, NCOMP, P, Q>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem);
+        cudaFuncSetAttribute(magma_grad_1d_kernel<T, 1, NCOMP, P, Q, MAXPQ>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem);
     }
     #else
     cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlock, device);
@@ -53,7 +54,7 @@ magma_grad_1d_kernel_driver(
         magma_int_t nblocks = (nelem + ntcol-1) / ntcol;
         dim3 threads(nthreads, ntcol, 1);
         dim3 grid(nblocks, 1, 1);
-        magma_grad_1d_kernel<T, 1, NCOMP, P, Q><<<grid, threads, shmem, magma_queue_get_cuda_stream(queue)>>>
+        magma_grad_1d_kernel<T, 1, NCOMP, P, Q, MAXPQ><<<grid, threads, shmem, magma_queue_get_cuda_stream(queue)>>>
         (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem);
         return (cudaPeekAtLastError() == cudaSuccess) ? 0 : 1;
     }
@@ -67,21 +68,21 @@ magma_grad_1d_ncomp(
                 const CeedScalar *dTgrad, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_grad_1d_kernel_driver<CeedScalar,1,P,Q>
-          (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_grad_1d_kernel_driver<CeedScalar,2,P,Q>
-          (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_grad_1d_kernel_driver<CeedScalar,3,P,Q>
-          (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -96,49 +97,49 @@ magma_grad_1d_ncomp_q(
                 const CeedScalar *dTgrad, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_grad_1d_ncomp<P, 1>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_grad_1d_ncomp<P, 2>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_grad_1d_ncomp<P, 3>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_grad_1d_ncomp<P, 4>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_grad_1d_ncomp<P, 5>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_grad_1d_ncomp<P, 6>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_grad_1d_ncomp<P, 7>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_grad_1d_ncomp<P, 8>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_grad_1d_ncomp<P, 9>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_grad_1d_ncomp<P,10>
-          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -152,49 +153,49 @@ magma_grad_1d_ncomp_q_p(
                 const CeedScalar *dTgrad, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_grad_1d_ncomp_q< 1>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_grad_1d_ncomp_q< 2>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_grad_1d_ncomp_q< 3>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_grad_1d_ncomp_q< 4>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_grad_1d_ncomp_q< 5>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_grad_1d_ncomp_q< 6>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_grad_1d_ncomp_q< 7>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_grad_1d_ncomp_q< 8>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_grad_1d_ncomp_q< 9>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_grad_1d_ncomp_q<10>
-          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dTgrad, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -208,7 +209,7 @@ magma_grad_1d(
     const CeedScalar *dTinterp, const CeedScalar *dTgrad, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -217,7 +218,7 @@ magma_grad_1d(
                         dTgrad, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/gradn_2d.cu
+++ b/backends/magma/kernels/cuda/gradn_2d.cu
@@ -24,7 +24,7 @@ magma_gradn_2d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradn_2d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * (P*MAXPQ);  // for reforming rU we need PxP, and for the intermediate output we need PxQ    
@@ -70,21 +70,21 @@ magma_gradn_2d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradn_2d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradn_2d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradn_2d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -99,49 +99,49 @@ magma_gradn_2d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradn_2d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_2d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_2d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_2d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_2d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_2d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_2d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_2d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_2d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_2d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -155,49 +155,49 @@ magma_gradn_2d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradn_2d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_2d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_2d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_2d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_2d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_2d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_2d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_2d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_2d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_2d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -212,7 +212,7 @@ magma_gradn_2d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -221,7 +221,7 @@ magma_gradn_2d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/gradn_3d.cu
+++ b/backends/magma/kernels/cuda/gradn_3d.cu
@@ -24,7 +24,7 @@ magma_gradn_3d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradn_3d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ*MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * max(P*P*P, (P*P*Q) + (P*Q*Q));  // rU needs P^2xP, the intermediate outputs need (P^2.Q + P.Q^2) 
@@ -70,21 +70,21 @@ magma_gradn_3d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradn_3d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradn_3d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradn_3d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -99,49 +99,49 @@ magma_gradn_3d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradn_3d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_3d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_3d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_3d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_3d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_3d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_3d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_3d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_3d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_3d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -155,49 +155,49 @@ magma_gradn_3d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradn_3d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_3d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_3d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_3d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_3d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_3d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_3d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_3d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_3d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_3d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -212,7 +212,7 @@ magma_gradn_3d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -221,7 +221,7 @@ magma_gradn_3d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/gradt_2d.cu
+++ b/backends/magma/kernels/cuda/gradt_2d.cu
@@ -24,7 +24,7 @@ magma_gradt_2d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradt_2d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * (P*MAXPQ);  // for reforming rU we need PxP, and for the intermediate output we need PxQ    
@@ -71,21 +71,21 @@ magma_gradt_2d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradt_2d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradt_2d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradt_2d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -100,49 +100,49 @@ magma_gradt_2d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradt_2d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_2d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_2d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_2d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_2d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_2d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_2d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_2d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_2d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_2d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -156,49 +156,49 @@ magma_gradt_2d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradt_2d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_2d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_2d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_2d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_2d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_2d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_2d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_2d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_2d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_2d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -213,7 +213,7 @@ magma_gradt_2d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -222,7 +222,7 @@ magma_gradt_2d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/gradt_3d.cu
+++ b/backends/magma/kernels/cuda/gradt_3d.cu
@@ -24,7 +24,7 @@ magma_gradt_3d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradt_3d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ*MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * max(P*P*P, (P*P*Q) + (P*Q*Q));  // rU needs P^2xP, the intermediate outputs need (P^2.Q + P.Q^2) 
@@ -70,21 +70,21 @@ magma_gradt_3d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradt_3d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradt_3d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradt_3d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -99,49 +99,49 @@ magma_gradt_3d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradt_3d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_3d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_3d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_3d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_3d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_3d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_3d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_3d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_3d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_3d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -155,49 +155,49 @@ magma_gradt_3d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradt_3d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_3d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_3d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_3d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_3d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_3d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_3d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_3d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_3d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_3d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -212,7 +212,7 @@ magma_gradt_3d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -221,7 +221,7 @@ magma_gradt_3d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/interp_1d.cu
+++ b/backends/magma/kernels/cuda/interp_1d.cu
@@ -24,14 +24,15 @@ magma_interp_1d_kernel_driver(
                 const T *dT, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
-    magma_int_t nthreads = max(P, Q); 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    const int MAXPQ = maxpq(P,Q);
+    magma_int_t nthreads = MAXPQ; 
+    magma_int_t ntcol =  MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_1D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * ntcol * ( NCOMP * (1*P + 1*Q) ); 
     shmem += sizeof(T) * (P*Q);
@@ -40,7 +41,7 @@ magma_interp_1d_kernel_driver(
     #if CUDA_VERSION >= 9000
     cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (shmem <= shmem_max) {
-        cudaFuncSetAttribute(magma_interp_1d_kernel<T, 1, NCOMP, P, Q>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem);
+        cudaFuncSetAttribute(magma_interp_1d_kernel<T, 1, NCOMP, P, Q, MAXPQ>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem);
     }
     #else
     cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlock, device);
@@ -53,7 +54,7 @@ magma_interp_1d_kernel_driver(
         magma_int_t nblocks = (nelem + ntcol-1) / ntcol;
         dim3 threads(nthreads, ntcol, 1);
         dim3 grid(nblocks	, 1, 1);
-        magma_interp_1d_kernel<T, 1, NCOMP, P, Q><<<grid, threads, shmem, magma_queue_get_cuda_stream(queue)>>>
+        magma_interp_1d_kernel<T, 1, NCOMP, P, Q, MAXPQ><<<grid, threads, shmem, magma_queue_get_cuda_stream(queue)>>>
         (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem);
         return (cudaPeekAtLastError() == cudaSuccess) ? 0 : 1;
     }
@@ -67,21 +68,21 @@ magma_interp_1d_ncomp(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_interp_1d_kernel_driver<CeedScalar,1,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_interp_1d_kernel_driver<CeedScalar,2,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_interp_1d_kernel_driver<CeedScalar,3,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -96,49 +97,49 @@ magma_interp_1d_ncomp_q(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp<P, 1>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp<P, 2>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp<P, 3>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp<P, 4>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp<P, 5>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp<P, 6>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp<P, 7>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp<P, 8>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp<P, 9>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp<P,10>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -152,49 +153,49 @@ magma_interp_1d_ncomp_q_p(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp_q< 1>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp_q< 2>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp_q< 3>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp_q< 4>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp_q< 5>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp_q< 6>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp_q< 7>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp_q< 8>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp_q< 9>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp_q<10>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -209,7 +210,7 @@ magma_interp_1d(
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -218,7 +219,7 @@ magma_interp_1d(
                         dT, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/interp_2d.cu
+++ b/backends/magma/kernels/cuda/interp_2d.cu
@@ -24,7 +24,7 @@ magma_interp_2d_kernel_driver(
                 const T *dT, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_interp_2d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += P*Q    *sizeof(T);  // for sT
     shmem += ntcol * ( P*MAXPQ*sizeof(T) );  // for reforming rU we need PxP, and for the intermediate output we need PxQ    
@@ -68,21 +68,21 @@ magma_interp_2d_ncomp(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_interp_2d_kernel_driver<CeedScalar,1,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_interp_2d_kernel_driver<CeedScalar,2,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_interp_2d_kernel_driver<CeedScalar,3,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -97,49 +97,49 @@ magma_interp_1d_ncomp_q(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_interp_2d_ncomp<P, 1>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_2d_ncomp<P, 2>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_2d_ncomp<P, 3>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_2d_ncomp<P, 4>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_2d_ncomp<P, 5>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_2d_ncomp<P, 6>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_2d_ncomp<P, 7>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_2d_ncomp<P, 8>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_2d_ncomp<P, 9>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_2d_ncomp<P,10>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -153,49 +153,49 @@ magma_interp_2d_ncomp_q_p(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp_q< 1>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp_q< 2>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp_q< 3>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp_q< 4>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp_q< 5>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp_q< 6>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp_q< 7>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp_q< 8>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp_q< 9>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp_q<10>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -210,7 +210,7 @@ magma_interp_2d(
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -219,7 +219,7 @@ magma_interp_2d(
                         dT, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/interp_3d.cu
+++ b/backends/magma/kernels/cuda/interp_3d.cu
@@ -24,7 +24,7 @@ magma_interp_3d_kernel_driver(
                 const T *dT, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_interp_3d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ*MAXPQ;
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T)* (P*Q);  // for sT
     shmem += sizeof(T)* ntcol * (max(P*P*MAXPQ, P*Q*Q));  // rU needs P^2xP, the intermediate output needs max(P^2xQ,PQ^2)    
@@ -68,21 +68,21 @@ magma_interp_3d_ncomp(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_interp_3d_kernel_driver<CeedScalar,1,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_interp_3d_kernel_driver<CeedScalar,2,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_interp_3d_kernel_driver<CeedScalar,3,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -97,49 +97,49 @@ magma_interp_1d_ncomp_q(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_interp_3d_ncomp<P, 1>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_3d_ncomp<P, 2>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_3d_ncomp<P, 3>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_3d_ncomp<P, 4>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_3d_ncomp<P, 5>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_3d_ncomp<P, 6>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_3d_ncomp<P, 7>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_3d_ncomp<P, 8>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_3d_ncomp<P, 9>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_3d_ncomp<P,10>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -153,49 +153,49 @@ magma_interp_3d_ncomp_q_p(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp_q< 1>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp_q< 2>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp_q< 3>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp_q< 4>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp_q< 5>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp_q< 6>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp_q< 7>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp_q< 8>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp_q< 9>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp_q<10>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -210,7 +210,7 @@ magma_interp_3d(
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -219,7 +219,7 @@ magma_interp_3d(
                         dT, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/magma_drestrictApply.cu
+++ b/backends/magma/kernels/cuda/magma_drestrictApply.cu
@@ -29,7 +29,7 @@ magma_readDofsOffset(const magma_int_t NCOMP, const magma_int_t compstride,
                      magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     magma_readDofsOffset_kernel<<<grid, threads, 0,
       magma_queue_get_cuda_stream(queue)>>>(NCOMP, compstride,
@@ -46,7 +46,7 @@ magma_readDofsStrided(const magma_int_t NCOMP, const magma_int_t esize,
                       magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     magma_readDofsStrided_kernel<<<grid, threads, 0,
       magma_queue_get_cuda_stream(queue)>>>(NCOMP, esize, nelem, 
@@ -63,7 +63,7 @@ magma_writeDofsOffset(const magma_int_t NCOMP, const magma_int_t compstride,
                       magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
    
     if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
       magma_writeDofsOffset_kernel_s<<<grid, threads, 0,
@@ -87,7 +87,7 @@ magma_writeDofsStrided(const magma_int_t NCOMP, const magma_int_t esize,
                        magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
       magma_writeDofsStrided_kernel_s<<<grid, threads, 0,

--- a/backends/magma/kernels/cuda/weight_1d.cu
+++ b/backends/magma/kernels/cuda/weight_1d.cu
@@ -22,14 +22,14 @@ template<typename T, int Q>
 static magma_int_t 
 magma_weight_1d_kernel_driver(
     const T *dqweight1d, T *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
     magma_int_t nthreads = Q; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_1D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * Q;  // for dqweight1d 
     shmem += sizeof(T) * ntcol * Q; // for output
@@ -62,49 +62,49 @@ static magma_int_t
 magma_weight_1d_q(
         magma_int_t Q, const CeedScalar *dqweight1d, 
         CeedScalar *dV, magma_int_t v_stride, 
-        magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+        magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 1>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 2>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 3>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 4>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 5>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 6>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 7>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 8>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 9>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar,10>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -116,9 +116,9 @@ extern "C" magma_int_t
 magma_weight_1d( 
     magma_int_t Q, const CeedScalar *dqweight1d, 
     CeedScalar *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
-    magma_weight_1d_q(Q, dqweight1d, dV, v_stride, nelem, maxthreads, queue);
+    magma_weight_1d_q(Q, dqweight1d, dV, v_stride, nelem, queue);
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/weight_2d.cu
+++ b/backends/magma/kernels/cuda/weight_2d.cu
@@ -22,14 +22,14 @@ template<typename T, int Q>
 static magma_int_t 
 magma_weight_2d_kernel_driver(
     const T *dqweight1d, T *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
     magma_int_t nthreads = Q; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * Q;  // for dqweight1d 
 
@@ -61,49 +61,49 @@ static magma_int_t
 magma_weight_2d_q(
         magma_int_t Q, const CeedScalar *dqweight1d, 
         CeedScalar *dV, magma_int_t v_stride, 
-        magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+        magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 1>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 2>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 3>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 4>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 5>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 6>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 7>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 8>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 9>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar,10>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -115,9 +115,9 @@ extern "C" magma_int_t
 magma_weight_2d( 
     magma_int_t Q, const CeedScalar *dqweight1d, 
     CeedScalar *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
-    magma_weight_2d_q(Q, dqweight1d, dV, v_stride, nelem, maxthreads, queue);
+    magma_weight_2d_q(Q, dqweight1d, dV, v_stride, nelem, queue);
     return launch_failed;
 }

--- a/backends/magma/kernels/cuda/weight_3d.cu
+++ b/backends/magma/kernels/cuda/weight_3d.cu
@@ -22,14 +22,14 @@ template<typename T, int Q>
 static magma_int_t 
 magma_weight_3d_kernel_driver(
     const T *dqweight1d, T *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
     magma_int_t nthreads = (Q*Q); 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * Q;  // for dqweight1d 
 
@@ -61,49 +61,49 @@ static magma_int_t
 magma_weight_3d_q(
         magma_int_t Q, const CeedScalar *dqweight1d, 
         CeedScalar *dV, magma_int_t v_stride, 
-        magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+        magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 1>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 2>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 3>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 4>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 5>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 6>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 7>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 8>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 9>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar,10>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -115,9 +115,9 @@ extern "C" magma_int_t
 magma_weight_3d( 
     magma_int_t Q, const CeedScalar *dqweight1d, 
     CeedScalar *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
-    magma_weight_3d_q(Q, dqweight1d, dV, v_stride, nelem, maxthreads, queue);
+    magma_weight_3d_q(Q, dqweight1d, dV, v_stride, nelem, queue);
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/gradn_2d.hip.cpp
+++ b/backends/magma/kernels/hip/gradn_2d.hip.cpp
@@ -24,7 +24,7 @@ magma_gradn_2d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradn_2d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * (P*MAXPQ);  // for reforming rU we need PxP, and for the intermediate output we need PxQ    
@@ -62,21 +62,21 @@ magma_gradn_2d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradn_2d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradn_2d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradn_2d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -91,49 +91,49 @@ magma_gradn_2d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradn_2d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_2d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_2d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_2d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_2d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_2d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_2d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_2d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_2d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_2d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -147,49 +147,49 @@ magma_gradn_2d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradn_2d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_2d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_2d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_2d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_2d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_2d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_2d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_2d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_2d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_2d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -204,7 +204,7 @@ magma_gradn_2d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -213,7 +213,7 @@ magma_gradn_2d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/gradn_3d.hip.cpp
+++ b/backends/magma/kernels/hip/gradn_3d.hip.cpp
@@ -24,7 +24,7 @@ magma_gradn_3d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradn_3d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ*MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * max(P*P*P, (P*P*Q) + (P*Q*Q));  // rU needs P^2xP, the intermediate outputs need (P^2.Q + P.Q^2) 
@@ -62,21 +62,21 @@ magma_gradn_3d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradn_3d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradn_3d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradn_3d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -91,49 +91,49 @@ magma_gradn_3d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradn_3d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_3d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_3d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_3d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_3d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_3d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_3d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_3d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_3d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_3d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -147,49 +147,49 @@ magma_gradn_3d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradn_3d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradn_3d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradn_3d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradn_3d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradn_3d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradn_3d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradn_3d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradn_3d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradn_3d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradn_3d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -204,7 +204,7 @@ magma_gradn_3d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -213,7 +213,7 @@ magma_gradn_3d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/gradt_2d.hip.cpp
+++ b/backends/magma/kernels/hip/gradt_2d.hip.cpp
@@ -24,7 +24,7 @@ magma_gradt_2d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradt_2d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * (P*MAXPQ);  // for reforming rU we need PxP, and for the intermediate output we need PxQ    
@@ -63,21 +63,21 @@ magma_gradt_2d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradt_2d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradt_2d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradt_2d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -92,49 +92,49 @@ magma_gradt_2d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradt_2d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_2d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_2d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_2d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_2d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_2d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_2d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_2d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_2d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_2d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -148,49 +148,49 @@ magma_gradt_2d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradt_2d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_2d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_2d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_2d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_2d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_2d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_2d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_2d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_2d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_2d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -205,7 +205,7 @@ magma_gradt_2d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -214,7 +214,7 @@ magma_gradt_2d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/gradt_3d.hip.cpp
+++ b/backends/magma/kernels/hip/gradt_3d.hip.cpp
@@ -24,7 +24,7 @@ magma_gradt_3d_kernel_driver(
                 const T *dinterp1d, const T *dgrad1d, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_gradt_3d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ*MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * 2*P*Q;  // for sTinterp and sTgrad
     shmem += sizeof(T) * ntcol * max(P*P*P, (P*P*Q) + (P*Q*Q));  // rU needs P^2xP, the intermediate outputs need (P^2.Q + P.Q^2) 
@@ -62,21 +62,21 @@ magma_gradt_3d_ncomp(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_gradt_3d_kernel_driver<CeedScalar,1,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_gradt_3d_kernel_driver<CeedScalar,2,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_gradt_3d_kernel_driver<CeedScalar,3,P,Q>
-          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -91,49 +91,49 @@ magma_gradt_3d_ncomp_q(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_gradt_3d_ncomp<P, 1>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_3d_ncomp<P, 2>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_3d_ncomp<P, 3>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_3d_ncomp<P, 4>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_3d_ncomp<P, 5>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_3d_ncomp<P, 6>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_3d_ncomp<P, 7>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_3d_ncomp<P, 8>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_3d_ncomp<P, 9>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_3d_ncomp<P,10>
-          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -147,49 +147,49 @@ magma_gradt_3d_ncomp_q_p(
                 const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, magma_trans_t transT,
                const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_gradt_3d_ncomp_q< 1>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_gradt_3d_ncomp_q< 2>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_gradt_3d_ncomp_q< 3>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_gradt_3d_ncomp_q< 4>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_gradt_3d_ncomp_q< 5>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_gradt_3d_ncomp_q< 6>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_gradt_3d_ncomp_q< 7>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_gradt_3d_ncomp_q< 8>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_gradt_3d_ncomp_q< 9>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_gradt_3d_ncomp_q<10>
-          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dinterp1d, dgrad1d, transT, dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV, dstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -204,7 +204,7 @@ magma_gradt_3d(
     const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, CeedTransposeMode tmode, 
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, magma_int_t dstrdU,
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, magma_int_t dstrdV,
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -213,7 +213,7 @@ magma_gradt_3d(
                         dinterp1d, dgrad1d, transT, 
                         dU, estrdU, cstrdU, dstrdU, 
                         dV, estrdV, cstrdV, dstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/interp_1d.hip.cpp
+++ b/backends/magma/kernels/hip/interp_1d.hip.cpp
@@ -24,14 +24,15 @@ magma_interp_1d_kernel_driver(
                 const T *dT, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
-    magma_int_t nthreads = max(P, Q); 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    const int MAXPQ = maxpq(P,Q);
+    magma_int_t nthreads = MAXPQ; 
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_1D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * ntcol * ( NCOMP * (1*P + 1*Q) ); 
     shmem += sizeof(T) * (P*Q);
@@ -46,7 +47,7 @@ magma_interp_1d_kernel_driver(
         magma_int_t nblocks = (nelem + ntcol-1) / ntcol;
         dim3 threads(nthreads, ntcol, 1);
         dim3 grid(nblocks	, 1, 1);
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(magma_interp_1d_kernel<T, 1, NCOMP, P, Q>), dim3(grid), dim3(threads), shmem, magma_queue_get_hip_stream(queue), dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem);
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(magma_interp_1d_kernel<T, 1, NCOMP, P, Q, MAXPQ>), dim3(grid), dim3(threads), shmem, magma_queue_get_hip_stream(queue), dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem);
         return (hipPeekAtLastError() == hipSuccess) ? 0 : 1;
     }
 }
@@ -59,21 +60,21 @@ magma_interp_1d_ncomp(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_interp_1d_kernel_driver<CeedScalar,1,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_interp_1d_kernel_driver<CeedScalar,2,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_interp_1d_kernel_driver<CeedScalar,3,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -88,49 +89,49 @@ magma_interp_1d_ncomp_q(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp<P, 1>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp<P, 2>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp<P, 3>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp<P, 4>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp<P, 5>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp<P, 6>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp<P, 7>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp<P, 8>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp<P, 9>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp<P,10>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -144,49 +145,49 @@ magma_interp_1d_ncomp_q_p(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp_q< 1>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp_q< 2>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp_q< 3>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp_q< 4>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp_q< 5>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp_q< 6>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp_q< 7>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp_q< 8>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp_q< 9>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp_q<10>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -201,7 +202,7 @@ magma_interp_1d(
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -210,7 +211,7 @@ magma_interp_1d(
                         dT, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/interp_2d.hip.cpp
+++ b/backends/magma/kernels/hip/interp_2d.hip.cpp
@@ -24,7 +24,7 @@ magma_interp_2d_kernel_driver(
                 const T *dT, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_interp_2d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += P*Q    *sizeof(T);  // for sT
     shmem += ntcol * ( P*MAXPQ*sizeof(T) );  // for reforming rU we need PxP, and for the intermediate output we need PxQ    
@@ -60,21 +60,21 @@ magma_interp_2d_ncomp(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_interp_2d_kernel_driver<CeedScalar,1,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_interp_2d_kernel_driver<CeedScalar,2,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_interp_2d_kernel_driver<CeedScalar,3,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -89,49 +89,49 @@ magma_interp_1d_ncomp_q(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_interp_2d_ncomp<P, 1>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_2d_ncomp<P, 2>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_2d_ncomp<P, 3>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_2d_ncomp<P, 4>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_2d_ncomp<P, 5>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_2d_ncomp<P, 6>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_2d_ncomp<P, 7>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_2d_ncomp<P, 8>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_2d_ncomp<P, 9>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_2d_ncomp<P,10>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -145,49 +145,49 @@ magma_interp_2d_ncomp_q_p(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp_q< 1>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp_q< 2>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp_q< 3>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp_q< 4>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp_q< 5>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp_q< 6>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp_q< 7>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp_q< 8>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp_q< 9>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp_q<10>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -202,7 +202,7 @@ magma_interp_2d(
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -211,7 +211,7 @@ magma_interp_2d(
                         dT, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/interp_3d.hip.cpp
+++ b/backends/magma/kernels/hip/interp_3d.hip.cpp
@@ -24,7 +24,7 @@ magma_interp_3d_kernel_driver(
                 const T *dT, magma_trans_t transT,
                 const T *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       T *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
@@ -32,7 +32,7 @@ magma_interp_3d_kernel_driver(
     const int MAXPQ = maxpq(P,Q);
 
     magma_int_t nthreads = MAXPQ*MAXPQ;
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T)* (P*Q);  // for sT
     shmem += sizeof(T)* ntcol * (max(P*P*MAXPQ, P*Q*Q));  // rU needs P^2xP, the intermediate output needs max(P^2xQ,PQ^2)    
@@ -60,21 +60,21 @@ magma_interp_3d_ncomp(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (ncomp) {
         case 1: 
           launch_failed = magma_interp_3d_kernel_driver<CeedScalar,1,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 2: 
           launch_failed = magma_interp_3d_kernel_driver<CeedScalar,2,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 3: 
           launch_failed = magma_interp_3d_kernel_driver<CeedScalar,3,P,Q>
-          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -89,49 +89,49 @@ magma_interp_1d_ncomp_q(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_interp_3d_ncomp<P, 1>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_3d_ncomp<P, 2>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_3d_ncomp<P, 3>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_3d_ncomp<P, 4>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_3d_ncomp<P, 5>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_3d_ncomp<P, 6>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_3d_ncomp<P, 7>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_3d_ncomp<P, 8>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_3d_ncomp<P, 9>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_3d_ncomp<P,10>
-          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -145,49 +145,49 @@ magma_interp_3d_ncomp_q_p(
                 const CeedScalar *dT, magma_trans_t transT,
                 const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
                       CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-                magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+                magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (P) {
         case  1: 
           launch_failed = magma_interp_1d_ncomp_q< 1>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_interp_1d_ncomp_q< 2>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_interp_1d_ncomp_q< 3>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_interp_1d_ncomp_q< 4>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_interp_1d_ncomp_q< 5>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_interp_1d_ncomp_q< 6>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_interp_1d_ncomp_q< 7>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_interp_1d_ncomp_q< 8>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_interp_1d_ncomp_q< 9>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_interp_1d_ncomp_q<10>
-          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, maxthreads, queue); 
+          (Q, ncomp, dT, transT, dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -202,7 +202,7 @@ magma_interp_3d(
     const CeedScalar *dT, CeedTransposeMode tmode,
     const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU, 
           CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
     magma_trans_t transT = (tmode == CEED_NOTRANSPOSE) ? MagmaNoTrans : MagmaTrans;
@@ -211,7 +211,7 @@ magma_interp_3d(
                         dT, transT, 
                         dU, estrdU, cstrdU, 
                         dV, estrdV, cstrdV, 
-                        nelem, maxthreads, queue);
+                        nelem, queue);
 
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/magma_drestrictApply.hip.cpp
+++ b/backends/magma/kernels/hip/magma_drestrictApply.hip.cpp
@@ -30,7 +30,7 @@ magma_readDofsOffset(const magma_int_t NCOMP, const magma_int_t compstride,
                      magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     hipLaunchKernelGGL(magma_readDofsOffset_kernel, dim3(grid), dim3(threads), 0, magma_queue_get_hip_stream(queue), NCOMP, compstride,
       esize, nelem, offsets, du, dv);
@@ -46,7 +46,7 @@ magma_readDofsStrided(const magma_int_t NCOMP, const magma_int_t esize,
                       magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     hipLaunchKernelGGL(magma_readDofsStrided_kernel, dim3(grid), dim3(threads), 0, magma_queue_get_hip_stream(queue), NCOMP, esize, nelem, 
       strides, du, dv);
@@ -62,7 +62,7 @@ magma_writeDofsOffset(const magma_int_t NCOMP, const magma_int_t compstride,
                       magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
       hipLaunchKernelGGL(magma_writeDofsOffset_kernel_s, dim3(grid), dim3(threads),
@@ -86,7 +86,7 @@ magma_writeDofsStrided(const magma_int_t NCOMP, const magma_int_t esize,
                        magma_queue_t queue)
 {
     magma_int_t grid    = nelem;
-    magma_int_t threads = 256;
+    magma_int_t threads = MAGMA_ERSTR_THREADS;
 
     if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
       hipLaunchKernelGGL(magma_writeDofsStrided_kernel_s, dim3(grid), dim3(threads),

--- a/backends/magma/kernels/hip/weight_1d.hip.cpp
+++ b/backends/magma/kernels/hip/weight_1d.hip.cpp
@@ -22,14 +22,14 @@ template<typename T, int Q>
 static magma_int_t 
 magma_weight_1d_kernel_driver(
     const T *dqweight1d, T *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
     magma_int_t nthreads = Q; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_1D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * Q;  // for dqweight1d 
     shmem += sizeof(T) * ntcol * Q; // for output
@@ -54,49 +54,49 @@ static magma_int_t
 magma_weight_1d_q(
         magma_int_t Q, const CeedScalar *dqweight1d, 
         CeedScalar *dV, magma_int_t v_stride, 
-        magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+        magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 1>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 2>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 3>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 4>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 5>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 6>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 7>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 8>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar, 9>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_weight_1d_kernel_driver<CeedScalar,10>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -108,9 +108,9 @@ extern "C" magma_int_t
 magma_weight_1d( 
     magma_int_t Q, const CeedScalar *dqweight1d, 
     CeedScalar *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
-    magma_weight_1d_q(Q, dqweight1d, dV, v_stride, nelem, maxthreads, queue);
+    magma_weight_1d_q(Q, dqweight1d, dV, v_stride, nelem, queue);
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/weight_2d.hip.cpp
+++ b/backends/magma/kernels/hip/weight_2d.hip.cpp
@@ -22,14 +22,14 @@ template<typename T, int Q>
 static magma_int_t 
 magma_weight_2d_kernel_driver(
     const T *dqweight1d, T *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
     magma_int_t nthreads = Q; 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_2D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * Q;  // for dqweight1d 
 
@@ -53,49 +53,49 @@ static magma_int_t
 magma_weight_2d_q(
         magma_int_t Q, const CeedScalar *dqweight1d, 
         CeedScalar *dV, magma_int_t v_stride, 
-        magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+        magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 1>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 2>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 3>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 4>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 5>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 6>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 7>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 8>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar, 9>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_weight_2d_kernel_driver<CeedScalar,10>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -107,9 +107,9 @@ extern "C" magma_int_t
 magma_weight_2d( 
     magma_int_t Q, const CeedScalar *dqweight1d, 
     CeedScalar *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
-    magma_weight_2d_q(Q, dqweight1d, dV, v_stride, nelem, maxthreads, queue);
+    magma_weight_2d_q(Q, dqweight1d, dV, v_stride, nelem, queue);
     return launch_failed;
 }

--- a/backends/magma/kernels/hip/weight_3d.hip.cpp
+++ b/backends/magma/kernels/hip/weight_3d.hip.cpp
@@ -22,14 +22,14 @@ template<typename T, int Q>
 static magma_int_t 
 magma_weight_3d_kernel_driver(
     const T *dqweight1d, T *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {
     magma_device_t device;
     magma_getdevice( &device );
     magma_int_t shmem_max, nthreads_max;
 
     magma_int_t nthreads = (Q*Q); 
-    magma_int_t ntcol = (maxthreads < nthreads) ? 1 : (maxthreads / nthreads);
+    magma_int_t ntcol = MAGMA_BASIS_NTCOL(nthreads, MAGMA_MAXTHREADS_3D);
     magma_int_t shmem  = 0;
     shmem += sizeof(T) * Q;  // for dqweight1d 
 
@@ -53,49 +53,49 @@ static magma_int_t
 magma_weight_3d_q(
         magma_int_t Q, const CeedScalar *dqweight1d, 
         CeedScalar *dV, magma_int_t v_stride, 
-        magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+        magma_int_t nelem, magma_queue_t queue)
 {
     magma_int_t launch_failed = 0;
     switch (Q) {
         case  1: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 1>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  2: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 2>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  3: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 3>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  4: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 4>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  5: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 5>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  6: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 6>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  7: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 7>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  8: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 8>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case  9: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar, 9>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         case 10: 
           launch_failed = magma_weight_3d_kernel_driver<CeedScalar,10>
-          (dqweight1d, dV, v_stride, nelem, maxthreads, queue); 
+          (dqweight1d, dV, v_stride, nelem, queue); 
           break;
         default: launch_failed = 1;
     }
@@ -107,9 +107,9 @@ extern "C" magma_int_t
 magma_weight_3d( 
     magma_int_t Q, const CeedScalar *dqweight1d, 
     CeedScalar *dV, magma_int_t v_stride, 
-    magma_int_t nelem, magma_int_t maxthreads, magma_queue_t queue)
+    magma_int_t nelem, magma_queue_t queue)
 {    
     magma_int_t launch_failed = 0;
-    magma_weight_3d_q(Q, dqweight1d, dV, v_stride, nelem, maxthreads, queue);
+    magma_weight_3d_q(Q, dqweight1d, dV, v_stride, nelem, queue);
     return launch_failed;
 }

--- a/backends/magma/magma_grad.c
+++ b/backends/magma/magma_grad.c
@@ -28,7 +28,7 @@ magma_grad(
   magma_int_t dstrdU,
   CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
   magma_int_t dstrdV,
-  magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_int_t *maxthreads,
+  magma_int_t nelem, magma_kernel_mode_t kernel_mode,
   magma_queue_t queue) {
   magma_int_t launch_failed = 0;
 
@@ -37,26 +37,26 @@ magma_grad(
       switch(dim) {
       case 1: launch_failed =  magma_grad_1d(P, Q, ncomp, dinterp1d, dgrad1d, tmode,
                                                dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem,
-                                               maxthreads[0], queue); break;
+                                               queue); break;
       case 2: launch_failed = magma_gradt_2d(P, Q, ncomp, dinterp1d, dgrad1d, tmode,
                                                dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV,
-                                               dstrdV, nelem, maxthreads[1], queue); break;
+                                               dstrdV, nelem, queue); break;
       case 3: launch_failed = magma_gradt_3d(P, Q, ncomp, dinterp1d, dgrad1d, tmode,
                                                dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV,
-                                               dstrdV, nelem, maxthreads[2], queue); break;
+                                               dstrdV, nelem, queue); break;
       default: launch_failed = 1;
       }
     } else {
       switch(dim) {
       case 1: launch_failed =  magma_grad_1d(P, Q, ncomp, dinterp1d, dgrad1d, tmode,
                                                dU, estrdU, cstrdU, dV, estrdV, cstrdV, nelem,
-                                               maxthreads[0], queue); break;
+                                               queue); break;
       case 2: launch_failed = magma_gradn_2d(P, Q, ncomp, dinterp1d, dgrad1d, tmode,
                                                dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV,
-                                               dstrdV, nelem, maxthreads[1], queue); break;
+                                               dstrdV, nelem, queue); break;
       case 3: launch_failed = magma_gradn_3d(P, Q, ncomp, dinterp1d, dgrad1d, tmode,
                                                dU, estrdU, cstrdU, dstrdU, dV, estrdV, cstrdV,
-                                               dstrdV, nelem, maxthreads[2], queue); break;
+                                               dstrdV, nelem, queue); break;
       default: launch_failed = 1;
       }
     }

--- a/backends/magma/magma_interp.c
+++ b/backends/magma/magma_interp.c
@@ -27,18 +27,18 @@ magma_interp(
   const CeedScalar *dT, CeedTransposeMode tmode,
   const CeedScalar *dU, magma_int_t estrdU, magma_int_t cstrdU,
   CeedScalar *dV, magma_int_t estrdV, magma_int_t cstrdV,
-  magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_int_t *maxthreads,
+  magma_int_t nelem, magma_kernel_mode_t kernel_mode,
   magma_queue_t queue) {
   magma_int_t launch_failed = 0;
 
   if (kernel_mode == MAGMA_KERNEL_DIM_SPECIFIC) {
     switch(dim) {
     case 1: launch_failed = magma_interp_1d(P, Q, ncomp, dT, tmode, dU, estrdU,
-                                              cstrdU, dV, estrdV, cstrdV, nelem, maxthreads[0], queue); break;
+                                              cstrdU, dV, estrdV, cstrdV, nelem, queue); break;
     case 2: launch_failed = magma_interp_2d(P, Q, ncomp, dT, tmode, dU, estrdU,
-                                              cstrdU, dV, estrdV, cstrdV, nelem, maxthreads[1], queue); break;
+                                              cstrdU, dV, estrdV, cstrdV, nelem, queue); break;
     case 3: launch_failed = magma_interp_3d(P, Q, ncomp, dT, tmode, dU, estrdU,
-                                              cstrdU, dV, estrdV, cstrdV, nelem, maxthreads[2], queue); break;
+                                              cstrdU, dV, estrdV, cstrdV, nelem, queue); break;
     default: launch_failed = 1;
     }
   } else {

--- a/backends/magma/magma_weight.c
+++ b/backends/magma/magma_weight.c
@@ -25,18 +25,18 @@ magma_weight(
   magma_int_t Q, magma_int_t dim,
   const CeedScalar *dqweight1d,
   CeedScalar *dV, magma_int_t v_stride,
-  magma_int_t nelem, magma_kernel_mode_t kernel_mode, magma_int_t *maxthreads,
+  magma_int_t nelem, magma_kernel_mode_t kernel_mode,
   magma_queue_t queue) {
   magma_int_t launch_failed = 0;
 
   if (kernel_mode == MAGMA_KERNEL_DIM_SPECIFIC) {
     switch(dim) {
     case 1: launch_failed = magma_weight_1d(Q, dqweight1d, dV, v_stride, nelem,
-                                              maxthreads[0], queue); break;
+                                              queue); break;
     case 2: launch_failed = magma_weight_2d(Q, dqweight1d, dV, v_stride, nelem,
-                                              maxthreads[1], queue); break;
+                                              queue); break;
     case 3: launch_failed = magma_weight_3d(Q, dqweight1d, dV, v_stride, nelem,
-                                              maxthreads[2], queue); break;
+                                              queue); break;
     default: launch_failed = 1;
     }
   } else {


### PR DESCRIPTION
This PR adds some changes to improve performance of the hip-gen and hipMAGMA backends:
 - Add launch bounds to hip-gen kernels, hip-ref QFunction kernels, and MAGMA backend kernels
 - Add flag for double precision atomics on MI250x: to the Makefile for code compiled when building the library (currently just the MAGMA restrictions), and to the flags passed to hiprtc for most HIP backend kernels.  I have confirmed that adding this flag to hiprtc changes the emitted instruction from `global_atomic_cmpswap_x2` to `global_atomic_add_f64` for gfx90a.  I think it is fine to add it all the time because it seems to be ignored if the `HIP_ARCH` does not support double precision atomics (e.g., when testing on Noether).
 
**Important question to resolve**
The atomics flag only works with ROCm >= 4.2.  Do we want to: 
  - update information such that ROCm 4.2 or newer is required, or 
  - add checks to only add the flag if ROCm is >= 4.2?  (Is there much demand out there to support ROCm 4.1 or older at this point?)