### PR TITLE
Fix t568 bug

### DIFF
--- a/tests/junit.py
+++ b/tests/junit.py
@@ -61,7 +61,6 @@ def skip_rule(test, resource):
         test.startswith('t507') and contains_any(resource, ['occa']),
         test.startswith('t318') and contains_any(resource, ['/gpu/cuda/ref']),
         test.startswith('t506') and contains_any(resource, ['/gpu/cuda/shared']),
-        test.startswith('t568') and (contains_any(resource, ['/gpu/cuda/gen']) or resource.startswith('/gpu/hip')),
         ))
 
 def run(test, backends):

--- a/tests/t568-operator.c
+++ b/tests/t568-operator.c
@@ -4,7 +4,7 @@
 #include <ceed.h>
 #include <stdlib.h>
 #include <math.h>
-#include "t534-operator.h"
+#include "t568-operator.h"
 
 int main(int argc, char **argv) {
   Ceed ceed;

--- a/tests/t568-operator.h
+++ b/tests/t568-operator.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#include <ceed.h>
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q,
+                      const CeedScalar *const *in,
+                      CeedScalar *const *out) {
+  // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
+  // the symmetric part of the result.
+
+  // in[0] is Jacobians with shape [2, nc=2, Q]
+  // in[1] is quadrature weights, size (Q)
+  const CeedScalar *J = in[0], *qw = in[1];
+
+  // out[0] is qdata, size (Q)
+  CeedScalar *qd = out[0];
+
+  // Quadrature point loop
+  for (CeedInt i=0; i<Q; i++) {
+    // J: 0 2   qd: 0 2   adj(J):  J22 -J12
+    //    1 3       2 1           -J21  J11
+    const CeedScalar J11 = J[i+Q*0];
+    const CeedScalar J21 = J[i+Q*1];
+    const CeedScalar J12 = J[i+Q*2];
+    const CeedScalar J22 = J[i+Q*3];
+    const CeedScalar w = qw[i] / (J11*J22 - J21*J12);
+    qd[i+Q*0] =   w * (J12*J12 + J22*J22);
+    qd[i+Q*2] =   w * (J11*J11 + J21*J21);
+    qd[i+Q*1] = - w * (J11*J12 + J21*J22);
+  }
+
+  return 0;
+}
+
+CEED_QFUNCTION(diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in,
+                     CeedScalar *const *out) {
+  // in[0] is gradient u, shape [2, nc=2, Q]
+  // in[1] is quadrature data, size (3*Q)
+  const CeedScalar *du = in[0], *qd = in[1];
+
+  // out[0] is output to multiply against gradient v, shape [2, nc=2, Q]
+  CeedScalar *dv = out[0];
+
+  // Quadrature point loop
+  for (CeedInt i=0; i<Q; i++) {
+    // Component loop
+    for (CeedInt c = 0; c < 2; c++) {
+      const CeedScalar du0 = du[i+c*Q+2*Q*0];
+      const CeedScalar du1 = du[i+c*Q+2*Q*1];
+      dv[i+c*Q+2*Q*0] = qd[i+Q*0]*du0 + qd[i+Q*2]*du1;
+      dv[i+c*Q+2*Q*1] = qd[i+Q*2]*du0 + qd[i+Q*1]*du1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #1064 

Rather than something GPU-specific, I think the problem was the QFunction that the test was using.  The test itself had `num_comp=2`, but it was using the same QFunction as t534, which has only one component. 

If we want to avoid code duplication, we could probably use the QFunctionContext to set the number of components and then write t534-operator.h in such a way that it would work for t534 and t568.   Would this be preferable? 