### PR TITLE
Move CeedQFunctionContextGetFieldLabel to backend interface

### DIFF
--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -255,6 +255,10 @@ CEED_EXTERN int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
 CEED_EXTERN int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
                                    CeedContextFieldLabel field_label,
                                    CeedContextFieldType field_type, void *value);
+CEED_EXTERN int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
+    CeedContextFieldLabel field_label, double *values);
+CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
+    CeedContextFieldLabel field_label, int *values);
 CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -250,6 +250,8 @@ CEED_EXTERN int CeedQFunctionContextGetBackendData(CeedQFunctionContext ctx,
     void *data);
 CEED_EXTERN int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx,
     void *data);
+CEED_EXTERN int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
+    const char *field_name, CeedContextFieldLabel *field_label);
 CEED_EXTERN int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
                                    CeedContextFieldLabel field_label,
                                    CeedContextFieldType field_type, void *value);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -677,8 +677,6 @@ CEED_EXTERN int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx,
 CEED_EXTERN int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx,
     const char *field_name, size_t field_offset, size_t num_values,
     const char *field_description);
-CEED_EXTERN int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
-    const char *field_name, CeedContextFieldLabel *field_label);
 CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
     const CeedContextFieldLabel **field_labels, CeedInt *num_fields);
 CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label,

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -682,10 +682,6 @@ CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
 CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label,
     const char **field_name, const char **field_description, size_t *num_values,
     CeedContextFieldType *field_type);
-CEED_EXTERN int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
-    CeedContextFieldLabel field_label, double *values);
-CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
-    CeedContextFieldLabel field_label, int *values);
 CEED_EXTERN int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx,
     size_t *ctx_size);
 CEED_EXTERN int CeedQFunctionContextView(CeedQFunctionContext ctx,

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -231,7 +231,7 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref User
+  @ref Backend
 **/
 int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
                                       const char *field_name,
@@ -261,7 +261,7 @@ int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref User
+  @ref Backend
 **/
 int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
                                    CeedContextFieldLabel field_label,
@@ -296,7 +296,7 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref User
+  @ref Backend
 **/
 int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
                                   CeedContextFieldLabel field_label, double *values) {
@@ -324,7 +324,7 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref User
+  @ref Backend
 **/
 int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
                                  CeedContextFieldLabel field_label, int *values) {

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -222,6 +222,36 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
+  @brief Get label for a registered QFunctionContext field, or `NULL` if no
+           field has been registered with this `field_name`
+
+  @param[in] ctx           CeedQFunctionContext
+  @param[in] field_name    Name of field to retrieve label
+  @param[out] field_label  Variable to field label
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
+                                      const char *field_name,
+                                      CeedContextFieldLabel *field_label) {
+  int ierr;
+
+  CeedInt field_index;
+  ierr = CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index);
+  CeedChk(ierr);
+
+  if (field_index != -1) {
+    *field_label = ctx->field_labels[field_index];
+  } else {
+    *field_label = NULL;
+  }
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Set QFunctionContext field
 
   @param ctx         CeedQFunctionContext
