### PR TITLE
Fluids - Fix memory leak

### DIFF
--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -12,8 +12,7 @@
 #include "../qfunctions/setupgeo.h"
 #include "../qfunctions/advection.h"
 
-PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm,
-                            void *ctx) {
+PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *ctx) {
   WindType             wind_type;
   BubbleType           bubble_type;
   BubbleContinuityType bubble_continuity_type;

--- a/examples/fluids/problems/advection2d.c
+++ b/examples/fluids/problems/advection2d.c
@@ -13,6 +13,7 @@
 #include "../qfunctions/advection2d.h"
 
 PetscErrorCode NS_ADVECTION2D(ProblemData *problem, DM dm, void *ctx) {
+
   WindType          wind_type;
   StabilizationType stab;
   SetupContext      setup_context;

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -63,7 +63,6 @@ static PetscErrorCode ModifyMesh(MPI_Comm comm, DM dm, PetscInt dim,
                                  PetscReal growth, PetscInt N,
                                  PetscReal refine_height, PetscReal top_angle,
                                  PetscReal node_locs[], PetscInt num_node_locs) {
-
   PetscInt ierr, narr, ncoords;
   PetscReal domain_min[3], domain_max[3], domain_size[3];
   PetscScalar *arr_coords;

--- a/examples/fluids/problems/channel.c
+++ b/examples/fluids/problems/channel.c
@@ -11,8 +11,7 @@
 #include "../navierstokes.h"
 #include "../qfunctions/channel.h"
 
-PetscErrorCode NS_CHANNEL(ProblemData *problem, DM dm,
-                          void *ctx) {
+PetscErrorCode NS_CHANNEL(ProblemData *problem, DM dm, void *ctx) {
 
   PetscInt ierr;
   User              user = *(User *)ctx;

--- a/examples/fluids/problems/eulervortex.c
+++ b/examples/fluids/problems/eulervortex.c
@@ -13,6 +13,7 @@
 #include "../qfunctions/eulervortex.h"
 
 PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *ctx) {
+
   EulerTestType     euler_test;
   User              user = *(User *)ctx;
   StabilizationType stab;

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -16,6 +16,7 @@
 static PetscErrorCode CheckPrimitiveWithTolerance(StatePrimitive sY,
     StatePrimitive aY, StatePrimitive bY, const char *name, PetscReal rtol_pressure,
     PetscReal rtol_velocity, PetscReal rtol_temperature) {
+
   PetscFunctionBeginUser;
   StatePrimitive eY; // relative error
   eY.pressure = (aY.pressure - bY.pressure) / sY.pressure;
@@ -35,6 +36,7 @@ static PetscErrorCode CheckPrimitiveWithTolerance(StatePrimitive sY,
 
 static PetscErrorCode UnitTests_Newtonian(User user,
     NewtonianIdealGasContext gas) {
+
   Units units = user->units;
   const CeedScalar eps = 1e-6;
   const CeedScalar kg = units->kilogram, m = units->meter, sec = units->second,
@@ -66,6 +68,7 @@ static PetscErrorCode UnitTests_Newtonian(User user,
 }
 
 PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx) {
+
   SetupContext      setup_context;
   User              user = *(User *)ctx;
   StabilizationType stab;

--- a/examples/fluids/problems/shocktube.c
+++ b/examples/fluids/problems/shocktube.c
@@ -22,6 +22,7 @@
 #include "../qfunctions/shocktube.h"
 
 PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx) {
+
   SetupContext      setup_context;
   User              user = *(User *)ctx;
   MPI_Comm          comm = PETSC_COMM_WORLD;
@@ -32,7 +33,6 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx) {
   PetscInt          ierr;
   ShockTubeContext  shocktube_ctx;
   CeedQFunctionContext shocktube_context;
-
 
   PetscFunctionBeginUser;
   ierr = PetscCalloc1(1, &setup_context); CHKERRQ(ierr);
@@ -173,6 +173,7 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx) {
 }
 
 PetscErrorCode PRINT_SHOCKTUBE(ProblemData *problem, AppCtx app_ctx) {
+
   MPI_Comm       comm = PETSC_COMM_WORLD;
   PetscErrorCode ierr;
   PetscFunctionBeginUser;

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -33,7 +33,6 @@
  */
 PetscErrorCode CalcCholeskyDecomp(MPI_Comm comm, PetscInt nprofs,
                                   const CeedScalar Rij[6][nprofs], CeedScalar Cij[6][nprofs]) {
-
   PetscFunctionBeginUser;
   for (PetscInt i=0; i<nprofs; i++) {
     Cij[0][i] = sqrt(Rij[0][i]);
@@ -196,7 +195,6 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm,
 static PetscErrorCode ReadSTGRand(const MPI_Comm comm,
                                   const char path[PETSC_MAX_PATH_LEN],
                                   STGShur14Context stg_ctx) {
-
   PetscErrorCode ierr;
   PetscInt ndims, dims[2];
   FILE *fp;
@@ -411,6 +409,7 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
 
 static inline PetscScalar FindDy(const PetscScalar ynodes[],
                                  const PetscInt nynodes, const PetscScalar y) {
+
   const PetscScalar half_mindy = 0.5 * (ynodes[1] - ynodes[0]);
   // ^^assuming min(dy) is first element off the wall
   PetscInt idx = -1; // Index
@@ -463,7 +462,6 @@ PetscErrorCode StrongSTGbcFunc(PetscInt dim, PetscReal time,
 
 PetscErrorCode SetupStrongSTG(DM dm, SimpleBC bc, ProblemData *problem,
                               STGShur14Context stg_ctx) {
-
   PetscErrorCode ierr;
   DMLabel label;
   const PetscInt comps[] = {0, 1, 2, 3};

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -673,6 +673,7 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user,
 
   }
   CeedElemRestrictionDestroy(&elem_restr_jd_i);
+  CeedOperatorDestroy(&op_ijacobian_vol);
   CeedVectorDestroy(&jac_data);
   PetscFunctionReturn(0);
 }


### PR DESCRIPTION
I was able to find only one libCEED related memory access violation. `petsc_dump` is also clean now.

Closes #983 