### PR TITLE
Support non-tensor elements with `cuda/gen` backend.

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -933,7 +933,13 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     if (emode != CEED_EVAL_WEIGHT) {
       ierr = CeedOperatorFieldGetBasis(opinputfields[i], &basis); CeedChkBackend(ierr);
       if (basis != CEED_BASIS_COLLOCATED) {
-        ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChkBackend(ierr);
+        bool isTensor;
+        ierr = CeedBasisIsTensor(basis, &isTensor); CeedChkBackend(ierr); 
+        if (isTensor) {
+          ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChkBackend(ierr);
+        } else {
+          ierr = CeedBasisGetNumNodes(basis, &P1d); CeedChkBackend(ierr);
+        }
         code << "  const CeedInt P_in_"<<i<<" = "<<P1d<<";\n";
       } else {
         code << "  const CeedInt P_in_"<<i<<" = "<<Q1d<<";\n";


### PR DESCRIPTION
Try using `dim == 1` for non-tensor basis to add support for non-tensor elements in the `cuda/gen` backend.