### PR TITLE
Fluids BCs performance updates

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -10,6 +10,10 @@ On this page we provide a summary of the main API changes, new features and exam
 
 - Added {c:func}`CeedOperatorSetName` for more readable {c:func}`CeedOperatorView` output.
 
+### Examples
+
+- Added various performance enhancements for {ref}`example-petsc-navier-stokes`
+
 (v0-10-1)=
 
 ## v0.10.1 (Apr 11, 2022)

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -144,12 +144,13 @@ struct User_private {
   Mat          interp_viz;
   Ceed         ceed;
   Units        units;
-  Vec          M;
+  Vec          M, Q_loc, Q_dot_loc;
   Physics      phys;
   AppCtx       app_ctx;
   CeedVector   q_ceed, q_dot_ceed, g_ceed, coo_values;
   CeedOperator op_rhs_vol, op_rhs, op_ifunction_vol, op_ifunction, op_ijacobian;
   bool matrices_set_up;
+  CeedScalar time, dt;
 };
 
 // Units

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -98,6 +98,8 @@ PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user,
   PetscFunctionReturn(0);
 }
 
+
+// Note: The BCs must be inserted *before* the other values are inserted into Q_loc
 PetscErrorCode DMPlexInsertBoundaryValues_NS(DM dm,
     PetscBool insert_essential, Vec Q_loc, PetscReal time, Vec face_geom_FVM,
     Vec cell_geom_FVM, Vec grad_FVM) {
@@ -107,6 +109,7 @@ PetscErrorCode DMPlexInsertBoundaryValues_NS(DM dm,
   PetscFunctionBegin;
 
   ierr = DMGetNamedLocalVector(dm, "Qbc", &Qbc); CHKERRQ(ierr);
+  ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
   ierr = VecAXPY(Q_loc, 1., Qbc); CHKERRQ(ierr);
   ierr = DMRestoreNamedLocalVector(dm, "Qbc", &Qbc); CHKERRQ(ierr);
 

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -93,7 +93,6 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
 
   // Update time dependent data
   if (user->time != t) {
-    ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
     ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
                                       NULL, NULL, NULL); CHKERRQ(ierr);
     if (user->phys->solution_time_label) {
@@ -161,7 +160,6 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G,
 
   // Update time dependent data
   if (user->time != t) {
-    ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
     ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
                                       NULL, NULL, NULL); CHKERRQ(ierr);
     if (user->phys->solution_time_label) {

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -325,7 +325,8 @@ PetscErrorCode FormIJacobian_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot,
     const PetscScalar *values;
     MatType mat_type;
     PetscCall(MatGetType(J_pre, &mat_type));
-    //if (strstr(mat_type, "kokkos") || strstr(mat_type, "cusparse")) mem_type = CEED_MEM_DEVICE;
+    if (strstr(mat_type, "kokkos")
+        || strstr(mat_type, "cusparse")) mem_type = CEED_MEM_DEVICE;
     CeedOperatorLinearAssemble(user->op_ijacobian, user->coo_values);
     CeedVectorGetArrayRead(user->coo_values, mem_type, &values);
     if (coo_vec) {

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -108,7 +108,6 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   ierr = DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc); CHKERRQ(ierr);
   ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
                                     NULL, NULL, NULL); CHKERRQ(ierr);
-  ierr = VecZeroEntries(G_loc); CHKERRQ(ierr);
 
   // Place PETSc vectors in CEED vectors
   ierr = VecGetArrayReadAndMemType(Q_loc, (const PetscScalar **)&q, &q_mem_type);
@@ -177,7 +176,6 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G,
   ierr = VecZeroEntries(Q_dot_loc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dm, Q_dot, INSERT_VALUES, Q_dot_loc);
   CHKERRQ(ierr);
-  ierr = VecZeroEntries(G_loc); CHKERRQ(ierr);
 
   // Place PETSc vectors in CEED vectors
   ierr = VecGetArrayReadAndMemType(Q_loc, &q, &q_mem_type); CHKERRQ(ierr);
@@ -230,7 +228,6 @@ static PetscErrorCode MatMult_NS_IJacobian(Mat J, Vec Q, Vec G) {
   // Global-to-local
   ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc); CHKERRQ(ierr);
-  ierr = VecZeroEntries(G_loc); CHKERRQ(ierr);
 
   // Place PETSc vectors in CEED vectors
   ierr = VecGetArrayReadAndMemType(Q_loc, &q, &q_mem_type); CHKERRQ(ierr);

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -81,33 +81,38 @@ PetscErrorCode ComputeLumpedMassMatrix(Ceed ceed, DM dm, CeedData ceed_data,
 //   This is the RHS of the ODE, given as u_t = G(t,u)
 //   This function takes in a state vector Q and writes into G
 PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
-
   User           user = *(User *)user_data;
   PetscScalar    *q, *g;
-  Vec            Q_loc, G_loc;
+  Vec            Q_loc = user->Q_loc, G_loc;
   PetscMemType   q_mem_type, g_mem_type;
   PetscErrorCode ierr;
   PetscFunctionBeginUser;
 
-  // Update context field labels
-  if (user->phys->solution_time_label)
-    CeedOperatorContextSetDouble(user->op_rhs, user->phys->solution_time_label, &t);
-  if (user->phys->timestep_size_label) {
-    PetscScalar dt;
-    ierr = TSGetTimeStep(ts,&dt); CHKERRQ(ierr);
-    CeedOperatorContextSetDouble(user->op_rhs, user->phys->timestep_size_label,
-                                 &dt);
-  }
-
-  // Get local vectors
-  ierr = DMGetLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
+  // Get local vector
   ierr = DMGetLocalVector(user->dm, &G_loc); CHKERRQ(ierr);
 
+  // Update time dependent data
+  if (user->time != t) {
+    ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
+    ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
+                                      NULL, NULL, NULL); CHKERRQ(ierr);
+    if (user->phys->solution_time_label) {
+      CeedOperatorContextSetDouble(user->op_rhs, user->phys->solution_time_label, &t);
+    }
+    user->time = t;
+  }
+  if (user->phys->timestep_size_label) {
+    PetscScalar dt;
+    ierr = TSGetTimeStep(ts, &dt); CHKERRQ(ierr);
+    if (user->dt != dt) {
+      CeedOperatorContextSetDouble(user->op_rhs, user->phys->timestep_size_label,
+                                   &dt);
+      user->dt = dt;
+    }
+  }
+
   // Global-to-local
-  ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc); CHKERRQ(ierr);
-  ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
-                                    NULL, NULL, NULL); CHKERRQ(ierr);
 
   // Place PETSc vectors in CEED vectors
   ierr = VecGetArrayReadAndMemType(Q_loc, (const PetscScalar **)&q, &q_mem_type);
@@ -135,7 +140,6 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   ierr = VecPointwiseMult(G, G, user->M); CHKERRQ(ierr);
 
   // Restore vectors
-  ierr = DMRestoreLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
   ierr = DMRestoreLocalVector(user->dm, &G_loc); CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -147,33 +151,37 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G,
   User              user = *(User *)user_data;
   const PetscScalar *q, *q_dot;
   PetscScalar       *g;
-  Vec               Q_loc, Q_dot_loc, G_loc;
+  Vec               Q_loc = user->Q_loc, Q_dot_loc = user->Q_dot_loc, G_loc;
   PetscMemType      q_mem_type, q_dot_mem_type, g_mem_type;
   PetscErrorCode    ierr;
   PetscFunctionBeginUser;
 
-  // Update context field labels
-  if (user->phys->solution_time_label)
-    CeedOperatorContextSetDouble(user->op_ifunction,
-                                 user->phys->solution_time_label, &t);
-  if (user->phys->timestep_size_label) {
-    PetscScalar dt;
-    ierr = TSGetTimeStep(ts,&dt); CHKERRQ(ierr);
-    CeedOperatorContextSetDouble(user->op_ifunction,
-                                 user->phys->timestep_size_label, &dt);
-  }
-
   // Get local vectors
-  ierr = DMGetLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
-  ierr = DMGetLocalVector(user->dm, &Q_dot_loc); CHKERRQ(ierr);
   ierr = DMGetLocalVector(user->dm, &G_loc); CHKERRQ(ierr);
 
+  // Update time dependent data
+  if (user->time != t) {
+    ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
+    ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
+                                      NULL, NULL, NULL); CHKERRQ(ierr);
+    if (user->phys->solution_time_label) {
+      CeedOperatorContextSetDouble(user->op_ifunction,
+                                   user->phys->solution_time_label, &t);
+    }
+    user->time = t;
+  }
+  if (user->phys->timestep_size_label) {
+    PetscScalar dt;
+    ierr = TSGetTimeStep(ts, &dt); CHKERRQ(ierr);
+    if (user->dt != dt) {
+      CeedOperatorContextSetDouble(user->op_ifunction,
+                                   user->phys->timestep_size_label, &dt);
+      user->dt = dt;
+    }
+  }
+
   // Global-to-local
