### PR TITLE
Memcheck QFContext

### DIFF
--- a/backends/memcheck/ceed-memcheck-blocked.c
+++ b/backends/memcheck/ceed-memcheck-blocked.c
@@ -30,6 +30,8 @@ static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",
                                 CeedQFunctionCreate_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionContextCreate",
+                                CeedQFunctionContextCreate_Memcheck); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/memcheck/ceed-memcheck-qfunctioncontext.c
+++ b/backends/memcheck/ceed-memcheck-qfunctioncontext.c
@@ -1,0 +1,228 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#include <ceed/ceed.h>
+#include <ceed/backend.h>
+#include <string.h>
+#include <valgrind/memcheck.h>
+#include "ceed-memcheck.h"
+
+//------------------------------------------------------------------------------
+// QFunctionContext has valid data
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextHasValidData_Memcheck(CeedQFunctionContext ctx,
+    bool *has_valid_data) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, (void *)&impl);
+  CeedChkBackend(ierr);
+
+  *has_valid_data = !!impl->data;
+
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext has borrowed data
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextHasBorrowedDataOfType_Memcheck(
+  CeedQFunctionContext ctx, CeedMemType mem_type,
+  bool *has_borrowed_data_of_type) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, (void *)&impl);
+  CeedChkBackend(ierr);
+  Ceed ceed;
+  ierr = CeedQFunctionContextGetCeed(ctx, &ceed); CeedChkBackend(ierr);
+
+  switch (mem_type) {
+  case CEED_MEM_HOST:
+    *has_borrowed_data_of_type = !!impl->data_borrowed;
+    break;
+  default:
+    // LCOV_EXCL_START
+    return CeedError(ceed, CEED_ERROR_BACKEND,
+                     "Can only set HOST memory for this backend");
+    // LCOV_EXCL_STOP
+    break;
+  }
+
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext Set Data
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextSetData_Memcheck(CeedQFunctionContext ctx,
+    CeedMemType mem_type, CeedCopyMode copy_mode, void *data) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, (void *)&impl);
+  CeedChkBackend(ierr);
+  size_t ctx_size;
+  ierr = CeedQFunctionContextGetContextSize(ctx, &ctx_size); CeedChkBackend(ierr);
+  Ceed ceed;
+  ierr = CeedQFunctionContextGetCeed(ctx, &ceed); CeedChkBackend(ierr);
+
+  if (mem_type != CEED_MEM_HOST)
+    // LCOV_EXCL_START
+    return CeedError(ceed, CEED_ERROR_BACKEND,
+                     "Can only set HOST memory for this backend");
+  // LCOV_EXCL_STOP
+
+  ierr = CeedFree(&impl->data_allocated); CeedChkBackend(ierr);
+  ierr = CeedFree(&impl->data_owned); CeedChkBackend(ierr);
+  switch (copy_mode) {
+  case CEED_COPY_VALUES:
+    ierr = CeedMallocArray(1, ctx_size, &impl->data_owned); CeedChkBackend(ierr);
+    impl->data_borrowed = NULL;
+    impl->data = impl->data_owned;
+    memcpy(impl->data, data, ctx_size);
+    break;
+  case CEED_OWN_POINTER:
+    impl->data_owned = data;
+    impl->data_borrowed = NULL;
+    impl->data = data;
+    break;
+  case CEED_USE_POINTER:
+    impl->data_borrowed = data;
+    impl->data = data;
+  }
+  // Copy data to check ctx_size bounds
+  ierr = CeedMallocArray(1, ctx_size, &impl->data_allocated);
+  CeedChkBackend(ierr);
+  memcpy(impl->data_allocated, impl->data, ctx_size);
+  impl->data = impl->data_allocated;
+  VALGRIND_DISCARD(impl->mem_block_id);
+  impl->mem_block_id = VALGRIND_CREATE_BLOCK(impl->data, ctx_size,
+                       "'QFunction backend context data copy'");
+
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext Take Data
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextTakeData_Memcheck(CeedQFunctionContext ctx,
+    CeedMemType mem_type, void *data) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, (void *)&impl);
+  CeedChkBackend(ierr);
+  Ceed ceed;
+  ierr = CeedQFunctionContextGetCeed(ctx, &ceed); CeedChkBackend(ierr);
+
+  if (mem_type != CEED_MEM_HOST)
+    // LCOV_EXCL_START
+    return CeedError(ceed, CEED_ERROR_BACKEND,
+                     "Can only provide HOST memory for this backend");
+  // LCOV_EXCL_STOP
+
+  *(void **)data = impl->data_borrowed;
+  impl->data_borrowed = NULL;
+  impl->data = NULL;
+  VALGRIND_DISCARD(impl->mem_block_id);
+  ierr = CeedFree(&impl->data_allocated); CeedChkBackend(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext Get Data
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextGetData_Memcheck(CeedQFunctionContext ctx,
+    CeedMemType mem_type, void *data) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, (void *)&impl);
+  CeedChkBackend(ierr);
+  Ceed ceed;
+  ierr = CeedQFunctionContextGetCeed(ctx, &ceed); CeedChkBackend(ierr);
+
+  if (mem_type != CEED_MEM_HOST)
+    // LCOV_EXCL_START
+    return CeedError(ceed, CEED_ERROR_BACKEND,
+                     "Can only provide HOST memory for this backend");
+  // LCOV_EXCL_STOP
+
+  *(void **)data = impl->data;
+
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext Restore Data
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextRestoreData_Memcheck(CeedQFunctionContext ctx) {
+  int ierr;
+  size_t ctx_size;
+  ierr = CeedQFunctionContextGetContextSize(ctx, &ctx_size); CeedChkBackend(ierr);
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, (void *)&impl);
+  CeedChkBackend(ierr);
+
+  if (impl->data_borrowed) {
+    memcpy(impl->data_borrowed, impl->data, ctx_size);
+  }
+  if (impl->data_owned) {
+    memcpy(impl->data_owned, impl->data, ctx_size);
+  }
+
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext Destroy
+//------------------------------------------------------------------------------
+static int CeedQFunctionContextDestroy_Memcheck(CeedQFunctionContext ctx) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  ierr = CeedQFunctionContextGetBackendData(ctx, &impl); CeedChkBackend(ierr);
+
+  ierr = CeedFree(&impl->data_allocated); CeedChkBackend(ierr);
+  ierr = CeedFree(&impl->data_owned); CeedChkBackend(ierr);
+  ierr = CeedFree(&impl); CeedChkBackend(ierr);
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// QFunctionContext Create
+//------------------------------------------------------------------------------
+int CeedQFunctionContextCreate_Memcheck(CeedQFunctionContext ctx) {
+  int ierr;
+  CeedQFunctionContext_Memcheck *impl;
+  Ceed ceed;
+  ierr = CeedQFunctionContextGetCeed(ctx, &ceed); CeedChkBackend(ierr);
+
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "HasValidData",
+                                CeedQFunctionContextHasValidData_Memcheck);
+  CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx,
+                                "HasBorrowedDataOfType",
+                                CeedQFunctionContextHasBorrowedDataOfType_Memcheck);
+  CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "SetData",
+                                CeedQFunctionContextSetData_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "TakeData",
+                                CeedQFunctionContextTakeData_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "GetData",
+                                CeedQFunctionContextGetData_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "GetDataRead",
+                                CeedQFunctionContextGetData_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "RestoreData",
+                                CeedQFunctionContextRestoreData_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "RestoreDataRead",
+                                CeedQFunctionContextRestoreData_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "QFunctionContext", ctx, "Destroy",
+                                CeedQFunctionContextDestroy_Memcheck); CeedChkBackend(ierr);
+
+  ierr = CeedCalloc(1, &impl); CeedChkBackend(ierr);
+  ierr = CeedQFunctionContextSetBackendData(ctx, impl); CeedChkBackend(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+//------------------------------------------------------------------------------

--- a/backends/memcheck/ceed-memcheck-serial.c
+++ b/backends/memcheck/ceed-memcheck-serial.c
@@ -31,6 +31,8 @@ static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
 
   ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionCreate",
                                 CeedQFunctionCreate_Memcheck); CeedChkBackend(ierr);
