### PR TITLE
petsc - update for PetscOptionsBegin/End

### DIFF
--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -75,8 +75,7 @@ PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *setup_ctx,
   // ------------------------------------------------------
   //              Command line Options
   // ------------------------------------------------------
-  ierr = PetscOptionsBegin(comm, NULL, "Options for ADVECTION problem",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Options for ADVECTION problem", NULL);
   // -- Physics
   ierr = PetscOptionsScalar("-rc", "Characteristic radius of thermal bubble",
                             NULL, rc, &rc, NULL); CHKERRQ(ierr);
@@ -148,7 +147,7 @@ PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *setup_ctx,
     CHKERRQ(ierr);
   }
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // ------------------------------------------------------
   //           Set up the PETSc context

--- a/examples/fluids/problems/advection2d.c
+++ b/examples/fluids/problems/advection2d.c
@@ -73,8 +73,7 @@ PetscErrorCode NS_ADVECTION2D(ProblemData *problem, DM dm, void *setup_ctx,
   // ------------------------------------------------------
   //              Command line Options
   // ------------------------------------------------------
-  ierr = PetscOptionsBegin(comm, NULL, "Options for ADVECTION2D problem",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Options for ADVECTION2D problem", NULL);
   // -- Physics
   ierr = PetscOptionsScalar("-rc", "Characteristic radius of thermal bubble",
                             NULL, rc, &rc, NULL); CHKERRQ(ierr);
@@ -130,7 +129,7 @@ PetscErrorCode NS_ADVECTION2D(ProblemData *problem, DM dm, void *setup_ctx,
     CHKERRQ(ierr);
   }
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // ------------------------------------------------------
   //           Set up the PETSc context

--- a/examples/fluids/problems/densitycurrent.c
+++ b/examples/fluids/problems/densitycurrent.c
@@ -40,8 +40,7 @@ PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *setup_ctx,
   // ------------------------------------------------------
   //              Command line Options
   // ------------------------------------------------------
-  ierr = PetscOptionsBegin(comm, NULL, "Options for DENSITY_CURRENT problem",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Options for DENSITY_CURRENT problem", NULL);
   ierr = PetscOptionsScalar("-rc", "Characteristic radius of thermal bubble",
                             NULL, rc, &rc, NULL); CHKERRQ(ierr);
   for (int i=0; i<3; i++) center[i] = .5*domain_size[i];
@@ -60,7 +59,7 @@ PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *setup_ctx,
     }
   }
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   PetscScalar meter = user->units->meter;
   rc = fabs(rc) * meter;

--- a/examples/fluids/problems/eulervortex.c
+++ b/examples/fluids/problems/eulervortex.c
@@ -73,8 +73,7 @@ PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *setup_ctx,
   // ------------------------------------------------------
   //              Command line Options
   // ------------------------------------------------------
-  ierr = PetscOptionsBegin(comm, NULL, "Options for EULER_VORTEX problem",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Options for EULER_VORTEX problem", NULL);
   // -- Physics
   ierr = PetscOptionsScalar("-vortex_strength", "Strength of Vortex",
                             NULL, vortex_strength, &vortex_strength, NULL);
@@ -120,7 +119,7 @@ PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *setup_ctx,
     CHKERRQ(ierr);
   }
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // ------------------------------------------------------
   //           Set up the PETSc context

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -77,9 +77,9 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *setup_ctx,
   // ------------------------------------------------------
   //              Command line Options
   // ------------------------------------------------------
-  ierr = PetscOptionsBegin(comm, NULL,
-                           "Options for Newtonian Ideal Gas based problem",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Options for Newtonian Ideal Gas based problem",
+                    NULL);
+
   // -- Physics
   ierr = PetscOptionsScalar("-theta0", "Reference potential temperature",
                             NULL, theta0, &theta0, NULL); CHKERRQ(ierr);
@@ -133,7 +133,7 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *setup_ctx,
                        "Warning! Use -stab supg only with -implicit\n");
     CHKERRQ(ierr);
   }
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // ------------------------------------------------------
   //           Set up the PETSc context

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -42,8 +42,8 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx,
   PetscErrorCode ierr;
   PetscFunctionBeginUser;
 
