### PR TITLE
ci - update codecov action version

### DIFF
--- a/.github/workflows/rust-test-with-style.yml
+++ b/.github/workflows/rust-test-with-style.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         args: '--run-types Doctests Tests --exclude-files backends/* gallery/* include/* interface/* --out Xml'
     - name: Codecov upload
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: ./cobertura.xml
         token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
I thought we had Julia codecov uploaded at some point, but it seems we don't anymore?