### PR TITLE
basis - use ncomp from 'from' basis for projection

### DIFF
--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -552,8 +552,8 @@ CEED_EXTERN int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo,
                                     const CeedScalar *div,
                                     const CeedScalar *q_ref,
                                     const CeedScalar *q_weights, CeedBasis *basis);
-CEED_EXTERN int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from, CeedBasis *basis_project);
-CEED_EXTERN int CeedBasisCreateProjectionMatrix(CeedBasis basis_to, CeedBasis basis_from, CeedScalar **interp_project);
+CEED_EXTERN int CeedBasisCreateProjection(CeedBasis basis_from, CeedBasis basis_to, CeedBasis *basis_project);
+CEED_EXTERN int CeedBasisCreateProjectionMatrix(CeedBasis basis_from, CeedBasis basis_to, CeedScalar **interp_project);
 CEED_EXTERN int CeedBasisReferenceCopy(CeedBasis basis, CeedBasis *basis_copy);
 CEED_EXTERN int CeedBasisView(CeedBasis basis, FILE *stream);
 CEED_EXTERN int CeedBasisApply(CeedBasis basis, CeedInt num_elem,

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -864,7 +864,7 @@ int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from,
   CeedScalar *q_ref, *q_weight, *grad;
   ierr = CeedBasisIsTensor(basis_to, &is_tensor); CeedChk(ierr);
   ierr = CeedBasisGetDimension(basis_to, &dim); CeedChk(ierr);
-  ierr = CeedBasisGetNumComponents(basis_to, &num_comp); CeedChk(ierr);
+  ierr = CeedBasisGetNumComponents(basis_from, &num_comp); CeedChk(ierr);
   if (is_tensor) {
     CeedInt P_1d_to, P_1d_from;
     ierr = CeedBasisGetNumNodes1D(basis_from, &P_1d_from); CeedChk(ierr);

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -837,6 +837,10 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp,
            the pesudoinverse `interp_to^+` is given by QR factorization.
          Note: `basis_from` and `basis_to` must have compatible quadrature
            spaces.
+         Note: `basis_project` will have the same number of components as
+           `basis_from`, regardless of the number of components that
+           `basis_to` has. If `basis_from` has 3 components and `basis_to`
+           has 5 components, then `basis_project` will have 3 components.
 
   @param[in] basis_to        CeedBasis to prolong to
   @param[in] basis_from      CeedBasis to prolong from

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -842,8 +842,8 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp,
            `basis_to` has. If `basis_from` has 3 components and `basis_to`
            has 5 components, then `basis_project` will have 3 components.
 
-  @param[in] basis_to        CeedBasis to prolong to
   @param[in] basis_from      CeedBasis to prolong from
+  @param[in] basis_to        CeedBasis to prolong to
   @param[out] basis_project  Address of the variable where the newly created
                                CeedBasis will be stored.
 
@@ -851,7 +851,7 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp,
 
   @ref User
 **/
-int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from,
+int CeedBasisCreateProjection(CeedBasis basis_from, CeedBasis basis_to,
                               CeedBasis *basis_project) {
   int ierr;
   Ceed ceed;
@@ -859,7 +859,7 @@ int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from,
 
   // Create projectior matrix
   CeedScalar *interp_project;
-  ierr = CeedBasisCreateProjectionMatrix(basis_to, basis_from,
+  ierr = CeedBasisCreateProjectionMatrix(basis_from, basis_to,
                                          &interp_project); CeedChk(ierr);
 
   // Build basis
@@ -910,8 +910,8 @@ int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from,
          Note: `basis_from` and `basis_to` must have compatible quadrature
            spaces.
 
-  @param[in] basis_to         CeedBasis to project to
   @param[in] basis_from       CeedBasis to project from
+  @param[in] basis_to         CeedBasis to project to
   @param[out] interp_project  Address of the variable where the newly created
                                 projection matrix will be stored.
 
@@ -919,8 +919,8 @@ int CeedBasisCreateProjection(CeedBasis basis_to, CeedBasis basis_from,
 
   @ref User
 **/
-int CeedBasisCreateProjectionMatrix(CeedBasis basis_to,
-                                    CeedBasis basis_from,
+int CeedBasisCreateProjectionMatrix(CeedBasis basis_from,
+                                    CeedBasis basis_to,
                                     CeedScalar **interp_project) {
   int ierr;
   Ceed ceed;

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -2052,7 +2052,7 @@ int CeedOperatorMultigridLevelCreate(CeedOperator op_fine,
   // Build prolongation matrix
   CeedBasis basis_fine, basis_c_to_f;
   ierr = CeedOperatorGetActiveBasis(op_fine, &basis_fine); CeedChk(ierr);
-  ierr = CeedBasisCreateProjection(basis_fine, basis_coarse, &basis_c_to_f);
+  ierr = CeedBasisCreateProjection(basis_coarse, basis_fine, &basis_c_to_f);
   CeedChk(ierr);
 
   // Core code


### PR DESCRIPTION
@jedbrown @jrwrigh I actually meant for this to skip the need for a dummy basis of the right number of components but reversed the order.