### PR TITLE
doc: Add CEED_QFUNCTION_ATTR to releasenotes

### DIFF
--- a/doc/sphinx/source/api/backend/CeedQFunction.rst
+++ b/doc/sphinx/source/api/backend/CeedQFunction.rst
@@ -6,3 +6,9 @@ CeedQFunction
    :path: ../../../../xml
    :content-only:
    :members:
+
+Macros
+--------------------------------------
+
+.. doxygendefine:: CEED_QFUNCTION_ATTR
+   :project: libCEED

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -15,6 +15,7 @@ On this page we provide a summary of the main API changes, new features and exam
 
 - Update `/cpu/self/memcheck/*` backends to help verify `CeedQFunctionContext` data sizes provided by user.
 - Added `CeedInt_FMT` to support potential future use of larger interger sizes.
+- Added CEED_QFUNCTION_ATTR for setting compiler attributes/pragmas to CEED_QFUNCTION_HELPER and CEED_QFUNCTION
 
 ### Bugfix
 


### PR DESCRIPTION
Forgot to add to the release notes for #1048.

Also, didn't realize that the `CEED_QFUNCTION_ATTR` isn't actually showing up in the docs. I'm assuming that's supposed to be happening. I just built the docs locally and it doesn't appear there either.