### PR TITLE
fluids: Make simulation continuation more flexible

### DIFF
--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -72,13 +72,25 @@ The following options are common among all problem types:
   - Frequency of output, in number of steps. `0` has no output, `-1` outputs final state only
   - `10`
 
-* - `-continue`
-  - Continue from previous solution
-  - `0`
-
 * - `-output_dir`
   - Output directory
   - `.`
+
+* - `-output_add_stepnum2bin`
+  - Whether to add step numbers to output binary files
+  - `false`
+
+* - `-continue`
+  - Continue from previous solution (input is step number of previous solution)
+  - `0`
+
+* - `-continue_filename`
+  - Path to solution binary file from which to continue from
+  - `[output_dir]/ns-solution.bin`
+
+* - `-continue_time_filename`
+  - Path to time stamp binary file from which to continue from
+  - `[output_dir]/ns-time.bin`
 
 * - `-bc_wall`
   - Use wall boundary conditions on this list of faces

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -121,6 +121,7 @@ struct AppCtx_private {
   char              cont_file[PETSC_MAX_PATH_LEN];
   char              cont_time_file[PETSC_MAX_PATH_LEN];
   char              output_dir[PETSC_MAX_PATH_LEN];
+  PetscBool         add_stepnum2bin;
   // Problem type arguments
   PetscFunctionList problems;
   char              problem_name[PETSC_MAX_PATH_LEN];

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -118,6 +118,8 @@ struct AppCtx_private {
   PetscInt          output_freq;
   PetscInt          viz_refine;
   PetscInt          cont_steps;
+  char              cont_file[PETSC_MAX_PATH_LEN];
+  char              cont_time_file[PETSC_MAX_PATH_LEN];
   char              output_dir[PETSC_MAX_PATH_LEN];
   // Problem type arguments
   PetscFunctionList problems;

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -87,6 +87,10 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx,
                          "Frequency of output, in number of steps",
                          NULL, app_ctx->output_freq, &app_ctx->output_freq, NULL); CHKERRQ(ierr);
 
+  PetscCall(PetscOptionsBool("-output_add_stepnum2bin",
+                             "Add step number to the binary outputs",
+                             NULL, app_ctx->add_stepnum2bin, &app_ctx->add_stepnum2bin, NULL));
+
   PetscCall(PetscStrncpy(app_ctx->output_dir, ".", 2));
   PetscCall(PetscOptionsString("-output_dir", "Output directory",
                                NULL, app_ctx->output_dir, app_ctx->output_dir,

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -226,14 +226,11 @@ PetscErrorCode PostProcess_NS(TS ts, CeedData ceed_data, DM dm,
 PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q) {
 
   PetscViewer    viewer;
-  char           file_path[PETSC_MAX_PATH_LEN];
   PetscErrorCode ierr;
   PetscFunctionBegin;
 
   // Read input
-  ierr = PetscSNPrintf(file_path, sizeof file_path, "%s/ns-solution.bin",
-                       app_ctx->output_dir); CHKERRQ(ierr);
-  ierr = PetscViewerBinaryOpen(comm, file_path, FILE_MODE_READ, &viewer);
+  ierr = PetscViewerBinaryOpen(comm, app_ctx->cont_file, FILE_MODE_READ, &viewer);
   CHKERRQ(ierr);
 
   // Load Q from existent solution

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -428,8 +428,14 @@ PetscErrorCode WriteOutput(User user, Vec Q, PetscInt step_no,
   PetscCall(DMRestoreLocalVector(user->dm, &Q_loc));
 
   // Save data in a binary file for continuation of simulations
-  PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-solution.bin",
-                          user->app_ctx->output_dir));
+  if (user->app_ctx->add_stepnum2bin) {
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path,
+                            "%s/ns-solution-%" PetscInt_FMT ".bin",
+                            user->app_ctx->output_dir, step_no + user->app_ctx->cont_steps));
+  } else {
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-solution.bin",
+                            user->app_ctx->output_dir));
+  }
   PetscCall(PetscViewerBinaryOpen(user->comm, file_path, FILE_MODE_WRITE,
                                   &viewer));
 
@@ -439,8 +445,14 @@ PetscErrorCode WriteOutput(User user, Vec Q, PetscInt step_no,
   // Save time stamp
   // Dimensionalize time back
   time /= user->units->second;
-  PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-time.bin",
-                          user->app_ctx->output_dir));
+  if (user->app_ctx->add_stepnum2bin) {
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path,
+                            "%s/ns-time-%" PetscInt_FMT ".bin",
+                            user->app_ctx->output_dir, step_no + user->app_ctx->cont_steps));
+  } else {
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-time.bin",
+                            user->app_ctx->output_dir));
+  }
   PetscCall(PetscViewerBinaryOpen(user->comm, file_path, FILE_MODE_WRITE,
                                   &viewer));
 

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -526,10 +526,8 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys,
     PetscReal   time;
     PetscInt    count;
     PetscViewer viewer;
-    char        file_path[PETSC_MAX_PATH_LEN];
-    ierr = PetscSNPrintf(file_path, sizeof file_path, "%s/ns-time.bin",
-                         app_ctx->output_dir); CHKERRQ(ierr);
-    ierr = PetscViewerBinaryOpen(comm, file_path, FILE_MODE_READ, &viewer);
+    ierr = PetscViewerBinaryOpen(comm, app_ctx->cont_time_file, FILE_MODE_READ,
+                                 &viewer);
     CHKERRQ(ierr);
     ierr = PetscViewerBinaryRead(viewer, &time, 1, &count, PETSC_REAL);
     CHKERRQ(ierr);


### PR DESCRIPTION
This branch does two primary things:
- Allows for the binary file used to continue the simulation to be explicitly specified
- Optionally appends the step number to the output binary files (both `ns-solution` and `ns-time`)

Combined, these allow for more flexible restart options (being able to continue at an arbitrary point in previous history, namely).
This also leaves open the option to select different types of files to restart from in the future (HDF5, CGNS, etc). 


Todo:
- [x] Document new options