### PR TITLE
Update error for multi-field diagonal assembly

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -799,7 +799,7 @@ static inline int CeedOperatorAssembleDiagonalSetup_Cuda(CeedOperator op,
       if (rstrin && rstrin != rstr)
         // LCOV_EXCL_START
         return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "Multi-field non-composite operator diagonal assembly not supported");
+                         "Backend does not implement multi-field non-composite operator diagonal assembly");
       // LCOV_EXCL_STOP
       rstrin = rstr;
       CeedEvalMode emode;
@@ -846,7 +846,7 @@ static inline int CeedOperatorAssembleDiagonalSetup_Cuda(CeedOperator op,
       if (rstrout && rstrout != rstr)
         // LCOV_EXCL_START
         return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "Multi-field non-composite operator diagonal assembly not supported");
+                         "Backend does not implement multi-field non-composite operator diagonal assembly");
       // LCOV_EXCL_STOP
       rstrout = rstr;
       CeedEvalMode emode;

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -795,7 +795,7 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op,
       if (rstrin && rstrin != rstr)
         // LCOV_EXCL_START
         return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "Multi-field non-composite operator diagonal assembly not supported");
+                         "Backend does not implement multi-field non-composite operator diagonal assembly");
       // LCOV_EXCL_STOP
       rstrin = rstr;
       CeedEvalMode emode;
@@ -842,7 +842,7 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op,
       if (rstrout && rstrout != rstr)
         // LCOV_EXCL_START
         return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "Multi-field non-composite operator diagonal assembly not supported");
+                         "Backend does not implement multi-field non-composite operator diagonal assembly");
       // LCOV_EXCL_STOP
       rstrout = rstr;
       CeedEvalMode emode;


### PR DESCRIPTION
This PR corrects the format of the error message for multi-field diagonal assembly on `cuda-ref` and `hip-ref `to start with
> Backend does not implement…