### PR TITLE
examples/fluids: use DMGetCellCoordinateDM to handle periodicity

### DIFF
--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -25,6 +25,7 @@ PetscErrorCode CreateDM(MPI_Comm comm, ProblemData *problem,
 
   // Set Tensor elements
   ierr = PetscOptionsSetValue(NULL, "-dm_plex_simplex", "0"); CHKERRQ(ierr);
+  ierr = PetscOptionsSetValue(NULL, "-dm_sparse_localize", "0"); CHKERRQ(ierr);
   // Set CL options
   ierr = DMSetFromOptions(*dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(*dm, NULL, "-dm_view"); CHKERRQ(ierr);


### PR DESCRIPTION
Note that without -dm_sparse_localize 0 (default=1), the cell DM will
only have cells with localized coordinates (and there is no vector
representation that contains both).