### PR TITLE
examples/fluids: Set euler_context->curr_time via context fields

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -149,11 +149,7 @@ int main(int argc, char **argv) {
   // Set up libCEED
   // ---------------------------------------------------------------------------
   // -- Set up libCEED objects
-  ierr = SetupLibceed(ceed, ceed_data, dm, user, app_ctx, problem, bc);
-  CHKERRQ(ierr);
-
-  // -- Set up context for QFunctions
-  ierr = problem->setup_ctx(ceed, ceed_data, app_ctx, setup_ctx, phys_ctx);
+  ierr = SetupLibceed(ceed, ceed_data, dm, user, app_ctx, problem, bc, setup_ctx);
   CHKERRQ(ierr);
 
   // ---------------------------------------------------------------------------

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -282,6 +282,7 @@ struct Physics_private {
   PetscBool                implicit;
   PetscBool                has_curr_time;
   PetscBool                has_neumann;
+  CeedContextFieldLabel    solution_time_label;
 };
 
 // Problem specific data
@@ -384,7 +385,7 @@ PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc,
                                        CeedOperator *op_apply);
 
 PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user,
-                            AppCtx app_ctx, ProblemData *problem, SimpleBC bc);
+                            AppCtx app_ctx, ProblemData *problem, SimpleBC bc, SetupContext setup_ctx);
 
 // -----------------------------------------------------------------------------
 // Time-stepping functions

--- a/examples/fluids/problems/eulervortex.c
+++ b/examples/fluids/problems/eulervortex.c
@@ -180,6 +180,9 @@ PetscErrorCode SetupContext_EULER_VORTEX(Ceed ceed, CeedData ceed_data,
   CeedQFunctionContextSetData(ceed_data->euler_context, CEED_MEM_HOST,
                               CEED_USE_POINTER,
                               sizeof(*phys->euler_ctx), phys->euler_ctx);
+  CeedQFunctionContextRegisterDouble(ceed_data->euler_context, "solution time",
+                                     offsetof(struct EulerContext_, curr_time), 1, "Phyiscal time of the solution");
+
   if (ceed_data->qf_ics)
     CeedQFunctionSetContext(ceed_data->qf_ics, ceed_data->euler_context);
   if (ceed_data->qf_rhs_vol)

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -205,11 +205,16 @@ PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc,
       CeedOperatorDestroy(&op_apply_outflow);
     }
   }
+
+  // ----- Get Context Labels for Operator
+  CeedOperatorContextGetFieldLabel(*op_apply, "solution time",
+                                   &phys->solution_time_label);
+
   PetscFunctionReturn(0);
 }
 
 PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user,
-                            AppCtx app_ctx, ProblemData *problem, SimpleBC bc) {
+                            AppCtx app_ctx, ProblemData *problem, SimpleBC bc, SetupContext setup_ctx) {
   PetscErrorCode ierr;
   PetscFunctionBeginUser;
 
@@ -451,6 +456,10 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user,
   // -- Apply CEED Operator for the geometric data
   CeedOperatorApply(ceed_data->op_setup_vol, ceed_data->x_coord,
                     ceed_data->q_data, CEED_REQUEST_IMMEDIATE);
+
+  // -- Set up context for QFunctions
+  ierr = problem->setup_ctx(ceed, ceed_data, app_ctx, setup_ctx, user->phys);
+  CHKERRQ(ierr);
 
   // -- Create and apply CEED Composite Operator for the entire domain
   if (!user->phys->implicit) { // RHS

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -89,8 +89,9 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   PetscErrorCode ierr;
   PetscFunctionBeginUser;
 
-  // Update EulerContext
-  if (user->phys->has_curr_time) user->phys->euler_ctx->curr_time = t;
+  // Update solution time
+  if (user->phys->solution_time_label)
+    CeedOperatorContextSetDouble(user->op_rhs, user->phys->solution_time_label, &t);
 
   // Get local vectors
   ierr = DMGetLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
@@ -146,8 +147,10 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G,
   PetscErrorCode    ierr;
   PetscFunctionBeginUser;
 
-  // Update EulerContext
-  if (user->phys->has_curr_time) user->phys->euler_ctx->curr_time = t;
+  // Update solution time
+  if (user->phys->solution_time_label)
+    CeedOperatorContextSetDouble(user->op_ifunction,
+                                 user->phys->solution_time_label, &t);
 
   // Get local vectors
   ierr = DMGetLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);


### PR DESCRIPTION
Set the `curr_time` for the euler context via `CeedContextFieldLabel ` rather than explicitly editing the euler context.