### PR TITLE
fluids: Fix time label for strong STG

### DIFF
--- a/examples/fluids/Makefile
+++ b/examples/fluids/Makefile
@@ -67,6 +67,15 @@ print: $(PETSc.pc) $(ceed.pc)
 	$(info OPT     : $(OPT))
 	@true
 
+print-% :
+	$(info [ variable name]: $*)
+	$(info [        origin]: $(origin $*))
+	$(info [        flavor]: $(flavor $*))
+	$(info [         value]: $(value $*))
+	$(info [expanded value]: $($*))
+	$(info )
+	@true
+
 clean:
 	$(RM) -r $(OBJDIR) navierstokes *.vtu *.bin* *.csv *.png
 
@@ -76,6 +85,6 @@ $(PETSc.pc):
 
 .PHONY: all print clean
 
-pkgconf = $(shell pkg-config $1 | sed -e 's/^"//g' -e 's/"$$//g')
+pkgconf = $(shell pkg-config $(if $(STATIC),--static) $1 | sed -e 's/^"//g' -e 's/"$$//g')
 
 -include $(src.o:%.o=%.d)

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -198,6 +198,7 @@ struct Physics_private {
   PetscBool                has_curr_time;
   PetscBool                has_neumann;
   CeedContextFieldLabel    solution_time_label;
+  CeedContextFieldLabel    stg_solution_time_label;
   CeedContextFieldLabel    timestep_size_label;
   CeedContextFieldLabel    ics_time_label;
   CeedContextFieldLabel    ijacobian_time_shift_label;


### PR DESCRIPTION
The solution time label for the strong STG boundary condition was not created or set. The strong form has it's own operator, and so needs it's own label. 

PR also includes some niceties from Jed to the fluids makefile.