### PR TITLE
Test for assembly w/non-square D

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -990,9 +990,6 @@ static inline int CeedOperatorAssembleDiagonalCore_Cuda(CeedOperator op,
   ierr = CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembledqf,
          &rstr, request); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionDestroy(&rstr); CeedChkBackend(ierr);
-  CeedScalar maxnorm = 0;
-  ierr = CeedVectorNorm(assembledqf, CEED_NORM_MAX, &maxnorm);
-  CeedChkBackend(ierr);
 
   // Setup
   if (!impl->diag) {
@@ -1036,7 +1033,7 @@ static inline int CeedOperatorAssembleDiagonalCore_Cuda(CeedOperator op,
   // Compute the diagonal of B^T D B
   int elemsPerBlock = 1;
   int grid = nelem/elemsPerBlock+((nelem/elemsPerBlock*elemsPerBlock<nelem)?1:0);
-  void *args[] = {(void *) &nelem, (void *) &maxnorm, &diag->d_identity,
+  void *args[] = {(void *) &nelem, &diag->d_identity,
                   &diag->d_interpin, &diag->d_gradin, &diag->d_interpout,
                   &diag->d_gradout, &diag->d_emodein, &diag->d_emodeout,
                   &assembledqfarray, &elemdiagarray

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -987,9 +987,6 @@ static inline int CeedOperatorAssembleDiagonalCore_Hip(CeedOperator op,
   ierr = CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembledqf,
          &rstr, request); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionDestroy(&rstr); CeedChkBackend(ierr);
-  CeedScalar maxnorm = 0;
-  ierr = CeedVectorNorm(assembledqf, CEED_NORM_MAX, &maxnorm);
-  CeedChkBackend(ierr);
 
   // Setup
   if (!impl->diag) {
@@ -1034,7 +1031,7 @@ static inline int CeedOperatorAssembleDiagonalCore_Hip(CeedOperator op,
   // Compute the diagonal of B^T D B
   int elemsPerBlock = 1;
   int grid = nelem/elemsPerBlock+((nelem/elemsPerBlock*elemsPerBlock<nelem)?1:0);
-  void *args[] = {(void *) &nelem, (void *) &maxnorm, &diag->d_identity,
+  void *args[] = {(void *) &nelem, &diag->d_identity,
                   &diag->d_interpin, &diag->d_gradin, &diag->d_interpout,
                   &diag->d_gradout, &diag->d_emodein, &diag->d_emodeout,
                   &assembledqfarray, &elemdiagarray

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -10,6 +10,10 @@ On this page we provide a summary of the main API changes, new features and exam
 
 - Added {c:func}`CeedOperatorSetName` for more readable {c:func}`CeedOperatorView` output.
 
+## Bugfix
+
+- Fix bugs in CPU implementation of {c:func}`CeedOperatorLinearAssemble` when there are different number of active input modes and active output modes.
+
 (v0-10-1)=
 
 ## v0.10.1 (Apr 11, 2022)

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -339,6 +339,14 @@ struct CeedQFunctionAssemblyData_private {
   CeedElemRestriction rstr;
 };
 
+struct CeedOperatorAssemblyData_private {
+  Ceed ceed;
+  CeedInt num_eval_mode_in, num_eval_mode_out;
+  CeedEvalMode *eval_mode_in, *eval_mode_out;
+  CeedScalar *B_in, *B_out;
+  CeedBasis basis_in, basis_out;
+};
+
 struct CeedOperator_private {
   Ceed ceed;
   CeedOperator op_fallback;
@@ -381,6 +389,7 @@ struct CeedOperator_private {
   bool is_composite;
   bool has_restriction;
   CeedQFunctionAssemblyData qf_assembled;
+  CeedOperatorAssemblyData op_assembled;
   CeedOperator *sub_operators;
   CeedInt num_suboperators;
   void *data;

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -82,6 +82,10 @@ typedef struct CeedTensorContract_private *CeedTensorContract;
 /// @ingroup CeedOperator
 typedef struct CeedQFunctionAssemblyData_private *CeedQFunctionAssemblyData;
 
+/// Handle for object handling assembled Operator data
+/// @ingroup CeedOperator
+typedef struct CeedOperatorAssemblyData_private *CeedOperatorAssemblyData;
+
 /* In the next 3 functions, p has to be the address of a pointer type, i.e. p
    has to be a pointer to a pointer. */
 CEED_INTERN int CeedMallocArray(size_t n, size_t unit, void *p);
@@ -114,9 +118,6 @@ CEED_EXTERN int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate,
                                       const char *obj_name);
 CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed delegate,
                                       const char *obj_name);
-CEED_EXTERN int CeedOperatorGetActiveBasis(CeedOperator op,
-                                      CeedBasis *active_basis);
-CEED_EXTERN int CeedOperatorGetActiveElemRestriction(CeedOperator op, CeedElemRestriction *active_rstr);
 CEED_EXTERN int CeedGetOperatorFallbackResource(Ceed ceed,
     const char **resource);
 CEED_EXTERN int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed);
@@ -273,6 +274,15 @@ CEED_EXTERN int CeedQFunctionAssemblyDataSetObjects(CeedQFunctionAssemblyData da
 CEED_EXTERN int CeedQFunctionAssemblyDataGetObjects(CeedQFunctionAssemblyData data, CeedVector *vec, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data);
 
+CEED_EXTERN int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op, CeedOperatorAssemblyData *data);
+CEED_EXTERN int CeedOperatorAssemblyDataGetEvalModes(CeedOperatorAssemblyData data, CeedInt *num_eval_mode_in, const CeedEvalMode **eval_mode_in, CeedInt *num_eval_mode_out, const CeedEvalMode **eval_mode_out);
+CEED_EXTERN int CeedOperatorAssemblyDataGetBases(CeedOperatorAssemblyData data, CeedBasis *basis_in, const CeedScalar **B_in, CeedBasis *basis_out, const CeedScalar **B_out);
+CEED_EXTERN int CeedOperatorAssemblyDataDestroy(CeedOperatorAssemblyData *data);
+
+CEED_EXTERN int CeedOperatorGetOperatorAssemblyData(CeedOperator op, CeedOperatorAssemblyData *data);
+CEED_EXTERN int CeedOperatorGetActiveBasis(CeedOperator op,
+                                      CeedBasis *active_basis);
+CEED_EXTERN int CeedOperatorGetActiveElemRestriction(CeedOperator op, CeedElemRestriction *active_rstr);
 CEED_EXTERN int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args);
 CEED_EXTERN int CeedOperatorIsSetupDone(CeedOperator op, bool *is_setup_done);
 CEED_EXTERN int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf);
@@ -285,7 +295,7 @@ CEED_EXTERN int CeedOperatorSetData(CeedOperator op, void *data);
 CEED_EXTERN int CeedOperatorReference(CeedOperator op);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
-CEED_INTERN int CeedMatrixMultiply(Ceed ceed, const CeedScalar *mat_A,
+CEED_INTERN int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A,
                                    const CeedScalar *mat_B, CeedScalar *mat_C,
                                    CeedInt m, CeedInt n, CeedInt kk);
 

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
@@ -44,17 +44,16 @@ extern "C" __launch_bounds__(BLOCK_SIZE)
         for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
           CeedInt b_in_index = emode_in * NQPTS * NNODES;
       	  for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-             CeedInt b_out_index = emode_out * NQPTS * NNODES;
-             CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
- 	     // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+            CeedInt b_out_index = emode_out * NQPTS * NNODES;
+            CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+ 	        // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
             for (CeedInt j = 0; j < NQPTS; j++) {
      	      result += B_out[b_out_index + j * NNODES  + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];  
-	    }
-
-          }// end of emode_out 
+	        }
+          } // end of emode_out 
         } // end of emode_in
         CeedInt val_index = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
-   	values_array[val_index] = result;
+   	    values_array[val_index] = result;
       } // end of out component
     } // end of in component
   } // end of element loop
@@ -96,15 +95,14 @@ extern "C" __launch_bounds__(BLOCK_SIZE)
           CeedInt qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e; 
           for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
             CeedInt b_in_index = emode_in * NQPTS * NNODES;
