### PR TITLE
examples/fluids: Create mesh from file distribution

### DIFF
--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -656,22 +656,22 @@ addition to the Newtonian Ideal Gas options:
   - `1.01E5`
   - `Pa`
 
-* - `-refine_height`
-  - Height at which `-Ndelta` number of elements should refined into
+* - `-platemesh_refine_height`
+  - Height at which `-platemesh_Ndelta` number of elements should refined into
   - `5.9E-4`
   - `m`
 
-* - `-Ndelta`
-  - Number of elements to keep below `-refine_height`
+* - `-platemesh_Ndelta`
+  - Number of elements to keep below `-platemesh_refine_height`
   - `45`
   -
 
-* - `-growth`
+* - `-platemesh_growth`
   - Growth rate of the elements in the refinement region
   - `1.08`
   -
 
-* - `-top_angle`
+* - `-platemesh_top_angle`
   - Downward angle of the top face of the domain. This face serves as an outlet.
   - `5`
   - `degrees`
@@ -679,6 +679,11 @@ addition to the Newtonian Ideal Gas options:
 * - `-stg_use`
   - Whether to use stg for the inflow conditions
   - `false`
+  -
+
+* - `-platemesh_y_node_locs_path`
+  - Path to file with y node locations. If empty, will use mesh warping instead.
+  - `""`
   -
 :::
 

--- a/examples/fluids/blasius.yaml
+++ b/examples/fluids/blasius.yaml
@@ -8,33 +8,31 @@ ts:
   max_time: 1.0e-3
 output_freq: 10
 
-#snes_max_it: 4
-#snes_convergence_test: skip
-
 ## Linear Settings:
 degree: 1
 dm_plex_box_faces: 40,60,1
-nDelta: 45
+platemesh_nDelta: 45
 
-## Quadratic Settings:
-#degree: 2
-#dm_plex_box_faces: 20,30,1
-#nDelta: 22
-#growth: 1.1664 # 1.08^2
+# # Quadratic Settings:
+# degree: 2
+# dm_plex_box_faces: 20,30,1
+# platemesh:
+#   nDelta: 22
+#   growth: 1.1664 # 1.08^2
 
 stab: 'supg'
 Ctau_t: 1
-#Ctau_v: 36,60,128 is what PHASTA has for p=1,2, 3
-## linear Settings:
+#Ctau_v: 36,60,128 is what PHASTA has for p=1,2,3
+# Linear Settings:
 Ctau_v: 36
 Ctau_C: 0.25
 Ctau_M: 0.25
 Ctau_E: 0.125
-## Quadratic Settings:
-#Ctau_v: 60
-#Ctau_C: 0.125
-#Ctau_M: 0.125
-#Ctau_E: 0.125
+# # Quadratic Settings:
+# Ctau_v: 60
+# Ctau_C: 0.125
+# Ctau_M: 0.125
+# Ctau_E: 0.125
 
 q_extra: 0
 

--- a/examples/fluids/index.md
+++ b/examples/fluids/index.md
@@ -618,3 +618,29 @@ numerous terms in the STG formulation.
 | $\{\kappa^n\}_{n=1}^N$ | k^n  | No           | Yes      |
 | $h_i$           | h_i    | Yes          | No   |
 | $d_w$           | d_w    | Yes          | No   |
+
+### Meshing
+
+The flat plate boundary layer example has custom meshing features to better
+resolve the flow. One of those is tilting the top of the domain, allowing for
+it to be a outflow boundary condition. The angle of this tilt is controled by
+`-platemesh_top_angle`
+
+The primary meshing feature is the ability to grade the mesh, providing better
+resolution near the wall. There are two methods to do this; algorithmically, or
+specifying the node locations via a file. Algorithmically, a base node
+distribution is defined at the inlet (assumed to be $\min(x)$) and then
+linearly stretched/squeezed to match the slanted top boundary condition. Nodes
+are placed such that `-platemesh_Ndelta` elements are within
+`-platemesh_refine_height` of the wall. They are placed such that the element
+height matches a geometric growth ratio defined by `-platemesh_growth`. The
+remaining elements are then distributed from `-platemesh_refine_height` to the
+top of the domain linearly in logarithmic space.
+
+Alternatively, a file may be specified containing the locations of each node.
+The file should be newline delimited, with the first line specifying the number
+of points and the rest being the locations of the nodes. The node locations
+used exactly at the inlet (assumed to be $\min(x)$) and linearly
+stretched/squeezed to match the slanted top boundary condition. The file is
+specified via `-platemesh_y_node_locs_path`. If this flag is given an empty
+string, then the algorithmic approach will be performed.

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -12,6 +12,41 @@
 #include "../qfunctions/blasius.h"
 #include "stg_shur14.h"
 
