### PR TITLE
backends cuda-shared: fix launch bounds to avoid invalid z dimension

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,7 +218,7 @@ lv-cuda:
     - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran
     - export CUDA_DIR=/usr/local/cuda-11.6
     - export CUDA_VISIBLE_DEVICES=GPU-c4529365-8229-f689-b43d-ccd7f1677079 # our RTX 2080 Super via nvidia-smi -L
-    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=1 && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
+    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=4 && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- FC ------------------" && $FC --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ noether-rocm:
 # Libraries for backends
 # -- MAGMA from dev branch
     - echo "-------------- MAGMA ---------------"
-    - export MAGMA_DIR=/projects/hipMAGMA && git -C $MAGMA_DIR describe
+    - export MAGMA_DIR=/projects/hipMAGMA/install && git -C $MAGMA_DIR describe
   script:
     - rm -f .SUCCESS
 # libCEED

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -80,8 +80,9 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt num_elem,
                            &d_u, &d_v
                           };
     if (dim == 1) {
-      CeedInt elems_per_block = CeedIntMax(512 / thread_1d,
-                                           1); // avoid >512 total threads
+      CeedInt elems_per_block = CeedIntMin(ceed_Cuda->device_prop.maxThreadsDim[2],
+                                           CeedIntMax(512 / thread_1d,
+                                               1)); // avoid >512 total threads
       CeedInt grid = num_elem/elems_per_block +
                      ((num_elem / elems_per_block*elems_per_block < num_elem) ? 1 : 0 );
       CeedInt shared_mem = elems_per_block*thread_1d*sizeof(CeedScalar);
@@ -125,8 +126,9 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt num_elem,
                          &data->c_G, &d_u, &d_v
                         };
     if (dim == 1) {
-      CeedInt elems_per_block = CeedIntMax(512 / thread_1d,
-                                           1); // avoid >512 total threads
+      CeedInt elems_per_block = CeedIntMin(ceed_Cuda->device_prop.maxThreadsDim[2],
+                                           CeedIntMax(512 / thread_1d,
+                                               1)); // avoid >512 total threads
       CeedInt grid = num_elem / elems_per_block +
                      ((num_elem / elems_per_block*elems_per_block<num_elem) ? 1 : 0 );
       CeedInt shared_mem = elems_per_block*thread_1d*sizeof(CeedScalar);

--- a/backends/magma/ceed-magma.h
+++ b/backends/magma/ceed-magma.h
@@ -48,10 +48,16 @@ typedef struct {
   CeedScalar *dqweight;
 } CeedBasisNonTensor_Magma;
 
+typedef enum {
+  OWNED_NONE = 0,
+  OWNED_UNPINNED,
+  OWNED_PINNED,
+} OwnershipMode;
+
 typedef struct {
   CeedInt *offsets;
   CeedInt *doffsets;
-  int  own_;
+  OwnershipMode own_;
   int down_;            // cover a case where we own Device memory
 } CeedElemRestriction_Magma;
 


### PR DESCRIPTION
The typical max z dimension size of a thread block is 64 and we were
computing larger values (like 85) in some cases.