-        	  for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-               CeedInt b_out_index = emode_out * NQPTS * NNODES;
-               CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
-   	     // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+        	for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
+              CeedInt b_out_index = emode_out * NQPTS * NNODES;
+              CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+   	          // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
               for (CeedInt j = 0; j < NQPTS; j++) {
-       	      result += B_out[b_out_index + j * NNODES  + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];  
-  	    }
-
-            }// end of emode_out 
+       	        result += B_out[b_out_index + j * NNODES  + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];  
+  	          }
+            } // end of emode_out 
           } // end of emode_in
           CeedInt val_index = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
      	  values_array[val_index] = result;

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h
@@ -53,15 +53,14 @@ extern "C" __device__ void CeedOperatorGetBasisPointer_Hip(const CeedScalar **ba
 // Core code for diagonal assembly
 //------------------------------------------------------------------------------
 __device__ void diagonalCore(const CeedInt nelem,
-    const CeedScalar maxnorm, const bool pointBlock,
-    const CeedScalar *identity,
+    const bool pointBlock, const CeedScalar *identity,
     const CeedScalar *interpin, const CeedScalar *gradin,
     const CeedScalar *interpout, const CeedScalar *gradout,
     const CeedEvalMode *emodein, const CeedEvalMode *emodeout,
     const CeedScalar *__restrict__ assembledqfarray,
     CeedScalar *__restrict__ elemdiagarray) {
   const int tid = threadIdx.x; // running with P threads, tid is evec node
-  const CeedScalar qfvaluebound = maxnorm*1e-12;
+  if (tid >= NNODES) return;
 
   // Compute the diagonal of B^T D B
   // Each element
@@ -93,8 +92,7 @@ __device__ void diagonalCore(const CeedInt nelem,
                 const CeedScalar qfvalue =
                   assembledqfarray[((((ein*NCOMP+compIn)*NUMEMODEOUT+eout)*
                                      NCOMP+compOut)*nelem+e)*NQPTS+q];
-                if (abs(qfvalue) > qfvaluebound)
-                  evalue += bt[q*NNODES+tid] * qfvalue * b[q*NNODES+tid];
+                evalue += bt[q*NNODES+tid] * qfvalue * b[q*NNODES+tid];
               }
               elemdiagarray[((compOut*NCOMP+compIn)*nelem+e)*NNODES+tid] += evalue;
             }
@@ -105,8 +103,7 @@ __device__ void diagonalCore(const CeedInt nelem,
               const CeedScalar qfvalue =
                 assembledqfarray[((((ein*NCOMP+compOut)*NUMEMODEOUT+eout)*
                                    NCOMP+compOut)*nelem+e)*NQPTS+q];
-              if (abs(qfvalue) > qfvaluebound)
-                evalue += bt[q*NNODES+tid] * qfvalue * b[q*NNODES+tid];
+              evalue += bt[q*NNODES+tid] * qfvalue * b[q*NNODES+tid];
             }
             elemdiagarray[(compOut*nelem+e)*NNODES+tid] += evalue;
           }
@@ -120,13 +117,13 @@ __device__ void diagonalCore(const CeedInt nelem,
 // Linear diagonal
 //------------------------------------------------------------------------------
 extern "C" __global__ void linearDiagonal(const CeedInt nelem,
-    const CeedScalar maxnorm, const CeedScalar *identity,
+    const CeedScalar *identity,
     const CeedScalar *interpin, const CeedScalar *gradin,
     const CeedScalar *interpout, const CeedScalar *gradout,
     const CeedEvalMode *emodein, const CeedEvalMode *emodeout,
     const CeedScalar *__restrict__ assembledqfarray,
     CeedScalar *__restrict__ elemdiagarray) {
-  diagonalCore(nelem, maxnorm, false, identity, interpin, gradin, interpout,
+  diagonalCore(nelem, false, identity, interpin, gradin, interpout,
                gradout, emodein, emodeout, assembledqfarray, elemdiagarray);
 }
 
@@ -134,13 +131,13 @@ extern "C" __global__ void linearDiagonal(const CeedInt nelem,
 // Linear point block diagonal
 //------------------------------------------------------------------------------
 extern "C" __global__ void linearPointBlockDiagonal(const CeedInt nelem,
-    const CeedScalar maxnorm, const CeedScalar *identity,
+    const CeedScalar *identity,
     const CeedScalar *interpin, const CeedScalar *gradin,
     const CeedScalar *interpout, const CeedScalar *gradout,
     const CeedEvalMode *emodein, const CeedEvalMode *emodeout,
     const CeedScalar *__restrict__ assembledqfarray,
     CeedScalar *__restrict__ elemdiagarray) {
-  diagonalCore(nelem, maxnorm, true, identity, interpin, gradin, interpout,
+  diagonalCore(nelem, true, identity, interpin, gradin, interpout,
                gradout, emodein, emodeout, assembledqfarray, elemdiagarray);
 }
 

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
@@ -44,17 +44,16 @@ extern "C" __launch_bounds__(BLOCK_SIZE)
         for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
           CeedInt b_in_index = emode_in * NQPTS * NNODES;
       	  for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-             CeedInt b_out_index = emode_out * NQPTS * NNODES;
-             CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
- 	     // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+            CeedInt b_out_index = emode_out * NQPTS * NNODES;
+            CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+ 	        // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
             for (CeedInt j = 0; j < NQPTS; j++) {
      	      result += B_out[b_out_index + j * NNODES  + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];  
-	    }
-
-          }// end of emode_out 
+	        }
+          } // end of emode_out 
         } // end of emode_in
         CeedInt val_index = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
-   	values_array[val_index] = result;
+   	    values_array[val_index] = result;
       } // end of out component
     } // end of in component
   } // end of element loop
@@ -96,15 +95,14 @@ extern "C" __launch_bounds__(BLOCK_SIZE)
           CeedInt qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e; 
           for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
             CeedInt b_in_index = emode_in * NQPTS * NNODES;
