### PR TITLE
GPU assembly: fix possible basis loading offset error

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -1290,7 +1290,7 @@ static int CeedSingleOperatorAssembleSetup_Cuda(CeedOperator op) {
                         cudaMemcpyHostToDevice); CeedChk_Cu(ceed, ierr);
       mat_start += esize * nqpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
-      ierr = cudaMemcpy(asmb->d_B_in, grad_in,
+      ierr = cudaMemcpy(&asmb->d_B_in[mat_start], grad_in,
                         dim * esize * nqpts * sizeof(CeedScalar),
                         cudaMemcpyHostToDevice); CeedChk_Cu(ceed, ierr);
       mat_start += dim * esize * nqpts;

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -1285,7 +1285,7 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op) {
                        hipMemcpyHostToDevice); CeedChk_Hip(ceed, ierr);
       mat_start += esize * nqpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
-      ierr = hipMemcpy(asmb->d_B_in, grad_in,
+      ierr = hipMemcpy(&asmb->d_B_in[mat_start], grad_in,
                        dim * esize * nqpts * sizeof(CeedScalar),
                        hipMemcpyHostToDevice); CeedChk_Hip(ceed, ierr);
       mat_start += dim * esize * nqpts;


### PR DESCRIPTION
Fix a bug that leads to incorrect basis matrix loading in the setup of GPU operator assembly if: 1) one of the input eval modes is `GRAD`, and 2) it is not the first eval mode.

Discovered through fluids examples (see https://github.com/CEED/libCEED/pull/962).