### PR TITLE
examples: use PetscInt_FMT instead of %D

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -259,11 +259,11 @@ int main(int argc, char **argv) {
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (P)       : %d\n"
                        "    Number of 1D Quadrature Points (Q) : %d\n"
-                       "    Global DoFs                        : %D\n"
-                       "    Owned DoFs                         : %D\n"
-                       "    DoFs per node                      : %D\n"
-                       "    Global nodes                       : %D\n"
-                       "    Owned nodes                        : %D\n",
+                       "    Global DoFs                        : %" PetscInt_FMT "\n"
+                       "    Owned DoFs                         : %" PetscInt_FMT "\n"
+                       "    DoFs per node                      : %" PetscInt_FMT "\n"
+                       "    Global nodes                       : %" PetscInt_FMT "\n"
+                       "    Owned nodes                        : %" PetscInt_FMT "\n",
                        num_P, num_Q, glob_dofs, owned_dofs, num_comp_q,
                        glob_nodes, owned_nodes); CHKERRQ(ierr);
   }

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -134,7 +134,7 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx,
         for (PetscInt w = 0; w < bc->num_wall; w++)
           if (bc->slips[c][s] == bc->walls[w])
             SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONG,
-                    "Boundary condition already set on face %D!\n",
+                    "Boundary condition already set on face %" PetscInt_FMT "!\n",
                     bc->walls[w]);
 
   // Inflow BCs

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -202,7 +202,7 @@ PetscErrorCode PostProcess_NS(TS ts, CeedData ceed_data, DM dm,
   ierr = TSGetStepNumber(ts, &steps); CHKERRQ(ierr);
   if (!app_ctx->test_mode) {
     ierr = PetscPrintf(PETSC_COMM_WORLD,
-                       "Time integrator took %D time steps to reach final time %g\n",
+                       "Time integrator took %" PetscInt_FMT " time steps to reach final time %g\n",
                        steps, (double)final_time); CHKERRQ(ierr);
   }
 

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -220,7 +220,8 @@ PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time,
   ierr = DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc); CHKERRQ(ierr);
 
   // Output
-  ierr = PetscSNPrintf(file_path, sizeof file_path, "%s/ns-%03D.vtu",
+  ierr = PetscSNPrintf(file_path, sizeof file_path,
+                       "%s/ns-%03" PetscInt_FMT ".vtu",
                        user->app_ctx->output_dir, step_no + user->app_ctx->cont_steps);
   CHKERRQ(ierr);
   ierr = PetscViewerVTKOpen(PetscObjectComm((PetscObject)Q), file_path,
@@ -241,7 +242,7 @@ PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time,
     ierr = DMGlobalToLocal(user->dm_viz, Q_refined, INSERT_VALUES, Q_refined_loc);
     CHKERRQ(ierr);
     ierr = PetscSNPrintf(file_path_refined, sizeof file_path_refined,
-                         "%s/nsrefined-%03D.vtu", user->app_ctx->output_dir,
+                         "%s/nsrefined-%03" PetscInt_FMT ".vtu", user->app_ctx->output_dir,
                          step_no + user->app_ctx->cont_steps);
     CHKERRQ(ierr);
     ierr = PetscViewerVTKOpen(PetscObjectComm((PetscObject)Q_refined),

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -190,9 +190,9 @@ int main(int argc, char **argv) {
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
-                       "    Global nodes                       : %D\n"
-                       "    DoF per node                       : %D\n"
-                       "    Global DoFs                        : %D\n",
+                       "    Global nodes                       : %" PetscInt_FMT "\n"
+                       "    DoF per node                       : %" PetscInt_FMT "\n"
+                       "    Global DoFs                        : %" PetscInt_FMT "\n",
                        used_resource, CeedMemTypes[mem_type_backend], P, Q,
                        g_size/num_comp_u, num_comp_u, g_size); CHKERRQ(ierr);
   }

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -183,10 +183,10 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm,
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (P)       : %d\n"
                        "    Number of 1D Quadrature Points (Q) : %d\n"
-                       "    Global nodes                       : %D\n"
-                       "    Local Elements                     : %D\n"
-                       "    Owned nodes                        : %D\n"
-                       "    DoF per node                       : %D\n",
+                       "    Global nodes                       : %" PetscInt_FMT "\n"
+                       "    Local Elements                     : %" PetscInt_FMT "\n"
+                       "    Owned nodes                        : %" PetscInt_FMT "\n"
+                       "    DoF per node                       : %" PetscInt_FMT "\n",
                        rp->bp_choice+1, rp->hostname, comm_size,
                        rp->ranks_per_node, vec_type, used_resource,
                        CeedMemTypes[mem_type_backend],
@@ -308,7 +308,7 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm,
                          "  KSP:\n"
                          "    KSP Type                           : %s\n"
                          "    KSP Convergence                    : %s\n"
-                         "    Total KSP Iterations               : %D\n"
+                         "    Total KSP Iterations               : %" PetscInt_FMT "\n"
                          "    Final rnorm                        : %e\n",
                          ksp_type, KSPConvergedReasons[reason], its,
                          (double)rnorm); CHKERRQ(ierr);

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -555,11 +555,14 @@ int main(int argc, char **argv) {
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (P)       : %d\n"
                        "    Number of 1D Quadrature Points (Q) : %d\n"
-                       "    Global nodes                       : %D\n"
-                       "    Process Decomposition              : %D %D %D\n"
-                       "    Local Elements                     : %D = %D %D %D\n"
-                       "    Owned nodes                        : %D = %D %D %D\n"
-                       "    DoF per node                       : %D\n",
+                       "    Global nodes                       : %" PetscInt_FMT "\n"
+                       "    Process Decomposition              : %" PetscInt_FMT
+                       " %" PetscInt_FMT " %" PetscInt_FMT "\n"
+                       "    Local Elements                     : %" PetscInt_FMT
+                       " = %" PetscInt_FMT " %" PetscInt_FMT " %" PetscInt_FMT "\n"
+                       "    Owned nodes                        : %" PetscInt_FMT
+                       " = %" PetscInt_FMT " %" PetscInt_FMT " %" PetscInt_FMT "\n"
+                       "    DoF per node                       : %" PetscInt_FMT "\n",
                        bp_choice+1, vec_type, used_resource,
                        CeedMemTypes[mem_type_backend],
                        P, Q,  gsize/num_comp_u, p[0], p[1], p[2], local_elem,
@@ -903,7 +906,7 @@ int main(int argc, char **argv) {
                          "  KSP:\n"
                          "    KSP Type                           : %s\n"
                          "    KSP Convergence                    : %s\n"
-                         "    Total KSP Iterations               : %D\n"
+                         "    Total KSP Iterations               : %" PetscInt_FMT "\n"
                          "    Final rnorm                        : %e\n",
                          ksp_type, KSPConvergedReasons[reason], its,
                          (double)rnorm); CHKERRQ(ierr);

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
-                       "    Global nodes                       : %D\n",
+                       "    Global nodes                       : %" PetscInt_FMT "\n",
                        bp_choice+1, ceed_resource, CeedMemTypes[mem_type_backend], P, Q,
                        g_size/num_comp_u); CHKERRQ(ierr);
   }
