### PR TITLE
fluids: Add option for STG fluctuations in initial condition

### DIFF
--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -769,6 +769,11 @@ Using the STG Inflow for the blasius problem adds the following command-line opt
   - `false`
   -
 
+* - `-stg_fluctuating_IC`
+  - "Extrude" the fluctuations through the domain as an initial condition
+  - `false`
+  -
+
 :::
 
 This problem can be run with the `blasius.yaml` file via:

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -321,10 +321,10 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx) {
   PetscScalar Kelvin = user->units->Kelvin;
   PetscScalar Pascal = user->units->Pascal;
 
-  T_inf   *= Kelvin;
+  T_inf  *= Kelvin;
   T_wall *= Kelvin;
   P0     *= Pascal;
-  U_inf   *= meter / second;
+  U_inf  *= meter / second;
   delta0 *= meter;
 
   PetscReal *mesh_ynodes = NULL;

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -358,7 +358,7 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx) {
     blasius_ctx->x_inflow = domain_min[0];
     blasius_ctx->eta_max  = 5 * domain_max[1] / blasius_ctx->delta0;
   }
-  PetscCall(ComputeChebyshevCoefficients(blasius_ctx));
+  if(!use_stg) PetscCall(ComputeChebyshevCoefficients(blasius_ctx));
 
   CeedQFunctionContextRestoreData(problem->apply_vol_rhs.qfunction_context,
                                   &newtonian_ig_ctx);

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -68,21 +68,20 @@ PetscErrorCode CalcCholeskyDecomp(MPI_Comm comm, PetscInt nprofs,
 static PetscErrorCode OpenPHASTADatFile(const MPI_Comm comm,
                                         const char path[PETSC_MAX_PATH_LEN], const PetscInt char_array_len,
                                         PetscInt dims[2], FILE **fp) {
-  PetscErrorCode ierr;
   PetscInt ndims;
   char line[char_array_len];
   char **array;
 
   PetscFunctionBeginUser;
-  ierr = PetscFOpen(comm, path, "r", fp); CHKERRQ(ierr);
-  ierr = PetscSynchronizedFGets(comm, *fp, char_array_len, line); CHKERRQ(ierr);
-  ierr = PetscStrToArray(line, ' ', &ndims, &array); CHKERRQ(ierr);
+  PetscCall(PetscFOpen(comm, path, "r", fp));
+  PetscCall(PetscSynchronizedFGets(comm, *fp, char_array_len, line));
+  PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
   if (ndims != 2) SETERRQ(comm, -1,
                             "Found %" PetscInt_FMT" dimensions instead of 2 on the first line of %s",
                             ndims, path);
 
   for (PetscInt i=0; i<ndims; i++)  dims[i] = atoi(array[i]);
-  ierr = PetscStrToArrayDestroy(ndims, array); CHKERRQ(ierr);
+  PetscCall(PetscStrToArrayDestroy(ndims, array));
   PetscFunctionReturn(0);
 }
 
@@ -98,15 +97,14 @@ static PetscErrorCode OpenPHASTADatFile(const MPI_Comm comm,
  */
 static PetscErrorCode GetNRows(const MPI_Comm comm,
                                const char path[PETSC_MAX_PATH_LEN], PetscInt *nrows) {
-  PetscErrorCode ierr;
   const PetscInt char_array_len = 512;
   PetscInt dims[2];
   FILE *fp;
 
   PetscFunctionBeginUser;
-  ierr = OpenPHASTADatFile(comm, path, char_array_len, dims, &fp); CHKERRQ(ierr);
+  PetscCall(OpenPHASTADatFile(comm, path, char_array_len, dims, &fp));
   *nrows = dims[0];
-  ierr = PetscFClose(comm, fp); CHKERRQ(ierr);
+  PetscCall(PetscFClose(comm, fp));
   PetscFunctionReturn(0);
 }
 
@@ -126,7 +124,6 @@ static PetscErrorCode GetNRows(const MPI_Comm comm,
  */
 static PetscErrorCode ReadSTGInflow(const MPI_Comm comm,
                                     const char path[PETSC_MAX_PATH_LEN], STGShur14Context stg_ctx) {
-  PetscErrorCode ierr;
   PetscInt ndims, dims[2];
   FILE *fp;
   const PetscInt char_array_len=512;
@@ -135,7 +132,7 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm,
 
   PetscFunctionBeginUser;
 
-  ierr = OpenPHASTADatFile(comm, path, char_array_len, dims, &fp); CHKERRQ(ierr);
+  PetscCall(OpenPHASTADatFile(comm, path, char_array_len, dims, &fp));
 
   CeedScalar rij[6][stg_ctx->nprofs];
   CeedScalar *wall_dist = &stg_ctx->data[stg_ctx->offsets.wall_dist];
@@ -145,8 +142,8 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm,
                                         &stg_ctx->data[stg_ctx->offsets.ubar];
 
   for (PetscInt i=0; i<stg_ctx->nprofs; i++) {
-    ierr = PetscSynchronizedFGets(comm, fp, char_array_len, line); CHKERRQ(ierr);
-    ierr = PetscStrToArray(line, ' ', &ndims, &array); CHKERRQ(ierr);
+    PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
+    PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
     if (ndims < dims[1]) SETERRQ(comm, -1,
                                    "Line %" PetscInt_FMT" of %s does not contain enough columns (%"
                                    PetscInt_FMT" instead of %" PetscInt_FMT")", i,
@@ -175,8 +172,8 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm,
   }
   CeedScalar (*cij)[stg_ctx->nprofs]  = (CeedScalar (*)[stg_ctx->nprofs])
                                         &stg_ctx->data[stg_ctx->offsets.cij];
-  ierr = CalcCholeskyDecomp(comm, stg_ctx->nprofs, rij, cij); CHKERRQ(ierr);
-  ierr = PetscFClose(comm, fp); CHKERRQ(ierr);
+  PetscCall(CalcCholeskyDecomp(comm, stg_ctx->nprofs, rij, cij));
+  PetscCall(PetscFClose(comm, fp));
   PetscFunctionReturn(0);
 }
 
@@ -194,7 +191,6 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm,
 static PetscErrorCode ReadSTGRand(const MPI_Comm comm,
                                   const char path[PETSC_MAX_PATH_LEN],
                                   STGShur14Context stg_ctx) {
-  PetscErrorCode ierr;
   PetscInt ndims, dims[2];
   FILE *fp;
   const PetscInt char_array_len = 512;
@@ -202,7 +198,7 @@ static PetscErrorCode ReadSTGRand(const MPI_Comm comm,
   char **array;
 
   PetscFunctionBeginUser;
-  ierr = OpenPHASTADatFile(comm, path, char_array_len, dims, &fp); CHKERRQ(ierr);
+  PetscCall(OpenPHASTADatFile(comm, path, char_array_len, dims, &fp));
 
   CeedScalar *phi = &stg_ctx->data[stg_ctx->offsets.phi];
   CeedScalar (*d)[stg_ctx->nmodes]     = (CeedScalar (*)[stg_ctx->nmodes])
@@ -211,8 +207,8 @@ static PetscErrorCode ReadSTGRand(const MPI_Comm comm,
                                          &stg_ctx->data[stg_ctx->offsets.sigma];
 
   for (PetscInt i=0; i<stg_ctx->nmodes; i++) {
-    ierr = PetscSynchronizedFGets(comm, fp, char_array_len, line); CHKERRQ(ierr);
-    ierr = PetscStrToArray(line, ' ', &ndims, &array); CHKERRQ(ierr);
+    PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
+    PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
     if (ndims < dims[1]) SETERRQ(comm, -1,
                                    "Line %" PetscInt_FMT" of %s does not contain enough columns (%"
                                    PetscInt_FMT" instead of %" PetscInt_FMT")", i,
@@ -226,7 +222,7 @@ static PetscErrorCode ReadSTGRand(const MPI_Comm comm,
     sigma[1][i] = (CeedScalar) atof(array[5]);
     sigma[2][i] = (CeedScalar) atof(array[6]);
   }
-  ierr = PetscFClose(comm, fp); CHKERRQ(ierr);
+  PetscCall(PetscFClose(comm, fp));
   PetscFunctionReturn(0);
 }
 
@@ -248,14 +244,13 @@ PetscErrorCode GetSTGContextData(const MPI_Comm comm, const DM dm,
                                  char stg_rand_path[PETSC_MAX_PATH_LEN],
                                  STGShur14Context *pstg_ctx,
                                  const CeedScalar ynodes[]) {
-  PetscErrorCode ierr;
   PetscInt nmodes, nprofs;
   STGShur14Context stg_ctx;
   PetscFunctionBeginUser;
 
   // Get options
-  ierr = GetNRows(comm, stg_rand_path, &nmodes); CHKERRQ(ierr);
-  ierr = GetNRows(comm, stg_inflow_path, &nprofs); CHKERRQ(ierr);
+  PetscCall(GetNRows(comm, stg_rand_path, &nmodes));
+  PetscCall(GetNRows(comm, stg_inflow_path, &nprofs));
   if (nmodes > STG_NMODES_MAX)
     SETERRQ(comm, 1, "Number of wavemodes in %s (%"
             PetscInt_FMT") exceeds STG_NMODES_MAX (%" PetscInt_FMT"). "
@@ -264,7 +259,7 @@ PetscErrorCode GetSTGContextData(const MPI_Comm comm, const DM dm,
 
   {
     STGShur14Context s;
-    ierr = PetscCalloc1(1, &s); CHKERRQ(ierr);
+    PetscCall(PetscCalloc1(1, &s));
     *s = **pstg_ctx;
     s->nmodes = nmodes;
     s->nprofs = nprofs;
@@ -280,13 +275,13 @@ PetscErrorCode GetSTGContextData(const MPI_Comm comm, const DM dm,
     s->offsets.ynodes    = s->offsets.lt        + nprofs;
     PetscInt total_num_scalars = s->offsets.ynodes + s->nynodes;
     s->total_bytes = sizeof(*stg_ctx) + total_num_scalars*sizeof(stg_ctx->data[0]);
-    ierr = PetscMalloc(s->total_bytes, &stg_ctx); CHKERRQ(ierr);
+    PetscCall(PetscMalloc(s->total_bytes, &stg_ctx));
     *stg_ctx = *s;
-    ierr = PetscFree(s); CHKERRQ(ierr);
+    PetscCall(PetscFree(s));
   }
 
-  ierr = ReadSTGInflow(comm, stg_inflow_path, stg_ctx); CHKERRQ(ierr);
-  ierr = ReadSTGRand(comm, stg_rand_path, stg_ctx); CHKERRQ(ierr);
+  PetscCall(ReadSTGInflow(comm, stg_inflow_path, stg_ctx));
+  PetscCall(ReadSTGRand(comm, stg_rand_path, stg_ctx));
 
   if (stg_ctx->nynodes > 0) {
     CeedScalar *ynodes_ctx = &stg_ctx->data[stg_ctx->offsets.ynodes];
@@ -313,7 +308,7 @@ PetscErrorCode GetSTGContextData(const MPI_Comm comm, const DM dm,
     }
   } //end calculate kappa
 
-  ierr = PetscFree(*pstg_ctx); CHKERRQ(ierr);
+  PetscCall(PetscFree(*pstg_ctx));
   *pstg_ctx = stg_ctx;
   PetscFunctionReturn(0);
 }
@@ -322,7 +317,6 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
                         User user, const bool prescribe_T,
                         const CeedScalar theta0, const CeedScalar P0,
                         const CeedScalar ynodes[], const CeedInt nynodes) {
-  PetscErrorCode ierr;
   char stg_inflow_path[PETSC_MAX_PATH_LEN] = "./STGInflow.dat";
   char stg_rand_path[PETSC_MAX_PATH_LEN]   = "./STGRand.dat";
   PetscBool  mean_only          = PETSC_FALSE,
@@ -336,26 +330,26 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
 
   // Get options
   PetscOptionsBegin(comm, NULL, "STG Boundary Condition Options", NULL);
-  ierr = PetscOptionsString("-stg_inflow_path", "Path to STGInflow.dat", NULL,
-                            stg_inflow_path, stg_inflow_path,
-                            sizeof(stg_inflow_path), NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsString("-stg_rand_path", "Path to STGInflow.dat", NULL,
-                            stg_rand_path,stg_rand_path,
-                            sizeof(stg_rand_path), NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsReal("-stg_alpha", "Growth rate of the wavemodes", NULL,
-                          alpha, &alpha, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsReal("-stg_u0", "Advective velocity for the fluctuations",
-                          NULL, u0, &u0, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsBool("-stg_mean_only", "Only apply mean profile",
-                          NULL, mean_only, &mean_only, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsBool("-stg_strong", "Enforce STG inflow strongly",
-                          NULL, use_stgstrong, &use_stgstrong, NULL); CHKERRQ(ierr);
+  PetscCall(PetscOptionsString("-stg_inflow_path", "Path to STGInflow.dat", NULL,
+                               stg_inflow_path, stg_inflow_path,
+                               sizeof(stg_inflow_path), NULL));
+  PetscCall(PetscOptionsString("-stg_rand_path", "Path to STGInflow.dat", NULL,
+                               stg_rand_path,stg_rand_path,
+                               sizeof(stg_rand_path), NULL));
+  PetscCall(PetscOptionsReal("-stg_alpha", "Growth rate of the wavemodes", NULL,
+                             alpha, &alpha, NULL));
+  PetscCall(PetscOptionsReal("-stg_u0", "Advective velocity for the fluctuations",
+                             NULL, u0, &u0, NULL));
+  PetscCall(PetscOptionsBool("-stg_mean_only", "Only apply mean profile",
+                             NULL, mean_only, &mean_only, NULL));
+  PetscCall(PetscOptionsBool("-stg_strong", "Enforce STG inflow strongly",
+                             NULL, use_stgstrong, &use_stgstrong, NULL));
   PetscCall(PetscOptionsBool("-stg_fluctuating_IC",
                              "\"Extrude\" the fluctuations through the domain as an initial condition",
                              NULL, use_fluctuating_IC, &use_fluctuating_IC, NULL));
   PetscOptionsEnd();
 
-  ierr = PetscCalloc1(1, &global_stg_ctx); CHKERRQ(ierr);
+  PetscCall(PetscCalloc1(1, &global_stg_ctx));
   global_stg_ctx->alpha              = alpha;
   global_stg_ctx->u0                 = u0;
   global_stg_ctx->is_implicit        = user->phys->implicit;
@@ -369,12 +363,12 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
   {
     // Calculate dx assuming constant spacing
     PetscReal domain_min[3], domain_max[3], domain_size[3];
-    ierr = DMGetBoundingBox(dm, domain_min, domain_max); CHKERRQ(ierr);
+    PetscCall(DMGetBoundingBox(dm, domain_min, domain_max));
     for (PetscInt i=0; i<3; i++) domain_size[i] = domain_max[i] - domain_min[i];
 
     PetscInt nmax = 3, faces[3];
-    ierr = PetscOptionsGetIntArray(NULL, NULL, "-dm_plex_box_faces", faces, &nmax,
-                                   NULL); CHKERRQ(ierr);
+    PetscCall(PetscOptionsGetIntArray(NULL, NULL, "-dm_plex_box_faces", faces,
+                                      &nmax, NULL));
     global_stg_ctx->dx = domain_size[0]/faces[0];
     global_stg_ctx->dz = domain_size[2]/faces[2];
   }
@@ -385,8 +379,8 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
   CeedQFunctionContextRestoreData(problem->apply_vol_rhs.qfunction_context,
                                   &newtonian_ig_ctx);
 
-  ierr = GetSTGContextData(comm, dm, stg_inflow_path, stg_rand_path,
-                           &global_stg_ctx, ynodes); CHKERRQ(ierr);
+  PetscCall(GetSTGContextData(comm, dm, stg_inflow_path, stg_rand_path,
+                              &global_stg_ctx, ynodes));
 
   CeedQFunctionContextCreate(user->ceed, &stg_context);
   CeedQFunctionContextSetData(stg_context, CEED_MEM_HOST,
@@ -423,7 +417,6 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
 
 static inline PetscScalar FindDy(const PetscScalar ynodes[],
                                  const PetscInt nynodes, const PetscScalar y) {
-
   const PetscScalar half_mindy = 0.5 * (ynodes[1] - ynodes[0]);
   // ^^assuming min(dy) is first element off the wall
   PetscInt idx = -1; // Index
@@ -443,7 +436,6 @@ static inline PetscScalar FindDy(const PetscScalar ynodes[],
 PetscErrorCode StrongSTGbcFunc(PetscInt dim, PetscReal time,
                                const PetscReal x[], PetscInt Nc, PetscScalar bcval[], void *ctx) {
   PetscFunctionBeginUser;
-
   const STGShur14Context stg_ctx = (STGShur14Context) ctx;
   PetscScalar qn[stg_ctx->nmodes], u[3], ubar[3], cij[6], eps, lt;
   const bool mean_only      = stg_ctx->mean_only;
@@ -477,7 +469,6 @@ PetscErrorCode StrongSTGbcFunc(PetscInt dim, PetscReal time,
 
 PetscErrorCode SetupStrongSTG(DM dm, SimpleBC bc, ProblemData *problem,
                               Physics phys) {
-  PetscErrorCode ierr;
   DMLabel label;
   PetscFunctionBeginUser;
 
@@ -494,13 +485,13 @@ PetscErrorCode SetupStrongSTG(DM dm, SimpleBC bc, ProblemData *problem,
     break;
   }
 
-  ierr = DMGetLabel(dm, "Face Sets", &label); CHKERRQ(ierr);
+  PetscCall(DMGetLabel(dm, "Face Sets", &label));
   // Set wall BCs
   if (bc->num_inflow > 0) {
-    ierr = DMAddBoundary(dm, DM_BC_ESSENTIAL, "STG", label,
-                         bc->num_inflow, bc->inflows, 0, num_comps,
-                         comps, (void(*)(void))StrongSTGbcFunc,
-                         NULL, global_stg_ctx, NULL);  CHKERRQ(ierr);
+    PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "STG", label,
+                            bc->num_inflow, bc->inflows, 0, num_comps,
+                            comps, (void(*)(void))StrongSTGbcFunc,
+                            NULL, global_stg_ctx, NULL));
   }
 
   PetscFunctionReturn(0);

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -325,8 +325,9 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
   PetscErrorCode ierr;
   char stg_inflow_path[PETSC_MAX_PATH_LEN] = "./STGInflow.dat";
   char stg_rand_path[PETSC_MAX_PATH_LEN]   = "./STGRand.dat";
-  PetscBool  mean_only     = PETSC_FALSE,
-             use_stgstrong = PETSC_FALSE;
+  PetscBool  mean_only          = PETSC_FALSE,
+             use_stgstrong      = PETSC_FALSE,
+             use_fluctuating_IC = PETSC_FALSE;
   CeedScalar u0            = 0.0,
              alpha         = 1.01;
   CeedQFunctionContext stg_context;
@@ -349,17 +350,21 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem,
                           NULL, mean_only, &mean_only, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsBool("-stg_strong", "Enforce STG inflow strongly",
                           NULL, use_stgstrong, &use_stgstrong, NULL); CHKERRQ(ierr);
+  PetscCall(PetscOptionsBool("-stg_fluctuating_IC",
+                             "\"Extrude\" the fluctuations through the domain as an initial condition",
+                             NULL, use_fluctuating_IC, &use_fluctuating_IC, NULL));
   PetscOptionsEnd();
 
   ierr = PetscCalloc1(1, &global_stg_ctx); CHKERRQ(ierr);
-  global_stg_ctx->alpha         = alpha;
-  global_stg_ctx->u0            = u0;
-  global_stg_ctx->is_implicit   = user->phys->implicit;
-  global_stg_ctx->prescribe_T   = prescribe_T;
-  global_stg_ctx->mean_only     = mean_only;
-  global_stg_ctx->theta0        = theta0;
-  global_stg_ctx->P0            = P0;
-  global_stg_ctx->nynodes       = nynodes;
+  global_stg_ctx->alpha              = alpha;
+  global_stg_ctx->u0                 = u0;
+  global_stg_ctx->is_implicit        = user->phys->implicit;
+  global_stg_ctx->prescribe_T        = prescribe_T;
+  global_stg_ctx->mean_only          = mean_only;
+  global_stg_ctx->use_fluctuating_IC = use_fluctuating_IC;
+  global_stg_ctx->theta0             = theta0;
+  global_stg_ctx->P0                 = P0;
+  global_stg_ctx->nynodes            = nynodes;
 
   {
     // Calculate dx assuming constant spacing

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -308,15 +308,18 @@ CEED_QFUNCTION(Preprocess_STGShur14)(void *ctx, CeedInt Q,
 CEED_QFUNCTION(ICsSTG)(void *ctx, CeedInt Q,
                        const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
-  const CeedScalar (*X)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
-
+  const CeedScalar (*x)[CEED_Q_VLA]      = (const CeedScalar(*)[CEED_Q_VLA])in[0],
+      (*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   // Outputs
   CeedScalar (*q0)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
 
   const STGShur14Context stg_ctx = (STGShur14Context) ctx;
-  CeedScalar u[3], cij[6], eps, lt;
+  CeedScalar qn[STG_NMODES_MAX], u[3], ubar[3], cij[6], eps, lt;
+  const CeedScalar dx     = stg_ctx->dx;
+  const CeedScalar time   = stg_ctx->time;
   const CeedScalar theta0 = stg_ctx->theta0;
   const CeedScalar P0     = stg_ctx->P0;
+  const CeedScalar mu     = stg_ctx->newtonian_ctx.mu;
   const CeedScalar cv     = stg_ctx->newtonian_ctx.cv;
   const CeedScalar cp     = stg_ctx->newtonian_ctx.cp;
   const CeedScalar Rd     = cp - cv;
@@ -324,7 +327,26 @@ CEED_QFUNCTION(ICsSTG)(void *ctx, CeedInt Q,
 
   CeedPragmaSIMD
   for(CeedInt i=0; i<Q; i++) {
-    InterpolateProfile(X[1][i], u, cij, &eps, &lt, stg_ctx);
+    const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
+    // *INDENT-OFF*
+    const CeedScalar dXdx[3][3] = {{q_data[1][i], q_data[2][i], q_data[3][i]},
+                                   {q_data[4][i], q_data[5][i], q_data[6][i]},
+                                   {q_data[7][i], q_data[8][i], q_data[9][i]}
+                                  };
+    // *INDENT-ON*
+
+    CeedScalar h[3];
+    h[0] = dx;
+    for (CeedInt j=1; j<3; j++)
+      h[j] = 2/sqrt(Square(dXdx[0][j]) + Square(dXdx[1][j]) + Square(dXdx[2][j]));
+
+    InterpolateProfile(x_i[1], ubar, cij, &eps, &lt, stg_ctx);
+    if (stg_ctx->use_fluctuating_IC) {
+      CalcSpectrum(x_i[1], eps, lt, h, mu/rho, qn, stg_ctx);
+      STGShur14_Calc(x_i, time, ubar, cij, qn, u, stg_ctx);
+    } else {
+      for (CeedInt j=0; j<3; j++) u[j] = ubar[j];
+    }
 
     switch (stg_ctx->newtonian_ctx.state_var) {
     case STATEVAR_CONSERVATIVE:

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -100,7 +100,7 @@ CEED_QFUNCTION_HELPER void InterpolateProfile(const CeedScalar wall_dist,
  * @param[in]  Ektot  Total turbulent kinetic energy of spectrum
  * @returns    qn     Spectrum coefficient
  */
-CeedScalar CEED_QFUNCTION_HELPER(Calc_qn)(const CeedScalar kappa,
+CEED_QFUNCTION_HELPER CeedScalar Calc_qn (const CeedScalar kappa,
     const CeedScalar dkappa, const CeedScalar keta, const CeedScalar kcut,
     const CeedScalar ke, const CeedScalar Ektot_inv) {
   const CeedScalar feta_x_fcut   = exp(-Square(12*kappa/keta)
@@ -110,7 +110,7 @@ CeedScalar CEED_QFUNCTION_HELPER(Calc_qn)(const CeedScalar kappa,
 }
 
 // Calculate hmax, ke, keta, and kcut
-void CEED_QFUNCTION_HELPER(SpectrumConstants)(const CeedScalar wall_dist,
+CEED_QFUNCTION_HELPER void SpectrumConstants (const CeedScalar wall_dist,
     const CeedScalar eps, const CeedScalar lt, const CeedScalar h[3],
     const CeedScalar nu, CeedScalar *hmax, CeedScalar *ke,
     CeedScalar *keta, CeedScalar *kcut) {
@@ -133,7 +133,7 @@ void CEED_QFUNCTION_HELPER(SpectrumConstants)(const CeedScalar wall_dist,
  * @param[in]  stg_ctx   STGShur14Context for the problem
  * @param[out] qn        Spectrum coefficients, [nmodes]
  */
-void CEED_QFUNCTION_HELPER(CalcSpectrum)(const CeedScalar wall_dist,
+CEED_QFUNCTION_HELPER void CalcSpectrum (const CeedScalar wall_dist,
     const CeedScalar eps, const CeedScalar lt, const CeedScalar h[3],
     const CeedScalar nu, CeedScalar qn[], const STGShur14Context stg_ctx) {
 
@@ -163,7 +163,7 @@ void CEED_QFUNCTION_HELPER(CalcSpectrum)(const CeedScalar wall_dist,
  * @param[out] u       Velocity at X and t
  * @param[in]  stg_ctx STGShur14Context for the problem
  */
-void CEED_QFUNCTION_HELPER(STGShur14_Calc)(const CeedScalar X[3],
+CEED_QFUNCTION_HELPER void STGShur14_Calc (const CeedScalar X[3],
     const CeedScalar t, const CeedScalar ubar[3], const CeedScalar cij[6],
     const CeedScalar qn[], CeedScalar u[3],
     const STGShur14Context stg_ctx) {
@@ -210,7 +210,7 @@ void CEED_QFUNCTION_HELPER(STGShur14_Calc)(const CeedScalar X[3],
  * @param[out] u         Velocity at X and t
  * @param[in]  stg_ctx   STGShur14Context for the problem
  */
-void CEED_QFUNCTION_HELPER(STGShur14_Calc_PrecompEktot)(const CeedScalar X[3],
+CEED_QFUNCTION_HELPER void STGShur14_Calc_PrecompEktot(const CeedScalar X[3],
     const CeedScalar t, const CeedScalar ubar[3], const CeedScalar cij[6],
     const CeedScalar Ektot, const CeedScalar h[3], const CeedScalar wall_dist,
     const CeedScalar eps, const CeedScalar lt, const CeedScalar nu, CeedScalar u[3],

--- a/examples/fluids/qfunctions/stg_shur14_type.h
+++ b/examples/fluids/qfunctions/stg_shur14_type.h
@@ -29,12 +29,13 @@ struct STGShur14Context_ {
   CeedScalar dx;          // !< dx used for h calculation
   CeedScalar dz;          // !< dz used for h calculation
   bool       prescribe_T; // !< Prescribe temperature weakly
+  bool       use_fluctuating_IC; // !< Only apply the mean profile
   struct NewtonianIdealGasContext_ newtonian_ctx;
 
   struct {
     size_t sigma, d, phi; // !< Random number set, [nmodes,3], [nmodes,3], [nmodes]
     size_t kappa;     // !< Wavemode frequencies in increasing order, [nmodes]
-    size_t wall_dist;   // !< Distance to wall for Inflow Profie, [nprof]
+    size_t wall_dist; // !< Distance to wall for Inflow Profie, [nprof]
     size_t ubar;      // !< Mean velocity, [nprof, 3]
     size_t cij;       // !< Cholesky decomposition [nprof, 6]
     size_t eps;       // !< Turbulent Disspation [nprof, 6]

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -386,6 +386,8 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user,
   CeedQFunctionSetContext(ceed_data->qf_ics, problem->ics.qfunction_context);
   CeedQFunctionContextDestroy(&problem->ics.qfunction_context);
   CeedQFunctionAddInput(ceed_data->qf_ics, "x", num_comp_x, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(ceed_data->qf_ics, "qdata", q_data_size_vol,
+                        CEED_EVAL_NONE);
   CeedQFunctionAddOutput(ceed_data->qf_ics, "q0", num_comp_q, CEED_EVAL_NONE);
 
   // -- Create QFunction for RHS
@@ -506,6 +508,8 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user,
   CeedOperatorCreate(ceed, ceed_data->qf_ics, NULL, NULL, &ceed_data->op_ics);
   CeedOperatorSetField(ceed_data->op_ics, "x", ceed_data->elem_restr_x,
                        ceed_data->basis_xc, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(ceed_data->op_ics, "qdata", ceed_data->elem_restr_qd_i,
+                       CEED_BASIS_COLLOCATED, ceed_data->q_data);
   CeedOperatorSetField(ceed_data->op_ics, "q0", ceed_data->elem_restr_q,
                        CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
   CeedOperatorContextGetFieldLabel(ceed_data->op_ics, "evaluation time",


### PR DESCRIPTION
- Extrudes the STG fluctuations downstream of the inflow (using the STG method's inherent dependence on streamwise distance)

Example: 
![image](https://user-images.githubusercontent.com/20801821/201232268-bb83cced-9e6f-4700-bad4-ae00790997c9.png)