### PR TITLE
Cleaner density inflow

### DIFF
--- a/examples/fluids/blasius.yaml
+++ b/examples/fluids/blasius.yaml
@@ -27,9 +27,9 @@ Ctau_t: 1
 #Ctau_v: 36,60,128 is what PHASTA has for p=1,2, 3
 ## linear Settings:
 Ctau_v: 36
-Ctau_C: 0.5
-Ctau_M: 0.5
-Ctau_E: 0.5
+Ctau_C: 0.25
+Ctau_M: 0.25
+Ctau_E: 0.125
 ## Quadratic Settings:
 #Ctau_v: 60
 #Ctau_C: 0.125

--- a/examples/fluids/blasius.yaml
+++ b/examples/fluids/blasius.yaml
@@ -4,7 +4,12 @@ implicit: true
 ts:
   adapt_type: 'none'
   type: 'beuler'
-  dt: 6.4e-5
+  dt: 0.2e-5
+  max_time: 1.0e-3
+  output_freq: 10
+
+#snes_max_it: 4 
+#snes_convergence_test: skip
 
 ## Linear Settings:
 degree: 1
@@ -20,10 +25,17 @@ nDelta: 45
 stab: 'supg'
 Ctau_t: 1
 #Ctau_v: 36,60,128 is what PHASTA has for p=1,2, 3
+## linear Settings:
 Ctau_v: 36
 Ctau_C: 0.5
 Ctau_M: 0.5
 Ctau_E: 0.5
+## Quadratic Settings:
+#Ctau_v: 60
+#Ctau_C: 0.125
+#Ctau_M: 0.125
+#Ctau_E: 0.125
+
 q_extra: 0
 
 dm_plex_box_lower: 0,0,0

--- a/examples/fluids/blasius.yaml
+++ b/examples/fluids/blasius.yaml
@@ -6,7 +6,7 @@ ts:
   type: 'beuler'
   dt: 0.2e-5
   max_time: 1.0e-3
-  output_freq: 10
+output_freq: 10
 
 #snes_max_it: 4 
 #snes_convergence_test: skip

--- a/examples/fluids/blasius.yaml
+++ b/examples/fluids/blasius.yaml
@@ -4,7 +4,7 @@ implicit: true
 ts:
   adapt_type: 'none'
   type: 'beuler'
-  dt: 5.e-8
+  dt: 6.4e-5
 
 ## Linear Settings:
 degree: 1
@@ -21,14 +21,15 @@ stab: 'supg'
 Ctau_t: 1
 #Ctau_v: 36,60,128 is what PHASTA has for p=1,2, 3
 Ctau_v: 36
-Ctau_C: 0.125
-Ctau_M: 1.0
-Ctau_E: 0.125
+Ctau_C: 0.5
+Ctau_M: 0.5
+Ctau_E: 0.5
 q_extra: 0
 
 dm_plex_box_lower: 0,0,0
 dm_plex_box_upper: 4.2e-3,4.2e-3,5.e-5
 dm_plex_dim: 3