-        	  for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-               CeedInt b_out_index = emode_out * NQPTS * NNODES;
-               CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
-   	     // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+        	for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
+              CeedInt b_out_index = emode_out * NQPTS * NNODES;
+              CeedInt qf_index = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+   	          // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
               for (CeedInt j = 0; j < NQPTS; j++) {
-       	      result += B_out[b_out_index + j * NNODES  + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];  
-  	    }
-
-            }// end of emode_out 
+       	        result += B_out[b_out_index + j * NNODES  + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];  
+  	          }
+            } // end of emode_out 
           } // end of emode_in
           CeedInt val_index = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
      	  values_array[val_index] = result;

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -418,9 +418,9 @@ int CeedBasisSetTensorContract(CeedBasis basis, CeedTensorContract contract) {
 
   @ref Utility
 **/
-int CeedMatrixMultiply(Ceed ceed, const CeedScalar *mat_A,
-                       const CeedScalar *mat_B, CeedScalar *mat_C, CeedInt m,
-                       CeedInt n, CeedInt kk) {
+int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A,
+                             const CeedScalar *mat_B, CeedScalar *mat_C,
+                             CeedInt m, CeedInt n, CeedInt kk) {
   for (CeedInt i=0; i<m; i++)
     for (CeedInt j=0; j<n; j++) {
       CeedScalar sum = 0;
@@ -1740,12 +1740,12 @@ int CeedSimultaneousDiagonalization(Ceed ceed, CeedScalar *mat_A,
       mat_C[j*n+i]  = mat_G[i*n+j];
     }
   // -- X = (D^-1/2 G^T) A
-  ierr = CeedMatrixMultiply(ceed, (const CeedScalar *)mat_C,
-                            (const CeedScalar *)mat_A, mat_X, n, n, n);
+  ierr = CeedMatrixMatrixMultiply(ceed, (const CeedScalar *)mat_C,
+                                  (const CeedScalar *)mat_A, mat_X, n, n, n);
   CeedChk(ierr);
   // -- C = (D^-1/2 G^T A) (G D^-1/2)
-  ierr = CeedMatrixMultiply(ceed, (const CeedScalar *)mat_X,
-                            (const CeedScalar *)mat_G, mat_C, n, n, n);
+  ierr = CeedMatrixMatrixMultiply(ceed, (const CeedScalar *)mat_X,
+                                  (const CeedScalar *)mat_G, mat_C, n, n, n);
   CeedChk(ierr);
 
   // Compute Q^T C Q = lambda
@@ -1765,8 +1765,8 @@ int CeedSimultaneousDiagonalization(Ceed ceed, CeedScalar *mat_A,
 
   // Set X = (G D^1/2)^-T Q
   //       = G D^-1/2 Q
-  ierr = CeedMatrixMultiply(ceed, (const CeedScalar *)mat_G,
-                            (const CeedScalar *)mat_C, mat_X, n, n, n);
+  ierr = CeedMatrixMatrixMultiply(ceed, (const CeedScalar *)mat_G,
+                                  (const CeedScalar *)mat_C, mat_X, n, n, n);
   CeedChk(ierr);
 
   // Cleanup

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1701,8 +1701,9 @@ int CeedOperatorDestroy(CeedOperator *op) {
   // Destroy fallback
   ierr = CeedOperatorDestroy(&(*op)->op_fallback); CeedChk(ierr);
 
-  // Destroy QF assembly cache
+  // Destroy assembly data
   ierr = CeedQFunctionAssemblyDataDestroy(&(*op)->qf_assembled); CeedChk(ierr);
+  ierr = CeedOperatorAssemblyDataDestroy(&(*op)->op_assembled); CeedChk(ierr);
 
   ierr = CeedFree(&(*op)->input_fields); CeedChk(ierr);
   ierr = CeedFree(&(*op)->output_fields); CeedChk(ierr);

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -294,7 +294,7 @@ static int CeedOperatorCreateActivePointBlockRestriction(
 
   @ref Developer
 **/
-static inline int CeedSingleOperatorAssembleAddDiagonal(CeedOperator op,
+static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op,
     CeedRequest *request, const bool is_pointblock, CeedVector assembled) {
   int ierr;
   Ceed ceed;
@@ -1722,8 +1722,8 @@ int CeedOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedVector assembled,
     ierr = CeedCompositeOperatorLinearAssembleAddDiagonal(op, request,
            false, assembled); CeedChk(ierr);
   } else {
-    ierr = CeedSingleOperatorAssembleAddDiagonal(op, request, false, assembled);
-    CeedChk(ierr);
+    ierr = CeedSingleOperatorAssembleAddDiagonal_Core(op, request, false,
+           assembled); CeedChk(ierr);
   }
 
   return CEED_ERROR_SUCCESS;
@@ -1860,7 +1860,7 @@ int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op,
     ierr = CeedCompositeOperatorLinearAssembleAddDiagonal(op, request,
            true, assembled); CeedChk(ierr);
   } else {
-    ierr = CeedSingleOperatorAssembleAddDiagonal(op, request, true, assembled);
+    ierr = CeedSingleOperatorAssembleAddDiagonal_Core(op, request, true, assembled);
     CeedChk(ierr);
   }
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -678,23 +678,23 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
     for (CeedInt comp_in = 0; comp_in < num_comp; comp_in++) {
       for (CeedInt comp_out = 0; comp_out < num_comp; comp_out++) {
         // Compute B^T*D
-        const CeedInt mat_size = elem_size * num_qpts*num_eval_mode_in;
-        for (CeedInt i = 0; i < mat_size; i++) BTD_mat[i] = 0.0;
         for (CeedInt n = 0; n < elem_size; n++) {
           for (CeedInt q = 0; q < num_qpts; q++) {
             for (CeedInt e_in = 0; e_in < num_eval_mode_in; e_in++) {
+              const CeedInt btd_index = n*(num_qpts*num_eval_mode_in) +
+                                        (num_eval_mode_in*q + e_in);
+              CeedScalar sum = 0.0;
               for (CeedInt e_out = 0; e_out < num_eval_mode_out; e_out++) {
-                const CeedInt btd_index = n*(num_qpts*num_eval_mode_in) +
-                                          (num_eval_mode_in*q + e_in);
                 const CeedInt b_out_index = (num_eval_mode_out*q + e_out)*elem_size + n;
                 const CeedInt eval_mode_index = ((e_in*num_comp+comp_in)*num_eval_mode_out
                                                  +e_out)*num_comp + comp_out;
                 const CeedInt qf_index = q*layout_qf[0] + eval_mode_index*layout_qf[1] +
                                          e*layout_qf[2];
                 if (fabs(assembled_qf_array[qf_index]) > qf_value_bound) {
-                  BTD_mat[btd_index] += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
+                  sum += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
                 }
               }
+              BTD_mat[btd_index] = sum;
             }
           }
         }

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -9,6 +9,7 @@
 #include <ceed/backend.h>
 #include <ceed-impl.h>
 #include <math.h>
+#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -226,6 +227,7 @@ static inline void CeedOperatorGetBasisPointer(CeedEvalMode eval_mode,
   case CEED_EVAL_CURL:
     break; // Caught by QF Assembly
   }
+  assert(*basis_ptr != NULL);
 }
 
 /**
@@ -314,101 +316,28 @@ static inline int CeedSingleOperatorAssembleAddDiagonal(CeedOperator op,
   CeedScalar max_norm = 0;
   ierr = CeedVectorNorm(assembled_qf, CEED_NORM_MAX, &max_norm); CeedChk(ierr);
 
-  // Determine active input basis
-  CeedOperatorField *op_fields;
-  CeedQFunctionField *qf_fields;
-  ierr = CeedOperatorGetFields(op, NULL, &op_fields, NULL, NULL); CeedChk(ierr);
-  ierr = CeedQFunctionGetFields(qf, NULL, &qf_fields, NULL, NULL); CeedChk(ierr);
-  CeedInt num_eval_mode_in = 0, num_comp, dim = 1;
-  CeedEvalMode *eval_mode_in = NULL;
-  CeedBasis basis_in = NULL;
-  CeedElemRestriction rstr_in = NULL;
-  for (CeedInt i=0; i<num_input_fields; i++) {
-    CeedVector vec;
-    ierr = CeedOperatorFieldGetVector(op_fields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE) {
-      CeedElemRestriction rstr;
-      ierr = CeedOperatorFieldGetBasis(op_fields[i], &basis_in); CeedChk(ierr);
-      ierr = CeedBasisGetNumComponents(basis_in, &num_comp); CeedChk(ierr);
-      ierr = CeedBasisGetDimension(basis_in, &dim); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetElemRestriction(op_fields[i], &rstr); CeedChk(ierr);
-      if (rstr_in && rstr_in != rstr)
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "Multi-field non-composite operator diagonal assembly not supported");
-      // LCOV_EXCL_STOP
-      rstr_in = rstr;
-      CeedEvalMode eval_mode;
-      ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode); CeedChk(ierr);
-      switch (eval_mode) {
-      case CEED_EVAL_NONE:
-      case CEED_EVAL_INTERP:
-        ierr = CeedRealloc(num_eval_mode_in + 1, &eval_mode_in); CeedChk(ierr);
-        eval_mode_in[num_eval_mode_in] = eval_mode;
-        num_eval_mode_in += 1;
-        break;
-      case CEED_EVAL_GRAD:
-        ierr = CeedRealloc(num_eval_mode_in + dim, &eval_mode_in); CeedChk(ierr);
-        for (CeedInt d=0; d<dim; d++)
-          eval_mode_in[num_eval_mode_in+d] = eval_mode;
-        num_eval_mode_in += dim;
-        break;
-      case CEED_EVAL_WEIGHT:
-      case CEED_EVAL_DIV:
-      case CEED_EVAL_CURL:
-        break; // Caught by QF Assembly
-      }
-    }
-  }
-
-  // Determine active output basis
-  ierr = CeedOperatorGetFields(op, NULL, NULL, NULL, &op_fields); CeedChk(ierr);
-  ierr = CeedQFunctionGetFields(qf, NULL, NULL, NULL, &qf_fields); CeedChk(ierr);
-  CeedInt num_eval_mode_out = 0;
-  CeedEvalMode *eval_mode_out = NULL;
-  CeedBasis basis_out = NULL;
-  CeedElemRestriction rstr_out = NULL;
-  for (CeedInt i=0; i<num_output_fields; i++) {
-    CeedVector vec;
-    ierr = CeedOperatorFieldGetVector(op_fields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE) {
-      CeedElemRestriction rstr;
-      ierr = CeedOperatorFieldGetBasis(op_fields[i], &basis_out); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetElemRestriction(op_fields[i], &rstr); CeedChk(ierr);
-      if (rstr_out && rstr_out != rstr)
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "Multi-field non-composite operator diagonal assembly not supported");
-      // LCOV_EXCL_STOP
-      rstr_out = rstr;
-      CeedEvalMode eval_mode;
-      ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode); CeedChk(ierr);
-      switch (eval_mode) {
-      case CEED_EVAL_NONE:
-      case CEED_EVAL_INTERP:
-        ierr = CeedRealloc(num_eval_mode_out + 1, &eval_mode_out); CeedChk(ierr);
-        eval_mode_out[num_eval_mode_out] = eval_mode;
-        num_eval_mode_out += 1;
-        break;
-      case CEED_EVAL_GRAD:
-        ierr = CeedRealloc(num_eval_mode_out + dim, &eval_mode_out); CeedChk(ierr);
-        for (CeedInt d=0; d<dim; d++)
-          eval_mode_out[num_eval_mode_out+d] = eval_mode;
-        num_eval_mode_out += dim;
-        break;
-      case CEED_EVAL_WEIGHT:
-      case CEED_EVAL_DIV:
-      case CEED_EVAL_CURL:
-        break; // Caught by QF Assembly
-      }
-    }
-  }
+  // Get assembly data
+  CeedOperatorAssemblyData data;
+  ierr = CeedOperatorGetOperatorAssemblyData(op, &data); CeedChk(ierr);
+  const CeedEvalMode *eval_mode_in, *eval_mode_out;
+  CeedInt num_eval_mode_in, num_eval_mode_out;
+  ierr = CeedOperatorAssemblyDataGetEvalModes(data, &num_eval_mode_in,
+         &eval_mode_in, &num_eval_mode_out, &eval_mode_out); CeedChk(ierr);
+  CeedBasis basis_in, basis_out;
+  ierr = CeedOperatorAssemblyDataGetBases(data, &basis_in, NULL, &basis_out,
+                                          NULL); CeedChk(ierr);
+  CeedInt num_comp;
+  ierr = CeedBasisGetNumComponents(basis_in, &num_comp); CeedChk(ierr);
 
   // Assemble point block diagonal restriction, if needed
-  CeedElemRestriction diag_rstr = rstr_out;
+  CeedElemRestriction diag_rstr;
+  ierr = CeedOperatorGetActiveElemRestriction(op, &diag_rstr); CeedChk(ierr);
   if (is_pointblock) {
-    ierr = CeedOperatorCreateActivePointBlockRestriction(rstr_out, &diag_rstr);
+    CeedElemRestriction point_block_rstr;
+    ierr = CeedOperatorCreateActivePointBlockRestriction(diag_rstr,
+           &point_block_rstr);
     CeedChk(ierr);
+    diag_rstr = point_block_rstr;
   }
 
   // Create diagonal vector
@@ -428,17 +357,20 @@ static inline int CeedSingleOperatorAssembleAddDiagonal(CeedOperator op,
   ierr = CeedElemRestrictionGetNumElements(diag_rstr, &num_elem); CeedChk(ierr);
   ierr = CeedBasisGetNumNodes(basis_in, &num_nodes); CeedChk(ierr);
   ierr = CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts); CeedChk(ierr);
+
   // Basis matrices
   const CeedScalar *interp_in, *interp_out, *grad_in, *grad_out;
   CeedScalar *identity = NULL;
-  bool evalNone = false;
-  for (CeedInt i=0; i<num_eval_mode_in; i++)
-    evalNone = evalNone || (eval_mode_in[i] == CEED_EVAL_NONE);
-  for (CeedInt i=0; i<num_eval_mode_out; i++)
-    evalNone = evalNone || (eval_mode_out[i] == CEED_EVAL_NONE);
-  if (evalNone) {
+  bool has_eval_none = false;
+  for (CeedInt i = 0; i < num_eval_mode_in; i++) {
+    has_eval_none = has_eval_none || (eval_mode_in[i] == CEED_EVAL_NONE);
+  }
+  for (CeedInt i = 0; i<num_eval_mode_out; i++) {
+    has_eval_none = has_eval_none || (eval_mode_out[i] == CEED_EVAL_NONE);
+  }
+  if (has_eval_none) {
     ierr = CeedCalloc(num_qpts*num_nodes, &identity); CeedChk(ierr);
-    for (CeedInt i=0; i<(num_nodes<num_qpts?num_nodes:num_qpts); i++)
+    for (CeedInt i = 0; i < (num_nodes < num_qpts ? num_nodes : num_qpts); i++)
       identity[i*num_nodes+i] = 1.0;
   }
   ierr = CeedBasisGetInterp(basis_in, &interp_in); CeedChk(ierr);
@@ -506,8 +438,6 @@ static inline int CeedSingleOperatorAssembleAddDiagonal(CeedOperator op,
   }
   ierr = CeedVectorDestroy(&assembled_qf); CeedChk(ierr);
   ierr = CeedVectorDestroy(&elem_diag); CeedChk(ierr);
-  ierr = CeedFree(&eval_mode_in); CeedChk(ierr);
-  ierr = CeedFree(&eval_mode_out); CeedChk(ierr);
   ierr = CeedFree(&identity); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
@@ -588,9 +518,7 @@ static int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset,
   ierr = CeedVectorCreate(ceed, num_nodes, &index_vec); CeedChk(ierr);
   CeedScalar *array;
   ierr = CeedVectorGetArrayWrite(index_vec, CEED_MEM_HOST, &array); CeedChk(ierr);
-  for (CeedInt i = 0; i < num_nodes; ++i) {
-    array[i] = i;
-  }
+  for (CeedInt i = 0; i < num_nodes; i++) array[i] = i;
   ierr = CeedVectorRestoreArray(index_vec, &array); CeedChk(ierr);
   CeedVector elem_dof;
   ierr = CeedVectorCreate(ceed, num_elem * elem_size * num_comp, &elem_dof);
@@ -605,15 +533,15 @@ static int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset,
 
   // Determine i, j locations for element matrices
   CeedInt count = 0;
-  for (CeedInt e = 0; e < num_elem; ++e) {
-    for (CeedInt comp_in = 0; comp_in < num_comp; ++comp_in) {
-      for (CeedInt comp_out = 0; comp_out < num_comp; ++comp_out) {
-        for (CeedInt i = 0; i < elem_size; ++i) {
-          for (CeedInt j = 0; j < elem_size; ++j) {
-            const CeedInt elem_dof_index_row = (i)*layout_er[0] +
+  for (CeedInt e = 0; e < num_elem; e++) {
+    for (CeedInt comp_in = 0; comp_in < num_comp; comp_in++) {
+      for (CeedInt comp_out = 0; comp_out < num_comp; comp_out++) {
+        for (CeedInt i = 0; i < elem_size; i++) {
+          for (CeedInt j = 0; j < elem_size; j++) {
+            const CeedInt elem_dof_index_row = i*layout_er[0] +
                                                (comp_out)*layout_er[1] + e*layout_er[2];
-            const CeedInt elem_dof_index_col = (j)*layout_er[0] +
-                                               (comp_in)*layout_er[1] + e*layout_er[2];
+            const CeedInt elem_dof_index_col = j*layout_er[0] +
+                                               comp_in*layout_er[1] + e*layout_er[2];
 
             const CeedInt row = elem_dof_a[elem_dof_index_row];
             const CeedInt col = elem_dof_a[elem_dof_index_col];
@@ -683,7 +611,8 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   CeedElemRestriction rstr_q;
   ierr = CeedOperatorLinearAssembleQFunctionBuildOrUpdate(
            op, &assembled_qf, &rstr_q, CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
-
+  CeedScalar max_norm = 0;
+  ierr = CeedVectorNorm(assembled_qf, CEED_NORM_MAX, &max_norm); CeedChk(ierr);
   CeedSize qf_length;
   ierr = CeedVectorGetLength(assembled_qf, &qf_length); CeedChk(ierr);
 
@@ -693,85 +622,16 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   ierr = CeedOperatorGetFields(op, &num_input_fields, &input_fields,
                                &num_output_fields, &output_fields); CeedChk(ierr);
 
-  // Determine active input basis
-  CeedQFunctionField *qf_fields;
-  ierr = CeedQFunctionGetFields(qf, NULL, &qf_fields, NULL, NULL); CeedChk(ierr);
-  CeedInt num_eval_mode_in = 0, dim = 1;
-  CeedEvalMode *eval_mode_in = NULL;
-  CeedBasis basis_in = NULL;
-  CeedElemRestriction rstr_in = NULL;
-  for (CeedInt i=0; i<num_input_fields; i++) {
-    CeedVector vec;
-    ierr = CeedOperatorFieldGetVector(input_fields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE) {
-      ierr = CeedOperatorFieldGetBasis(input_fields[i], &basis_in);
-      CeedChk(ierr);
-      ierr = CeedBasisGetDimension(basis_in, &dim); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr_in);
-      CeedChk(ierr);
-      CeedEvalMode eval_mode;
-      ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode);
-      CeedChk(ierr);
-      switch (eval_mode) {
-      case CEED_EVAL_NONE:
-      case CEED_EVAL_INTERP:
-        ierr = CeedRealloc(num_eval_mode_in + 1, &eval_mode_in); CeedChk(ierr);
-        eval_mode_in[num_eval_mode_in] = eval_mode;
-        num_eval_mode_in += 1;
-        break;
-      case CEED_EVAL_GRAD:
-        ierr = CeedRealloc(num_eval_mode_in + dim, &eval_mode_in); CeedChk(ierr);
-        for (CeedInt d=0; d<dim; d++) {
-          eval_mode_in[num_eval_mode_in+d] = eval_mode;
-        }
-        num_eval_mode_in += dim;
-        break;
-      case CEED_EVAL_WEIGHT:
-      case CEED_EVAL_DIV:
-      case CEED_EVAL_CURL:
-        break; // Caught by QF Assembly
-      }
-    }
-  }
-
-  // Determine active output basis
-  ierr = CeedQFunctionGetFields(qf, NULL, NULL, NULL, &qf_fields); CeedChk(ierr);
-  CeedInt num_eval_mode_out = 0;
-  CeedEvalMode *eval_mode_out = NULL;
-  CeedBasis basis_out = NULL;
-  CeedElemRestriction rstr_out = NULL;
-  for (CeedInt i=0; i<num_output_fields; i++) {
-    CeedVector vec;
-    ierr = CeedOperatorFieldGetVector(output_fields[i], &vec); CeedChk(ierr);
-    if (vec == CEED_VECTOR_ACTIVE) {
-      ierr = CeedOperatorFieldGetBasis(output_fields[i], &basis_out);
-      CeedChk(ierr);
-      ierr = CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr_out);
-      CeedChk(ierr);
-      CeedEvalMode eval_mode;
-      ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode);
-      CeedChk(ierr);
-      switch (eval_mode) {
-      case CEED_EVAL_NONE:
-      case CEED_EVAL_INTERP:
-        ierr = CeedRealloc(num_eval_mode_out + 1, &eval_mode_out); CeedChk(ierr);
-        eval_mode_out[num_eval_mode_out] = eval_mode;
-        num_eval_mode_out += 1;
-        break;
-      case CEED_EVAL_GRAD:
-        ierr = CeedRealloc(num_eval_mode_out + dim, &eval_mode_out); CeedChk(ierr);
-        for (CeedInt d=0; d<dim; d++) {
-          eval_mode_out[num_eval_mode_out+d] = eval_mode;
-        }
-        num_eval_mode_out += dim;
-        break;
-      case CEED_EVAL_WEIGHT:
-      case CEED_EVAL_DIV:
-      case CEED_EVAL_CURL:
-        break; // Caught by QF Assembly
-      }
-    }
-  }
+  // Get assembly data
+  CeedOperatorAssemblyData data;
+  ierr = CeedOperatorGetOperatorAssemblyData(op, &data); CeedChk(ierr);
+  const CeedEvalMode *eval_mode_in, *eval_mode_out;
+  CeedInt num_eval_mode_in, num_eval_mode_out;
+  ierr = CeedOperatorAssemblyDataGetEvalModes(data, &num_eval_mode_in,
+         &eval_mode_in, &num_eval_mode_out, &eval_mode_out); CeedChk(ierr);
+  CeedBasis basis_in, basis_out;
+  ierr = CeedOperatorAssemblyDataGetBases(data, &basis_in, NULL, &basis_out,
+                                          NULL); CeedChk(ierr);
 
   if (num_eval_mode_in == 0 || num_eval_mode_out == 0)
     // LCOV_EXCL_START
@@ -779,10 +639,14 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
                      "Cannot assemble operator with out inputs/outputs");
   // LCOV_EXCL_STOP
 
+  CeedElemRestriction active_rstr;
   CeedInt num_elem, elem_size, num_qpts, num_comp;
-  ierr = CeedElemRestrictionGetNumElements(rstr_in, &num_elem); CeedChk(ierr);
-  ierr = CeedElemRestrictionGetElementSize(rstr_in, &elem_size); CeedChk(ierr);
-  ierr = CeedElemRestrictionGetNumComponents(rstr_in, &num_comp); CeedChk(ierr);
+  ierr = CeedOperatorGetActiveElemRestriction(op, &active_rstr); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetNumElements(active_rstr, &num_elem); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetElementSize(active_rstr, &elem_size);
+  CeedChk(ierr);
+  ierr = CeedElemRestrictionGetNumComponents(active_rstr, &num_comp);
+  CeedChk(ierr);
   ierr = CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts); CeedChk(ierr);
 
   CeedInt local_num_entries = elem_size*num_comp * elem_size*num_comp * num_elem;
@@ -801,99 +665,46 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   ierr = CeedElemRestrictionDestroy(&rstr_q); CeedChk(ierr);
 
   // we store B_mat_in, B_mat_out, BTD, elem_mat in row-major order
-  CeedScalar B_mat_in[(num_qpts * num_eval_mode_in) * elem_size];
-  CeedScalar B_mat_out[(num_qpts * num_eval_mode_out) * elem_size];
-  CeedScalar D_mat[num_eval_mode_out * num_eval_mode_in *
-                                     num_qpts]; // logically 3-tensor
-  CeedScalar BTD[elem_size * num_qpts*num_eval_mode_in];
+  const CeedScalar *B_mat_in, *B_mat_out;
+  ierr = CeedOperatorAssemblyDataGetBases(data, NULL, &B_mat_in, NULL,
+                                          &B_mat_out); CeedChk(ierr);
+  CeedScalar BTD_mat[elem_size * num_qpts*num_eval_mode_in];
   CeedScalar elem_mat[elem_size * elem_size];
   CeedInt count = 0;
   CeedScalar *vals;
   ierr = CeedVectorGetArrayWrite(values, CEED_MEM_HOST, &vals); CeedChk(ierr);
-  for (CeedInt e = 0; e < num_elem; ++e) {
-    for (CeedInt comp_in = 0; comp_in < num_comp; ++comp_in) {
-      for (CeedInt comp_out = 0; comp_out < num_comp; ++comp_out) {
-        for (CeedInt ell = 0; ell < (num_qpts * num_eval_mode_in) * elem_size; ++ell) {
-          B_mat_in[ell] = 0.0;
-        }
-        for (CeedInt ell = 0; ell < (num_qpts * num_eval_mode_out) * elem_size; ++ell) {
-          B_mat_out[ell] = 0.0;
-        }
-        // Store block-diagonal D matrix as collection of small dense blocks
-        for (CeedInt ell = 0; ell < num_eval_mode_in*num_eval_mode_out*num_qpts;
-             ++ell) {
-          D_mat[ell] = 0.0;
+  const CeedScalar qf_value_bound = max_norm*100*CEED_EPSILON;
+  for (CeedInt e = 0; e < num_elem; e++) {
+    for (CeedInt comp_in = 0; comp_in < num_comp; comp_in++) {
+      for (CeedInt comp_out = 0; comp_out < num_comp; comp_out++) {
+        // Compute B^T*D
+        const CeedInt mat_size = elem_size * num_qpts*num_eval_mode_in;
+        for (CeedInt i = 0; i < mat_size; i++) BTD_mat[i] = 0.0;
+        for (CeedInt n = 0; n < elem_size; n++) {
+          for (CeedInt q = 0; q < num_qpts; q++) {
+            for (CeedInt e_in = 0; e_in < num_eval_mode_in; e_in++) {
+              for (CeedInt e_out = 0; e_out < num_eval_mode_out; e_out++) {
+                const CeedInt btd_index = n*(num_qpts*num_eval_mode_in) +
+                                          (num_eval_mode_in*q + e_in);
+                const CeedInt b_out_index = (num_eval_mode_out*q + e_out)*elem_size + n;
+                const CeedInt eval_mode_index = ((e_in*num_comp+comp_in)*num_eval_mode_out
+                                                 +e_out)*num_comp + comp_out;
+                const CeedInt qf_index = q*layout_qf[0] + eval_mode_index*layout_qf[1] +
+                                         e*layout_qf[2];
+                if (fabs(assembled_qf_array[qf_index]) > qf_value_bound) {
+                  BTD_mat[btd_index] += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
+                }
+              }
+            }
+          }
         }
         // form element matrix itself (for each block component)
-        for (CeedInt ell = 0; ell < elem_size*elem_size; ++ell) {
-          elem_mat[ell] = 0.0;
-        }
-        for (CeedInt q = 0; q < num_qpts; ++q) {
-          for (CeedInt n = 0; n < elem_size; ++n) {
-            CeedInt d_in = -1;
-            for (CeedInt e_in = 0; e_in < num_eval_mode_in; ++e_in) {
-              const CeedInt qq = num_eval_mode_in*q;
-              if (eval_mode_in[e_in] == CEED_EVAL_INTERP) {
-                B_mat_in[(qq+e_in)*elem_size + n] += interp_in[q * elem_size + n];
-              } else if (eval_mode_in[e_in] == CEED_EVAL_GRAD) {
-                d_in += 1;
-                B_mat_in[(qq+e_in)*elem_size + n] +=
-                  grad_in[(d_in*num_qpts+q) * elem_size + n];
-              } else {
-                // LCOV_EXCL_START
-                return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Not implemented!");
-                // LCOV_EXCL_STOP
-              }
-            }
-            CeedInt d_out = -1;
-            for (CeedInt e_out = 0; e_out < num_eval_mode_out; ++e_out) {
-              const CeedInt qq = num_eval_mode_out*q;
-              if (eval_mode_out[e_out] == CEED_EVAL_INTERP) {
-                B_mat_out[(qq+e_out)*elem_size + n] += interp_in[q * elem_size + n];
-              } else if (eval_mode_out[e_out] == CEED_EVAL_GRAD) {
-                d_out += 1;
-                B_mat_out[(qq+e_out)*elem_size + n] +=
-                  grad_in[(d_out*num_qpts+q) * elem_size + n];
-              } else {
-                // LCOV_EXCL_START
-                return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Not implemented!");
-                // LCOV_EXCL_STOP
-              }
-            }
-          }
-          for (CeedInt ei = 0; ei < num_eval_mode_out; ++ei) {
-            for (CeedInt ej = 0; ej < num_eval_mode_in; ++ej) {
-              const CeedInt eval_mode_index = ((ei*num_comp+comp_in)*num_eval_mode_in+ej)
-                                              *num_comp
-                                              +comp_out;
-              const CeedInt index = q*layout_qf[0] + eval_mode_index*layout_qf[1] +
-                                    e*layout_qf[2];
-              D_mat[(ei*num_eval_mode_in+ej)*num_qpts + q] += assembled_qf_array[index];
-            }
-          }
-        }
-        // Compute B^T*D
-        for (CeedInt ell = 0; ell < elem_size*num_qpts*num_eval_mode_in; ++ell) {
-          BTD[ell] = 0.0;
-        }
-        for (CeedInt j = 0; j<elem_size; ++j) {
-          for (CeedInt q = 0; q<num_qpts; ++q) {
-            const CeedInt qq = num_eval_mode_out*q;
-            for (CeedInt ei = 0; ei < num_eval_mode_in; ++ei) {
-              for (CeedInt ej = 0; ej < num_eval_mode_out; ++ej) {
-                BTD[j*(num_qpts*num_eval_mode_in) + (qq+ei)] +=
-                  B_mat_out[(qq+ej)*elem_size + j] * D_mat[(ei*num_eval_mode_in+ej)*num_qpts + q];
-              }
-            }
-          }
-        }
-
-        ierr = CeedMatrixMultiply(ceed, BTD, B_mat_in, elem_mat, elem_size,
-                                  elem_size, num_qpts*num_eval_mode_in); CeedChk(ierr);
+        ierr = CeedMatrixMatrixMultiply(ceed, BTD_mat, B_mat_in, elem_mat, elem_size,
+                                        elem_size, num_qpts*num_eval_mode_in); CeedChk(ierr);
 
         // put element matrix in coordinate data structure
-        for (CeedInt i = 0; i < elem_size; ++i) {
-          for (CeedInt j = 0; j < elem_size; ++j) {
+        for (CeedInt i = 0; i < elem_size; i++) {
+          for (CeedInt j = 0; j < elem_size; j++) {
             vals[offset + count] = elem_mat[i*elem_size + j];
             count++;
           }
@@ -910,8 +721,6 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset,
   ierr = CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array);
   CeedChk(ierr);
   ierr = CeedVectorDestroy(&assembled_qf); CeedChk(ierr);
-  ierr = CeedFree(&eval_mode_in); CeedChk(ierr);
-  ierr = CeedFree(&eval_mode_out); CeedChk(ierr);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -1363,6 +1172,302 @@ int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data) {
   ierr = CeedDestroy(&(*data)->ceed); CeedChk(ierr);
   ierr = CeedVectorDestroy(&(*data)->vec); CeedChk(ierr);
   ierr = CeedElemRestrictionDestroy(&(*data)->rstr); CeedChk(ierr);
+
+  ierr = CeedFree(data); CeedChk(ierr);
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get CeedOperatorAssemblyData
+
+  @param[in] op     CeedOperator to assemble
+  @param[out] data  CeedQFunctionAssemblyData
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedOperatorGetOperatorAssemblyData(CeedOperator op,
+                                        CeedOperatorAssemblyData *data) {
+  int ierr;
+
+  if (!op->op_assembled) {
+    CeedOperatorAssemblyData data;
+
+    ierr = CeedOperatorAssemblyDataCreate(op->ceed, op, &data); CeedChk(ierr);
+    op->op_assembled = data;
+  }
+  *data = op->op_assembled;
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Create object holding CeedOperator assembly data
+
+  @param[in] ceed   A Ceed object where the CeedOperatorAssemblyData will be created
+  @param[in] op     CeedOperator to be assembled
+  @param[out] data  Address of the variable where the newly created
+                      CeedOperatorAssemblyData will be stored
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op,
+                                   CeedOperatorAssemblyData *data) {
+  int ierr;
+
+  ierr = CeedCalloc(1, data); CeedChk(ierr);
+  (*data)->ceed = ceed;
+  ierr = CeedReference(ceed); CeedChk(ierr);
+
+  // Build OperatorAssembly data
+  CeedQFunction qf;
+  CeedQFunctionField *qf_fields;
+  CeedOperatorField *op_fields;
+  CeedInt num_input_fields;
+  ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
+  ierr = CeedQFunctionGetFields(qf, &num_input_fields, &qf_fields, NULL, NULL);
+  CeedChk(ierr);
+  ierr = CeedOperatorGetFields(op, NULL, &op_fields, NULL, NULL); CeedChk(ierr);
+
+  // Determine active input basis
+  CeedInt num_eval_mode_in = 0, dim = 1;
+  CeedEvalMode *eval_mode_in = NULL;
+  CeedBasis basis_in = NULL;
+  for (CeedInt i=0; i<num_input_fields; i++) {
+    CeedVector vec;
+    ierr = CeedOperatorFieldGetVector(op_fields[i], &vec); CeedChk(ierr);
+    if (vec == CEED_VECTOR_ACTIVE) {
+      ierr = CeedOperatorFieldGetBasis(op_fields[i], &basis_in);
+      CeedChk(ierr);
+      ierr = CeedBasisGetDimension(basis_in, &dim); CeedChk(ierr);
+      CeedEvalMode eval_mode;
+      ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode);
+      CeedChk(ierr);
+      switch (eval_mode) {
+      case CEED_EVAL_NONE:
+      case CEED_EVAL_INTERP:
+        ierr = CeedRealloc(num_eval_mode_in + 1, &eval_mode_in); CeedChk(ierr);
+        eval_mode_in[num_eval_mode_in] = eval_mode;
+        num_eval_mode_in += 1;
+        break;
+      case CEED_EVAL_GRAD:
+        ierr = CeedRealloc(num_eval_mode_in + dim, &eval_mode_in); CeedChk(ierr);
+        for (CeedInt d=0; d<dim; d++) {
+          eval_mode_in[num_eval_mode_in+d] = eval_mode;
+        }
+        num_eval_mode_in += dim;
+        break;
+      case CEED_EVAL_WEIGHT:
+      case CEED_EVAL_DIV:
+      case CEED_EVAL_CURL:
+        break; // Caught by QF Assembly
+      }
+    }
+  }
+  (*data)->num_eval_mode_in = num_eval_mode_in;
+  (*data)->eval_mode_in = eval_mode_in;
+  ierr = CeedBasisReferenceCopy(basis_in, &(*data)->basis_in); CeedChk(ierr);
+
+  // Determine active output basis
+  CeedInt num_output_fields;
+  ierr = CeedQFunctionGetFields(qf, NULL, NULL, &num_output_fields, &qf_fields);
+  CeedChk(ierr);
+  ierr = CeedOperatorGetFields(op, NULL, NULL, NULL, &op_fields); CeedChk(ierr);
+  CeedInt num_eval_mode_out = 0;
+  CeedEvalMode *eval_mode_out = NULL;
+  CeedBasis basis_out = NULL;
+  for (CeedInt i=0; i<num_output_fields; i++) {
+    CeedVector vec;
+    ierr = CeedOperatorFieldGetVector(op_fields[i], &vec); CeedChk(ierr);
+    if (vec == CEED_VECTOR_ACTIVE) {
+      ierr = CeedOperatorFieldGetBasis(op_fields[i], &basis_out);
+      CeedChk(ierr);
+      CeedEvalMode eval_mode;
+      ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode);
+      CeedChk(ierr);
+      switch (eval_mode) {
+      case CEED_EVAL_NONE:
+      case CEED_EVAL_INTERP:
+        ierr = CeedRealloc(num_eval_mode_out + 1, &eval_mode_out); CeedChk(ierr);
+        eval_mode_out[num_eval_mode_out] = eval_mode;
+        num_eval_mode_out += 1;
+        break;
+      case CEED_EVAL_GRAD:
+        ierr = CeedRealloc(num_eval_mode_out + dim, &eval_mode_out); CeedChk(ierr);
+        for (CeedInt d=0; d<dim; d++) {
+          eval_mode_out[num_eval_mode_out+d] = eval_mode;
+        }
+        num_eval_mode_out += dim;
+        break;
+      case CEED_EVAL_WEIGHT:
+      case CEED_EVAL_DIV:
+      case CEED_EVAL_CURL:
+        break; // Caught by QF Assembly
+      }
+    }
+  }
+  (*data)->num_eval_mode_out = num_eval_mode_out;
+  (*data)->eval_mode_out = eval_mode_out;
+  ierr = CeedBasisReferenceCopy(basis_out, &(*data)->basis_out); CeedChk(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get CeedOperator CeedEvalModes for assembly
+
+  @param[in] data                CeedOperatorAssemblyData
+  @param[out] num_eval_mode_in   Pointer to hold number of input CeedEvalModes, or NULL
+  @param[out] eval_mode_in       Pointer to hold input CeedEvalModes, or NULL
+  @param[out] num_eval_mode_out  Pointer to hold number of output CeedEvalModes, or NULL
+  @param[out] eval_mode_out      Pointer to hold output CeedEvalModes, or NULL
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedOperatorAssemblyDataGetEvalModes(CeedOperatorAssemblyData data,
+    CeedInt *num_eval_mode_in, const CeedEvalMode **eval_mode_in,
+    CeedInt *num_eval_mode_out, const CeedEvalMode **eval_mode_out) {
+  if (num_eval_mode_in) *num_eval_mode_in   = data->num_eval_mode_in;
+  if (eval_mode_in) *eval_mode_in           = data->eval_mode_in;
+  if (num_eval_mode_out) *num_eval_mode_out = data->num_eval_mode_out;
+  if (eval_mode_out) *eval_mode_out         = data->eval_mode_out;
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get CeedOperator CeedBasis data for assembly
+
+  @param[in] data        CeedOperatorAssemblyData
+  @param[out] basis_in   Pointer to hold active input CeedBasis, or NULL
+  @param[out] B_in       Pointer to hold assembled active input B, or NULL
+  @param[out] basis_out  Pointer to hold active output CeedBasis, or NULL
+  @param[out] B_out      Pointer to hold assembled active output B, or NULL
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedOperatorAssemblyDataGetBases(CeedOperatorAssemblyData data,
+                                     CeedBasis *basis_in, const CeedScalar **B_in, CeedBasis *basis_out,
+                                     const CeedScalar **B_out) {
+  int ierr;
+
+  // Assemble B_in, B_out if needed
+  if (B_in && !data->B_in) {
+    CeedInt num_qpts, elem_size;
+    CeedScalar *B_in, *identity = NULL;
+    const CeedScalar *interp_in, *grad_in;
+    bool has_eval_none = false;
+
+    ierr = CeedBasisGetNumQuadraturePoints(data->basis_in, &num_qpts);
+    CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes(data->basis_in, &elem_size); CeedChk(ierr);
+    ierr = CeedCalloc(num_qpts * elem_size * data->num_eval_mode_in, &B_in);
+    CeedChk(ierr);
+
+    for (CeedInt i = 0; i < data->num_eval_mode_in; i++) {
+      has_eval_none = has_eval_none || (data->eval_mode_in[i] == CEED_EVAL_NONE);
+    }
+    if (has_eval_none) {
+      ierr = CeedCalloc(num_qpts * elem_size, &identity); CeedChk(ierr);
+      for (CeedInt i = 0; i < (elem_size < num_qpts ? elem_size : num_qpts); i++) {
+        identity[i * elem_size + i] = 1.0;
+      }
+    }
+    ierr = CeedBasisGetInterp(data->basis_in, &interp_in); CeedChk(ierr);
+    ierr = CeedBasisGetGrad(data->basis_in, &grad_in); CeedChk(ierr);
+
+    for (CeedInt q = 0; q < num_qpts; q++) {
+      for (CeedInt n = 0; n < elem_size; n++) {
+        CeedInt d_in = -1;
+        for (CeedInt e_in = 0; e_in < data->num_eval_mode_in; e_in++) {
+          const CeedInt qq = data->num_eval_mode_in * q;
+          const CeedScalar *b = NULL;
+
+          if (data->eval_mode_in[e_in] == CEED_EVAL_GRAD) d_in++;
+          CeedOperatorGetBasisPointer(data->eval_mode_in[e_in], identity,
+                                      interp_in, &grad_in[d_in * num_qpts * elem_size], &b); CeedChk(ierr);
+          B_in[(qq + e_in)*elem_size + n] = b[q * elem_size + n];
+        }
+      }
+    }
+    data->B_in = B_in;
+  }
+
+  if (B_out && !data->B_out) {
+    CeedInt num_qpts, elem_size;
+    CeedScalar *B_out, *identity = NULL;
+    const CeedScalar *interp_out, *grad_out;
+    bool has_eval_none = false;
+
+    ierr = CeedBasisGetNumQuadraturePoints(data->basis_out, &num_qpts);
+    CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes(data->basis_out, &elem_size); CeedChk(ierr);
+    ierr = CeedCalloc(num_qpts * elem_size * data->num_eval_mode_out, &B_out);
+    CeedChk(ierr);
+
+    for (CeedInt i = 0; i < data->num_eval_mode_out; i++) {
+      has_eval_none = has_eval_none || (data->eval_mode_out[i] == CEED_EVAL_NONE);
+    }
+    if (has_eval_none) {
+      ierr = CeedCalloc(num_qpts * elem_size, &identity); CeedChk(ierr);
+      for (CeedInt i = 0; i < (elem_size < num_qpts ? elem_size : num_qpts); i++) {
+        identity[i * elem_size + i] = 1.0;
+      }
+    }
+    ierr = CeedBasisGetInterp(data->basis_out, &interp_out); CeedChk(ierr);
+    ierr = CeedBasisGetGrad(data->basis_out, &grad_out); CeedChk(ierr);
+
+    for (CeedInt q = 0; q < num_qpts; q++) {
+      for (CeedInt n = 0; n < elem_size; n++) {
+        CeedInt d_out = -1;
+        for (CeedInt e_out = 0; e_out < data->num_eval_mode_out; e_out++) {
+          const CeedInt qq = data->num_eval_mode_out * q;
+          const CeedScalar *b = NULL;
+
+          if (data->eval_mode_out[e_out] == CEED_EVAL_GRAD) d_out++;
+          CeedOperatorGetBasisPointer(data->eval_mode_out[e_out], identity,
+                                      interp_out, &grad_out[d_out * num_qpts * elem_size], &b); CeedChk(ierr);
+          B_out[(qq + e_out)*elem_size + n] = b[q * elem_size + n];
+        }
+      }
+    }
+    data->B_out = B_out;
+  }
+
+  if (basis_in) *basis_in   = data->basis_in;
+  if (B_in) *B_in           = data->B_in;
+  if (basis_out) *basis_out = data->basis_out;
+  if (B_out) *B_out         = data->B_out;
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Destroy CeedOperatorAssemblyData
+
+  @param[out] data  CeedOperatorAssemblyData to destroy
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedOperatorAssemblyDataDestroy(CeedOperatorAssemblyData *data) {
+  int ierr;
+
+  if (!*data) return CEED_ERROR_SUCCESS;
+
+  ierr = CeedDestroy(&(*data)->ceed); CeedChk(ierr);
+  ierr = CeedBasisDestroy(&(*data)->basis_in); CeedChk(ierr);
+  ierr = CeedBasisDestroy(&(*data)->basis_out); CeedChk(ierr);
+  ierr = CeedFree(&(*data)->B_in); CeedChk(ierr);
+  ierr = CeedFree(&(*data)->B_out); CeedChk(ierr);
 
   ierr = CeedFree(data); CeedChk(ierr);
   return CEED_ERROR_SUCCESS;

--- a/tests/t568-operator.c
+++ b/tests/t568-operator.c
@@ -1,0 +1,187 @@
+/// @file
+/// Test assembly of Poisson operator with extra input field (non-square D)
+/// \test Test assembly of Poisson operator with extra input field (non-square D)
+#include <ceed.h>
+#include <stdlib.h>
+#include <math.h>
+#include "t534-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed ceed;
+  CeedElemRestriction elem_restr_x, elem_restr_u,
+                      elem_restr_qd_i;
+  CeedBasis basis_x, basis_u;
+  CeedQFunction qf_setup, qf_diff;
+  CeedOperator op_setup, op_diff;
+  CeedVector q_data, X, U, V;
+  CeedInt P = 3, Q = 3, dim = 2, num_comp = 2;
+  CeedInt n_x = 1, n_y = 1;
+  CeedInt num_elem = n_x * n_y;
+  CeedInt num_dofs = (n_x*(P-1)+1)*(n_y*(P-1)+1), num_qpts = num_elem*Q*Q;
+  CeedInt ind_x[num_elem*P*P];
+  CeedScalar assembled[num_comp*num_comp*num_dofs*num_dofs];
+  CeedScalar x[dim*num_dofs], assembled_true[num_comp*num_comp*num_dofs*num_dofs];
+  CeedScalar *u;
+  const CeedScalar *v;
+
+  CeedInit(argv[1], &ceed);
+
+  // DoF Coordinates
+  for (CeedInt i=0; i<n_x*(P-1)+1; i++)
+    for (CeedInt j=0; j<n_y*(P-1)+1; j++) {
+      x[i+j*(n_x*2+1)+0*num_dofs] = (CeedScalar) i / (n_x * (P-1));
+      x[i+j*(n_x*2+1)+1*num_dofs] = (CeedScalar) j / (n_y * (P-1));
+    }
+  CeedVectorCreate(ceed, dim*num_dofs, &X);
+  CeedVectorSetArray(X, CEED_MEM_HOST, CEED_USE_POINTER, x);
+
+  // Qdata Vector
+  CeedVectorCreate(ceed, num_qpts*dim*(dim+1)/2, &q_data);
+
+  // Element Setup
+  for (CeedInt i=0; i<num_elem; i++) {
+    CeedInt col, row, offset;
+    col = i % n_x;
+    row = i / n_x;
+    offset = col*(P-1) + row*(n_x*(P-1)+1)*(P-1);
+    for (CeedInt j=0; j<P; j++)
+      for (CeedInt k=0; k<P; k++)
+        ind_x[P*(P*i+k)+j] = offset + k*P + j;
+  }
+
+  // Restrictions
+  CeedElemRestrictionCreate(ceed, num_elem, P*P, dim, num_dofs, dim*num_dofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restr_x);
+  CeedElemRestrictionCreate(ceed, num_elem, P*P, num_comp, num_dofs,
+                            num_comp*num_dofs,
+                            CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restr_u);
+  CeedInt strides_qd[3] = {1, Q*Q*num_elem, Q*Q}; /* *NOPAD* */
+  CeedElemRestrictionCreateStrided(ceed, num_elem, Q*Q, dim*(dim+1)/2,
+                                   num_qpts*dim*(dim+1)/2, strides_qd, &elem_restr_qd_i);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, P, Q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp, P, Q, CEED_GAUSS,
+                                  &basis_u);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, diff, diff_loc, &qf_diff);
+  CeedQFunctionAddInput(qf_diff, "qdata", dim*(dim+1)/2, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_diff, "du", num_comp*dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_diff, "dummy u", num_comp, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_diff, "dv", num_comp*dim, CEED_EVAL_GRAD);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x,
+                       CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restr_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "qdata", elem_restr_qd_i, CEED_BASIS_COLLOCATED,
+                       CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
+                     &op_diff);
+  CeedOperatorSetField(op_diff, "qdata", elem_restr_qd_i, CEED_BASIS_COLLOCATED,
+                       q_data);
+  CeedOperatorSetField(op_diff, "du", elem_restr_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dummy u", elem_restr_u, basis_u,
+                       CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dv", elem_restr_u, basis_u, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, X, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fuly assemble operator
+  for (CeedInt k=0; k<num_comp*num_comp*num_dofs*num_dofs; k++) {
+    assembled[k] = 0.0;
+    assembled_true[k] = 0.0;
+  }
+  CeedSize nentries;
+  CeedInt *rows;
+  CeedInt *cols;
+  CeedVector values;
+  CeedOperatorLinearAssembleSymbolic(op_diff, &nentries, &rows, &cols);
+  CeedVectorCreate(ceed, nentries, &values);
+  CeedOperatorLinearAssemble(op_diff, values);
+  const CeedScalar *vals;
+  CeedVectorGetArrayRead(values, CEED_MEM_HOST, &vals);
+  for (CeedInt k=0; k<nentries; k++) {
+    assembled[rows[k]*num_comp*num_dofs + cols[k]] += vals[k];
+  }
+  CeedVectorRestoreArrayRead(values, &vals);
+
+  // Manually assemble operator
+  CeedVectorCreate(ceed, num_comp*num_dofs, &U);
+  CeedVectorSetValue(U, 0.0);
+  CeedVectorCreate(ceed, num_comp*num_dofs, &V);
+  CeedInt indOld = -1;
+
+  for (CeedInt comp_in=0; comp_in<num_comp; comp_in++) {
+    for (CeedInt node_in=0; node_in<num_dofs; node_in++) {
+      // Set input
+      CeedVectorGetArray(U, CEED_MEM_HOST, &u);
+      CeedInt ind = node_in + comp_in*num_dofs;
+      u[ind] = 1.0;
+      if (ind > 0)
+        u[indOld] = 0.0;
+      indOld = ind;
+      CeedVectorRestoreArray(U, &u);
+
+      // Compute effect of DoF j
+      CeedOperatorApply(op_diff, U, V, CEED_REQUEST_IMMEDIATE);
+
+      CeedVectorGetArrayRead(V, CEED_MEM_HOST, &v);
+      for (CeedInt k=0; k<num_dofs*num_comp; k++) {
+        assembled_true[k*num_dofs*num_comp + ind] = v[k];
+      }
+      CeedVectorRestoreArrayRead(V, &v);
+    }
+  }
+
+  // Check output
+  for (CeedInt node_in=0; node_in<num_dofs; node_in++) {
+    for (CeedInt comp_in=0; comp_in<num_comp; comp_in++) {
+      for (CeedInt node_out=0; node_out<num_dofs; node_out++) {
+        for (CeedInt comp_out=0; comp_out<num_comp; comp_out++) {
+          const CeedInt index = (node_out + comp_out*num_dofs)*num_comp + node_in +
+                                comp_in*num_dofs;
+          const CeedScalar assembled_value = assembled[index];
+          const CeedScalar assembled_true_value = assembled_true[index];
+          if (fabs(assembled_value - assembled_true_value) >
+              100.*CEED_EPSILON)
+            // LCOV_EXCL_START
+            printf("[(%d, %d), (%d, %d)] Error in assembly: %f != %f\n",
+                   node_out, comp_out, node_in, comp_in,
+                   assembled_value, assembled_true_value);
+          // LCOV_EXCL_STOP
+        }
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  CeedVectorDestroy(&values);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_diff);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_diff);
+  CeedElemRestrictionDestroy(&elem_restr_u);
+  CeedElemRestrictionDestroy(&elem_restr_x);
+  CeedElemRestrictionDestroy(&elem_restr_qd_i);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_x);
+  CeedVectorDestroy(&X);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&U);
+  CeedVectorDestroy(&V);
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
fixes #987

Before:
```
jeth8984@noether:/projects/jeremy/ratel$ make prove -j search=t103 PROVE_OPTS=-v
------------------------------------
--------------- RATEL --------------
------------------------------------

CEED_DIR      = /projects/jeremy/libCEED
PETSC_DIR     = /projects/ratel/petsc
PETSC_ARCH    = ratel-testing-serial

------------------------------------

Testing with libCEED backends: /cpu/self
Testing on 1 processes
prove -v --exec 'tests/tap.sh' t103-static-elasticity
t103-static-elasticity .. 
1..6
# Test Name: neo-hookean
# NPROC_TEST: 1
# TESTARGS: -ceed {ceed_resource} -yml tests/elasticity-neo-hookean-initial.yml
ok 1 t103-static-elasticity /cpu/self
not ok 2 t103-static-elasticity /cpu/self stdout
# + Error in Jacobian: Y_aij - Y_shell = 5.60089e+01
ok 3 t103-static-elasticity /cpu/self stderr
# Test Name: mooney-rivlin
# NPROC_TEST: 1
# TESTARGS: -ceed {ceed_resource} -yml tests/elasticity-mooney-rivlin-initial.yml
ok 4 t103-static-elasticity /cpu/self
not ok 5 t103-static-elasticity /cpu/self stdout
# + Error in Jacobian: Y_aij - Y_shell = 5.69579e+01
ok 6 t103-static-elasticity /cpu/self stderr
Failed 2/6 subtests 

Test Summary Report
-------------------
t103-static-elasticity (Wstat: 0 Tests: 6 Failed: 2)
  Failed tests:  2, 5
Files=1, Tests=6,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.50 cusr  0.15 csys =  0.66 CPU)
Result: FAIL
make: *** [Makefile:357: prove] Error 1
```

After:
```
jeth8984@noether:/projects/jeremy/ratel$ make prove -j search=t103 PROVE_OPTS=-v
------------------------------------
--------------- RATEL --------------
------------------------------------

CEED_DIR      = /projects/jeremy/libCEED
PETSC_DIR     = /projects/ratel/petsc
PETSC_ARCH    = ratel-testing-serial

------------------------------------

Testing with libCEED backends: /cpu/self
Testing on 1 processes
prove -v --exec 'tests/tap.sh' t103-static-elasticity
t103-static-elasticity .. 
1..6
# Test Name: neo-hookean
# NPROC_TEST: 1
# TESTARGS: -ceed {ceed_resource} -yml tests/elasticity-neo-hookean-initial.yml
ok 1 t103-static-elasticity /cpu/self
ok 2 t103-static-elasticity /cpu/self stdout
ok 3 t103-static-elasticity /cpu/self stderr
# Test Name: mooney-rivlin
# NPROC_TEST: 1
# TESTARGS: -ceed {ceed_resource} -yml tests/elasticity-mooney-rivlin-initial.yml
ok 4 t103-static-elasticity /cpu/self
ok 5 t103-static-elasticity /cpu/self stdout
ok 6 t103-static-elasticity /cpu/self stderr
ok
All tests successful.
Files=1, Tests=6,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.53 cusr  0.13 csys =  0.68 CPU)
Result: PASS
```