### PR TITLE
Use backend functions for SyncArray in CUDA and HIP

### DIFF
--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -843,6 +843,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedVector, SetArray),
     CEED_FTABLE_ENTRY(CeedVector, TakeArray),
     CEED_FTABLE_ENTRY(CeedVector, SetValue),
+    CEED_FTABLE_ENTRY(CeedVector, SyncArray),
     CEED_FTABLE_ENTRY(CeedVector, GetArray),
     CEED_FTABLE_ENTRY(CeedVector, GetArrayRead),
     CEED_FTABLE_ENTRY(CeedVector, GetArrayWrite),


### PR DESCRIPTION
Previously, the `SyncArray` interface function never used the backend implementations, and the sync functions inside the cuda-ref and hip-ref backends were only called directly by other backend functions.

(As mentioned in #948)