### PR TITLE
Add test for non-symmetric assembly

### DIFF
--- a/tests/t566-operator.c
+++ b/tests/t566-operator.c
@@ -27,10 +27,10 @@ int main(int argc, char **argv) {
   CeedInit(argv[1], &ceed);
 
   // DoF Coordinates
-  for (CeedInt i=0; i<n_x*2+1; i++)
-    for (CeedInt j=0; j<n_y*2+1; j++) {
-      x[i+j*(n_x*2+1)+0*num_dofs] = (CeedScalar) i / (2*n_x);
-      x[i+j*(n_x*2+1)+1*num_dofs] = (CeedScalar) j / (2*n_y);
+  for (CeedInt i=0; i<n_x*(P-1)+1; i++)
+    for (CeedInt j=0; j<n_y*(P-1)+1; j++) {
+      x[i+j*(n_x*2+1)+0*num_dofs] = (CeedScalar) i / (n_x * (P-1));
+      x[i+j*(n_x*2+1)+1*num_dofs] = (CeedScalar) j / (n_y * (P-1));
     }
   CeedVectorCreate(ceed, dim*num_dofs, &X);
   CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
@@ -43,10 +43,10 @@ int main(int argc, char **argv) {
     CeedInt col, row, offset;
     col = i % n_x;
     row = i / n_x;
-    offset = col*(P-1) + row*(n_x*2+1)*(P-1);
+    offset = col*(P-1) + row*(n_x*(P-1)+1)*(P-1);
     for (CeedInt j=0; j<P; j++)
       for (CeedInt k=0; k<P; k++)
-        ind_x[P*(P*i+k)+j] = offset + k*(n_x*2+1) + j;
+        ind_x[P*(P*i+k)+j] = offset + k*P + j;
   }
 
   // Restrictions
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreate(ceed, num_elem, P*P, num_comp, num_dofs,
                             num_comp*num_dofs,
                             CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restr_u);
-  CeedInt strides_qd[3] = {1, Q*Q, Q*Q};
+  CeedInt strides_qd[3] = {1, Q*Q*num_elem, Q*Q};
   CeedElemRestrictionCreateStrided(ceed, num_elem, Q*Q, 1, num_qpts, strides_qd,
                                    &elem_restr_qd_i);
 

--- a/tests/t566-operator.c
+++ b/tests/t566-operator.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
   CeedInt P = 3, Q = 3, dim = 2, num_comp = 2;
   CeedInt n_x = 1, n_y = 1;
   CeedInt num_elem = n_x * n_y;
-  CeedInt num_dofs = (n_x*2+1)*(n_y*2+1), num_qpts = num_elem*Q*Q;
+  CeedInt num_dofs = (n_x*(P-1)+1)*(n_y*(P-1)+1), num_qpts = num_elem*Q*Q;
   CeedInt ind_x[num_elem*P*P];
   CeedScalar assembled[num_comp*num_comp*num_dofs*num_dofs];
   CeedScalar x[dim*num_dofs], assembled_true[num_comp*num_comp*num_dofs*num_dofs];

--- a/tests/t566-operator.c
+++ b/tests/t566-operator.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
 
       CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
       for (CeedInt k=0; k<num_dofs*num_comp; k++) {
-        assembled_true[ind*num_dofs*num_comp + k] = v[k];
+        assembled_true[k*num_dofs*num_comp + ind] = v[k];
       }
       CeedVectorRestoreArrayRead(V, &v);
     }
@@ -146,15 +146,15 @@ int main(int argc, char **argv) {
     for (CeedInt comp_in=0; comp_in<num_comp; comp_in++) {
       for (CeedInt node_out=0; node_out<num_dofs; node_out++) {
         for (CeedInt comp_out=0; comp_out<num_comp; comp_out++) {
-          const CeedInt index = (node_in + comp_in*num_dofs)*num_comp + node_out +
-                                comp_out*num_dofs;
+          const CeedInt index = (node_out + comp_out*num_dofs)*num_comp + node_in +
+                                comp_in*num_dofs;
           const CeedScalar assembled_value = assembled[index];
           const CeedScalar assembled_true_value = assembled_true[index];
           if (fabs(assembled_value - assembled_true_value) >
               100.*CEED_EPSILON)
             // LCOV_EXCL_START
             printf("[(%d, %d), (%d, %d)] Error in assembly: %f != %f\n",
-                   node_in, comp_in, node_out, comp_out,
+                   node_out, comp_out, node_in, comp_in,
                    assembled_value, assembled_true_value);
           // LCOV_EXCL_STOP
         }

--- a/tests/t566-operator.c
+++ b/tests/t566-operator.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreate(ceed, num_elem, P*P, num_comp, num_dofs,
                             num_comp*num_dofs,
                             CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restr_u);
-  CeedInt strides_qd[3] = {1, Q*Q*num_elem, Q*Q};
+  CeedInt strides_qd[3] = {1, Q*Q*num_elem, Q*Q}; /* *NOPAD* */
   CeedElemRestrictionCreateStrided(ceed, num_elem, Q*Q, 1, num_qpts, strides_qd,
                                    &elem_restr_qd_i);
 

--- a/tests/t566-operator.h
+++ b/tests/t566-operator.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q,
+                      const CeedScalar *const *in,
+                      CeedScalar *const *out) {
+  const CeedScalar *weight = in[0], *J = in[1];
+  CeedScalar *rho = out[0];
+  for (CeedInt i=0; i<Q; i++) {
+    rho[i] = weight[i] * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
+                     CeedScalar *const *out) {
+  const CeedScalar *rho = in[0], *u = in[1];
+  CeedScalar *v = out[0];
+
+  const CeedScalar scale[2][2] = {
+    {1.0, 2.0},
+    {3.0, 4.0},
+  };
+
+  for (CeedInt i = 0; i < Q; i++) {
+    for (CeedInt c_out = 0; c_out < 2; c_out++) {
+      v[i+Q*c_out] = 0.0;
+      for (CeedInt c_in = 0; c_in < 2; c_in++) {
+        v[i+Q*c_out] += rho[i] * u[i+Q*c_in] * scale[c_in][c_out];
+      }
+    }
+  }
+  return 0;
+}

--- a/tests/t566-operator.h
+++ b/tests/t566-operator.h
@@ -18,19 +18,23 @@ CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q,
 
 CEED_QFUNCTION(mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
                      CeedScalar *const *out) {
-  const CeedScalar *rho = in[0], *u = in[1];
-  CeedScalar *v = out[0];
+  // *INDENT-OFF*
+  const CeedScalar (*q_data)             = (const CeedScalar(*))in[0],
+                        (*u)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  CeedScalar            (*v)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  // *INDENT-ON*
 
+  const CeedScalar num_comp = 2;
   const CeedScalar scale[2][2] = {
     {1.0, 2.0},
     {3.0, 4.0},
   };
 
   for (CeedInt i = 0; i < Q; i++) {
-    for (CeedInt c_out = 0; c_out < 2; c_out++) {
-      v[i+Q*c_out] = 0.0;
-      for (CeedInt c_in = 0; c_in < 2; c_in++) {
-        v[i+Q*c_out] += rho[i] * u[i+Q*c_in] * scale[c_in][c_out];
+    for (CeedInt c_out = 0; c_out < num_comp; c_out++) {
+      v[c_out][i] = 0.0;
+      for (CeedInt c_in = 0; c_in < num_comp; c_in++) {
+        v[c_out][i] += q_data[i] * u[c_in][i] * scale[c_in][c_out];
       }
     }
   }

--- a/tests/t567-operator.c
+++ b/tests/t567-operator.c
@@ -1,0 +1,184 @@
+/// @file
+/// Test assembly of non-symmetric Poisson operator (multi-component)
+/// \test Test assembly of non-symmetric Poisson operator (multi-component)
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t567-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction elem_restr_x, elem_restr_u,
+                      elem_restr_qd_i;
+  CeedBasis basis_x, basis_u;
+  CeedQFunction qf_setup, qf_diff;
+  CeedOperator op_setup, op_diff;
+  CeedVector q_data, X, U, V;
+  CeedInt P = 3, Q = 3, dim = 2, num_comp = 2;
+  CeedInt n_x = 1, n_y = 1;
+  CeedInt num_elem = n_x * n_y;
+  CeedInt num_dofs = (n_x*(P-1)+1)*(n_y*(P-1)+1), num_qpts = num_elem*Q*Q;
+  CeedInt ind_x[num_elem*P*P];
+  CeedScalar assembled[num_comp*num_comp*num_dofs*num_dofs];
+  CeedScalar x[dim*num_dofs], assembled_true[num_comp*num_comp*num_dofs*num_dofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<n_x*(P-1)+1; i++)
+    for (CeedInt j=0; j<n_y*(P-1)+1; j++) {
+      x[i+j*(n_x*2+1)+0*num_dofs] = (CeedScalar) i / (n_x * (P-1));
+      x[i+j*(n_x*2+1)+1*num_dofs] = (CeedScalar) j / (n_y * (P-1));
+    }
+  CeedVectorCreate(ceed, dim*num_dofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vector
+  CeedVectorCreate(ceed, num_qpts*dim*(dim+1)/2, &q_data);
+
+  // Element Setup
+  for (CeedInt i=0; i<num_elem; i++) {
+    CeedInt col, row, offset;
+    col = i % n_x;
+    row = i / n_x;
+    offset = col*(P-1) + row*(n_x*(P-1)+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        ind_x[P*(P*i+k)+j] = offset + k*P + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, num_elem, P*P, dim, num_dofs, dim*num_dofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restr_x);
+  CeedElemRestrictionCreate(ceed, num_elem, P*P, num_comp, num_dofs,
+                            num_comp*num_dofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restr_u);
+  CeedInt strides_qd[3] = {1, Q*Q*num_elem, Q*Q}; /* *NOPAD* */
+  CeedElemRestrictionCreateStrided(ceed, num_elem, Q*Q, dim*(dim+1)/2,
+                                   num_qpts*dim*(dim+1)/2, strides_qd, &elem_restr_qd_i);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp, P, Q, CEED_GAUSS,
+                                  &basis_u);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, diff, diff_loc, &qf_diff);
+  CeedQFunctionAddInput(qf_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_diff, "u", num_comp*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_diff, "v", num_comp*dim, CEED_EVAL_GRAD);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restr_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "qdata", elem_restr_qd_i, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diff);
+  CeedOperatorSetField(op_diff, "qdata", elem_restr_qd_i, CEED_BASIS_COLLOCATED,
+                       q_data);
+  CeedOperatorSetField(op_diff, "u", elem_restr_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "v", elem_restr_u, basis_u, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, X, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fuly assemble operator
+  for (CeedInt k=0; k<num_comp*num_comp*num_dofs*num_dofs; k++) {
+    assembled[k] = 0.0;
+    assembled_true[k] = 0.0;
+  }
+  CeedSize nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedVector values;
+  CeedOperatorLinearAssembleSymbolic(op_diff, &nentries, &rows, &cols);
+  CeedVectorCreate(ceed, nentries, &values);
+  CeedOperatorLinearAssemble(op_diff, values);
+  const CeedScalar *vals;
+  CeedVectorGetArrayRead(values, CEED_MEM_HOST, &vals);
+  for (CeedInt k=0; k<nentries; k++) {
+    assembled[rows[k]*num_comp*num_dofs + cols[k]] += vals[k];
+  }
+  CeedVectorRestoreArrayRead(values, &vals);
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, num_comp*num_dofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, num_comp*num_dofs, &V);
+  CeedInt indOld = -1;
+
+  for (CeedInt comp_in=0; comp_in<num_comp; comp_in++) {
+    for (CeedInt node_in=0; node_in<num_dofs; node_in++) {
+      // Set input
+      CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+      CeedInt ind = node_in + comp_in*num_dofs;
+      u[ind] = 1.0;
+      if (ind > 0)
+        u[indOld] = 0.0;
+      indOld = ind;
+      CeedVectorRestoreArray(U, &u);
+
+      // Compute effect of DoF j
+      CeedOperatorApply(op_diff, U, V, CEED_REQUEST_IMMEDIATE);
+
+      CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+      for (CeedInt k=0; k<num_dofs*num_comp; k++) {
+        assembled_true[k*num_dofs*num_comp + ind] = v[k];
+      }
+      CeedVectorRestoreArrayRead(V, &v);
+    }
+  }
+
+  // Check output
+  for (CeedInt node_in=0; node_in<num_dofs; node_in++) {
+    for (CeedInt comp_in=0; comp_in<num_comp; comp_in++) {
+      for (CeedInt node_out=0; node_out<num_dofs; node_out++) {
+        for (CeedInt comp_out=0; comp_out<num_comp; comp_out++) {
+          const CeedInt index = (node_out + comp_out*num_dofs)*num_comp + node_in +
+                                comp_in*num_dofs;
+          const CeedScalar assembled_value = assembled[index];
+          const CeedScalar assembled_true_value = assembled_true[index];
+          if (fabs(assembled_value - assembled_true_value) >
+              100.*CEED_EPSILON)
+            // LCOV_EXCL_START
+            printf("[(%d, %d), (%d, %d)] Error in assembly: %f != %f\n",
+                   node_out, comp_out, node_in, comp_in,
+                   assembled_value, assembled_true_value);
+          // LCOV_EXCL_STOP
+        }
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  CeedVectorDestroy(&values);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_diff);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_diff);
+  CeedElemRestrictionDestroy(&elem_restr_u);
+  CeedElemRestrictionDestroy(&elem_restr_x);
+  CeedElemRestrictionDestroy(&elem_restr_qd_i);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_x);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t567-operator.h
+++ b/tests/t567-operator.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q,
+                      const CeedScalar *const *in,
+                      CeedScalar *const *out) {
+    // *INDENT-OFF*
+  const CeedScalar                  *w = in[0],
+                   (*J)[2][CEED_Q_VLA] = (const CeedScalar(*)[2][CEED_Q_VLA])in[1];
+  CeedScalar     (*q_data)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+    // *INDENT-ON*
+
+  // Quadrature point loop
+  CeedPragmaSIMD
+  for (CeedInt i=0; i<Q; i++) {
+    // Qdata stored in Voigt convention
+    // J: 0 2   q_data: 0 2   adj(J):  J11 -J01
+    //    1 3           2 1           -J10  J00
+    const CeedScalar J00 = J[0][0][i];
+    const CeedScalar J10 = J[0][1][i];
+    const CeedScalar J01 = J[1][0][i];
+    const CeedScalar J11 = J[1][1][i];
+    const CeedScalar qw = w[i] / (J00*J11 - J10*J01);
+    q_data[0][i] =   qw * (J01*J01 + J11*J11);
+    q_data[1][i] =   qw * (J00*J00 + J10*J10);
+    q_data[2][i] = - qw * (J00*J01 + J10*J11);
+  } // End of Quadrature Point Loop
+
+  return 0;
+}
+
+CEED_QFUNCTION(diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
+                     CeedScalar *const *out) {
+    // *INDENT-OFF*
+  const CeedScalar (*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0],
+                       (*ug)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  CeedScalar           (*vg)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+    // *INDENT-ON*
+
+  const CeedInt dim = 2;
+  const CeedScalar scale[2][2] = {
+    {1.0, 2.0},
+    {3.0, 4.0},
+  };
+
+  // Quadrature point loop
+  CeedPragmaSIMD
+  for (CeedInt i=0; i<Q; i++) {
+    // Read qdata (dXdxdXdxT symmetric matrix)
+    // Stored in Voigt convention
+    // 0 2
+    // 2 1
+    // *INDENT-OFF*
+    const CeedScalar dXdxdXdxT[2][2] = {{q_data[0][i],
+                                         q_data[2][i]},
+                                        {q_data[2][i],
+                                         q_data[1][i]}
+                                       };
+    // *INDENT-ON*
+
+    // Apply Poisson operator
+    // j = direction of vg
+    for (CeedInt j=0; j<dim; j++)
+      vg[j][i] = (ug[0][i] * dXdxdXdxT[0][j] * scale[0][j] +
+                  ug[1][i] * dXdxdXdxT[1][j] * scale[1][j]);
+  } // End of Quadrature Point Loop
+
+  return 0;
+}

--- a/tests/t567-operator.h
+++ b/tests/t567-operator.h
@@ -36,12 +36,13 @@ CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q,
 CEED_QFUNCTION(diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
                      CeedScalar *const *out) {
     // *INDENT-OFF*
-  const CeedScalar (*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0],
-                       (*ug)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
-  CeedScalar           (*vg)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  const CeedScalar (*q_data)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[0],
+                       (*ug)[2][CEED_Q_VLA] = (const CeedScalar(*)[2][CEED_Q_VLA])in[1];
+  CeedScalar           (*vg)[2][CEED_Q_VLA] = (CeedScalar(*)[2][CEED_Q_VLA])out[0];
     // *INDENT-ON*
 
   const CeedInt dim = 2;
+  const CeedScalar num_comp = 2;
   const CeedScalar scale[2][2] = {
     {1.0, 2.0},
     {3.0, 4.0},
@@ -64,9 +65,12 @@ CEED_QFUNCTION(diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
 
     // Apply Poisson operator
     // j = direction of vg
-    for (CeedInt j=0; j<dim; j++)
-      vg[j][i] = (ug[0][i] * dXdxdXdxT[0][j] * scale[0][j] +
-                  ug[1][i] * dXdxdXdxT[1][j] * scale[1][j]);
+    for (CeedInt j=0; j<dim; j++) {
+      for (CeedInt k=0; k<num_comp; k++) {
+        vg[j][k][i] = (ug[0][k][i] * dXdxdXdxT[0][j] * scale[0][j] +
+                       ug[1][k][i] * dXdxdXdxT[1][j] * scale[1][j]);
+      }
+    }
   } // End of Quadrature Point Loop
 
   return 0;


### PR DESCRIPTION
@jedbrown @nbeams 

I added t566, though it looks like this test shows the CPU and GPU failing in the same way?

This should help us track down the assembly issue for the fluids PR.