### PR TITLE
op - include num_elem and num_qpts in view

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -8,6 +8,8 @@ On this page we provide a summary of the main API changes, new features and exam
 
 ### Interface changes
 
+- Added {c:func}`CeedOperatorSetName` for more readable {c:func}`CeedOperatorView` output.
+
 (v0-10-1)=
 
 ## v0.10.1 (Apr 11, 2022)

--- a/examples/rust/ex1-volume/src/main.rs
+++ b/examples/rust/ex1-volume/src/main.rs
@@ -178,6 +178,7 @@ fn example_1(options: opt::Opt) -> libceed::Result<()> {
     // Operator that build the quadrature data for the mass operator
     let op_build = ceed
         .operator(qf_build, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("build qdata")?
         .field("dx", &restr_mesh, &basis_mesh, VectorOpt::Active)?
         .field(
             "weights",
@@ -226,6 +227,7 @@ fn example_1(options: opt::Opt) -> libceed::Result<()> {
     // Mass Operator
     let op_mass = ceed
         .operator(qf_mass, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("mass")?
         .field("u", &restr_solution, &basis_solution, VectorOpt::Active)?
         .field("qdata", &restr_qdata, BasisOpt::Collocated, &qdata)?
         .field("v", &restr_solution, &basis_solution, VectorOpt::Active)?

--- a/examples/rust/ex2-surface/src/main.rs
+++ b/examples/rust/ex2-surface/src/main.rs
@@ -220,6 +220,7 @@ fn example_2(options: opt::Opt) -> libceed::Result<()> {
     // Operator that build the quadrature data for the diff operator
     let op_build = ceed
         .operator(qf_build, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("build qdata")?
         .field("dx", &restr_mesh, &basis_mesh, VectorOpt::Active)?
         .field(
             "weights",
@@ -305,6 +306,7 @@ fn example_2(options: opt::Opt) -> libceed::Result<()> {
     // Diff Operator
     let op_diff = ceed
         .operator(qf_diff, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("Poisson")?
         .field("du", &restr_solution, &basis_solution, VectorOpt::Active)?
         .field("qdata", &restr_qdata, BasisOpt::Collocated, &qdata)?
         .field("dv", &restr_solution, &basis_solution, VectorOpt::Active)?

--- a/examples/rust/ex3-vector-volume/src/main.rs
+++ b/examples/rust/ex3-vector-volume/src/main.rs
@@ -187,6 +187,7 @@ fn example_3(options: opt::Opt) -> libceed::Result<()> {
     // Operator that build the quadrature data for the mass operator
     let op_build = ceed
         .operator(qf_build, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("build qdata")?
         .field("dx", &restr_mesh, &basis_mesh, VectorOpt::Active)?
         .field(
             "weights",
@@ -239,6 +240,7 @@ fn example_3(options: opt::Opt) -> libceed::Result<()> {
     // Mass Operator
     let op_mass = ceed
         .operator(qf_mass, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("mass")?
         .field("u", &restr_solution, &basis_solution, VectorOpt::Active)?
         .field("qdata", &restr_qdata, BasisOpt::Collocated, &qdata)?
         .field("v", &restr_solution, &basis_solution, VectorOpt::Active)?

--- a/examples/rust/ex4-vector-surface/src/main.rs
+++ b/examples/rust/ex4-vector-surface/src/main.rs
@@ -227,6 +227,7 @@ fn example_4(options: opt::Opt) -> libceed::Result<()> {
     // Operator that build the quadrature data for the diff operator
     let op_build = ceed
         .operator(qf_build, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("build qdata")?
         .field("dx", &restr_mesh, &basis_mesh, VectorOpt::Active)?
         .field(
             "weights",
@@ -326,6 +327,7 @@ fn example_4(options: opt::Opt) -> libceed::Result<()> {
     // Diff Operator
     let op_diff = ceed
         .operator(qf_diff, QFunctionOpt::None, QFunctionOpt::None)?
+        .name("Poisson")?
         .field("du", &restr_solution, &basis_solution, VectorOpt::Active)?
         .field("qdata", &restr_qdata, BasisOpt::Collocated, &qdata)?
         .field("dv", &restr_solution, &basis_solution, VectorOpt::Active)?

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -373,6 +373,7 @@ struct CeedOperator_private {
   CeedQFunction qf;
   CeedQFunction dqf;
   CeedQFunction dqfT;
+  const char *name;
   bool is_immutable;
   bool is_interface_setup;
   bool is_backend_setup;

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -747,6 +747,7 @@ CEED_EXTERN int CeedOperatorMultigridLevelCreateH1(CeedOperator op_fine,
 CEED_EXTERN int CeedOperatorCreateFDMElementInverse(CeedOperator op,
     CeedOperator *fdm_inv, CeedRequest *request);
 CEED_EXTERN int CeedOperatorSetNumQuadraturePoints(CeedOperator op, CeedInt num_qpts);
+CEED_EXTERN int CeedOperatorSetName(CeedOperator op, const char *name);
 CEED_EXTERN int CeedOperatorView(CeedOperator op, FILE *stream);
 CEED_EXTERN int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem);

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -1074,8 +1074,8 @@ CEED_EXTERN void fCeedCompositeOperatorCreate(int *ceed, int *op, int *err) {
 #define fCeedOperatorSetField \
     FORTRAN_NAME(ceedoperatorsetfield,CEEDOPERATORSETFIELD)
 CEED_EXTERN void fCeedOperatorSetField(int *op, const char *field_name, int *r,
-                                       int *b,
-                                       int *v, int *err, fortran_charlen_t field_name_len) {
+                                       int *b, int *v, int *err,
+                                       fortran_charlen_t field_name_len) {
   FIX_STRING(field_name);
   CeedElemRestriction r_;
   CeedBasis b_;
@@ -1119,7 +1119,16 @@ CEED_EXTERN void fCeedCompositeOperatorAddSub(int *compositeop, int *subop,
   CeedOperator subop_ = CeedOperator_dict[*subop];
 
   *err = CeedCompositeOperatorAddSub(compositeop_, subop_);
-  if (*err) return;
+}
+
+#define fCeedOperatorSetName \
+    FORTRAN_NAME(ceedoperatorsetname, CEEDOPERATORSETNAME)
+CEED_EXTERN void fCeedOperatorSetName(int *op, const char *name, int *err,
+                                      fortran_charlen_t name_len) {
+  FIX_STRING(name);
+  CeedOperator op_ = CeedOperator_dict[*op];
+
+  *err = CeedOperatorSetName(op_, name_c);
 }
 
 #define fCeedOperatorLinearAssembleQFunction \

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -143,7 +143,7 @@ static int CeedOperatorFieldView(CeedOperatorField field,
   const char *pre = sub ? "  " : "";
   const char *in_out = input ? "Input" : "Output";
 
-  fprintf(stream, "%s    %s Field [%d]:\n"
+  fprintf(stream, "%s    %s field %d:\n"
           "%s      Name: \"%s\"\n",
           pre, in_out, field_number, pre, qf_field->field_name);
 
@@ -181,17 +181,17 @@ int CeedOperatorSingleView(CeedOperator op, bool sub, FILE *stream) {
   fprintf(stream, "%s  %d elements with %d quadrature points each\n",
           pre, num_elem, num_qpts);
 
-  fprintf(stream, "%s  %d Field%s\n", pre, total_fields,
+  fprintf(stream, "%s  %d field%s\n", pre, total_fields,
           total_fields>1 ? "s" : "");
 
-  fprintf(stream, "%s  %d Input Field%s:\n", pre, op->qf->num_input_fields,
+  fprintf(stream, "%s  %d input field%s:\n", pre, op->qf->num_input_fields,
           op->qf->num_input_fields>1 ? "s" : "");
   for (CeedInt i=0; i<op->qf->num_input_fields; i++) {
     ierr = CeedOperatorFieldView(op->input_fields[i], op->qf->input_fields[i],
                                  i, sub, 1, stream); CeedChk(ierr);
   }
 
-  fprintf(stream, "%s  %d Output Field%s:\n", pre, op->qf->num_output_fields,
+  fprintf(stream, "%s  %d output field%s:\n", pre, op->qf->num_output_fields,
           op->qf->num_output_fields>1 ? "s" : "");
   for (CeedInt i=0; i<op->qf->num_output_fields; i++) {
     ierr = CeedOperatorFieldView(op->output_fields[i], op->qf->output_fields[i],
@@ -1187,7 +1187,7 @@ int CeedOperatorView(CeedOperator op, FILE *stream) {
     fprintf(stream, "Composite CeedOperator\n");
 
     for (CeedInt i=0; i<op->num_suboperators; i++) {
-      fprintf(stream, "  SubOperator [%d]:\n", i);
+      fprintf(stream, "  SubOperator %d:\n", i);
       ierr = CeedOperatorSingleView(op->sub_operators[i], 1, stream);
       CeedChk(ierr);
     }

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -172,8 +172,14 @@ int CeedOperatorSingleView(CeedOperator op, bool sub, FILE *stream) {
   int ierr;
   const char *pre = sub ? "  " : "";
 
+  CeedInt num_elem, num_qpts;
+  ierr = CeedOperatorGetNumElements(op, &num_elem); CeedChk(ierr);
+  ierr = CeedOperatorGetNumQuadraturePoints(op, &num_qpts); CeedChk(ierr);
+
   CeedInt total_fields = 0;
   ierr = CeedOperatorGetNumArgs(op, &total_fields); CeedChk(ierr);
+  fprintf(stream, "%s  %d elements with %d quadrature points each\n",
+          pre, num_elem, num_qpts);
 
   fprintf(stream, "%s  %d Field%s\n", pre, total_fields,
           total_fields>1 ? "s" : "");

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -968,7 +968,7 @@ int CeedQFunctionSetUserFlopsEstimate(CeedQFunction qf, CeedSize flops) {
 int CeedQFunctionView(CeedQFunction qf, FILE *stream) {
   int ierr;
 
-  fprintf(stream, "%sCeedQFunction %s\n",
+  fprintf(stream, "%sCeedQFunction - %s\n",
           qf->is_gallery ? "Gallery " : "User ",
           qf->is_gallery ? qf->gallery_name : qf->kernel_name);
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -143,7 +143,7 @@ static int CeedQFunctionFieldView(CeedQFunctionField field,
   ierr = CeedQFunctionFieldGetSize(field, &size); CeedChk(ierr);
   CeedEvalMode eval_mode;
   ierr = CeedQFunctionFieldGetEvalMode(field, &eval_mode); CeedChk(ierr);
-  fprintf(stream, "    %s Field [%d]:\n"
+  fprintf(stream, "    %s field %d:\n"
           "      Name: \"%s\"\n"
           "      Size: %d\n"
           "      EvalMode: \"%s\"\n",
@@ -972,14 +972,14 @@ int CeedQFunctionView(CeedQFunction qf, FILE *stream) {
           qf->is_gallery ? "Gallery " : "User ",
           qf->is_gallery ? qf->gallery_name : qf->kernel_name);
 
-  fprintf(stream, "  %d Input Field%s:\n", qf->num_input_fields,
+  fprintf(stream, "  %d input field%s:\n", qf->num_input_fields,
           qf->num_input_fields>1 ? "s" : "");
   for (CeedInt i=0; i<qf->num_input_fields; i++) {
     ierr = CeedQFunctionFieldView(qf->input_fields[i], i, 1, stream);
     CeedChk(ierr);
   }
 
-  fprintf(stream, "  %d Output Field%s:\n", qf->num_output_fields,
+  fprintf(stream, "  %d output field%s:\n", qf->num_output_fields,
           qf->num_output_fields>1 ? "s" : "");
   for (CeedInt i=0; i<qf->num_output_fields; i++) {
     ierr = CeedQFunctionFieldView(qf->output_fields[i], i, 0, stream);

--- a/julia/LibCEED.jl/test/rundevtests.jl
+++ b/julia/LibCEED.jl/test/rundevtests.jl
@@ -1,6 +1,26 @@
 using Test, LibCEED, LinearAlgebra, StaticArrays
 
 @testset "LibCEED Development Tests" begin
+    @testset "QFunction" begin
+        c = Ceed()
+        @test showstr(create_interior_qfunction(c, "Poisson3DApply")) == """
+             Gallery CeedQFunction Poisson3DApply
+               2 input fields:
+                 Input field 0:
+                   Name: "du"
+                   Size: 3
+                   EvalMode: "gradient"
+                 Input field 1:
+                   Name: "qdata"
+                   Size: 6
+                   EvalMode: "none"
+               1 output field:
+                 Output field 0:
+                   Name: "dv"
+                   Size: 3
+                   EvalMode: "gradient\""""
+    end
+
     @testset "Operator" begin
         c = Ceed()
         @interior_qf id = (
@@ -26,13 +46,13 @@ using Test, LibCEED, LinearAlgebra, StaticArrays
         @test showstr(op) == """
              CeedOperator
                1 elements with 27 quadrature points each
-               2 Fields
-               1 Input Field:
-                 Input Field [0]:
+               2 fields
+               1 input field:
+                 Input field 0:
                    Name: "input"
                    Active vector
-               1 Output Field:
-                 Output Field [0]:
+               1 output field:
+                 Output field 0:
                    Name: "output"
                    Active vector"""
     end

--- a/julia/LibCEED.jl/test/rundevtests.jl
+++ b/julia/LibCEED.jl/test/rundevtests.jl
@@ -4,7 +4,7 @@ using Test, LibCEED, LinearAlgebra, StaticArrays
     @testset "QFunction" begin
         c = Ceed()
         @test showstr(create_interior_qfunction(c, "Poisson3DApply")) == """
-             Gallery CeedQFunction Poisson3DApply
+             Gallery CeedQFunction - Poisson3DApply
                2 input fields:
                  Input field 0:
                    Name: "du"

--- a/julia/LibCEED.jl/test/rundevtests.jl
+++ b/julia/LibCEED.jl/test/rundevtests.jl
@@ -1,3 +1,39 @@
 using Test, LibCEED, LinearAlgebra, StaticArrays
 
-@testset "LibCEED Development Tests" begin end
+@testset "LibCEED Development Tests" begin
+    @testset "Operator" begin
+        c = Ceed()
+        @interior_qf id = (
+            c,
+            (input, :in, EVAL_INTERP),
+            (output, :out, EVAL_INTERP),
+            begin
+                output[] = input
+            end,
+        )
+        b = create_tensor_h1_lagrange_basis(c, 3, 1, 3, 3, GAUSS_LOBATTO)
+        n = getnumnodes(b)
+        offsets = Vector{CeedInt}(0:n-1)
+        r = create_elem_restriction(c, 1, n, 1, 1, n, offsets)
+        op = Operator(
+            c;
+            qf=id,
+            fields=[
+                (:input, r, b, CeedVectorActive()),
+                (:output, r, b, CeedVectorActive()),
+            ],
+        )
+        @test showstr(op) == """
+             CeedOperator
+               1 elements with 27 quadrature points each
+               2 Fields
+               1 Input Field:
+                 Input Field [0]:
+                   Name: "input"
+                   Active vector
+               1 Output Field:
+                 Output Field [0]:
+                   Name: "output"
+                   Active vector"""
+    end
+end

--- a/julia/LibCEED.jl/test/runtests.jl
+++ b/julia/LibCEED.jl/test/runtests.jl
@@ -221,23 +221,6 @@ else
             apply!(id, Q, [v1], [v2])
             @test @witharray(a = v2, a == v)
 
-            @test showstr(create_interior_qfunction(c, "Poisson3DApply")) == """
-                Gallery CeedQFunction Poisson3DApply
-                  2 Input Fields:
-                    Input Field [0]:
-                      Name: "du"
-                      Size: 3
-                      EvalMode: "gradient"
-                    Input Field [1]:
-                      Name: "qdata"
-                      Size: 6
-                      EvalMode: "none"
-                  1 Output Field:
-                    Output Field [0]:
-                      Name: "dv"
-                      Size: 3
-                      EvalMode: "gradient\""""
-
             @interior_qf id2 = (c, (a, :in, EVAL_INTERP), (b, :out, EVAL_INTERP), b .= a)
             v2[] = 0.0
             apply!(id2, Q, [v1], [v2])

--- a/julia/LibCEED.jl/test/runtests.jl
+++ b/julia/LibCEED.jl/test/runtests.jl
@@ -296,18 +296,6 @@ else
                     (:output, r, b, CeedVectorActive()),
                 ],
             )
-            @test showstr(op) == """
-                CeedOperator
-                  1 elements with 27 quadrature points each
-                  2 Fields
-                  1 Input Field:
-                    Input Field [0]:
-                      Name: "input"
-                      Active vector
-                  1 Output Field:
-                    Output Field [0]:
-                      Name: "output"
-                      Active vector"""
 
             v = rand(CeedScalar, n)
             v1 = CeedVector(c, v)

--- a/julia/LibCEED.jl/test/runtests.jl
+++ b/julia/LibCEED.jl/test/runtests.jl
@@ -298,6 +298,7 @@ else
             )
             @test showstr(op) == """
                 CeedOperator
+                  1 elements with 27 quadrature points each
                   2 Fields
                   1 Input Field:
                     Input Field [0]:

--- a/python/ceed_operator.py
+++ b/python/ceed_operator.py
@@ -108,6 +108,17 @@ class _OperatorBase(ABC):
                                                                        d._pointer[0], request)
         self._ceed._check_error(err_code)
 
+    # Set name
+    def name(self, name):
+        """Set name of Operator for print output
+
+           Args:
+             name: Name to set"""
+
+        name = ffi.new("char[]", name.encode('ascii'))
+        err_code = lib.CeedOperatorSetName(self._pointer[0], name)
+        self._ceed._check_error(err_code)
+
     # Apply CeedOperator
     def apply(self, u, v, request=REQUEST_IMMEDIATE):
         """Apply Operator to a vector.

--- a/python/tests/output/test_402.out
+++ b/python/tests/output/test_402.out
@@ -1,4 +1,4 @@
-User CeedQFunction setup_mass
+User CeedQFunction - setup_mass
   2 input fields:
     Input field 0:
       Name: "w"
@@ -14,7 +14,7 @@ User CeedQFunction setup_mass
       Size: 1
       EvalMode: "none"
 
-User CeedQFunction apply_mass
+User CeedQFunction - apply_mass
   2 input fields:
     Input field 0:
       Name: "qdata"

--- a/python/tests/output/test_402.out
+++ b/python/tests/output/test_402.out
@@ -1,31 +1,31 @@
 User CeedQFunction setup_mass
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "w"
       Size: 1
       EvalMode: "quadrature weights"
-    Input Field [1]:
+    Input field 1:
       Name: "dx"
       Size: 1
       EvalMode: "gradient"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
 
 User CeedQFunction apply_mass
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-    Input Field [1]:
+    Input field 1:
       Name: "u"
       Size: 1
       EvalMode: "interpolation"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Size: 1
       EvalMode: "interpolation"

--- a/python/tests/output/test_413.out
+++ b/python/tests/output/test_413.out
@@ -1,4 +1,4 @@
-Gallery CeedQFunction Mass1DBuild
+Gallery CeedQFunction - Mass1DBuild
   2 input fields:
     Input field 0:
       Name: "dx"
@@ -14,7 +14,7 @@ Gallery CeedQFunction Mass1DBuild
       Size: 1
       EvalMode: "none"
 
-Gallery CeedQFunction MassApply
+Gallery CeedQFunction - MassApply
   2 input fields:
     Input field 0:
       Name: "u"

--- a/python/tests/output/test_413.out
+++ b/python/tests/output/test_413.out
@@ -1,31 +1,31 @@
 Gallery CeedQFunction Mass1DBuild
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "dx"
       Size: 1
       EvalMode: "gradient"
-    Input Field [1]:
+    Input field 1:
       Name: "weights"
       Size: 1
       EvalMode: "quadrature weights"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
 
 Gallery CeedQFunction MassApply
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "u"
       Size: 1
       EvalMode: "interpolation"
-    Input Field [1]:
+    Input field 1:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Size: 1
       EvalMode: "interpolation"

--- a/python/tests/output/test_504.out
+++ b/python/tests/output/test_504.out
@@ -1,4 +1,5 @@
 CeedOperator
+  15 elements with 8 quadrature points each
   3 Fields
   2 Input Fields:
     Input Field [0]:
@@ -14,6 +15,7 @@ CeedOperator
       Active vector
 
 CeedOperator
+  15 elements with 8 quadrature points each
   3 Fields
   2 Input Fields:
     Input Field [0]:

--- a/python/tests/output/test_504.out
+++ b/python/tests/output/test_504.out
@@ -1,31 +1,31 @@
 CeedOperator
   15 elements with 8 quadrature points each
-  3 Fields
-  2 Input Fields:
-    Input Field [0]:
+  3 fields
+  2 input fields:
+    Input field 0:
       Name: "weights"
       No vector
-    Input Field [1]:
+    Input field 1:
       Name: "dx"
       Active vector
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "rho"
       Collocated basis
       Active vector
 
 CeedOperator
   15 elements with 8 quadrature points each
-  3 Fields
-  2 Input Fields:
-    Input Field [0]:
+  3 fields
+  2 input fields:
+    Input field 0:
       Name: "rho"
       Collocated basis
-    Input Field [1]:
+    Input field 1:
       Name: "u"
       Active vector
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Active vector
 

--- a/python/tests/output/test_523.out
+++ b/python/tests/output/test_523.out
@@ -1,5 +1,6 @@
 Composite CeedOperator
   SubOperator [0]:
+    6 elements with 4 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -13,6 +14,7 @@ Composite CeedOperator
         Name: "rho"
         Collocated basis
   SubOperator [1]:
+    6 elements with 16 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -28,6 +30,7 @@ Composite CeedOperator
 
 Composite CeedOperator
   SubOperator [0]:
+    6 elements with 4 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -41,6 +44,7 @@ Composite CeedOperator
         Name: "v"
         Active vector
   SubOperator [1]:
+    6 elements with 16 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:

--- a/python/tests/output/test_523.out
+++ b/python/tests/output/test_523.out
@@ -1,60 +1,60 @@
 Composite CeedOperator
-  SubOperator [0]:
+  SubOperator 0:
     6 elements with 4 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "weights"
         No vector
-      Input Field [1]:
+      Input field 1:
         Name: "dx"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "rho"
         Collocated basis
-  SubOperator [1]:
+  SubOperator 1:
     6 elements with 16 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "weights"
         No vector
-      Input Field [1]:
+      Input field 1:
         Name: "dx"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "rho"
         Collocated basis
 
 Composite CeedOperator
-  SubOperator [0]:
+  SubOperator 0:
     6 elements with 4 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "rho"
         Collocated basis
-      Input Field [1]:
+      Input field 1:
         Name: "u"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "v"
         Active vector
-  SubOperator [1]:
+  SubOperator 1:
     6 elements with 16 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "rho"
         Collocated basis
-      Input Field [1]:
+      Input field 1:
         Name: "u"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "v"
         Active vector
 

--- a/python/tests/output/test_523.out
+++ b/python/tests/output/test_523.out
@@ -1,5 +1,5 @@
-Composite CeedOperator
-  SubOperator 0:
+Composite CeedOperator - setup
+  SubOperator 0 - triangle elements:
     6 elements with 4 quadrature points each
     3 fields
     2 input fields:
@@ -13,7 +13,7 @@ Composite CeedOperator
       Output field 0:
         Name: "rho"
         Collocated basis
-  SubOperator 1:
+  SubOperator 1 - quadralateral elements:
     6 elements with 16 quadrature points each
     3 fields
     2 input fields:
@@ -28,8 +28,8 @@ Composite CeedOperator
         Name: "rho"
         Collocated basis
 
-Composite CeedOperator
-  SubOperator 0:
+Composite CeedOperator - mass
+  SubOperator 0 - triangle elements:
     6 elements with 4 quadrature points each
     3 fields
     2 input fields:
@@ -43,7 +43,7 @@ Composite CeedOperator
       Output field 0:
         Name: "v"
         Active vector
-  SubOperator 1:
+  SubOperator 1 - quadralateral elements:
     6 elements with 16 quadrature points each
     3 fields
     2 input fields:

--- a/python/tests/test-5-operator.py
+++ b/python/tests/test-5-operator.py
@@ -1224,6 +1224,7 @@ def test_523(ceed_resource, capsys):
 
     # Operators
     op_setup_tet = ceed.Operator(qf_setup_tet)
+    op_setup_tet.name('triangle elements')
     op_setup_tet.set_field("weights", libceed.ELEMRESTRICTION_NONE, bx_tet,
                            libceed.VECTOR_NONE)
     op_setup_tet.set_field("dx", rx_tet, bx_tet, libceed.VECTOR_ACTIVE)
@@ -1231,6 +1232,7 @@ def test_523(ceed_resource, capsys):
                            qdata_tet)
 
     op_mass_tet = ceed.Operator(qf_mass_tet)
+    op_mass_tet.name('triangle elements')
     op_mass_tet.set_field("rho", rui_tet, libceed.BASIS_COLLOCATED, qdata_tet)
     op_mass_tet.set_field("u", ru_tet, bu_tet, libceed.VECTOR_ACTIVE)
     op_mass_tet.set_field("v", ru_tet, bu_tet, libceed.VECTOR_ACTIVE)
@@ -1278,6 +1280,7 @@ def test_523(ceed_resource, capsys):
 
     # Operators
     op_setup_hex = ceed.Operator(qf_setup_tet)
+    op_setup_hex.name("quadralateral elements")
     op_setup_hex.set_field("weights", libceed.ELEMRESTRICTION_NONE, bx_hex,
                            libceed.VECTOR_NONE)
     op_setup_hex.set_field("dx", rx_hex, bx_hex, libceed.VECTOR_ACTIVE)
@@ -1285,6 +1288,7 @@ def test_523(ceed_resource, capsys):
                            qdata_hex)
 
     op_mass_hex = ceed.Operator(qf_mass_hex)
+    op_mass_hex.name("quadralateral elements")
     op_mass_hex.set_field("rho", rui_hex, libceed.BASIS_COLLOCATED, qdata_hex)
     op_mass_hex.set_field("u", ru_hex, bu_hex, libceed.VECTOR_ACTIVE)
     op_mass_hex.set_field("v", ru_hex, bu_hex, libceed.VECTOR_ACTIVE)
@@ -1293,11 +1297,13 @@ def test_523(ceed_resource, capsys):
 
     # Setup
     op_setup = ceed.CompositeOperator()
+    op_setup.name('setup')
     op_setup.add_sub(op_setup_tet)
     op_setup.add_sub(op_setup_hex)
 
     # Apply mass matrix
     op_mass = ceed.CompositeOperator()
+    op_mass.name('mass')
     op_mass.add_sub(op_mass_tet)
     op_mass.add_sub(op_mass_hex)
 

--- a/tests/output/t402-qfunction-f.out
+++ b/tests/output/t402-qfunction-f.out
@@ -1,4 +1,4 @@
-User CeedQFunction setup
+User CeedQFunction - setup
   1 input field:
     Input field 0:
       Name: "w"
@@ -9,7 +9,7 @@ User CeedQFunction setup
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-User CeedQFunction mass
+User CeedQFunction - mass
   2 input fields:
     Input field 0:
       Name: "qdata"

--- a/tests/output/t402-qfunction-f.out
+++ b/tests/output/t402-qfunction-f.out
@@ -1,26 +1,26 @@
 User CeedQFunction setup
-  1 Input Field:
-    Input Field [0]:
+  1 input field:
+    Input field 0:
       Name: "w"
       Size: 1
       EvalMode: "quadrature weights"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
 User CeedQFunction mass
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-    Input Field [1]:
+    Input field 1:
       Name: "u"
       Size: 1
       EvalMode: "interpolation"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Size: 1
       EvalMode: "interpolation"

--- a/tests/output/t402-qfunction.out
+++ b/tests/output/t402-qfunction.out
@@ -1,4 +1,4 @@
-User CeedQFunction setup
+User CeedQFunction - setup
   1 input field:
     Input field 0:
       Name: "w"
@@ -9,7 +9,7 @@ User CeedQFunction setup
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-User CeedQFunction mass
+User CeedQFunction - mass
   2 input fields:
     Input field 0:
       Name: "qdata"

--- a/tests/output/t402-qfunction.out
+++ b/tests/output/t402-qfunction.out
@@ -1,26 +1,26 @@
 User CeedQFunction setup
-  1 Input Field:
-    Input Field [0]:
+  1 input field:
+    Input field 0:
       Name: "w"
       Size: 1
       EvalMode: "quadrature weights"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
 User CeedQFunction mass
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-    Input Field [1]:
+    Input field 1:
       Name: "u"
       Size: 1
       EvalMode: "interpolation"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Size: 1
       EvalMode: "interpolation"

--- a/tests/output/t413-qfunction-f.out
+++ b/tests/output/t413-qfunction-f.out
@@ -1,4 +1,4 @@
-Gallery CeedQFunction Mass1DBuild
+Gallery CeedQFunction - Mass1DBuild
   2 input fields:
     Input field 0:
       Name: "dx"
@@ -13,7 +13,7 @@ Gallery CeedQFunction Mass1DBuild
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-Gallery CeedQFunction MassApply
+Gallery CeedQFunction - MassApply
   2 input fields:
     Input field 0:
       Name: "u"

--- a/tests/output/t413-qfunction-f.out
+++ b/tests/output/t413-qfunction-f.out
@@ -1,30 +1,30 @@
 Gallery CeedQFunction Mass1DBuild
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "dx"
       Size: 1
       EvalMode: "gradient"
-    Input Field [1]:
+    Input field 1:
       Name: "weights"
       Size: 1
       EvalMode: "quadrature weights"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
 Gallery CeedQFunction MassApply
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "u"
       Size: 1
       EvalMode: "interpolation"
-    Input Field [1]:
+    Input field 1:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Size: 1
       EvalMode: "interpolation"

--- a/tests/output/t413-qfunction.out
+++ b/tests/output/t413-qfunction.out
@@ -1,4 +1,4 @@
-Gallery CeedQFunction Mass1DBuild
+Gallery CeedQFunction - Mass1DBuild
   2 input fields:
     Input field 0:
       Name: "dx"
@@ -13,7 +13,7 @@ Gallery CeedQFunction Mass1DBuild
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-Gallery CeedQFunction MassApply
+Gallery CeedQFunction - MassApply
   2 input fields:
     Input field 0:
       Name: "u"

--- a/tests/output/t413-qfunction.out
+++ b/tests/output/t413-qfunction.out
@@ -1,30 +1,30 @@
 Gallery CeedQFunction Mass1DBuild
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "dx"
       Size: 1
       EvalMode: "gradient"
-    Input Field [1]:
+    Input field 1:
       Name: "weights"
       Size: 1
       EvalMode: "quadrature weights"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
 Gallery CeedQFunction MassApply
-  2 Input Fields:
-    Input Field [0]:
+  2 input fields:
+    Input field 0:
       Name: "u"
       Size: 1
       EvalMode: "interpolation"
-    Input Field [1]:
+    Input field 1:
       Name: "qdata"
       Size: 1
       EvalMode: "none"
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Size: 1
       EvalMode: "interpolation"

--- a/tests/output/t504-operator-f.out
+++ b/tests/output/t504-operator-f.out
@@ -1,29 +1,29 @@
 CeedOperator
   15 elements with 8 quadrature points each
-  3 Fields
-  2 Input Fields:
-    Input Field [0]:
+  3 fields
+  2 input fields:
+    Input field 0:
       Name: "weight"
       No vector
-    Input Field [1]:
+    Input field 1:
       Name: "dx"
       Active vector
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "rho"
       Collocated basis
       Active vector
 CeedOperator
   15 elements with 8 quadrature points each
-  3 Fields
-  2 Input Fields:
-    Input Field [0]:
+  3 fields
+  2 input fields:
+    Input field 0:
       Name: "rho"
       Collocated basis
-    Input Field [1]:
+    Input field 1:
       Name: "u"
       Active vector
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Active vector

--- a/tests/output/t504-operator-f.out
+++ b/tests/output/t504-operator-f.out
@@ -1,4 +1,5 @@
 CeedOperator
+  15 elements with 8 quadrature points each
   3 Fields
   2 Input Fields:
     Input Field [0]:
@@ -13,6 +14,7 @@ CeedOperator
       Collocated basis
       Active vector
 CeedOperator
+  15 elements with 8 quadrature points each
   3 Fields
   2 Input Fields:
     Input Field [0]:

--- a/tests/output/t504-operator.out
+++ b/tests/output/t504-operator.out
@@ -1,29 +1,29 @@
 CeedOperator
   15 elements with 8 quadrature points each
-  3 Fields
-  2 Input Fields:
-    Input Field [0]:
+  3 fields
+  2 input fields:
+    Input field 0:
       Name: "weight"
       No vector
-    Input Field [1]:
+    Input field 1:
       Name: "dx"
       Active vector
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "rho"
       Collocated basis
       Active vector
 CeedOperator
   15 elements with 8 quadrature points each
-  3 Fields
-  2 Input Fields:
-    Input Field [0]:
+  3 fields
+  2 input fields:
+    Input field 0:
       Name: "rho"
       Collocated basis
-    Input Field [1]:
+    Input field 1:
       Name: "u"
       Active vector
-  1 Output Field:
-    Output Field [0]:
+  1 output field:
+    Output field 0:
       Name: "v"
       Active vector

--- a/tests/output/t504-operator.out
+++ b/tests/output/t504-operator.out
@@ -1,4 +1,5 @@
 CeedOperator
+  15 elements with 8 quadrature points each
   3 Fields
   2 Input Fields:
     Input Field [0]:
@@ -13,6 +14,7 @@ CeedOperator
       Collocated basis
       Active vector
 CeedOperator
+  15 elements with 8 quadrature points each
   3 Fields
   2 Input Fields:
     Input Field [0]:

--- a/tests/output/t523-operator-f.out
+++ b/tests/output/t523-operator-f.out
@@ -1,5 +1,5 @@
-Composite CeedOperator
-  SubOperator 0:
+Composite CeedOperator - setup
+  SubOperator 0 - triangle elements:
     6 elements with 4 quadrature points each
     3 fields
     2 input fields:
@@ -13,7 +13,7 @@ Composite CeedOperator
       Output field 0:
         Name: "rho"
         Collocated basis
-  SubOperator 1:
+  SubOperator 1 - quadralateral elements:
     6 elements with 16 quadrature points each
     3 fields
     2 input fields:
@@ -27,8 +27,8 @@ Composite CeedOperator
       Output field 0:
         Name: "rho"
         Collocated basis
-Composite CeedOperator
-  SubOperator 0:
+Composite CeedOperator - mass
+  SubOperator 0 - triangle elements:
     6 elements with 4 quadrature points each
     3 fields
     2 input fields:
@@ -42,7 +42,7 @@ Composite CeedOperator
       Output field 0:
         Name: "v"
         Active vector
-  SubOperator 1:
+  SubOperator 1 - quadralateral elements:
     6 elements with 16 quadrature points each
     3 fields
     2 input fields:

--- a/tests/output/t523-operator-f.out
+++ b/tests/output/t523-operator-f.out
@@ -1,5 +1,6 @@
 Composite CeedOperator
   SubOperator [0]:
+    6 elements with 4 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -13,6 +14,7 @@ Composite CeedOperator
         Name: "rho"
         Collocated basis
   SubOperator [1]:
+    6 elements with 16 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -27,6 +29,7 @@ Composite CeedOperator
         Collocated basis
 Composite CeedOperator
   SubOperator [0]:
+    6 elements with 4 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -40,6 +43,7 @@ Composite CeedOperator
         Name: "v"
         Active vector
   SubOperator [1]:
+    6 elements with 16 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:

--- a/tests/output/t523-operator-f.out
+++ b/tests/output/t523-operator-f.out
@@ -1,58 +1,58 @@
 Composite CeedOperator
-  SubOperator [0]:
+  SubOperator 0:
     6 elements with 4 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "weight"
         No vector
-      Input Field [1]:
+      Input field 1:
         Name: "dx"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "rho"
         Collocated basis
-  SubOperator [1]:
+  SubOperator 1:
     6 elements with 16 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "weight"
         No vector
-      Input Field [1]:
+      Input field 1:
         Name: "dx"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "rho"
         Collocated basis
 Composite CeedOperator
-  SubOperator [0]:
+  SubOperator 0:
     6 elements with 4 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "rho"
         Collocated basis
-      Input Field [1]:
+      Input field 1:
         Name: "u"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "v"
         Active vector
-  SubOperator [1]:
+  SubOperator 1:
     6 elements with 16 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "rho"
         Collocated basis
-      Input Field [1]:
+      Input field 1:
         Name: "u"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "v"
         Active vector

--- a/tests/output/t523-operator.out
+++ b/tests/output/t523-operator.out
@@ -1,5 +1,5 @@
-Composite CeedOperator
-  SubOperator 0:
+Composite CeedOperator - setup
+  SubOperator 0 - triangle elements:
     6 elements with 4 quadrature points each
     3 fields
     2 input fields:
@@ -13,7 +13,7 @@ Composite CeedOperator
       Output field 0:
         Name: "rho"
         Collocated basis
-  SubOperator 1:
+  SubOperator 1 - quadralateral elements:
     6 elements with 16 quadrature points each
     3 fields
     2 input fields:
@@ -27,8 +27,8 @@ Composite CeedOperator
       Output field 0:
         Name: "rho"
         Collocated basis
-Composite CeedOperator
-  SubOperator 0:
+Composite CeedOperator - mass
+  SubOperator 0 - triangle elements:
     6 elements with 4 quadrature points each
     3 fields
     2 input fields:
@@ -42,7 +42,7 @@ Composite CeedOperator
       Output field 0:
         Name: "v"
         Active vector
-  SubOperator 1:
+  SubOperator 1 - quadralateral elements:
     6 elements with 16 quadrature points each
     3 fields
     2 input fields:

--- a/tests/output/t523-operator.out
+++ b/tests/output/t523-operator.out
@@ -1,5 +1,6 @@
 Composite CeedOperator
   SubOperator [0]:
+    6 elements with 4 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -13,6 +14,7 @@ Composite CeedOperator
         Name: "rho"
         Collocated basis
   SubOperator [1]:
+    6 elements with 16 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -27,6 +29,7 @@ Composite CeedOperator
         Collocated basis
 Composite CeedOperator
   SubOperator [0]:
+    6 elements with 4 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:
@@ -40,6 +43,7 @@ Composite CeedOperator
         Name: "v"
         Active vector
   SubOperator [1]:
+    6 elements with 16 quadrature points each
     3 Fields
     2 Input Fields:
       Input Field [0]:

--- a/tests/output/t523-operator.out
+++ b/tests/output/t523-operator.out
@@ -1,58 +1,58 @@
 Composite CeedOperator
-  SubOperator [0]:
+  SubOperator 0:
     6 elements with 4 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "weight"
         No vector
-      Input Field [1]:
+      Input field 1:
         Name: "dx"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "rho"
         Collocated basis
-  SubOperator [1]:
+  SubOperator 1:
     6 elements with 16 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "weight"
         No vector
-      Input Field [1]:
+      Input field 1:
         Name: "dx"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "rho"
         Collocated basis
 Composite CeedOperator
-  SubOperator [0]:
+  SubOperator 0:
     6 elements with 4 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "rho"
         Collocated basis
-      Input Field [1]:
+      Input field 1:
         Name: "u"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "v"
         Active vector
-  SubOperator [1]:
+  SubOperator 1:
     6 elements with 16 quadrature points each
-    3 Fields
-    2 Input Fields:
-      Input Field [0]:
+    3 fields
+    2 input fields:
+      Input field 0:
         Name: "rho"
         Collocated basis
-      Input Field [1]:
+      Input field 1:
         Name: "u"
         Active vector
-    1 Output Field:
-      Output Field [0]:
+    1 output field:
+      Output field 0:
         Name: "v"
         Active vector

--- a/tests/t523-operator-f.f90
+++ b/tests/t523-operator-f.f90
@@ -121,7 +121,8 @@
 ! ---- Setup Tet
       call ceedoperatorcreate(ceed,qf_setuptet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuptet,err)
-      call ceedoperatorsetfield(op_setuptet, 'weight',&
+      call ceedoperatorsetname(op_setuptet,'triangle elements',err)
+      call ceedoperatorsetfield(op_setuptet,'weight',&
      & ceed_elemrestriction_none,bxtet,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuptet,'dx',erestrictxtet,&
      & bxtet,ceed_vector_active,err)
@@ -130,6 +131,7 @@
 ! ---- Mass Tet
       call ceedoperatorcreate(ceed,qf_masstet,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masstet,err)
+      call ceedoperatorsetname(op_masstet,'triangle elements',err)
       call ceedoperatorsetfield(op_masstet,'rho',erestrictuitet,&
      & ceed_basis_collocated,qdatatet,err)
       call ceedoperatorsetfield(op_masstet,'u',erestrictutet,&
@@ -184,6 +186,7 @@
 ! ---- Setup Hex
       call ceedoperatorcreate(ceed,qf_setuphex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_setuphex,err)
+      call ceedoperatorsetname(op_setuphex,'quadralateral elements',err)
       call ceedoperatorsetfield(op_setuphex,'weight',&
      & ceed_elemrestriction_none,bxhex,ceed_vector_none,err)
       call ceedoperatorsetfield(op_setuphex,'dx',erestrictxhex,&
@@ -193,6 +196,7 @@
 ! ---- Mass Hex
       call ceedoperatorcreate(ceed,qf_masshex,ceed_qfunction_none,&
      & ceed_qfunction_none,op_masshex,err)
+      call ceedoperatorsetname(op_masshex,'quadralateral elements',err)
       call ceedoperatorsetfield(op_masshex,'rho',erestrictuihex,&
      & ceed_basis_collocated,qdatahex,err)
       call ceedoperatorsetfield(op_masshex,'u',erestrictuhex,&
@@ -202,10 +206,12 @@
 
 ! Composite Operators
       call ceedcompositeoperatorcreate(ceed,op_setup,err)
+      call ceedoperatorsetname(op_setup,'setup',err)
       call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
       call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
 
       call ceedcompositeoperatorcreate(ceed,op_mass,err)
+      call ceedoperatorsetname(op_mass,'mass',err)
       call ceedcompositeoperatoraddsub(op_mass,op_masstet,err)
       call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
 

--- a/tests/t523-operator.c
+++ b/tests/t523-operator.c
@@ -109,6 +109,7 @@ int main(int argc, char **argv) {
   // ---- Setup _tet
   CeedOperatorCreate(ceed, qf_setup_tet, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setup_tet);
+  CeedOperatorSetName(op_setup_tet, "triangle elements");
   CeedOperatorSetField(op_setup_tet, "weight", CEED_ELEMRESTRICTION_NONE,
                        basis_x_tet,
                        CEED_VECTOR_NONE);
@@ -119,6 +120,7 @@ int main(int argc, char **argv) {
   // ---- Mass _tet
   CeedOperatorCreate(ceed, qf_mass_tet, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_mass_tet);
+  CeedOperatorSetName(op_mass_tet, "triangle elements");
   CeedOperatorSetField(op_mass_tet, "rho", elem_restr_qd_tet,
                        CEED_BASIS_COLLOCATED,
                        q_data_tet);
@@ -170,6 +172,7 @@ int main(int argc, char **argv) {
   // -- Operators
   CeedOperatorCreate(ceed, qf_setup_hex, CEED_QFUNCTION_NONE,
                      CEED_QFUNCTION_NONE, &op_setup_hex);
+  CeedOperatorSetName(op_setup_hex, "quadralateral elements");
   CeedOperatorSetField(op_setup_hex, "weight", CEED_ELEMRESTRICTION_NONE,
                        basis_x_hex,
                        CEED_VECTOR_NONE);
@@ -180,6 +183,7 @@ int main(int argc, char **argv) {
 
   CeedOperatorCreate(ceed, qf_mass_hex, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
                      &op_mass_hex);
+  CeedOperatorSetName(op_mass_hex, "quadralateral elements");
   CeedOperatorSetField(op_mass_hex, "rho", elem_restr_qd_i_hex,
                        CEED_BASIS_COLLOCATED,
                        q_data_hex);
@@ -191,12 +195,14 @@ int main(int argc, char **argv) {
   // Set up Composite Operators
   // -- Create
   CeedCompositeOperatorCreate(ceed, &op_setup);
+  CeedOperatorSetName(op_setup, "setup");
   // -- Add SubOperators
   CeedCompositeOperatorAddSub(op_setup, op_setup_tet);
   CeedCompositeOperatorAddSub(op_setup, op_setup_hex);
 
   // -- Create
   CeedCompositeOperatorCreate(ceed, &op_mass);
+  CeedOperatorSetName(op_mass, "mass");
   // -- Add SubOperators
   CeedCompositeOperatorAddSub(op_mass, op_mass_tet);
   CeedCompositeOperatorAddSub(op_mass, op_mass_hex);


### PR DESCRIPTION
This adds a bit to the CeedOperatorView output. Sample output:

```
CeedOperator
  15 elements with 8 quadrature points each
  3 fields
  2 input fields:
    Input field 0:
      Name: "weight"
      No vector
    Input field 1:
      Name: "dx"
      Active vector
  1 output field:
    Output field 0:
      Name: "rho"
      Collocated basis
      Active vector
```