### PR TITLE
fluids: Create utils.h of QF helper functions

### DIFF
--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -16,10 +16,6 @@
 #include "stg_shur14.h"
 #include "../qfunctions/stg_shur14.h"
 
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
-
 STGShur14Context global_stg_ctx;
 
 /*

--- a/examples/fluids/qfunctions/advection2d.h
+++ b/examples/fluids/qfunctions/advection2d.h
@@ -13,10 +13,7 @@
 
 #include <math.h>
 #include <ceed.h>
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
+#include "utils.h"
 
 typedef struct SetupContext_ *SetupContext;
 struct SetupContext_ {
@@ -36,8 +33,6 @@ struct AdvectionContext_ {
   bool implicit;
   int stabilization; // See StabilizationType: 0=none, 1=SU, 2=SUPG
 };
-
-CEED_QFUNCTION_HELPER CeedScalar Square(CeedScalar x) { return x*x; }
 
 // *****************************************************************************
 // This QFunction sets the initial conditions and the boundary conditions

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <ceed.h>
 #include "newtonian_types.h"
+#include "utils.h"
 
 typedef struct BlasiusContext_ *BlasiusContext;
 struct BlasiusContext_ {
@@ -27,10 +28,6 @@ struct BlasiusContext_ {
   CeedScalar x_inflow;  // !< Location of inflow in x
   struct NewtonianIdealGasContext_ newtonian_ctx;
 };
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
 
 void CEED_QFUNCTION_HELPER(BlasiusSolution)(const CeedScalar y,
     const CeedScalar Uinf, const CeedScalar x0, const CeedScalar x,
@@ -192,7 +189,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q,
   const CeedScalar x_inflow = context->x_inflow;
   const bool       weakT    = context->weakT;
   const CeedScalar rho_0    = P0 / (Rd * theta0);
-  const CeedScalar x0       = Uinf*rho_0 / (mu*25/ (delta0*delta0) );
+  const CeedScalar x0       = Uinf*rho_0 / (mu*25/ Square(delta0) );
 
   CeedPragmaSIMD
   // Quadrature Point Loop

--- a/examples/fluids/qfunctions/densitycurrent.h
+++ b/examples/fluids/qfunctions/densitycurrent.h
@@ -18,10 +18,7 @@
 #include <math.h>
 #include <ceed.h>
 #include "newtonian_types.h"
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
+#include "utils.h"
 
 // *****************************************************************************
 // This function sets the initial conditions and the boundary conditions

--- a/examples/fluids/qfunctions/eulervortex.h
+++ b/examples/fluids/qfunctions/eulervortex.h
@@ -18,10 +18,7 @@
 
 #include <math.h>
 #include <ceed.h>
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
+#include "utils.h"
 
 typedef struct EulerContext_ *EulerContext;
 struct EulerContext_ {

--- a/examples/fluids/qfunctions/newtonian.h
+++ b/examples/fluids/qfunctions/newtonian.h
@@ -16,10 +16,7 @@
 #include <ceed.h>
 #include "newtonian_types.h"
 #include "newtonian_state.h"
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
+#include "utils.h"
 
 // *****************************************************************************
 // Helper function for computing flux Jacobian

--- a/examples/fluids/qfunctions/newtonian_state.h
+++ b/examples/fluids/qfunctions/newtonian_state.h
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <ceed.h>
 #include "newtonian_types.h"
+#include "utils.h"
 
 typedef struct {
   CeedScalar pressure;
@@ -125,16 +126,6 @@ CEED_QFUNCTION_HELPER void KMStrainRate(const State grad_s[3],
   strain_rate[3] = weight * (grad_s[2].Y.velocity[1] + grad_s[1].Y.velocity[2]);
   strain_rate[4] = weight * (grad_s[2].Y.velocity[0] + grad_s[0].Y.velocity[2]);
   strain_rate[5] = weight * (grad_s[1].Y.velocity[0] + grad_s[0].Y.velocity[1]);
-}
-
-CEED_QFUNCTION_HELPER void KMUnpack(const CeedScalar v[6], CeedScalar A[3][3]) {
-  const CeedScalar weight = 1 / sqrt(2.);
-  A[0][0] = v[0];
-  A[1][1] = v[1];
-  A[2][2] = v[2];
-  A[2][1] = A[1][2] = weight * v[3];
-  A[2][0] = A[0][2] = weight * v[4];
-  A[1][0] = A[0][1] = weight * v[5];
 }
 
 CEED_QFUNCTION_HELPER void NewtonianStress(NewtonianIdealGasContext gas,

--- a/examples/fluids/qfunctions/newtonian_types.h
+++ b/examples/fluids/qfunctions/newtonian_types.h
@@ -53,10 +53,4 @@ struct NewtonianIdealGasContext_ {
   StabilizationType stabilization;
 };
 
-CEED_QFUNCTION_HELPER CeedScalar Square(CeedScalar x) { return x*x; }
-CEED_QFUNCTION_HELPER CeedScalar Dot3(const CeedScalar u[3],
-                                      const CeedScalar v[3]) {
-  return u[0]*v[0] + u[1]*v[1] + u[2]*v[2];
-}
-
 #endif // newtonian_types_h

--- a/examples/fluids/qfunctions/newtonian_types.h
+++ b/examples/fluids/qfunctions/newtonian_types.h
@@ -1,3 +1,10 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
 #ifndef newtonian_types_h
 #define newtonian_types_h
 

--- a/examples/fluids/qfunctions/shocktube.h
+++ b/examples/fluids/qfunctions/shocktube.h
@@ -27,10 +27,7 @@
 
 #include <math.h>
 #include <ceed.h>
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
+#include "utils.h"
 
 typedef struct SetupContext_ *SetupContext;
 struct SetupContext_ {

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -20,15 +20,9 @@
 #include <ceed.h>
 #include <stdlib.h>
 #include "stg_shur14_type.h"
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846
-#endif
+#include "utils.h"
 
 #define STG_NMODES_MAX 1024
-
-CEED_QFUNCTION_HELPER CeedScalar Max(CeedScalar a, CeedScalar b) { return a < b ? b : a; }
-CEED_QFUNCTION_HELPER CeedScalar Min(CeedScalar a, CeedScalar b) { return a < b ? a : b; }
 
 /*
  * @brief Interpolate quantities from input profile to given location
@@ -115,7 +109,7 @@ void CEED_QFUNCTION_HELPER(CalcSpectrum)(const CeedScalar dw,
 
   const CeedScalar hmax = Max( Max(h[0], h[1]), h[2]);
   const CeedScalar ke   = dw==0 ? 1e16 : 2*M_PI/Min(2*dw, 3*lt);
-  const CeedScalar keta = 2*M_PI*pow(pow(nu,3.0)/eps, -0.25);
+  const CeedScalar keta = 2*M_PI*pow(Cube(nu)/eps, -0.25);
   const CeedScalar kcut =
     M_PI/ Min( Max(Max(h[1], h[2]), 0.3*hmax) + 0.1*dw, hmax );
   CeedScalar fcut, feta, Ektot=0.0;
@@ -253,7 +247,7 @@ CEED_QFUNCTION(STGShur14_Inflow)(void *ctx, CeedInt Q,
 
     CeedScalar h[3];
     for (CeedInt j=0; j<3; j++)
-      h[j] = 2/sqrt(dXdx[0][j]*dXdx[0][j] + dXdx[1][j]*dXdx[1][j]);
+      h[j] = 2/sqrt(Square(dXdx[0][j]) + Square(dXdx[1][j]));
     h[0] = dx;
 
     InterpolateProfile(X[1][i], ubar, cij, &eps, &lt, stg_ctx);

--- a/examples/fluids/qfunctions/utils.h
+++ b/examples/fluids/qfunctions/utils.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#ifndef utils_h
+#define utils_h
+
+#include <math.h>
+#include <ceed.h>
+
+#ifndef M_PI
+#define M_PI    3.14159265358979323846
+#endif
+
+CEED_QFUNCTION_HELPER CeedScalar Max(CeedScalar a, CeedScalar b) { return a < b ? b : a; }
+CEED_QFUNCTION_HELPER CeedScalar Min(CeedScalar a, CeedScalar b) { return a < b ? a : b; }
+
+CEED_QFUNCTION_HELPER CeedScalar Square(CeedScalar x) { return x*x; }
+CEED_QFUNCTION_HELPER CeedScalar Cube(CeedScalar x) { return x*x*x; }
+
+// @brief Dot product of 3 element vectors
+CEED_QFUNCTION_HELPER CeedScalar Dot3(const CeedScalar u[3],
+                                      const CeedScalar v[3]) {
+  return u[0]*v[0] + u[1]*v[1] + u[2]*v[2];
+}
+
+// @brief Unpack Kelvin-Mandel notation symmetric tensor into full tensor
+CEED_QFUNCTION_HELPER void KMUnpack(const CeedScalar v[6], CeedScalar A[3][3]) {
+  const CeedScalar weight = 1 / sqrt(2.);
+  A[0][0] = v[0];
+  A[1][1] = v[1];
+  A[2][2] = v[2];
+  A[2][1] = A[1][2] = weight * v[3];
+  A[2][0] = A[0][2] = weight * v[4];
+  A[1][0] = A[0][1] = weight * v[5];
+}
+
+#endif // utils_h


### PR DESCRIPTION
Takes a bunch of QF helper functions and puts them into one place to be included wherever needed.

Thought I was going to "need" to do this for some work in #1009, but didn't end up needing it. Figured I'd extract it out as a separate PR rather than scrapping it.