### PR TITLE
Update Python testing to avoid distutils

### DIFF
--- a/python/tests/setup-qfunctions.py
+++ b/python/tests/setup-qfunctions.py
@@ -15,7 +15,7 @@
 # testbed platforms, in support of the nation's exascale computing imperative.
 
 import os
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import libceed
 CEED_DIR = os.path.dirname(libceed.__file__)
 

--- a/python/tests/test-4-qfunction.py
+++ b/python/tests/test-4-qfunction.py
@@ -21,7 +21,7 @@ TOL = libceed.EPSILON * 256
 
 
 def load_qfs_so():
-    from distutils.sysconfig import get_config_var
+    from sysconfig import get_config_var
     import ctypes
 
     file_dir = os.path.dirname(os.path.abspath(__file__))

--- a/python/tests/test-5-operator.py
+++ b/python/tests/test-5-operator.py
@@ -22,7 +22,7 @@ TOL = libceed.EPSILON * 256
 
 
 def load_qfs_so():
-    from distutils.sysconfig import get_config_var
+    from sysconfig import get_config_var
     import ctypes
 
     file_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Fixes #979

Python CI output now contains no deprecation warnings:
https://github.com/CEED/libCEED/runs/6921825917?check_suite_focus=true