### PR TITLE
CeedOperatorAssemblePointBlockDiagonal: fix restriction sizes for subdomain integral

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -733,25 +733,25 @@ static int CreatePBRestriction(CeedElemRestriction rstr,
   CeedChkBackend(ierr);
 
   // Expand offsets
-  CeedInt nelem, ncomp, elemsize, compstride, max = 1, *pbOffsets;
+  CeedInt nelem, ncomp, elemsize, compstride, *pbOffsets;
+  CeedSize l_size;
   ierr = CeedElemRestrictionGetNumElements(rstr, &nelem); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionGetNumComponents(rstr, &ncomp); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionGetElementSize(rstr, &elemsize); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionGetCompStride(rstr, &compstride);
   CeedChkBackend(ierr);
+  ierr = CeedElemRestrictionGetLVectorSize(rstr, &l_size); CeedChkBackend(ierr);
   CeedInt shift = ncomp;
   if (compstride != 1)
     shift *= ncomp;
   ierr = CeedCalloc(nelem*elemsize, &pbOffsets); CeedChkBackend(ierr);
   for (CeedInt i = 0; i < nelem*elemsize; i++) {
     pbOffsets[i] = offsets[i]*shift;
-    if (pbOffsets[i] > max)
-      max = pbOffsets[i];
   }
 
   // Create new restriction
   ierr = CeedElemRestrictionCreate(ceed, nelem, elemsize, ncomp*ncomp, 1,
-                                   max + ncomp*ncomp, CEED_MEM_HOST,
+                                   l_size * ncomp, CEED_MEM_HOST,
                                    CEED_OWN_POINTER, pbOffsets, pbRstr);
   CeedChkBackend(ierr);
 

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -729,25 +729,25 @@ static int CreatePBRestriction(CeedElemRestriction rstr,
   CeedChkBackend(ierr);
 
   // Expand offsets
-  CeedInt nelem, ncomp, elemsize, compstride, max = 1, *pbOffsets;
+  CeedInt nelem, ncomp, elemsize, compstride, *pbOffsets;
+  CeedSize l_size;
   ierr = CeedElemRestrictionGetNumElements(rstr, &nelem); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionGetNumComponents(rstr, &ncomp); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionGetElementSize(rstr, &elemsize); CeedChkBackend(ierr);
   ierr = CeedElemRestrictionGetCompStride(rstr, &compstride);
   CeedChkBackend(ierr);
+  ierr = CeedElemRestrictionGetLVectorSize(rstr, &l_size); CeedChkBackend(ierr);
   CeedInt shift = ncomp;
   if (compstride != 1)
     shift *= ncomp;
   ierr = CeedCalloc(nelem*elemsize, &pbOffsets); CeedChkBackend(ierr);
   for (CeedInt i = 0; i < nelem*elemsize; i++) {
     pbOffsets[i] = offsets[i]*shift;
-    if (pbOffsets[i] > max)
-      max = pbOffsets[i];
   }
 
   // Create new restriction
   ierr = CeedElemRestrictionCreate(ceed, nelem, elemsize, ncomp*ncomp, 1,
-                                   max + ncomp*ncomp, CEED_MEM_HOST,
+                                   l_size * ncomp, CEED_MEM_HOST,
                                    CEED_OWN_POINTER, pbOffsets, pbRstr);
   CeedChkBackend(ierr);
 

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -13,6 +13,7 @@ On this page we provide a summary of the main API changes, new features and exam
 ### Bugfix
 
 - Fix storing of indices for `CeedElemRestriction` on the host with GPU backends.
+- Fix `CeedElemRestriction` sizing for {c:func}`CeedOperatorAssemblePointBlockDiagonal`.
 
 ### Examples
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -250,12 +250,13 @@ static int CeedOperatorCreateActivePointBlockRestriction(
   CeedChk(ierr);
 
   // Expand offsets
-  CeedInt num_elem, num_comp, elem_size, comp_stride, max = 1,
-                                                      *pointblock_offsets;
+  CeedInt num_elem, num_comp, elem_size, comp_stride, *pointblock_offsets;
+  CeedSize l_size;
   ierr = CeedElemRestrictionGetNumElements(rstr, &num_elem); CeedChk(ierr);
   ierr = CeedElemRestrictionGetNumComponents(rstr, &num_comp); CeedChk(ierr);
   ierr = CeedElemRestrictionGetElementSize(rstr, &elem_size); CeedChk(ierr);
   ierr = CeedElemRestrictionGetCompStride(rstr, &comp_stride); CeedChk(ierr);
+  ierr = CeedElemRestrictionGetLVectorSize(rstr, &l_size); CeedChk(ierr);
   CeedInt shift = num_comp;
   if (comp_stride != 1)
     shift *= num_comp;
@@ -263,13 +264,11 @@ static int CeedOperatorCreateActivePointBlockRestriction(
   CeedChk(ierr);
   for (CeedInt i = 0; i < num_elem*elem_size; i++) {
     pointblock_offsets[i] = offsets[i]*shift;
-    if (pointblock_offsets[i] > max)
-      max = pointblock_offsets[i];
   }
 
   // Create new restriction
   ierr = CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp*num_comp,
-                                   1, max + num_comp*num_comp, CEED_MEM_HOST,
+                                   1, l_size * num_comp, CEED_MEM_HOST,
                                    CEED_OWN_POINTER, pointblock_offsets, pointblock_rstr);
   CeedChk(ierr);
 


### PR DESCRIPTION
Formerly would give errors such as

interface/ceed-elemrestriction.c:862 in CeedElemRestrictionApply(): Output vector size 125050 not compatible with element restriction (124050, 6000)

(noted in https://github.com/CEED/libCEED/pull/994#discussion_r899808040)