### PR TITLE
examples/petsc: let DMSetFromOptions manage distribution

### DIFF
--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -407,20 +407,8 @@ static PetscErrorCode Run(RunParams rp, PetscInt num_resources,
                                NULL, NULL, NULL, PETSC_TRUE, &dm); CHKERRQ(ierr);
   }
 
-  {
-    DM dm_dist = NULL;
-    PetscPartitioner part;
-
-    ierr = DMPlexGetPartitioner(dm, &part); CHKERRQ(ierr);
-    ierr = PetscPartitionerSetFromOptions(part); CHKERRQ(ierr);
-    ierr = DMPlexDistribute(dm, 0, NULL, &dm_dist); CHKERRQ(ierr);
-    if (dm_dist) {
-      ierr = DMDestroy(&dm); CHKERRQ(ierr);
-      dm  = dm_dist;
-    }
-  }
-  // Disable default VECSTANDARD *after* distribution (which creates a Vec)
-  ierr = DMSetVecType(dm, NULL); CHKERRQ(ierr);
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
+  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
   for (PetscInt b = 0; b < num_bp_choices; b++) {
     DM dm_deg;

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -141,31 +141,18 @@ int main(int argc, char **argv) {
                                 &dm);
     CHKERRQ(ierr);
   } else {
-    // Create the mesh as a 0-refined sphere. This will create a cubic surface, not a box
+    // Create the mesh as a 0-refined sphere. This will create a cubic surface,
+    // not a box, and will snap to the unit sphere upon refinement.
     ierr = DMPlexCreateSphereMesh(PETSC_COMM_WORLD, topo_dim, simplex, 1., &dm);
     CHKERRQ(ierr);
     // Set the object name
     ierr = PetscObjectSetName((PetscObject)dm, "Sphere"); CHKERRQ(ierr);
-    // Distribute mesh over processes
-    {
-      DM dm_dist = NULL;
-      PetscPartitioner part;
-
-      ierr = DMPlexGetPartitioner(dm, &part); CHKERRQ(ierr);
-      ierr = PetscPartitionerSetFromOptions(part); CHKERRQ(ierr);
-      ierr = DMPlexDistribute(dm, 0, NULL, &dm_dist); CHKERRQ(ierr);
-      if (dm_dist) {
-        ierr = DMDestroy(&dm); CHKERRQ(ierr);
-        dm  = dm_dist;
-      }
-    }
     // Refine DMPlex with uniform refinement using runtime option -dm_refine
     ierr = DMPlexSetRefinementUniform(dm, PETSC_TRUE); CHKERRQ(ierr);
-    ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
-    ierr = ProjectToUnitSphere(dm); CHKERRQ(ierr);
-    // View DMPlex via runtime option
-    ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
   }
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
+  // View DMPlex via runtime option
+  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
   // Create DM
   ierr = SetupDMByDegree(dm, degree, num_comp_u, topo_dim, false,

--- a/examples/petsc/include/petscutils.h
+++ b/examples/petsc/include/petscutils.h
@@ -7,7 +7,6 @@
 #include <petscfe.h>
 
 CeedMemType MemTypeP2C(PetscMemType mtype);
-PetscErrorCode ProjectToUnitSphere(DM dm);
 PetscErrorCode Kershaw(DM dm_orig, PetscScalar eps);
 typedef PetscErrorCode (*BCFunction)(PetscInt dim, PetscReal time,
                                      const PetscReal x[],

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -164,22 +164,6 @@ int main(int argc, char **argv) {
                                NULL, NULL, PETSC_TRUE, &dm_orig); CHKERRQ(ierr);
   }
 
-  {
-    DM dm_dist = NULL;
-    PetscPartitioner part;
-
-    ierr = DMPlexGetPartitioner(dm_orig, &part); CHKERRQ(ierr);
-    ierr = PetscPartitionerSetFromOptions(part); CHKERRQ(ierr);
-    ierr = DMPlexDistribute(dm_orig, 0, NULL, &dm_dist); CHKERRQ(ierr);
-    if (dm_dist) {
-      ierr = DMDestroy(&dm_orig); CHKERRQ(ierr);
-      dm_orig = dm_dist;
-    }
-  }
-
-  // Apply Kershaw mesh transformation
-  ierr = Kershaw(dm_orig, eps); CHKERRQ(ierr);
-
   VecType vec_type;
   switch (mem_type_backend) {
   case CEED_MEM_HOST: vec_type = VECSTANDARD; break;
@@ -195,6 +179,10 @@ int main(int argc, char **argv) {
   }
   ierr = DMSetVecType(dm_orig, vec_type); CHKERRQ(ierr);
   ierr = DMSetFromOptions(dm_orig); CHKERRQ(ierr);
+  ierr = DMViewFromOptions(dm_orig, NULL, "-dm_view"); CHKERRQ(ierr);
+
+  // Apply Kershaw mesh transformation
+  ierr = Kershaw(dm_orig, eps); CHKERRQ(ierr);
 
   // Allocate arrays for PETSc objects for each level
   switch (coarsen) {

--- a/examples/petsc/src/petscutils.c
+++ b/examples/petsc/src/petscutils.c
@@ -8,32 +8,6 @@ CeedMemType MemTypeP2C(PetscMemType mem_type) {
 }
 
 // -----------------------------------------------------------------------------
-// Utility function taken from petsc/src/dm/impls/plex/examples/tutorials/ex7.c
-// -----------------------------------------------------------------------------
-PetscErrorCode ProjectToUnitSphere(DM dm) {
-  Vec            coordinates;
-  PetscScalar   *coords;
-  PetscInt       Nv, v, dim, d;
-  PetscErrorCode ierr;
-
-  PetscFunctionBeginUser;
-  ierr = DMGetCoordinatesLocal(dm, &coordinates); CHKERRQ(ierr);
-  ierr = VecGetLocalSize(coordinates, &Nv); CHKERRQ(ierr);
-  ierr = VecGetBlockSize(coordinates, &dim); CHKERRQ(ierr);
-  Nv  /= dim;
-  ierr = VecGetArray(coordinates, &coords); CHKERRQ(ierr);
-  for (v = 0; v < Nv; ++v) {
-    PetscReal r = 0.0;
-
-    for (d = 0; d < dim; ++d) r += PetscSqr(PetscRealPart(coords[v*dim+d]));
-    r = PetscSqrtReal(r);
-    for (d = 0; d < dim; ++d) coords[v*dim+d] /= r;
-  }
-  ierr = VecRestoreArray(coordinates, &coords); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
-};
-
-// -----------------------------------------------------------------------------
 // Apply 3D Kershaw mesh transformation
 // -----------------------------------------------------------------------------
 // Transition from a value of "a" for x=0, to a value of "b" for x=1.  Optionally
@@ -132,7 +106,6 @@ PetscErrorCode SetupDMByDegree(DM dm, PetscInt degree, PetscInt num_comp_u,
   ierr = PetscObjectGetComm((PetscObject)dm, &comm); CHKERRQ(ierr);
   ierr = PetscFECreateLagrange(comm, dim, num_comp_u, PETSC_FALSE, degree, degree,
                                &fe); CHKERRQ(ierr);
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMAddField(dm, NULL, (PetscObject)fe); CHKERRQ(ierr);
   {
     /* create FE field for coordinates */

--- a/examples/solids/elasticity.c
+++ b/examples/solids/elasticity.c
@@ -147,6 +147,7 @@ int main(int argc, char **argv) {
   }
   }
   ierr = DMSetVecType(dm_orig, vectype); CHKERRQ(ierr);
+  ierr = DMPlexDistributeSetDefault(dm_orig, PETSC_FALSE); CHKERRQ(ierr);
   ierr = DMSetFromOptions(dm_orig); CHKERRQ(ierr);
 
   // -- Setup DM by polynomial degree


### PR DESCRIPTION
Sphere meshes are automatically snapped to the unit sphere when refined.

I left explicit partitioning in solids (though Ratel uses the new
paradigm) because it has documented command-line arguments and maybe
someone wants to know how to avoid this distribution.


@rezgarshakeri This is somewhat related to #900. Partitioning and distribution is done automatically now in `DMSetFromOptions`, and our parallel tests are broken with latest PETSc as a result. Automatic distribution can be disabled with `DMPlexDistributeSetDefault()`.