-  ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc); CHKERRQ(ierr);
-  ierr = DMPlexInsertBoundaryValues(user->dm, PETSC_TRUE, Q_loc, t,
-                                    NULL, NULL, NULL); CHKERRQ(ierr);
-  ierr = VecZeroEntries(Q_dot_loc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dm, Q_dot, INSERT_VALUES, Q_dot_loc);
   CHKERRQ(ierr);
 
@@ -205,8 +213,6 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G,
   ierr = DMLocalToGlobal(user->dm, G_loc, ADD_VALUES, G); CHKERRQ(ierr);
 
   // Restore vectors
-  ierr = DMRestoreLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
-  ierr = DMRestoreLocalVector(user->dm, &Q_dot_loc); CHKERRQ(ierr);
   ierr = DMRestoreLocalVector(user->dm, &G_loc); CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
@@ -216,17 +222,17 @@ static PetscErrorCode MatMult_NS_IJacobian(Mat J, Vec Q, Vec G) {
   User user;
   const PetscScalar *q;
   PetscScalar       *g;
-  Vec               Q_loc, G_loc;
   PetscMemType      q_mem_type, g_mem_type;
   PetscErrorCode    ierr;
   PetscFunctionBeginUser;
-  MatShellGetContext(J, &user);
+  ierr = MatShellGetContext(J, &user); CHKERRQ(ierr);
+  Vec               Q_loc = user->Q_dot_loc, // Note - Q_dot_loc has zero BCs
+                    G_loc;
+
   // Get local vectors
-  ierr = DMGetLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
   ierr = DMGetLocalVector(user->dm, &G_loc); CHKERRQ(ierr);
 
   // Global-to-local
-  ierr = VecZeroEntries(Q_loc); CHKERRQ(ierr);
   ierr = DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc); CHKERRQ(ierr);
 
   // Place PETSc vectors in CEED vectors
@@ -251,7 +257,6 @@ static PetscErrorCode MatMult_NS_IJacobian(Mat J, Vec Q, Vec G) {
   ierr = DMLocalToGlobal(user->dm, G_loc, ADD_VALUES, G); CHKERRQ(ierr);
 
   // Restore vectors
-  ierr = DMRestoreLocalVector(user->dm, &Q_loc); CHKERRQ(ierr);
   ierr = DMRestoreLocalVector(user->dm, &G_loc); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
@@ -452,6 +457,8 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys,
                               1.e-12 * user->units->second,
                               1.e2 * user->units->second); CHKERRQ(ierr);
   ierr = TSSetFromOptions(*ts); CHKERRQ(ierr);
+  user->time = -1.0; // require all BCs and ctx to be updated
+  user->dt   = -1.0;
   if (!app_ctx->cont_steps) { // print initial condition
     if (!app_ctx->test_mode) {
       ierr = TSMonitor_NS(*ts, 0, 0., *Q, user); CHKERRQ(ierr);


### PR DESCRIPTION
- [x] Remove extra `VecZeroEntries()`
- [x] Only apply BCs if time changed
- [x] Separate `X_loc` for Jacobian and non-linear application