+  ierr = CeedSetBackendFunction(ceed, "Ceed", ceed, "QFunctionContextCreate",
+                                CeedQFunctionContextCreate_Memcheck); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/memcheck/ceed-memcheck.h
+++ b/backends/memcheck/ceed-memcheck.h
@@ -17,6 +17,16 @@ typedef struct {
   bool setup_done;
 } CeedQFunction_Memcheck;
 
+typedef struct {
+  int mem_block_id;
+  void *data;
+  void *data_allocated;
+  void *data_borrowed;
+  void *data_owned;
+} CeedQFunctionContext_Memcheck;
+
 CEED_INTERN int CeedQFunctionCreate_Memcheck(CeedQFunction qf);
+
+CEED_INTERN int CeedQFunctionContextCreate_Memcheck(CeedQFunctionContext ctx);
 
 #endif // _ceed_memcheck_h

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -10,6 +10,10 @@ On this page we provide a summary of the main API changes, new features and exam
 
 - Added {c:func}`CeedOperatorSetName` for more readable {c:func}`CeedOperatorView` output.
 
+### New features
+
+- Update `/cpu/self/memcheck/*` backends to help verify `CeedQFunctionContext` data sizes provided by user.
+
 (v0-10-1)=
 
 ## v0.10.1 (Apr 11, 2022)

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -359,8 +359,6 @@ int main(int argc, char **argv) {
   // -- Function list
   ierr = PetscFunctionListDestroy(&app_ctx->problems); CHKERRQ(ierr);
 
-  ierr = PetscFree(problem->bc_ctx); CHKERRQ(ierr);
-
   // -- Structs
   ierr = PetscFree(units); CHKERRQ(ierr);
   ierr = PetscFree(user); CHKERRQ(ierr);

--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -204,6 +204,9 @@ PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *ctx) {
   CeedQFunctionContextCreate(user->ceed, &problem->ics.qfunction_context);
   CeedQFunctionContextSetData(problem->ics.qfunction_context, CEED_MEM_HOST,
                               CEED_USE_POINTER, sizeof(*setup_context), setup_context);
+  CeedQFunctionContextSetDataDestroy(problem->ics.qfunction_context,
+                                     CEED_MEM_HOST,
+                                     FreeContextPetsc);
 
   CeedQFunctionContextCreate(user->ceed, &advection_context);
   CeedQFunctionContextSetData(advection_context, CEED_MEM_HOST,

--- a/examples/fluids/problems/advection2d.c
+++ b/examples/fluids/problems/advection2d.c
@@ -181,6 +181,9 @@ PetscErrorCode NS_ADVECTION2D(ProblemData *problem, DM dm, void *ctx) {
   CeedQFunctionContextCreate(user->ceed, &problem->ics.qfunction_context);
   CeedQFunctionContextSetData(problem->ics.qfunction_context, CEED_MEM_HOST,
                               CEED_USE_POINTER, sizeof(*setup_context), setup_context);
+  CeedQFunctionContextSetDataDestroy(problem->ics.qfunction_context,
+                                     CEED_MEM_HOST,
+                                     FreeContextPetsc);
 
   CeedQFunctionContextCreate(user->ceed, &advection_context);
   CeedQFunctionContextSetData(advection_context, CEED_MEM_HOST,

--- a/examples/fluids/problems/densitycurrent.c
+++ b/examples/fluids/problems/densitycurrent.c
@@ -27,7 +27,8 @@ PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *ctx) {
   problem->ics.qfunction = ICsDC;
   problem->ics.qfunction_loc = ICsDC_loc;
   problem->bc = Exact_DC;
-  setup_context = problem->bc_ctx;
+  CeedQFunctionContextGetData(problem->ics.qfunction_context, CEED_MEM_HOST,
+                              &setup_context);
 
   // ------------------------------------------------------
   //             Create the libCEED context
@@ -107,6 +108,10 @@ PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *ctx) {
   setup_context->dc_axis[0] = dc_axis[0];
   setup_context->dc_axis[1] = dc_axis[1];
   setup_context->dc_axis[2] = dc_axis[2];
+
+  problem->bc_ctx =
+    setup_context; // This is bad, context data should only be accessed via Get/Restore
+  CeedQFunctionContextRestoreData(problem->ics.qfunction_context, &setup_context);
 
   PetscFunctionReturn(0);
 }

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -264,6 +264,9 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx) {
   CeedQFunctionContextCreate(user->ceed, &problem->ics.qfunction_context);
   CeedQFunctionContextSetData(problem->ics.qfunction_context, CEED_MEM_HOST,
                               CEED_USE_POINTER, sizeof(*setup_context), setup_context);
+  CeedQFunctionContextSetDataDestroy(problem->ics.qfunction_context,
+                                     CEED_MEM_HOST,
+                                     FreeContextPetsc);
   CeedQFunctionContextRegisterDouble(problem->ics.qfunction_context,
                                      "evaluation time",
                                      (char *)&setup_context->time - (char *)setup_context, 1, "Time of evaluation");

--- a/examples/fluids/problems/shocktube.c
+++ b/examples/fluids/problems/shocktube.c
@@ -161,6 +161,9 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx) {
   CeedQFunctionContextCreate(user->ceed, &problem->ics.qfunction_context);
   CeedQFunctionContextSetData(problem->ics.qfunction_context, CEED_MEM_HOST,
                               CEED_USE_POINTER, sizeof(*setup_context), setup_context);
+  CeedQFunctionContextSetDataDestroy(problem->ics.qfunction_context,
+                                     CEED_MEM_HOST,
+                                     FreeContextPetsc);
 
   CeedQFunctionContextCreate(user->ceed, &shocktube_context);
   CeedQFunctionContextSetData(shocktube_context, CEED_MEM_HOST,

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -275,6 +275,7 @@ struct CeedQFunctionContext_private {
   int (*GetDataRead)(CeedQFunctionContext, CeedMemType, void *);
   int (*RestoreData)(CeedQFunctionContext);
   int (*RestoreDataRead)(CeedQFunctionContext);
+  int (*DataDestroy)(CeedQFunctionContext);
   int (*Destroy)(CeedQFunctionContext);
   CeedQFunctionContextDataDestroyUser data_destroy_function;
   CeedMemType data_destroy_mem_type;

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -260,6 +260,9 @@ CEED_EXTERN int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx,
     CeedContextFieldLabel field_label, double *values);
 CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
     CeedContextFieldLabel field_label, int *values);
+CEED_EXTERN int CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx,
+    CeedMemType *f_mem_type, CeedQFunctionContextDataDestroyUser *f);
+CEED_EXTERN int CeedQFunctionContextDestroyData(CeedQFunctionContext ctx);
 CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -262,7 +262,6 @@ CEED_EXTERN int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
     CeedContextFieldLabel field_label, int *values);
 CEED_EXTERN int CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx,
     CeedMemType *f_mem_type, CeedQFunctionContextDataDestroyUser *f);