-  ierr = PetscOptionsBegin(comm, NULL, "Navier-Stokes in PETSc with libCEED",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Navier-Stokes in PETSc with libCEED",
+                    NULL);
 
   ierr = PetscOptionsString("-ceed", "CEED resource specifier",
                             NULL, app_ctx->ceed_resource, app_ctx->ceed_resource,
@@ -148,7 +148,7 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx,
                               "Face IDs to apply outflow BC",
                               NULL, bc->outflows, &bc->num_outflow, NULL); CHKERRQ(ierr);
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   PetscFunctionReturn(0);
 }

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -92,9 +92,7 @@ int main(int argc, char **argv) {
   comm = PETSC_COMM_WORLD;
 
   // Read command line options
-  ierr = PetscOptionsBegin(comm, NULL, "CEED surface area problem with PETSc",
-                           NULL);
-  CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "CEED surface area problem with PETSc", NULL);
   problem_choice = SPHERE;
   ierr = PetscOptionsEnum("-problem",
                           "Problem to solve", NULL,
@@ -116,7 +114,7 @@ int main(int argc, char **argv) {
                           NULL, simplex, &simplex, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-degree", "Polynomial degree of tensor product basis",
                          NULL, degree, &degree, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Setup DM
   if (read_mesh) {

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -469,8 +469,7 @@ int main(int argc, char **argv) {
   rp->comm = comm;
 
   // Read command line options
-  ierr = PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL);
-  CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL);
   {
     PetscBool set;
     ierr = PetscOptionsEnumArray("-problem", "CEED benchmark problem to solve",
@@ -558,8 +557,7 @@ int main(int argc, char **argv) {
     if (flg) ranks_per_node = p;
   }
 
-  ierr = PetscOptionsEnd();
-  CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Register PETSc logging stage
   ierr = PetscLogStageRegister("Solve Stage", &rp->solve_stage);

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -439,7 +439,7 @@ int main(int argc, char **argv) {
   comm = PETSC_COMM_WORLD;
 
   // Read command line options
-  ierr = PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL);
   bp_choice = CEED_BP1;
   ierr = PetscOptionsEnum("-problem",
                           "CEED benchmark problem to solve", NULL,
@@ -480,7 +480,7 @@ int main(int argc, char **argv) {
                               "Min and max number of iterations to use during benchmarking",
                               NULL, ksp_max_it_clip, &two, NULL);
   CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
   P = degree + 1;
   Q = P + q_extra;
 

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
   comm = PETSC_COMM_WORLD;
 
   // Read command line options
-  ierr = PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL);
   bp_choice = CEED_BP1;
   ierr = PetscOptionsEnum("-problem",
                           "CEED benchmark problem to solve", NULL,
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
   simplex = PETSC_FALSE;
   ierr = PetscOptionsBool("-simplex", "Use simplices, or tensor product cells",
                           NULL, simplex, &simplex, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Setup DM
   if (read_mesh) {

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
   comm = PETSC_COMM_WORLD;
 
   // Parse command line options
-  ierr = PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "CEED BPs in PETSc", NULL);
   bp_choice = CEED_BP3;
   ierr = PetscOptionsEnum("-problem",
                           "CEED benchmark problem to solve", NULL,
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
     ierr = PetscOptionsIntArray("-cells","Number of cells per dimension", NULL,
                                 mesh_elem, &tmp, NULL); CHKERRQ(ierr);
   }
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Set up libCEED
   CeedInit(ceed_resource, &ceed);

--- a/examples/solids/problems/mooney-rivlin.c
+++ b/examples/solids/problems/mooney-rivlin.c
@@ -38,9 +38,8 @@ PetscErrorCode PhysicsSmootherContext_MR(MPI_Comm comm, Ceed ceed,
 
   PetscFunctionBegin;
 
-  ierr = PetscOptionsBegin(comm, NULL,
-                           "Mooney Rivlin physical parameters for smoother", NULL);
-  CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Mooney Rivlin physical parameters for smoother",
+                    NULL);
 
   ierr = PetscOptionsScalar("-nu_smoother", "Poisson's ratio for smoother",
                             NULL, nu_smoother, &nu_smoother, &nu_flag);
@@ -49,7 +48,7 @@ PetscErrorCode PhysicsSmootherContext_MR(MPI_Comm comm, Ceed ceed,
       nu_smoother >= 0.5) SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP,
                                     "Mooney-Rivlin model requires Poisson ratio -nu option in [0, .5)");
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr); // End of setting Physics
+  PetscOptionsEnd(); // End of setting Physics
 
   if (nu_flag) {
     // Copy context
@@ -84,8 +83,7 @@ PetscErrorCode ProcessPhysics_MR(MPI_Comm comm, Physics_MR phys, Units units) {
 
   PetscFunctionBeginUser;
 
-  ierr = PetscOptionsBegin(comm, NULL, "Mooney Rivlin physical parameters", NULL);
-  CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Mooney Rivlin physical parameters", NULL);
 
   ierr = PetscOptionsScalar("-mu_1", "Material Property mu_1", NULL,
                             phys->mu_1, &phys->mu_1, NULL); CHKERRQ(ierr);
@@ -118,7 +116,7 @@ PetscErrorCode ProcessPhysics_MR(MPI_Comm comm, Physics_MR phys, Units units) {
   CHKERRQ(ierr);
   units->kilogram = fabs(units->kilogram);
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr); // End of setting Physics
+  PetscOptionsEnd(); // End of setting Physics
 
   // Define derived units
   units->Pascal = units->kilogram / (units->meter * PetscSqr(units->second));

--- a/examples/solids/problems/neo-hookean.c
+++ b/examples/solids/problems/neo-hookean.c
@@ -38,15 +38,14 @@ PetscErrorCode PhysicsSmootherContext_NH(MPI_Comm comm, Ceed ceed,
 
   PetscFunctionBegin;
 
-  ierr = PetscOptionsBegin(comm, NULL,
-                           "Neo-Hookean physical parameters for smoother", NULL);
-  CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Neo-Hookean physical parameters for smoother",
+                    NULL);
 
   ierr = PetscOptionsScalar("-nu_smoother", "Poisson's ratio for smoother",
                             NULL, nu_smoother, &nu_smoother, &nu_flag);
   CHKERRQ(ierr);
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr); // End of setting Physics
+  PetscOptionsEnd(); // End of setting Physics
 
   if (nu_flag) {
     // Copy context
@@ -80,8 +79,7 @@ PetscErrorCode ProcessPhysics_NH(MPI_Comm comm, Physics_NH phys, Units units) {
 
   PetscFunctionBeginUser;
 
-  ierr = PetscOptionsBegin(comm, NULL, "Neo-Hookean physical parameters", NULL);
-  CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL, "Neo-Hookean physical parameters", NULL);
 
   ierr = PetscOptionsScalar("-nu", "Poisson's ratio", NULL, phys->nu, &phys->nu,
                             &nu_flag); CHKERRQ(ierr);
@@ -104,7 +102,7 @@ PetscErrorCode ProcessPhysics_NH(MPI_Comm comm, Physics_NH phys, Units units) {
   CHKERRQ(ierr);
   units->kilogram = fabs(units->kilogram);
 
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr); // End of setting Physics
+  PetscOptionsEnd(); // End of setting Physics
 
   // Check for all required options to be set
   if (!nu_flag) {

--- a/examples/solids/src/cl-options.c
+++ b/examples/solids/src/cl-options.c
@@ -20,9 +20,8 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx) {
 
   PetscFunctionBeginUser;
 
-  ierr = PetscOptionsBegin(comm, NULL,
-                           "Elasticity / Hyperelasticity in PETSc with libCEED",
-                           NULL); CHKERRQ(ierr);
+  PetscOptionsBegin(comm, NULL,
+                    "Elasticity / Hyperelasticity in PETSc with libCEED", NULL);
 
   ierr = PetscOptionsString("-ceed", "CEED resource specifier",
                             NULL, app_ctx->ceed_resource, app_ctx->ceed_resource,
@@ -210,7 +209,7 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx) {
     ierr = PetscViewerASCIIPrintf(app_ctx->energy_viewer, "%f,%e\n", 0., 0.);
     CHKERRQ(ierr);
   }
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr); // End of setting AppCtx
+  PetscOptionsEnd(); // End of setting AppCtx
 
   // Check for all required values set
   if (app_ctx->test_mode) {


### PR DESCRIPTION
I have only updated for PetscOptionsBegin/End no longer returning error codes. Do we also want to include swapping over to PetscCall().