### PR TITLE
Operator active data

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -24,6 +24,7 @@ for each release of libCEED.
 - Renamed `CeedElemTopology` entries for clearer namespacing between libCEED enums.
 - Added type `CeedSize` equivalent to `ptrdiff_t` for array sizes in {c:func}`CeedVectorCreate`, {c:func}`CeedVectorGetLength`, `CeedElemRestrictionCreate*`, {c:func}`CeedElemRestrictionGetLVectorSize`, and {c:func}`CeedOperatorLinearAssembleSymbolic`. This is a breaking change.
 - Added {c:func}`CeedOperatorSetQFunctionUpdated` to facilitate QFunction data re-use between operators sharing the same quadrature space, such as in a multigrid hierarchy.
+- Added {c:func}`CeedOperatorGetActiveVectorLengths` to get shape of CeedOperator.
 
 ### New features
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -368,6 +368,7 @@ struct CeedOperator_private {
   int (*Destroy)(CeedOperator);
   CeedOperatorField *input_fields;
   CeedOperatorField *output_fields;
+  CeedSize input_size, output_size;
   CeedInt num_elem;   /* Number of elements */
   CeedInt num_qpts;   /* Number of quadrature points over all elements */
   CeedInt num_fields; /* Number of fields that have been set */

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -708,6 +708,7 @@ CEED_EXTERN int CeedOperatorGetFields(CeedOperator op,
 CEED_EXTERN int CeedCompositeOperatorAddSub(CeedOperator composite_op,
     CeedOperator sub_op);
 CEED_EXTERN int CeedOperatorCheckReady(CeedOperator op);
+CEED_EXTERN int CeedOperatorGetActiveVectorLengths(CeedOperator op, CeedSize *input_size, CeedSize *output_size);
 CEED_EXTERN int CeedOperatorSetQFunctionAssemblyReuse(CeedOperator op, bool reuse_assembly_data);
 CEED_EXTERN int CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(CeedOperator op, bool needs_data_update);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunction(CeedOperator op,

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -204,10 +204,10 @@ int CeedOperatorSingleView(CeedOperator op, bool sub, FILE *stream) {
 }
 
 /**
-  @brief Find the active vector basis for a CeedOperator
+  @brief Find the active vector basis for a non-composite CeedOperator
 
   @param[in] op             CeedOperator to find active basis for
-  @param[out] active_basis  Basis for active input vector
+  @param[out] active_basis  Basis for active input vector or NULL for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -215,6 +215,7 @@ int CeedOperatorSingleView(CeedOperator op, bool sub, FILE *stream) {
 **/
 int CeedOperatorGetActiveBasis(CeedOperator op, CeedBasis *active_basis) {
   *active_basis = NULL;
+  if (op->is_composite) return CEED_ERROR_SUCCESS;
   for (int i = 0; i < op->qf->num_input_fields; i++)
     if (op->input_fields[i]->vec == CEED_VECTOR_ACTIVE) {
       *active_basis = op->input_fields[i]->basis;
@@ -234,10 +235,10 @@ int CeedOperatorGetActiveBasis(CeedOperator op, CeedBasis *active_basis) {
 }
 
 /**
-  @brief Find the active vector ElemRestriction for a CeedOperator
+  @brief Find the active vector ElemRestriction for a non-composite CeedOperator
 
   @param[in] op            CeedOperator to find active basis for
-  @param[out] active_rstr  ElemRestriction for active input vector
+  @param[out] active_rstr  ElemRestriction for active input vector or NULL for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -246,6 +247,7 @@ int CeedOperatorGetActiveBasis(CeedOperator op, CeedBasis *active_basis) {
 int CeedOperatorGetActiveElemRestriction(CeedOperator op,
     CeedElemRestriction *active_rstr) {
   *active_rstr = NULL;
+  if (op->is_composite) return CEED_ERROR_SUCCESS;
   for (int i = 0; i < op->qf->num_input_fields; i++)
     if (op->input_fields[i]->vec == CEED_VECTOR_ACTIVE) {
       *active_rstr = op->input_fields[i]->elem_restr;

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -459,13 +459,13 @@ static int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset,
                      "Composite operator not supported");
   // LCOV_EXCL_STOP
 
+  CeedSize num_nodes;
+  ierr = CeedOperatorGetActiveVectorLengths(op, &num_nodes, NULL); CeedChk(ierr);
   CeedElemRestriction rstr_in;
   ierr = CeedOperatorGetActiveElemRestriction(op, &rstr_in); CeedChk(ierr);
-  CeedSize num_nodes;
   CeedInt num_elem, elem_size, num_comp;
   ierr = CeedElemRestrictionGetNumElements(rstr_in, &num_elem); CeedChk(ierr);
   ierr = CeedElemRestrictionGetElementSize(rstr_in, &elem_size); CeedChk(ierr);
-  ierr = CeedElemRestrictionGetLVectorSize(rstr_in, &num_nodes); CeedChk(ierr);
   ierr = CeedElemRestrictionGetNumComponents(rstr_in, &num_comp); CeedChk(ierr);
   CeedInt layout_er[3];
   ierr = CeedElemRestrictionGetELayout(rstr_in, &layout_er); CeedChk(ierr);
@@ -1370,6 +1370,14 @@ int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled,
   int ierr;
   ierr = CeedOperatorCheckReady(op); CeedChk(ierr);
 
+  CeedSize input_size = 0, output_size = 0;
+  ierr = CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size);
+  CeedChk(ierr);
+  if (input_size != output_size)
+    // LCOV_EXCL_START
+    return CeedError(op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  // LCOV_EXCL_STOP
+
   // Use backend version, if available
   if (op->LinearAssembleDiagonal) {
     ierr = op->LinearAssembleDiagonal(op, assembled, request); CeedChk(ierr);
@@ -1427,6 +1435,14 @@ int CeedOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedVector assembled,
     CeedRequest *request) {
   int ierr;
   ierr = CeedOperatorCheckReady(op); CeedChk(ierr);
+
+  CeedSize input_size = 0, output_size = 0;
+  ierr = CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size);
+  CeedChk(ierr);
+  if (input_size != output_size)
+    // LCOV_EXCL_START
+    return CeedError(op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  // LCOV_EXCL_STOP
 
   // Use backend version, if available
   if (op->LinearAssembleAddDiagonal) {
@@ -1495,6 +1511,14 @@ int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op,
   int ierr;
   ierr = CeedOperatorCheckReady(op); CeedChk(ierr);
 
+  CeedSize input_size = 0, output_size = 0;
+  ierr = CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size);
+  CeedChk(ierr);
+  if (input_size != output_size)
+    // LCOV_EXCL_START
+    return CeedError(op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  // LCOV_EXCL_STOP
+
   // Use backend version, if available
   if (op->LinearAssemblePointBlockDiagonal) {
     ierr = op->LinearAssemblePointBlockDiagonal(op, assembled, request);
@@ -1560,6 +1584,14 @@ int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op,
     CeedVector assembled, CeedRequest *request) {
   int ierr;
   ierr = CeedOperatorCheckReady(op); CeedChk(ierr);
+
+  CeedSize input_size = 0, output_size = 0;
+  ierr = CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size);
+  CeedChk(ierr);
+  if (input_size != output_size)
+    // LCOV_EXCL_START
+    return CeedError(op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  // LCOV_EXCL_STOP
 
   // Use backend version, if available
   if (op->LinearAssembleAddPointBlockDiagonal) {


### PR DESCRIPTION
This PR

- explicitly makes `CeedOperatorGetActiveElemRestriction` and `CeedOperatorGetActiveBasis` for non-composite operators
- adds `CeedOperatorGetActiveVectorLengths`