### PR TITLE
QF Assembly - better object reuse

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -23,6 +23,7 @@ for each release of libCEED.
 - Added {c:func}`CeedQFunctionContextGetFieldDescriptions` to retreive user defined descriptions of fields that are registered with `CeedQFunctionContextRegister*`.
 - Renamed `CeedElemTopology` entries for clearer namespacing between libCEED enums.
 - Added type `CeedSize` equivalent to `ptrdiff_t` for array sizes in {c:func}`CeedVectorCreate`, {c:func}`CeedVectorGetLength`, `CeedElemRestrictionCreate*`, {c:func}`CeedElemRestrictionGetLVectorSize`, and {c:func}`CeedOperatorLinearAssembleSymbolic`. This is a breaking change.
+- Added {c:func}`CeedOperatorSetQFunctionUpdated` to facilitate QFunction data re-use between operators sharing the same quadrature space, such as in a multigrid hierarchy.
 
 ### New features
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -334,8 +334,8 @@ struct CeedQFunctionAssemblyData_private {
   Ceed ceed;
   int ref_count;
   bool is_setup;
-  bool is_update_flag_used;
-  bool is_update_needed;
+  bool reuse_data;
+  bool needs_data_update;
   CeedVector vec;
   CeedElemRestriction rstr;
 };

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -334,6 +334,8 @@ struct CeedQFunctionAssemblyData_private {
   Ceed ceed;
   int ref_count;
   bool is_setup;
+  bool is_update_flag_used;
+  bool is_update_needed;
   CeedVector vec;
   CeedElemRestriction rstr;
 };

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -330,6 +330,14 @@ struct CeedOperatorField_private {
   const char *field_name;          /* matching QFunction field name */
 };
 
+struct CeedQFunctionAssemblyData_private {
+  Ceed ceed;
+  int ref_count;
+  bool is_setup;
+  CeedVector vec;
+  CeedElemRestriction rstr;
+};
+
 struct CeedOperator_private {
   Ceed ceed;
   CeedOperator op_fallback;
@@ -369,9 +377,7 @@ struct CeedOperator_private {
   bool is_backend_setup;
   bool is_composite;
   bool has_restriction;
-  bool has_qf_assembled;
-  CeedVector qf_assembled;
-  CeedElemRestriction qf_assembled_rstr;
+  CeedQFunctionAssemblyData qf_assembled;
   CeedOperator *sub_operators;
   CeedInt num_suboperators;
   void *data;

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -82,6 +82,10 @@ CEED_EXTERN bool CeedDebugFlagEnv(void);
 /// @ingroup CeedBasis
 typedef struct CeedTensorContract_private *CeedTensorContract;
 
+/// Handle for object handling assembled QFunction data
+/// @ingroup CeedOperator
+typedef struct CeedQFunctionAssemblyData_private *CeedQFunctionAssemblyData;
+
 /* In the next 3 functions, p has to be the address of a pointer type, i.e. p
    has to be a pointer to a pointer. */
 CEED_INTERN int CeedMallocArray(size_t n, size_t unit, void *p);
@@ -251,6 +255,14 @@ CEED_EXTERN int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
                                    CeedContextFieldLabel field_label,
                                    CeedContextFieldType field_type, void *value);
 CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
+
+CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);
+CEED_EXTERN int CeedQFunctionAssemblyDataReference(CeedQFunctionAssemblyData data);
+CEED_EXTERN int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQFunctionAssemblyData *data_copy);
+CEED_EXTERN int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_setup);
+CEED_EXTERN int CeedQFunctionAssemblyDataSetObjects(CeedQFunctionAssemblyData data, CeedVector vec, CeedElemRestriction rstr);
+CEED_EXTERN int CeedQFunctionAssemblyDataGetObjects(CeedQFunctionAssemblyData data, CeedVector *vec, CeedElemRestriction *rstr);
+CEED_EXTERN int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data);
 
 CEED_EXTERN int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args);
 CEED_EXTERN int CeedOperatorIsSetupDone(CeedOperator op, bool *is_setup_done);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -258,7 +258,8 @@ CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);
 CEED_EXTERN int CeedQFunctionAssemblyDataReference(CeedQFunctionAssemblyData data);
-CEED_EXTERN int CeedQFunctionAssemblyDataSetQFunctionUpdated(CeedQFunctionAssemblyData data, bool is_update_needed);
+CEED_EXTERN int CeedQFunctionAssemblyDataSetReuse(CeedQFunctionAssemblyData data, bool reuse_assembly_data);
+CEED_EXTERN int CeedQFunctionAssemblyDataSetUpdateNeeded(CeedQFunctionAssemblyData data, bool needs_data_update);
 CEED_EXTERN int CeedQFunctionAssemblyDataIsUpdateNeeded(CeedQFunctionAssemblyData data, bool *is_update_needed);
 CEED_EXTERN int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQFunctionAssemblyData *data_copy);
 CEED_EXTERN int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_setup);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -258,6 +258,8 @@ CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);
 CEED_EXTERN int CeedQFunctionAssemblyDataReference(CeedQFunctionAssemblyData data);
