### PR TITLE
Add CEED_QFUNCTION_ATTR for inlining

### DIFF
--- a/include/ceed/types.h
+++ b/include/ceed/types.h
@@ -15,6 +15,28 @@
 
 /**
   @ingroup CeedQFunction
+  This macro defines compiler attributes to the CEED_QFUNCTION to force inlining
+    for called functions. The `inline` declaration does not necessarily enforce a
+    compiler to inline a function. This can be deterimental to performance, so
+    here we force inlining to occur unless inlining has been forced off (like
+    during debugging).
+**/
+#ifndef CEED_QFUNCTION_ATTR
+#ifndef __NO_INLINE__
+#  if defined(__GNUC__) || defined(__clang__)
+#    define CEED_QFUNCTION_ATTR __attribute__((flatten))
+#  elif defined(__INTEL_COMPILER)
+#    define CEED_QFUNCTION_ATTR _Pragma("forceinline")
+#  else
+#    define CEED_QFUNCTION_ATTR
+#  endif
+#else
+#  define CEED_QFUNCTION_ATTR
+#endif
+#endif
+
+/**
+  @ingroup CeedQFunction
   This macro populates the correct function annotations for User QFunction
     source for code generation backends or populates default values for CPU
     backends. It also creates a variable `name_loc` populated with the correct
@@ -23,7 +45,7 @@
 #ifndef CEED_QFUNCTION
 #define CEED_QFUNCTION(name) \
   static const char name ## _loc[] = __FILE__ ":" #name;        \
-  static int name
+  CEED_QFUNCTION_ATTR static int name
 #endif
 
 /**
@@ -33,7 +55,7 @@
     values for CPU backends.
 **/
 #ifndef CEED_QFUNCTION_HELPER
-#define CEED_QFUNCTION_HELPER static inline
+#define CEED_QFUNCTION_HELPER CEED_QFUNCTION_ATTR static inline
 #endif
 
 /**

--- a/python/build_ceed_cffi.py
+++ b/python/build_ceed_cffi.py
@@ -21,6 +21,7 @@ for header_path in ["include/ceed/types.h", "include/ceed/ceed.h"]:
         lines += [line.strip() for line in f if
                   not (line.startswith("#") and not line.startswith("#include")) and
                   not line.startswith("  static") and
+                  not line.startswith("  CEED_QFUNCTION_ATTR") and
                   "CeedErrorImpl" not in line and
                   "const char *, ...);" not in line and
                   not line.startswith("CEED_EXTERN const char *const") and


### PR DESCRIPTION
GCC doesn't like to inline all Qfunction helpers, so this forces it do so if inlining is allowed at all.

This was originally apart of #1035, but has been stripped out into this PR. A more detailed discussion is in https://github.com/CEED/libCEED/pull/1035#discussion_r938446943, but to summarize:

GCC (and presumably other compilers) may elect to not inline a function, even with the `inline` modifier specified. This can lead to detrimental performance, particularly if the inlining is required to allow for further optimizations (such as passing a function pointer to a helper function). Forcing a function to always be inlined can however lead to a poor debugging experience. Thus we add a `CEED_QFUNCTION_ATTR` macro that is created based on compiler-set macros (namely `__NO_INLINE__`) which activates forced inlining. This macro is then embedded into the `CEED_QFUNCTION` definition.