+# Faces labeled 1=z- 2=z+ 3=y- 4=y+ 5=x+ 6=x-
 bc_slip_z: 1,2
 bc_wall: 3
 wall_comps: 1,2,3

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -299,7 +299,7 @@ struct BlasiusContext_ {
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
-  CeedInt weakT;    // !< flag to set Temperature at inflow
+  CeedInt weakT;        // !< flag to set Temperature at inflow
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -299,6 +299,7 @@ struct BlasiusContext_ {
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
+  CeedInt weakT;    // !< flag to set Temperature at inflow
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -295,11 +295,11 @@ struct ChannelContext_ {
 typedef struct BlasiusContext_ *BlasiusContext;
 struct BlasiusContext_ {
   bool       implicit;  // !< Using implicit timesteping or not
+  bool       weakT;     // !< flag to set Temperature at inflow
   CeedScalar delta0;    // !< Boundary layer height at inflow
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
-  CeedInt weakT;        // !< flag to set Temperature at inflow
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -122,11 +122,11 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *setup_ctx,
   PetscReal  top_angle     = 5;    // degrees
   CeedScalar theta0        = 288.; // K
   CeedScalar P0            = 1.01e5; // Pa
-  CeedInt    weakT         = 0; // if not changed to 1 weak density will be chosen
+  PetscBool  weakT         = PETSC_FALSE; // weak density or temperature
 
   PetscOptionsBegin(comm, NULL, "Options for CHANNEL problem", NULL);
-  ierr = PetscOptionsInt("-weakT", "Change from rho weak to T weak at inflow",
-                            NULL, weakT, &weakT, NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsBool("-weakT", "Change from rho weak to T weak at inflow",
+                          NULL, weakT, &weakT, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsScalar("-Uinf", "Velocity at boundary layer edge",
                             NULL, Uinf, &Uinf, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsScalar("-delta0", "Boundary layer height at inflow",
@@ -162,7 +162,7 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *setup_ctx,
   ierr = modifyMesh(dm, problem->dim, growth, Ndelta, refine_height, top_angle);
   CHKERRQ(ierr);
 
-  user->phys->blasius_ctx->weakT     = weakT;
+  user->phys->blasius_ctx->weakT     = !!weakT;
   user->phys->blasius_ctx->Uinf      = Uinf;
   user->phys->blasius_ctx->delta0    = delta0;
   user->phys->blasius_ctx->theta0    = theta0;

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -20,6 +20,7 @@ struct BlasiusContext_ {
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
+  CeedInt weakT;    // !< flag to weakly set Temperature at inflow if not set weak rho instead
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif
@@ -121,8 +122,11 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *setup_ctx,
   PetscReal  top_angle     = 5;    // degrees
   CeedScalar theta0        = 288.; // K
   CeedScalar P0            = 1.01e5; // Pa
+  CeedInt    weakT         = 0; // if not changed to 1 weak density will be chosen
 
   PetscOptionsBegin(comm, NULL, "Options for CHANNEL problem", NULL);
+  ierr = PetscOptionsInt("-weakT", "Change from rho weak to T weak at inflow",
+                            NULL, weakT, &weakT, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsScalar("-Uinf", "Velocity at boundary layer edge",
                             NULL, Uinf, &Uinf, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsScalar("-delta0", "Boundary layer height at inflow",
@@ -158,6 +162,7 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *setup_ctx,
   ierr = modifyMesh(dm, problem->dim, growth, Ndelta, refine_height, top_angle);
   CHKERRQ(ierr);
 
+  user->phys->blasius_ctx->weakT     = weakT;
   user->phys->blasius_ctx->Uinf      = Uinf;
   user->phys->blasius_ctx->delta0    = delta0;
   user->phys->blasius_ctx->theta0    = theta0;

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -20,7 +20,7 @@ struct BlasiusContext_ {
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
-  CeedInt weakT;    // !< flag to weakly set Temperature at inflow if not set weak rho instead
+  CeedInt weakT;        // !< flag to weakly set Temperature at inflow if not set weak rho instead
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -25,7 +25,7 @@ struct BlasiusContext_ {
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
-  CeedInt weakT;    // !< flag to set Temperature weakly at inflow
+  CeedInt weakT;        // !< flag to set Temperature weakly at inflow
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif
@@ -184,6 +184,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
   const CeedScalar cv     = context->newtonian_ctx.cv;
   const CeedScalar cp     = context->newtonian_ctx.cp;
   const CeedScalar Rd     = cp - cv;
+  const CeedScalar gamma  = cp/cv;
 
   const CeedScalar theta0 = context->theta0;
   const CeedScalar P0     = context->P0;
@@ -203,7 +204,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
     // We can effect this by swapping the sign on this weight
     const CeedScalar wdetJb  = (implicit ? -1. : 1.) * q_data_sur[0][i];
 
-    // Calcualte prescribed inflow values
+    // Calculate inflow values
     const CeedScalar x[3] = {X[0][i], X[1][i], X[2][i]};
     CeedScalar velocity[3] = {0.};
     CeedScalar t12;
@@ -217,7 +218,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
       rho = q[0][i];
       // Temperature is being set weakly (theta0) and for constant cv this sets E_internal
       E_internal = rho * cv * theta0;
-      // Find pressure using state inside the domain
+      // Find pressure using 
       P=rho*Rd*theta0; // interior rho with exterior T
       E_kinetic = .5 * rho * (velocity[0]*velocity[0] +
                               velocity[1]*velocity[1] +
@@ -324,7 +325,7 @@ CEED_QFUNCTION(Blasius_Outflow)(void *ctx, CeedInt Q,
     const CeedScalar u_normal  = norm[0]*u[0] + norm[1]*u[1] +
                                  norm[2]*u[2]; // Normal velocity
 
-    // Calculate outflow traction values
+    // Calculate prescribed outflow traction values
     const CeedScalar x[3] = {X[0][i], X[1][i], X[2][i]};
     CeedScalar velocity[3] = {0.};
     CeedScalar t12;

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -203,6 +203,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
 
     // Calcualte prescribed inflow values
     const CeedScalar x[3] = {X[0][i], X[1][i], X[2][i]};
+//  Try fixing rho weakly on the inflow to a value  consistent with theta0 and P0
 
     // Find pressure using state inside the domain
     const CeedScalar rho = q[0][i];
@@ -313,7 +314,7 @@ CEED_QFUNCTION(Blasius_Outflow)(void *ctx, CeedInt Q,
     const CeedScalar u_normal  = norm[0]*u[0] + norm[1]*u[1] +
                                  norm[2]*u[2]; // Normal velocity
 
-    // Calculate prescribed outflow traction values
+    // Calculate outflow traction values
     const CeedScalar x[3] = {X[0][i], X[1][i], X[2][i]};
     CeedScalar velocity[3] = {0.};
     CeedScalar t12;

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -25,6 +25,7 @@ struct BlasiusContext_ {
   CeedScalar Uinf;      // !< Velocity at boundary layer edge
   CeedScalar P0;        // !< Pressure at outflow
   CeedScalar theta0;    // !< Temperature at inflow
+  CeedInt weakT;    // !< flag to set Temperature weakly at inflow
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
 #endif
@@ -188,6 +189,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
   const CeedScalar P0     = context->P0;
   const CeedScalar delta0 = context->delta0;
   const CeedScalar Uinf   = context->Uinf;
+  const CeedInt weakT     = context->weakT;
   const CeedScalar rho_0  = P0 / (Rd * theta0);
   const CeedScalar x0     = Uinf*rho_0 / (mu*25/ (delta0*delta0) );
 
@@ -203,25 +205,33 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
 
     // Calcualte prescribed inflow values
     const CeedScalar x[3] = {X[0][i], X[1][i], X[2][i]};
-//  Try fixing rho weakly on the inflow to a value  consistent with theta0 and P0
-
-    // Find pressure using state inside the domain
-    const CeedScalar rho = q[0][i];
-    const CeedScalar P = rho * Rd * theta0; // interior rho with exterior T
-
-    // Find inflow state using calculated P and prescribed velocity, theta0
-    const CeedScalar e_internal = cv * theta0;
-
     CeedScalar velocity[3] = {0.};
     CeedScalar t12;
     BlasiusSolution(x[1], Uinf, x0, x[0], rho_0, &velocity[0], &velocity[1],
                     &t12, &context->newtonian_ctx);
 
-    const CeedScalar E_kinetic = .5 * rho * (velocity[0]*velocity[0] +
-                                 velocity[1]*velocity[1] +
-                                 velocity[2]*velocity[2]);
-    const CeedScalar E = rho * e_internal + E_kinetic;  // use interior rho
-    // from T       and  u exterior
+    // enabling user to choose between weak T and weak rho inflow
+    CeedScalar rho,E_internal, P, E_kinetic;
+    if(weakT==1) {
+      // rho should be from the current solution
+      rho = q[0][i];
+      // Temperature is being set weakly (theta0) and for constant cv this sets E_internal
+      E_internal = rho * cv * theta0;
+      // Find pressure using state inside the domain
+      P=rho*Rd*theta0; // interior rho with exterior T
+      E_kinetic = .5 * rho * (velocity[0]*velocity[0] +
+                              velocity[1]*velocity[1] +
+                              velocity[2]*velocity[2]);
+    } else {
+      //  Fixing rho weakly on the inflow to a value  consistent with theta0 and P0
+      rho =  rho_0;
+      E_kinetic = .5 * rho * (velocity[0]*velocity[0] +
+                              velocity[1]*velocity[1] +
+                              velocity[2]*velocity[2]);
+      E_internal = q[4][i] - E_kinetic; // uses set rho and u but E from solution
+      P = E_internal * (gamma - 1.);
+    }
+    const CeedScalar E = E_internal + E_kinetic;  
     // ---- Normal vect
     const CeedScalar norm[3] = {q_data_sur[1][i],
                                 q_data_sur[2][i],

--- a/examples/fluids/qfunctions/newtonian.h
+++ b/examples/fluids/qfunctions/newtonian.h
@@ -120,8 +120,7 @@ CEED_QFUNCTION_HELPER void computeFluxJacobian_NSp(CeedScalar dF[3][5][5],
 //        [row][col] of A_i
       dF[i][j+1][0] = drdP * u[i] * u[j] + ((i==j) ? 1. : 0.); // F^{{m_j} wrt p
       for (CeedInt k=0; k<3; k++) { // k counts the wrt vel_k
-        // this loop handles middle columns for all 5 rows
-        dF[i][0][k+1]   =  ((i==k) ? rho  : 0.);   // F^c wrt vel_k
+        dF[i][0][k+1]   =  ((i==k) ? rho  : 0.);   // F^c wrt u_k
         dF[i][j+1][k+1] = (((j==k) ? u[i] : 0.) +  // F^m_j wrt u_k
                            ((i==k) ? u[j] : 0.) ) * rho;
         dF[i][4][k+1]   = rho * u[i] * u[k]

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -78,11 +78,6 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx,
                          "Regular refinement levels for visualization",
                          NULL, app_ctx->viz_refine, &app_ctx->viz_refine, NULL); CHKERRQ(ierr);
 
-//  app_ctx->weakT = 0;
-//  ierr = PetscOptionsInt("-weakT",
-//                         "weak inflow switched from rho (default) to T",
-//                         NULL, app_ctx->weakT, &app_ctx->weakT, NULL); CHKERRQ(ierr);
-
   app_ctx->output_freq = 10;
   ierr = PetscOptionsInt("-output_freq",
                          "Frequency of output, in number of steps",

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -78,6 +78,11 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx,
                          "Regular refinement levels for visualization",
                          NULL, app_ctx->viz_refine, &app_ctx->viz_refine, NULL); CHKERRQ(ierr);
 
+//  app_ctx->weakT = 0;
+//  ierr = PetscOptionsInt("-weakT",
+//                         "weak inflow switched from rho (default) to T",
+//                         NULL, app_ctx->weakT, &app_ctx->weakT, NULL); CHKERRQ(ierr);
+
   app_ctx->output_freq = 10;
   ierr = PetscOptionsInt("-output_freq",
                          "Frequency of output, in number of steps",


### PR DESCRIPTION
This pull request adds the option to choose between two variables, density or temperature, set weakly on the inflow.  So far, density  is far more stable than temperature which tends to produce oscillations for both SUPG and Galkerkin for p=1.  Without setting any flags, density will be chosen but with the flag -weakT it will be replaced by weak temperature.  Both options are subsonic inflow boundary conditions meaning one of the two will be applied with the inflow velocity leaving the last variable free to be determined by the solution  as is consistent with 4 incoming characteristics.  Note that no change was made to the application of weak traction at the inlet and this is still also applied at both the inflow and the outflow (where weak pressure is also applied).