### PR TITLE
Doc fixes

### DIFF
--- a/doc/sphinx/source/api/Ceed.rst
+++ b/doc/sphinx/source/api/Ceed.rst
@@ -31,3 +31,6 @@ Typedefs and Enumerations
 
 .. doxygenenum:: CeedMemType
    :project: libCEED
+
+.. doxygenenum:: CeedErrorType
+   :project: libCEED

--- a/doc/sphinx/source/api/CeedBasis.rst
+++ b/doc/sphinx/source/api/CeedBasis.rst
@@ -14,8 +14,6 @@ Discrete element bases and quadrature
    :content-only:
    :members:
 
-.. _CeedBasis-Typedefs and Enumerations:
-
 Typedefs and Enumerations
 --------------------------------------
 


### PR DESCRIPTION
I'm still trying to figure out why Doxygen is duplicating the definition of `CeedEvalMode`