### PR TITLE
pc - fix GPU single operator fallback

### DIFF
--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -1295,7 +1295,13 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op) {
 }
 
 //------------------------------------------------------------------------------
-// Single operator assembly
+// Assemble matrix data for COO matrix of assembled operator.
+// The sparsity pattern is set by CeedOperatorLinearAssembleSymbolic.
+//
+// Note that this (and other assembly routines) currently assume only one
+// active input restriction/basis per operator (could have multiple basis eval
+// modes).
+// TODO: allow multiple active input restrictions/basis objects
 //------------------------------------------------------------------------------
 static int CeedSingleOperatorAssemble_Hip(CeedOperator op, CeedInt offset,
     CeedVector values) {
@@ -1353,21 +1359,6 @@ static int CeedSingleOperatorAssemble_Hip(CeedOperator op, CeedInt offset,
 }
 
 //------------------------------------------------------------------------------
-// Assemble matrix data for COO matrix of assembled operator.
-// The sparsity pattern is set by CeedOperatorLinearAssembleSymbolic.
-//
-// Note that this (and other assembly routines) currently assume only one
-// active input restriction/basis per operator (could have multiple basis eval
-// modes).
-// TODO: allow multiple active input restrictions/basis objects
-//------------------------------------------------------------------------------
-int CeedOperatorLinearAssemble_Hip(CeedOperator op, CeedVector values) {
-  int ierr = CeedSingleOperatorAssemble_Hip(op, 0, values);
-  CeedChkBackend(ierr);
-  return CEED_ERROR_SUCCESS;
-}
-
-//------------------------------------------------------------------------------
 // Create operator
 //------------------------------------------------------------------------------
 int CeedOperatorCreate_Hip(CeedOperator op) {
@@ -1394,7 +1385,7 @@ int CeedOperatorCreate_Hip(CeedOperator op) {
                                 CeedOperatorLinearAssembleAddPointBlockDiagonal_Hip);
   CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op,
-                                "LinearAssemble", CeedOperatorLinearAssemble_Hip);
+                                "LinearAssembleSingle", CeedSingleOperatorAssemble_Hip);
   CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd",
                                 CeedOperatorApplyAdd_Hip); CeedChkBackend(ierr);

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -356,6 +356,7 @@ struct CeedOperator_private {
   int (*LinearAssembleSymbolic)(CeedOperator, CeedSize *, CeedInt **,
                                 CeedInt **);
   int (*LinearAssemble)(CeedOperator, CeedVector);
+  int (*LinearAssembleSingle)(CeedOperator, CeedInt, CeedVector);
   int (*CreateFDMElementInverse)(CeedOperator, CeedOperator *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -927,6 +927,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleAddPointBlockDiagonal),
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSymbolic),
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssemble),
+    CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSingle),
     CEED_FTABLE_ENTRY(CeedOperator, CreateFDMElementInverse),
     CEED_FTABLE_ENTRY(CeedOperator, Apply),
     CEED_FTABLE_ENTRY(CeedOperator, ApplyComposite),

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -553,7 +553,8 @@ int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource) {
   CeedChk(ierr);
 
   // Check validity
-  ceed->has_valid_op_fallback_resource = strlen(ceed->op_fallback_resource) > 0 &&
+  ceed->has_valid_op_fallback_resource = ceed->op_fallback_resource &&
+                                         ceed->resource &&
                                          strcmp(ceed->op_fallback_resource, ceed->resource);
 
   return CEED_ERROR_SUCCESS;


### PR DESCRIPTION
Good catch @nbeams, this should fix it. It seems to be working locally for me when I use `CEED_DEBUG=1 ./build/t565-operator /gpu/cuda > out.txt` and look at the generated kernels.