### PR TITLE
basis - add CeedBasisCreateProlongation

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -6,13 +6,10 @@ On this page we provide a summary of the main API changes, new features and exam
 
 ## Current `main` branch
 
-### Bugfix
-
-- Fix bug in setting device id for GPU backends.
-
 ### Interface changes
 
 - Added {c:func}`CeedOperatorSetName` for more readable {c:func}`CeedOperatorView` output.
+- Added {c:func}`CeedBasisCreateProjection` to facilitate interpolation between nodes for separate `CeedBases`.
 
 ### New features
 
@@ -20,6 +17,7 @@ On this page we provide a summary of the main API changes, new features and exam
 
 ### Bugfix
 
+- Fix bug in setting device id for GPU backends.
 - Fix storing of indices for `CeedElemRestriction` on the host with GPU backends.
 - Fix `CeedElemRestriction` sizing for {c:func}`CeedOperatorAssemblePointBlockDiagonal`.
 - Fix bugs in CPU implementation of {c:func}`CeedOperatorLinearAssemble` when there are different number of active input modes and active output modes.

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -552,6 +552,8 @@ CEED_EXTERN int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo,
                                     const CeedScalar *div,
                                     const CeedScalar *q_ref,
                                     const CeedScalar *q_weights, CeedBasis *basis);
