### PR TITLE
Prepare for v0.10.1 patch

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: "libCEED: Efficient Extensible Discretization"
-version: 0.10.0
+version: 0.10.1
 date-released: 2021-07-07
 license:  BSD-2-Clause
 message: "Please cite the following works when using this software."

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = libCEED
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.10.0
+PROJECT_NUMBER         = v0.10.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/ceed.pc.template
+++ b/ceed.pc.template
@@ -4,7 +4,7 @@ libdir=${prefix}/lib
 
 Name: CEED
 Description: Code for Efficient Extensible Discretization
-Version: 0.10.0
+Version: 0.10.1
 Cflags: -I${includedir}
 Libs: -L${libdir} -lceed
 Libs.private: %libs_private%

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -1,11 +1,16 @@
 # Changes/Release Notes
 
-On this page we provide a summary of the main API changes, new features and examples
-for each release of libCEED.
+On this page we provide a summary of the main API changes, new features and examples for each release of libCEED.
 
 (main)=
 
 ## Current `main` branch
+
+### Interface changes
+
+(v0-10-1)=
+
+## v0.10.1 (Apr 11, 2022)
 
 ### Interface changes
 

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -241,8 +241,8 @@ CEED_EXTERN int CeedResetErrorMessage(Ceed, const char **err_msg);
 /// @ingroup Ceed
 #define CEED_VERSION_MAJOR 0
 #define CEED_VERSION_MINOR 10
-#define CEED_VERSION_PATCH 0
-#define CEED_VERSION_RELEASE false
+#define CEED_VERSION_PATCH 1
+#define CEED_VERSION_RELEASE true
 
 /// Compile-time check that the the current library version is at least as
 /// recent as the specified version. This macro is typically used in


### PR DESCRIPTION
The flop counting interface currently only lives in the C API, so I think we only need to tag the patch on the C API.