+static PetscErrorCode GetYNodeLocs(const MPI_Comm comm,
+                                   const char path[PETSC_MAX_PATH_LEN], PetscReal **pynodes,
+                                   PetscInt *nynodes) {
+  PetscErrorCode ierr;
+  PetscInt ndims, dims[2];
+  FILE *fp;
+  const PetscInt char_array_len = 512;
+  char line[char_array_len];
+  char **array;
+  PetscReal *node_locs;
+  PetscFunctionBeginUser;
+
+  ierr = PetscFOpen(comm, path, "r", &fp); CHKERRQ(ierr);
+  ierr = PetscSynchronizedFGets(comm, fp, char_array_len, line); CHKERRQ(ierr);
+  ierr = PetscStrToArray(line, ' ', &ndims, &array); CHKERRQ(ierr);
+
+  for (PetscInt i=0; i<ndims; i++)  dims[i] = atoi(array[i]);
+  if (ndims<2) dims[1] = 1; // Assume 1 column of data is not otherwise specified
+  *nynodes = dims[0];
+  ierr = PetscMalloc1(*nynodes, &node_locs); CHKERRQ(ierr);
+
+  for (PetscInt i=0; i<dims[0]; i++) {
+    ierr = PetscSynchronizedFGets(comm, fp, char_array_len, line); CHKERRQ(ierr);
+    ierr = PetscStrToArray(line, ' ', &ndims, &array); CHKERRQ(ierr);
+    if (ndims < dims[1]) SETERRQ(comm, -1,
+                                   "Line %d of %s does not contain enough columns (%d instead of %d)", i,
+                                   path, ndims, dims[1]);
+
+    node_locs[i] = (PetscReal) atof(array[0]);
+  }
+  ierr = PetscFClose(comm, fp); CHKERRQ(ierr);
+  *pynodes = node_locs;
+  PetscFunctionReturn(0);
+}
+
 /* \brief Modify the domain and mesh for blasius
  *
  * Modifies mesh such that `N` elements are within `refine_height` with a
@@ -20,10 +55,14 @@
  *
  * The top surface is also angled downwards, so that it may be used as an
  * outflow. It's angle is controlled by `top_angle` (in units of degrees).
+ *
+ * If `node_locs` is not NULL, then the nodes will be placed at `node_locs`
+ * locations.
  */