-CEED_EXTERN int CeedQFunctionContextDestroyData(CeedQFunctionContext ctx);
 CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
 CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -696,7 +696,8 @@ CEED_EXTERN int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx,
     size_t *ctx_size);
 CEED_EXTERN int CeedQFunctionContextView(CeedQFunctionContext ctx,
     FILE *stream);
-CEED_EXTERN int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_mem_type, CeedQFunctionContextDataDestroyUser f);
+CEED_EXTERN int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx,
+    CeedMemType f_mem_type, CeedQFunctionContextDataDestroyUser f);
 CEED_EXTERN int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx);
 
 CEED_EXTERN int CeedOperatorCreate(Ceed ceed, CeedQFunction qf,

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -344,6 +344,58 @@ int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx,
 }
 
 /**
+  @brief Get additional destroy routine for CeedQFunctionContext user data
+
+  @param[in] ctx          CeedQFunctionContext to get user destroy function
+  @param[out] f_mem_type  Memory type to use when passing data into `f`
+  @param[out] f           Additional routine to use to destroy user data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx,
+                                       CeedMemType *f_mem_type, CeedQFunctionContextDataDestroyUser *f) {
+  if (f_mem_type) *f_mem_type = ctx->data_destroy_mem_type;
+  if (f) *f = ctx->data_destroy_function;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Destroy user data held by CeedQFunctionContext, using function set by
+     CeedQFunctionContextSetDataDestroy, if applicable
+
+  @param[in,out] ctx  CeedQFunctionContext to destroy user data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextDestroyData(CeedQFunctionContext ctx) {
+  int ierr;
+
+  if (ctx->DataDestroy) {
+    ierr = ctx->DataDestroy(ctx); CeedChk(ierr);
+  } else {
+    CeedQFunctionContextDataDestroyUser data_destroy_function;
+    CeedMemType data_destroy_mem_type;
+
+    ierr = CeedQFunctionContextGetDataDestroy(ctx, &data_destroy_mem_type,
+           &data_destroy_function); CeedChk(ierr);
+    if (data_destroy_function) {
+      void *data;
+
+      ierr = CeedQFunctionContextGetData(ctx, data_destroy_mem_type, &data);
+      CeedChk(ierr);
+      ierr = data_destroy_function(data); CeedChk(ierr);
+      ierr = CeedQFunctionContextRestoreData(ctx, &data); CeedChk(ierr);
+    }
+  }
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Increment the reference counter for a CeedQFunctionContext
 
   @param ctx  CeedQFunctionContext to increment the reference counter
@@ -460,6 +512,7 @@ int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type,
                      "access lock is already in use");
   // LCOV_EXCL_STOP
 
+  ierr = CeedQFunctionContextDestroyData(ctx); CeedChk(ierr);
   ctx->ctx_size = size;
   ierr = ctx->SetData(ctx, mem_type, copy_mode, data); CeedChk(ierr);
   ctx->state += 2;
@@ -807,15 +860,14 @@ int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream) {
 /**
   @brief Set additional destroy routine for CeedQFunctionContext user data
 
-  @param ctx        CeedQFunctionContext to set user destroy function
-  @param f_mem_type Memory type to use when passing data into `f`
-  @param f          Additional routine to use to destroy user data
+  @param[in] ctx         CeedQFunctionContext to set user destroy function
+  @param[in] f_mem_type  Memory type to use when passing data into `f`
+  @param[in] f           Additional routine to use to destroy user data
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
-
 int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx,
                                        CeedMemType f_mem_type, CeedQFunctionContextDataDestroyUser f) {
   if (!f)
@@ -850,14 +902,7 @@ int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx) {
                      "lock is in use");
   // LCOV_EXCL_STOP
 
-  if ((*ctx)->data_destroy_function) {
-    void *data;
-
-    ierr = CeedQFunctionContextGetData(*ctx, (*ctx)->data_destroy_mem_type, &data);
-    CeedChk(ierr);
-    ierr = (*ctx)->data_destroy_function(data); CeedChk(ierr);
-    ierr = CeedQFunctionContextRestoreData(*ctx, &data); CeedChk(ierr);
-  }
+  ierr = CeedQFunctionContextDestroyData(*ctx); CeedChk(ierr);
   if ((*ctx)->Destroy) {
     ierr = (*ctx)->Destroy(*ctx); CeedChk(ierr);
   }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -919,6 +919,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
     CEED_FTABLE_ENTRY(CeedQFunctionContext, GetDataRead),
     CEED_FTABLE_ENTRY(CeedQFunctionContext, RestoreData),
     CEED_FTABLE_ENTRY(CeedQFunctionContext, RestoreDataRead),
+    CEED_FTABLE_ENTRY(CeedQFunctionContext, DataDestroy),
     CEED_FTABLE_ENTRY(CeedQFunctionContext, Destroy),
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleQFunction),
     CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleQFunctionUpdate),

--- a/tests/t404-qfunction.c
+++ b/tests/t404-qfunction.c
@@ -11,10 +11,12 @@ int main(int argc, char **argv) {
 
   CeedInit(argv[1], &ceed);
 
+  // Set borrowed pointer
   CeedQFunctionContextCreate(ceed, &ctx);
   CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_USE_POINTER,
                               sizeof(ctxData), &ctxData);
 
+  // Update borrowed pointer
   CeedQFunctionContextGetData(ctx, CEED_MEM_HOST, &ctxDataCopy);
   ctxDataCopy[4] = 6;
   CeedQFunctionContextRestoreData(ctx, &ctxDataCopy);
@@ -23,7 +25,26 @@ int main(int argc, char **argv) {
     printf("error modifying data: %f != 6.0\n", ctxData[4]);
   // LCOV_EXCL_STOP
 
+  // Take back borrowed pointer
   CeedQFunctionContextTakeData(ctx, CEED_MEM_HOST, &ctxDataCopy);
+  if (ctxDataCopy[4] != 6)
+    // LCOV_EXCL_START
+    printf("error accessing borrowed data: %f != 6.0\n", ctxDataCopy[4]);
+  // LCOV_EXCL_STOP
+
+  // Set copied data
+  ctxData[4] = 6;
+  CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES,
+                              sizeof(ctxData), &ctxData);
+
+  // Check copied data
+  CeedQFunctionContextGetData(ctx, CEED_MEM_HOST, &ctxDataCopy);
+  if (ctxDataCopy[4] != 6)
+    // LCOV_EXCL_START
+    printf("error accessing copied data: %f != 6.0\n", ctxDataCopy[4]);
+  // LCOV_EXCL_STOP
+  CeedQFunctionContextRestoreData(ctx, &ctxDataCopy);
+
   CeedQFunctionContextDestroy(&ctx);
   CeedDestroy(&ceed);
   return 0;

--- a/tests/t408-qfunction.c
+++ b/tests/t408-qfunction.c
@@ -17,9 +17,9 @@ int main(int argc, char **argv) {
 
   // Get data access
   CeedQFunctionContextGetDataRead(ctx, CEED_MEM_HOST, &ctxDataCopy);
-  if (ctxData[4] != 5)
+  if (ctxDataCopy[4] != 5)
     // LCOV_EXCL_START
-    printf("error reading data: %f != 5.0\n", ctxData[4]);
+    printf("error reading data: %f != 5.0\n", ctxDataCopy[4]);
   // LCOV_EXCL_STOP
   CeedQFunctionContextRestoreDataRead(ctx, &ctxDataCopy);
 


### PR DESCRIPTION
Fixes #965 

This PR adds a internal copy of the QFContext data in the Memcheck backend to replicate the behavior of the GPU backends. This catches size mismatches like we saw in fluids development.

I also added some naming to the memory blocks to help make the Valgrind output a bit more human friendly.