### PR TITLE
Fix small memory leaks in JIT source code management

### DIFF
--- a/backends/magma/ceed-magma-basis.c
+++ b/backends/magma/ceed-magma-basis.c
@@ -757,6 +757,11 @@ int CeedBasisCreateTensorH1_Magma(CeedInt dim, CeedInt P1d, CeedInt Q1d,
                   data->queue);
 
   ierr = CeedBasisSetData(basis, impl); CeedChkBackend(ierr);
+  ierr = CeedFree(&magma_common_path); CeedChkBackend(ierr);
+  ierr = CeedFree(&interp_path); CeedChkBackend(ierr);
+  ierr = CeedFree(&grad_path); CeedChkBackend(ierr);
+  ierr = CeedFree(&weight_path); CeedChkBackend(ierr);
+  ierr = CeedFree(&basis_kernel_source); CeedChkBackend(ierr);
 
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/magma/ceed-magma-restriction.c
+++ b/backends/magma/ceed-magma-restriction.c
@@ -320,6 +320,9 @@ int CeedElemRestrictionCreate_Magma(CeedMemType mtype, CeedCopyMode cmode,
   CeedChkBackend(ierr);
   ierr = CeedSetBackendFunction(ceed, "ElemRestriction", r, "Destroy",
                                 CeedElemRestrictionDestroy_Magma); CeedChkBackend(ierr);
+  ierr = CeedFree(&restriction_kernel_path); CeedChkBackend(ierr);
+  ierr = CeedFree(&restriction_kernel_source); CeedChkBackend(ierr);
+
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -171,6 +171,7 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed,
           memcpy(ceed_relative_path, &next_left_chevron[1], ceed_relative_path_length);
           ierr = CeedGetJitAbsolutePath(ceed, ceed_relative_path, &include_source_path);
           CeedChk(ierr);
+          ierr = CeedFree(&ceed_relative_path); CeedChk(ierr);
         }
         // ---- Recursive call to load source to buffer
         CeedDebug256(ceed, 2, "JiT Including: %s\n", include_source_path);


### PR DESCRIPTION
I introduced memory leaks in the MAGMA backend when switching to RTC (did not explicitly free the buffers used in loading source files).  In the course of testing, I found another (very minor) missing `CeedFree` that affects all backends using JIT.
This PR adds these `CeedFree` calls.

I'm not sure I've quite squashed all the potential leaks, though.  Valgrind is still reporting slight differences between `/gpu/hip/ref`, `/gpu/hip/magma`, and `/cpu/self/ref/serial` for some tests that I tried.  Though -- even cpu-ref says some memory is "definitely lost" -- is this something anyone else has seen before?  (E.g., t205-elemrestriction: cpu-ref, 337,984 bytes; gpu-ref, 338,512 bytes; magma, 338,589).
Edit: I see now that linking hipblas and/or hipsparse will create reported memory leaks, even without using the GPU.  Have confirmed through a test that doesn't use libCEED at all.