### PR TITLE
Small bug in operator cloning

### DIFF
--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -68,7 +68,6 @@ int CeedOperatorCreateFallback(CeedOperator op) {
   ierr = ceed_ref->OperatorCreate(op_ref); CeedChk(ierr);
   ierr = CeedQFunctionAssemblyDataReferenceCopy(op->qf_assembled,
          &op_ref->qf_assembled); CeedChk(ierr);
-  ierr = CeedOperatorSetName(op_ref, op->name); CeedChk(ierr);
   op->op_fallback = op_ref;
 
   // Clone QF


### PR DESCRIPTION
I introduced a small bug in operator cloning for fallback.

Currently, the fallback Operator shares the same interface data but has separate backend data. This strange state of affairs led to this bug. A better fix probably is to rework this to use the refcounting and destroy the fallback Operator like normal.