@@ -326,7 +326,7 @@ int main(int argc, char **argv) {
                          "  KSP:\n"
                          "    KSP Type                           : %s\n"
                          "    KSP Convergence                    : %s\n"
-                         "    Total KSP Iterations               : %D\n"
+                         "    Total KSP Iterations               : %" PetscInt_FMT "\n"
                          "    Final rnorm                        : %e\n",
                          ksp_type, KSPConvergedReasons[reason], its,
                          (double)rnorm); CHKERRQ(ierr);

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -112,12 +112,12 @@ int main(int argc, char **argv) {
                             "Epsilon parameter for Kershaw mesh transformation",
                             NULL, eps, &eps, NULL);
   if (eps > 1 || eps <= 0) SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_OUTOFRANGE,
-                                     "-eps %D must be (0,1]", eps);
+                                     "-eps %g must be (0,1]", (double)PetscRealPart(eps));
   degree = test_mode ? 3 : 2;
   ierr = PetscOptionsInt("-degree", "Polynomial degree of tensor product basis",
                          NULL, degree, &degree, NULL); CHKERRQ(ierr);
   if (degree < 1) SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_OUTOFRANGE,
-                            "-degree %D must be at least 1", degree);
+                            "-degree %" PetscInt_FMT " must be at least 1", degree);
   q_extra = bp_options[bp_choice].q_extra;
   ierr = PetscOptionsInt("-q_extra", "Number of extra quadrature points",
                          NULL, q_extra, &q_extra, NULL); CHKERRQ(ierr);