+CEED_EXTERN int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from, CeedBasis *basis_project);
+CEED_EXTERN int CeedBasisCreateProjectionMatrix(CeedBasis basis_to, CeedBasis basis_from, CeedScalar **interp_project);
 CEED_EXTERN int CeedBasisReferenceCopy(CeedBasis basis, CeedBasis *basis_copy);
 CEED_EXTERN int CeedBasisView(CeedBasis basis, FILE *stream);
 CEED_EXTERN int CeedBasisApply(CeedBasis basis, CeedInt num_elem,

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -830,6 +830,172 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp,
 }
 
 /**
+  @brief Create a CeedBasis for projection from the nodes of `basis_from`
+           to the nodes of `basis_to`. Only `CEED_EVAL_INTERP` will be
+           valid for the new basis, `basis_project`. This projection is
+           given by `interp_project = interp_to^+ * interp_from`, where
+           the pesudoinverse `interp_to^+` is given by QR factorization.
+         Note: `basis_from` and `basis_to` must have compatible quadrature
+           spaces.
+
+  @param[in] basis_to        CeedBasis to prolong to
+  @param[in] basis_from      CeedBasis to prolong from
+  @param[out] basis_project  Address of the variable where the newly created
+                               CeedBasis will be stored.
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from,
+                              CeedBasis *basis_project) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis_to, &ceed); CeedChk(ierr);
+
+  // Create projectior matrix
+  CeedScalar *interp_project;
+  ierr = CeedBasisCreateProjectionMatrix(basis_to, basis_from,
+                                         &interp_project); CeedChk(ierr);
+
+  // Build basis
+  bool is_tensor;
+  CeedInt dim, num_comp;
+  CeedScalar *q_ref, *q_weight, *grad;
+  ierr = CeedBasisIsTensor(basis_to, &is_tensor); CeedChk(ierr);
+  ierr = CeedBasisGetDimension(basis_to, &dim); CeedChk(ierr);
+  ierr = CeedBasisGetNumComponents(basis_to, &num_comp); CeedChk(ierr);
+  if (is_tensor) {
+    CeedInt P_1d_to, P_1d_from;
+    ierr = CeedBasisGetNumNodes1D(basis_from, &P_1d_from); CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes1D(basis_to, &P_1d_to); CeedChk(ierr);
+    ierr = CeedCalloc(P_1d_to, &q_ref); CeedChk(ierr);
+    ierr = CeedCalloc(P_1d_to, &q_weight); CeedChk(ierr);
+    ierr = CeedCalloc(P_1d_to * P_1d_from * dim, &grad); CeedChk(ierr);
+    ierr = CeedBasisCreateTensorH1(ceed, dim, num_comp, P_1d_from, P_1d_to,
+                                   interp_project, grad, q_ref, q_weight, basis_project);
+    CeedChk(ierr);
+  } else {
+    CeedElemTopology topo;
+    ierr = CeedBasisGetTopology(basis_to, &topo); CeedChk(ierr);
+    CeedInt num_nodes_to, num_nodes_from;
+    ierr = CeedBasisGetNumNodes(basis_from, &num_nodes_from); CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes(basis_to, &num_nodes_to); CeedChk(ierr);
+    ierr = CeedCalloc(num_nodes_to * dim, &q_ref); CeedChk(ierr);
+    ierr = CeedCalloc(num_nodes_to, &q_weight); CeedChk(ierr);
+    ierr = CeedCalloc(num_nodes_to * num_nodes_from * dim, &grad); CeedChk(ierr);
+    ierr = CeedBasisCreateH1(ceed, topo, num_comp, num_nodes_from, num_nodes_to,
+                             interp_project, grad, q_ref, q_weight, basis_project);
+    CeedChk(ierr);
+  }
+
+  // Cleanup
+  ierr = CeedFree(&interp_project); CeedChk(ierr);
+  ierr = CeedFree(&q_ref); CeedChk(ierr);
+  ierr = CeedFree(&q_weight); CeedChk(ierr);
+  ierr = CeedFree(&grad); CeedChk(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Create the interpolation matrix for projection from the nodes of
+           `basis_from` to the nodes of `basis_to`. This projection is
+           given by `interp_project = interp_to^+ * interp_from`, where
+           the pesudoinverse `interp_to^+` is given by QR factorization.
+         Note: `basis_from` and `basis_to` must have compatible quadrature
+           spaces.
+
+  @param[in] basis_to         CeedBasis to project to
+  @param[in] basis_from       CeedBasis to project from
+  @param[out] interp_project  Address of the variable where the newly created
+                                projection matrix will be stored.
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedBasisCreateProjectionMatrix(CeedBasis basis_to,
+                                    CeedBasis basis_from,
+                                    CeedScalar **interp_project) {
+  int ierr;
+  Ceed ceed;
+  ierr = CeedBasisGetCeed(basis_to, &ceed); CeedChk(ierr);
+
+  // Check for compatible quadrature spaces
+  CeedInt Q_to, Q_from;
+  ierr = CeedBasisGetNumQuadraturePoints(basis_to, &Q_to); CeedChk(ierr);
+  ierr = CeedBasisGetNumQuadraturePoints(basis_from, &Q_from); CeedChk(ierr);
+  if (Q_to != Q_from)
+    // LCOV_EXCL_START
+    return CeedError(ceed, CEED_ERROR_DIMENSION,
+                     "Bases must have compatible quadrature spaces");
+  // LCOV_EXCL_STOP
+
+  // Coarse to fine basis
+  CeedInt P_to, P_from, Q = Q_to;
+  bool is_tensor_to, is_tensor_from;
+  ierr = CeedBasisIsTensor(basis_to, &is_tensor_to); CeedChk(ierr);
+  ierr = CeedBasisIsTensor(basis_from, &is_tensor_from); CeedChk(ierr);
+  CeedScalar *interp_to, *interp_from, *tau;
+  if (is_tensor_to && is_tensor_from) {
+    ierr = CeedBasisGetNumNodes1D(basis_to, &P_to); CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes1D(basis_from, &P_from); CeedChk(ierr);
+    ierr = CeedBasisGetNumQuadraturePoints1D(basis_from, &Q); CeedChk(ierr);
+  } else if (!is_tensor_to && !is_tensor_from) {
+    ierr = CeedBasisGetNumNodes(basis_to, &P_to); CeedChk(ierr);
+    ierr = CeedBasisGetNumNodes(basis_from, &P_from); CeedChk(ierr);
+  } else {
+    // LCOV_EXCL_START
+    return CeedError(ceed, CEED_ERROR_MINOR,
+                     "Bases must both be tensor or non-tensor");
+    // LCOV_EXCL_STOP
+  }
+
+  ierr = CeedMalloc(Q * P_from, &interp_from); CeedChk(ierr);
+  ierr = CeedMalloc(Q * P_to, &interp_to); CeedChk(ierr);
+  ierr = CeedCalloc(P_to * P_from, interp_project); CeedChk(ierr);
+  ierr = CeedMalloc(Q, &tau); CeedChk(ierr);
+  const CeedScalar *interp_to_source = NULL, *interp_from_source = NULL;
+  if (is_tensor_to) {
+    ierr = CeedBasisGetInterp1D(basis_to, &interp_to_source); CeedChk(ierr);
+    ierr = CeedBasisGetInterp1D(basis_from, &interp_from_source); CeedChk(ierr);
+  } else {
+    ierr = CeedBasisGetInterp(basis_to, &interp_to_source); CeedChk(ierr);
+    ierr = CeedBasisGetInterp(basis_from, &interp_from_source); CeedChk(ierr);
+  }
+  memcpy(interp_to, interp_to_source, Q * P_to * sizeof(interp_to_source[0]));
+  memcpy(interp_from, interp_from_source,
+         Q * P_from * sizeof(interp_from_source[0]));
+
+  // -- QR Factorization, interp_to = Q R
+  ierr = CeedQRFactorization(ceed, interp_to, tau, Q, P_to); CeedChk(ierr);
+
+  // -- Apply Qtranspose, interp_to = Qtranspose interp_from
+  ierr = CeedHouseholderApplyQ(interp_from, interp_to, tau, CEED_TRANSPOSE,
+                               Q, P_from, P_to, P_from, 1); CeedChk(ierr);
+
+  // -- Apply Rinv, interp_project = Rinv interp_c
+  for (CeedInt j = 0; j < P_from; j++) { // Column j
+    (*interp_project)[j + P_from * (P_to - 1)] = interp_from[j + P_from *
+        (P_to - 1)] / interp_to[P_to * P_to - 1];
+    for (CeedInt i = P_to - 2; i >= 0; i--) { // Row i
+      (*interp_project)[j + P_from * i] = interp_from[j + P_from * i];
+      for (CeedInt k = i+1; k < P_to; k++) {
+        (*interp_project)[j + P_from * i] -= interp_to[k + P_to * i]*
+                                             (*interp_project)[j + P_from * k];
+      }
+      (*interp_project)[j + P_from * i] /= interp_to[i + P_to * i];
+    }
+  }
+  ierr = CeedFree(&tau); CeedChk(ierr);
+  ierr = CeedFree(&interp_to); CeedChk(ierr);
+  ierr = CeedFree(&interp_from); CeedChk(ierr);
+
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Copy the pointer to a CeedBasis. Both pointers should
            be destroyed with `CeedBasisDestroy()`;
            Note: If `*basis_copy` is non-NULL, then it is assumed that


### PR DESCRIPTION
This is a refactor that exposes the prolongation basis setup to users. This will let me take the coordinates basis and the solution basis and interpolate from a lower order coordinates basis to a higher order solution basis. I think that this is the last piece of the puzzle for Dirichlet BCs in libCEED.