+CEED_EXTERN int CeedQFunctionAssemblyDataSetQFunctionUpdated(CeedQFunctionAssemblyData data, bool is_update_needed);
+CEED_EXTERN int CeedQFunctionAssemblyDataIsUpdateNeeded(CeedQFunctionAssemblyData data, bool *is_update_needed);
 CEED_EXTERN int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQFunctionAssemblyData *data_copy);
 CEED_EXTERN int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_setup);
 CEED_EXTERN int CeedQFunctionAssemblyDataSetObjects(CeedQFunctionAssemblyData data, CeedVector vec, CeedElemRestriction rstr);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -702,7 +702,8 @@ CEED_EXTERN int CeedOperatorGetFields(CeedOperator op,
 CEED_EXTERN int CeedCompositeOperatorAddSub(CeedOperator composite_op,
     CeedOperator sub_op);
 CEED_EXTERN int CeedOperatorCheckReady(CeedOperator op);
-CEED_EXTERN int CeedOperatorSetQFunctionUpdated(CeedOperator op);
+CEED_EXTERN int CeedOperatorSetQFunctionAssemblyReuse(CeedOperator op, bool reuse_assembly_data);
+CEED_EXTERN int CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(CeedOperator op, bool needs_data_update);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunction(CeedOperator op,
     CeedVector *assembled, CeedElemRestriction *rstr, CeedRequest *request);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunctionBuildOrUpdate(CeedOperator op,

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -702,6 +702,7 @@ CEED_EXTERN int CeedOperatorGetFields(CeedOperator op,
 CEED_EXTERN int CeedCompositeOperatorAddSub(CeedOperator composite_op,
     CeedOperator sub_op);
 CEED_EXTERN int CeedOperatorCheckReady(CeedOperator op);
+CEED_EXTERN int CeedOperatorSetQFunctionUpdated(CeedOperator op);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunction(CeedOperator op,
     CeedVector *assembled, CeedElemRestriction *rstr, CeedRequest *request);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunctionBuildOrUpdate(CeedOperator op,

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -579,6 +579,8 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf,
     (*op)->dqfT = dqfT;
     ierr = CeedQFunctionReference(dqfT); CeedChk(ierr);
   }
+  ierr = CeedQFunctionAssemblyDataCreate(ceed, &(*op)->qf_assembled);
+  CeedChk(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &(*op)->input_fields); CeedChk(ierr);
   ierr = CeedCalloc(CEED_FIELD_MAX, &(*op)->output_fields); CeedChk(ierr);
   ierr = ceed->OperatorCreate(*op); CeedChk(ierr);
@@ -1428,16 +1430,12 @@ int CeedOperatorDestroy(CeedOperator *op) {
   if ((*op)->op_fallback) {
     ierr = (*op)->qf_fallback->Destroy((*op)->qf_fallback); CeedChk(ierr);
     ierr = CeedFree(&(*op)->qf_fallback); CeedChk(ierr);
-    ierr = CeedVectorDestroy(&(*op)->op_fallback->qf_assembled); CeedChk(ierr);
-    ierr = CeedElemRestrictionDestroy(&(*op)->op_fallback->qf_assembled_rstr);
-    CeedChk(ierr);
     ierr = (*op)->op_fallback->Destroy((*op)->op_fallback); CeedChk(ierr);
     ierr = CeedFree(&(*op)->op_fallback); CeedChk(ierr);
   }
 
   // Destroy QF assembly cache
-  ierr = CeedVectorDestroy(&(*op)->qf_assembled); CeedChk(ierr);
-  ierr = CeedElemRestrictionDestroy(&(*op)->qf_assembled_rstr); CeedChk(ierr);
+  ierr = CeedQFunctionAssemblyDataDestroy(&(*op)->qf_assembled); CeedChk(ierr);
 
   ierr = CeedFree(&(*op)->input_fields); CeedChk(ierr);
   ierr = CeedFree(&(*op)->output_fields); CeedChk(ierr);

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -881,6 +881,9 @@ static int CeedSingleOperatorMultigridLevel(CeedOperator op_fine,
                                   op_fine->output_fields[i]->vec); CeedChk(ierr);
     }
   }
+  // -- Clone QFunctionAssemblyData
+  ierr = CeedQFunctionAssemblyDataReferenceCopy(op_fine->qf_assembled,
+         &(*op_coarse)->qf_assembled); CeedChk(ierr);
 
   // Multiplicity vector
   CeedVector mult_vec, mult_e_vec;

--- a/tests/t530-operator.c
+++ b/tests/t530-operator.c
@@ -91,6 +91,10 @@ int main(int argc, char **argv) {
   CeedOperatorApply(op_setup, X, q_data, CEED_REQUEST_IMMEDIATE);
 
   // Assemble QFunction
+  CeedOperatorSetQFunctionUpdated(op_mass);
+  CeedOperatorLinearAssembleQFunction(op_mass, &A, &elem_restr_lin_i,
+                                      CEED_REQUEST_IMMEDIATE);
+  // Second call will be no-op since SetQFunctionUpdated was not called
   CeedOperatorLinearAssembleQFunction(op_mass, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t530-operator.c
+++ b/tests/t530-operator.c
@@ -91,10 +91,12 @@ int main(int argc, char **argv) {
   CeedOperatorApply(op_setup, X, q_data, CEED_REQUEST_IMMEDIATE);
 
   // Assemble QFunction
-  CeedOperatorSetQFunctionUpdated(op_mass);
+  CeedOperatorSetQFunctionAssemblyReuse(op_mass, true);
+  CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(op_mass, true);
   CeedOperatorLinearAssembleQFunction(op_mass, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
   // Second call will be no-op since SetQFunctionUpdated was not called
+  CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(op_mass, false);
   CeedOperatorLinearAssembleQFunction(op_mass, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t531-operator.c
+++ b/tests/t531-operator.c
@@ -110,6 +110,10 @@ int main(int argc, char **argv) {
   CeedVectorRestoreArrayRead(v, &vv);
 
   // Assemble QFunction
+  CeedOperatorSetQFunctionUpdated(op_diff);
+  CeedOperatorLinearAssembleQFunction(op_diff, &A, &elem_restr_lin_i,
+                                      CEED_REQUEST_IMMEDIATE);
+  // Second call will be no-op since SetQFunctionUpdated was not called
   CeedOperatorLinearAssembleQFunction(op_diff, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t531-operator.c
+++ b/tests/t531-operator.c
@@ -110,10 +110,11 @@ int main(int argc, char **argv) {
   CeedVectorRestoreArrayRead(v, &vv);
 
   // Assemble QFunction
-  CeedOperatorSetQFunctionUpdated(op_diff);
+  CeedOperatorSetQFunctionAssemblyReuse(op_diff, true);
   CeedOperatorLinearAssembleQFunction(op_diff, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
   // Second call will be no-op since SetQFunctionUpdated was not called
+  CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(op_diff, false);
   CeedOperatorLinearAssembleQFunction(op_diff, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t532-operator.c
+++ b/tests/t532-operator.c
@@ -147,6 +147,10 @@ int main(int argc, char **argv) {
   // LCOV_EXCL_STOP
 
   // Assemble QFunction
+  CeedOperatorSetQFunctionUpdated(op_apply);
+  CeedOperatorLinearAssembleQFunction(op_apply, &A, &elem_restr_lin_i,
+                                      CEED_REQUEST_IMMEDIATE);
+  // Second call will be no-op since SetQFunctionUpdated was not called
   CeedOperatorLinearAssembleQFunction(op_apply, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
 

--- a/tests/t532-operator.c
+++ b/tests/t532-operator.c
@@ -147,10 +147,11 @@ int main(int argc, char **argv) {
   // LCOV_EXCL_STOP
 
   // Assemble QFunction
-  CeedOperatorSetQFunctionUpdated(op_apply);
+  CeedOperatorSetQFunctionAssemblyReuse(op_apply, true);
   CeedOperatorLinearAssembleQFunction(op_apply, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
   // Second call will be no-op since SetQFunctionUpdated was not called
+  CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(op_apply, false);
   CeedOperatorLinearAssembleQFunction(op_apply, &A, &elem_restr_lin_i,
                                       CEED_REQUEST_IMMEDIATE);
 


### PR DESCRIPTION
Full discussion on Slack. This significantly reduces memory usage in code using the multigrid interface.
```
heaptrack build/ex02-quasistatic-elasticity -order 3 -dm_plex_shape schwarz_p -dm_plex_tps_thickness .2 -dm_plex_tps_extent 2,2,2 -dm_plex_tps_layers 1 -dm_plex_tps_refine 2 -material fs-current-nh -E 1 -nu .3 -bc_clamp 1 -bc_traction 2 -bc_traction_2 .002,0,0 -ts_dt 1 -ts_adapt_monitor -snes_monitor -ksp_converged_reason -dm_view -ksp_rtol 1e-3 -snes_converged_reason -ksp_view_singularvalues -pc_type jacobi
```
This example in Ratel went from 1.1 GB to 339 MB total memory usage due to this PR