@@ -273,9 +273,9 @@ int main(int argc, char **argv) {
                        "  Mesh:\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
-                       "    Global Nodes                       : %D\n"
-                       "    Owned Nodes                        : %D\n"
-                       "    DoF per node                       : %D\n"
+                       "    Global Nodes                       : %" PetscInt_FMT "\n"
+                       "    Owned Nodes                        : %" PetscInt_FMT "\n"
+                       "    DoF per node                       : %" PetscInt_FMT "\n"
                        "  Multigrid:\n"
                        "    Number of Levels                   : %d\n",
                        bp_choice+1, vec_type, used_resource,
@@ -296,10 +296,10 @@ int main(int argc, char **argv) {
   for (int i=0; i<num_levels; i++) {
     // Print level information
     if (!test_mode && (i == 0 || i == fine_level)) {
-      ierr = PetscPrintf(comm,"    Level %D (%s):\n"
+      ierr = PetscPrintf(comm,"    Level %" PetscInt_FMT " (%s):\n"
                          "      Number of 1D Basis Nodes (p)     : %d\n"
-                         "      Global Nodes                     : %D\n"
-                         "      Owned Nodes                      : %D\n",
+                         "      Global Nodes                     : %" PetscInt_FMT "\n"
+                         "      Owned Nodes                      : %" PetscInt_FMT "\n",
                          i, (i? "fine" : "coarse"), level_degrees[i] + 1,
                          g_size[i]/num_comp_u, l_size[i]/num_comp_u); CHKERRQ(ierr);
     }
@@ -562,7 +562,7 @@ int main(int argc, char **argv) {
                          "  KSP:\n"
                          "    KSP Type                           : %s\n"
                          "    KSP Convergence                    : %s\n"
-                         "    Total KSP Iterations               : %D\n"
+                         "    Total KSP Iterations               : %" PetscInt_FMT "\n"
                          "    Final rnorm                        : %e\n",
                          ksp_type, KSPConvergedReasons[reason], its,
                          (double)rnorm); CHKERRQ(ierr);

--- a/examples/solids/elasticity.c
+++ b/examples/solids/elasticity.c
@@ -388,9 +388,9 @@ int main(int argc, char **argv) {
                        "    File                               : %s\n"
                        "    Number of 1D Basis Nodes (p)       : %d\n"
                        "    Number of 1D Quadrature Points (q) : %d\n"
-                       "    Global nodes                       : %D\n"
-                       "    Owned nodes                        : %D\n"
-                       "    DoF per node                       : %D\n"
+                       "    Global nodes                       : %" PetscInt_FMT "\n"
+                       "    Owned nodes                        : %" PetscInt_FMT "\n"
+                       "    DoF per node                       : %" PetscInt_FMT "\n"
                        "  Multigrid:\n"
                        "    Type                               : %s\n"
                        "    Number of Levels                   : %d\n",
@@ -412,10 +412,10 @@ int main(int argc, char **argv) {
       for (PetscInt i = 0; i < 2; i++) {
         CeedInt level = i ? fine_level : 0;
         ierr = PetscPrintf(comm,
-                           "    Level %D (%s):\n"
+                           "    Level %" PetscInt_FMT " (%s):\n"
                            "      Number of 1D Basis Nodes (p)     : %d\n"
-                           "      Global Nodes                     : %D\n"
-                           "      Owned Nodes                      : %D\n",
+                           "      Global Nodes                     : %" PetscInt_FMT "\n"
+                           "      Owned Nodes                      : %" PetscInt_FMT "\n",
                            level, i ? "fine" : "coarse",
                            app_ctx->level_degrees[level] + 1,
                            U_g_size[level]/num_comp_u, U_l_size[level]/num_comp_u);
@@ -763,7 +763,7 @@ int main(int argc, char **argv) {
                        "    SNES Convergence                   : %s\n"
                        "    Number of Load Increments          : %d\n"
                        "    Completed Load Increments          : %d\n"
-                       "    Total SNES Iterations              : %D\n"
+                       "    Total SNES Iterations              : %" PetscInt_FMT "\n"
                        "    Final rnorm                        : %e\n",
                        snes_type, SNESConvergedReasons[reason],
                        app_ctx->num_increments, increment - 1,
@@ -777,7 +777,7 @@ int main(int argc, char **argv) {
     ierr = PetscPrintf(comm,
                        "  Linear Solver:\n"
                        "    KSP Type                           : %s\n"
-                       "    Total KSP Iterations               : %D\n",
+                       "    Total KSP Iterations               : %" PetscInt_FMT "\n",
                        ksp_type, ksp_its); CHKERRQ(ierr);
 
     // -- PC

--- a/examples/solids/src/misc.c
+++ b/examples/solids/src/misc.c
@@ -131,7 +131,7 @@ PetscErrorCode ViewSolution(MPI_Comm comm, AppCtx app_ctx, Vec U,
 
   // Build file name
   ierr = PetscSNPrintf(output_filename, sizeof output_filename,
-                       "%s/solution-%03D.vtu", app_ctx->output_dir,
+                       "%s/solution-%03" PetscInt_FMT ".vtu", app_ctx->output_dir,
                        increment); CHKERRQ(ierr);
 
   // Increment sequence


### PR DESCRIPTION
This fixes many warnings now that PETSc uses printf format string
attribute checkers.