-static PetscErrorCode ModifyMesh(DM dm, PetscInt dim, PetscReal growth,
-                                 PetscInt N, PetscReal refine_height,
-                                 PetscReal top_angle) {
+static PetscErrorCode ModifyMesh(MPI_Comm comm, DM dm, PetscInt dim,
+                                 PetscReal growth, PetscInt N,
+                                 PetscReal refine_height, PetscReal top_angle,
+                                 PetscReal node_locs[], PetscInt num_node_locs) {
 
   PetscInt ierr, narr, ncoords;
   PetscReal domain_min[3], domain_max[3], domain_size[3];
@@ -49,23 +88,44 @@ static PetscErrorCode ModifyMesh(DM dm, PetscInt dim, PetscReal growth,
   PetscInt nmax = 3, faces[3];
   ierr = PetscOptionsGetIntArray(NULL, NULL, "-dm_plex_box_faces", faces, &nmax,
                                  NULL); CHKERRQ(ierr);
+  // Get element size of the box mesh, for indexing each node
+  const PetscReal dybox = domain_size[1]/faces[1];
 
-  // Calculate the first element height
-  PetscReal dybox = domain_size[1]/faces[1];
-  PetscReal dy1   = refine_height*(growth-1)/(pow(growth, N)-1);
+  if (!node_locs) {
+    // Calculate the first element height
+    PetscReal dy1   = refine_height*(growth-1)/(pow(growth, N)-1);
 
-  // Calculate log of sizing outside BL
-  PetscReal logdy = (log(domain_max[1]) - log(refine_height)) / (faces[1] - N);
+    // Calculate log of sizing outside BL
+    PetscReal logdy = (log(domain_max[1]) - log(refine_height)) / (faces[1] - N);
 
-  for(PetscInt i=0; i<ncoords; i++) {
-    PetscInt y_box_index = round(coords[i][1]/dybox);
-    if(y_box_index <= N) {
-      coords[i][1] = (1 - (coords[i][0]/domain_max[0])*angle_coeff) *
-                     dy1*(pow(growth, coords[i][1]/dybox)-1)/(growth-1);
-    } else {
-      PetscInt j = y_box_index - N;
-      coords[i][1] = (1 - (coords[i][0]/domain_max[0])*angle_coeff) *
-                     exp(log(refine_height) + logdy*j);
+    for (PetscInt i=0; i<ncoords; i++) {
+      PetscInt y_box_index = round(coords[i][1]/dybox);
+      if (y_box_index <= N) {
+        coords[i][1] = (1 - ((coords[i][0] - domain_min[0])/domain_size[0])*angle_coeff)
+                       * dy1 * (pow(growth, coords[i][1]/dybox)-1)/(growth-1);
+      } else {
+        PetscInt j = y_box_index - N;
+        coords[i][1] = (1 - ((coords[i][0] - domain_min[0])/domain_size[0])*angle_coeff)
+                       * exp(log(refine_height) + logdy*j);
+      }
+    }
+  } else {
+    // Error checking
+    if (num_node_locs < faces[1] +1)
+      SETERRQ(comm, -1, "The y_node_locs_path has too few locations; "
+              "There are %d + 1 nodes, but only %d locations given",
+              faces[1]+1, num_node_locs);
+    if (num_node_locs > faces[1] +1) {
+      ierr = PetscPrintf(comm, "WARNING: y_node_locs_path has more locations (%d) "
+                         "than the mesh has nodes (%d). This maybe unintended.",
+                         num_node_locs, faces[1]+1); CHKERRQ(ierr);
+    }
+
+    for (PetscInt i=0; i<ncoords; i++) {
+      // Determine which y-node we're at
+      PetscInt y_box_index = round(coords[i][1]/dybox);
+      coords[i][1] = (1 - ((coords[i][0] - domain_min[0])/domain_size[0])*angle_coeff)
+                     * node_locs[y_box_index];
     }
   }
 
@@ -109,6 +169,7 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx) {
   PetscReal  mesh_growth        = 1.08;   // [-]
   PetscInt   mesh_Ndelta        = 45;     // [-]
   PetscReal  mesh_top_angle     = 5;      // degrees
+  char mesh_ynodes_path[PETSC_MAX_PATH_LEN] = "";
 
   PetscOptionsBegin(comm, NULL, "Options for CHANNEL problem", NULL);
   ierr = PetscOptionsBool("-weakT", "Change from rho weak to T weak at inflow",
@@ -133,6 +194,11 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx) {
   ierr = PetscOptionsScalar("-platemesh_top_angle",
                             "Geometric top_angle rate of boundary layer mesh",
                             NULL, mesh_top_angle, &mesh_top_angle, NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsString("-platemesh_y_node_locs_path",
+                            "Path to file with y node locations. "
+                            "If empty, will use the algorithmic mesh warping.", NULL,
+                            mesh_ynodes_path, mesh_ynodes_path,
+                            sizeof(mesh_ynodes_path), NULL); CHKERRQ(ierr);
   ierr = PetscOptionsBool("-stg_use", "Use STG inflow boundary condition",
                           NULL, use_stg, &use_stg, NULL); CHKERRQ(ierr);
   PetscOptionsEnd();
@@ -147,8 +213,16 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx) {
   Uinf   *= meter / second;
   delta0 *= meter;
 
-  ierr = ModifyMesh(dm, problem->dim, mesh_growth, mesh_Ndelta, mesh_refine_height, mesh_top_angle);
-  CHKERRQ(ierr);
+  PetscReal *mesh_ynodes = NULL;
+  PetscInt  mesh_nynodes = 0;
+  if (strcmp(mesh_ynodes_path, "")) {
+    ierr = GetYNodeLocs(comm, mesh_ynodes_path, &mesh_ynodes, &mesh_nynodes);
+    CHKERRQ(ierr);
+  }
+  ierr = ModifyMesh(comm, dm, problem->dim, mesh_growth, mesh_Ndelta,
+                    mesh_refine_height, mesh_top_angle, mesh_ynodes,
+                    mesh_nynodes); CHKERRQ(ierr);
+  ierr = PetscFree(mesh_ynodes); CHKERRQ(ierr);
 
   // Some properties depend on parameters from NewtonianIdealGas
   CeedQFunctionContextGetData(problem->apply_vol_rhs.qfunction_context,

--- a/examples/fluids/tests-output/blasius_stgtest.yaml
+++ b/examples/fluids/tests-output/blasius_stgtest.yaml
@@ -9,8 +9,9 @@ ts:
 output_freq: 10
 
 dm_plex_box_faces: 3,30,1
-nDelta: 22
-growth: 1.1664 # 1.08^2
+platemesh:
+  Ndelta: 22
+  growth: 1.1664 # 1.08^2
 
 stab: 'supg'
 Ctau_t: 1


### PR DESCRIPTION
For the flat plate boundary layer problems, allow for the wall-normal node distribution to be defined by a file of node locations.

Note this is currently feature complete, but awaits #868 to be merged. (though it could technically be merged before as well).