### PR TITLE
doc - fix ref warning for hoverxref_role_types

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -164,6 +164,9 @@ html_sidebars = {
 # hoverxref options
 hoverxref_auto_ref = True
 hoverxref_mathjax = True
+hoverxref_role_types = {
+    'ref': 'modal',
+}
 
 latex_macros = r"""
 \def \diff {\operatorname{d}\!}


### PR DESCRIPTION
This silences a harmless warning