@@ -650,36 +680,6 @@ int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx,
     const CeedContextFieldLabel **field_labels, CeedInt *num_fields) {
   *field_labels = ctx->field_labels;
   *num_fields = ctx->num_fields;
-  return CEED_ERROR_SUCCESS;
-}
-
-/**
-  @brief Get label for a registered QFunctionContext field, or `NULL` if no
-           field has been registered with this `field_name`
-
-  @param[in] ctx           CeedQFunctionContext
-  @param[in] field_name    Name of field to retrieve label
-  @param[out] field_label  Variable to field label
-
-  @return An error code: 0 - success, otherwise - failure
-
-  @ref User
-**/
-int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx,
-                                      const char *field_name,
-                                      CeedContextFieldLabel *field_label) {
-  int ierr;
-
-  CeedInt field_index;
-  ierr = CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index);
-  CeedChk(ierr);
-
-  if (field_index != -1) {
-    *field_label = ctx->field_labels[field_index];
-  } else {
-    *field_label = NULL;
-  }
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -288,6 +288,62 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx,
 }
 
 /**
+  @brief Set QFunctionContext field holding a double precision value
+
+  @param ctx         CeedQFunctionContext
+  @param field_label Label for field to register
+  @param values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
+                                  CeedContextFieldLabel field_label, double *values) {
+  int ierr;
+
+  if (!field_label)
+    // LCOV_EXCL_START
+    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
+                     "Invalid field label");
+  // LCOV_EXCL_STOP
+
+  ierr = CeedQFunctionContextSetGeneric(ctx, field_label,
+                                        CEED_CONTEXT_FIELD_DOUBLE,
+                                        values); CeedChk(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set QFunctionContext field holding an int32 value
+
+  @param ctx         CeedQFunctionContext
+  @param field_label Label for field to register
+  @param values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
+                                 CeedContextFieldLabel field_label, int *values) {
+  int ierr;
+
+  if (!field_label)
+    // LCOV_EXCL_START
+    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
+                     "Invalid field label");
+  // LCOV_EXCL_STOP
+
+  ierr = CeedQFunctionContextSetGeneric(ctx, field_label,
+                                        CEED_CONTEXT_FIELD_INT32,
+                                        values); CeedChk(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Increment the reference counter for a CeedQFunctionContext
 
   @param ctx  CeedQFunctionContext to increment the reference counter
@@ -705,62 +761,6 @@ int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label,
   if (field_description) *field_description = label->description;
   if (num_values) *num_values = label->num_values;
   if (field_type) *field_type = label->type;
-  return CEED_ERROR_SUCCESS;
-}
-
-/**
-  @brief Set QFunctionContext field holding a double precision value
-
-  @param ctx         CeedQFunctionContext
-  @param field_label Label for field to register
-  @param values      Values to set
-
-  @return An error code: 0 - success, otherwise - failure
-
-  @ref User
-**/
-int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
-                                  CeedContextFieldLabel field_label, double *values) {
-  int ierr;
-
-  if (!field_label)
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
-                     "Invalid field label");
-  // LCOV_EXCL_STOP
-
-  ierr = CeedQFunctionContextSetGeneric(ctx, field_label,
-                                        CEED_CONTEXT_FIELD_DOUBLE,
-                                        values); CeedChk(ierr);
-
-  return CEED_ERROR_SUCCESS;
-}
-
-/**
-  @brief Set QFunctionContext field holding an int32 value
-
-  @param ctx         CeedQFunctionContext
-  @param field_label Label for field to register
-  @param values      Values to set
-
-  @return An error code: 0 - success, otherwise - failure
-
-  @ref User
-**/
-int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
-                                 CeedContextFieldLabel field_label, int *values) {
-  int ierr;
-
-  if (!field_label)
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED,
-                     "Invalid field label");
-  // LCOV_EXCL_STOP
-
-  ierr = CeedQFunctionContextSetGeneric(ctx, field_label,
-                                        CEED_CONTEXT_FIELD_INT32,
-                                        values); CeedChk(ierr);
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/tests/t407-qfunction.c
+++ b/tests/t407-qfunction.c
@@ -2,6 +2,7 @@
 /// Test registering and setting QFunctionContext fields
 /// \test Test registering and setting QFunctionContext fields
 #include <ceed.h>
+#include <ceed/backend.h>
 #include <stddef.h>
 #include <string.h>
 


### PR DESCRIPTION
With the addition of `CeedOperatorContextGetFieldLabel()`, users shouldn't need to use `CeedQFunctionContextGetFieldLabel()`. Same with `CeedQFunctionContextSet*()`. I left `CeedQFunctionContextGetAllFieldLabels()` and `CeedContextFieldLabelGetDescription()` as those should still be useful to general users who want to make pretty output about a QFunctionContext.