### PR TITLE
examples/fluids: upgrade to HLLC

### DIFF
--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -569,17 +569,22 @@ The newtonian wave problem has the following command-line options in addition to
   - Default value
   - Unit
 
-* - `-velocity_freestream`
+* - `-freestream_riemann`
+  - Riemann solver for boundaries (HLL or HLLC)
+  - `hllc`
+  -
+
+* - `-freestream_velocity`
   - Freestream velocity vector
   - `0,0,0`
   - `m/s`
 
-* - `-temperature_freestream`
+* - `-freestream_temperature`
   - Freestream temperature
   - `288`
   - `K`
 
-* - `-pressure_freestream`
+* - `-freestream_pressure`
   - Freestream pressure
   - `1.01e5`
   - `Pa`

--- a/examples/fluids/index.md
+++ b/examples/fluids/index.md
@@ -427,8 +427,10 @@ E &= \frac{p_\infty}{\gamma -1}\left(1+A\exp\left(\frac{-(\bar{x}^2 + \bar{y}^2)
 $$
 
 where $A$ and $\sigma$ are the amplitude and width of the perturbation, respectively, and $(\bar{x}, \bar{y}) = (x-x_e, y-y_e)$ is the distance to the epicenter of the perturbation, $(x_e, y_e)$.
+The simulation produces a strong acoustic wave and leaves behind a cold thermal bubble that advects at the fluid velocity.
 
-Currently, a HLL (Harten, Lax, van Leer) Riemann solver is implemented under the freestream boundary condition. The formulation for the HLL solver is given in {cite}`toro2009`.
+The boundary conditions are freestream in the x and y directions. When using an HLL (Harten, Lax, van Leer) Riemann solver {cite}`toro2009` (option `-freestream_riemann hll`), the acoustic waves exit the domain cleanly, but when the thermal bubble reaches the boundary, it produces strong thermal oscillations that become acoustic waves reflecting into the domain.
+This problem can be fixed using a more sophisticated Riemann solver such as HLLC {cite}`toro2009` (option `-freestream_riemann hllc`, which is default), which is a linear constant-pressure wave that transports temperature and transverse momentum at the fluid velocity.
 
 ## Density Current
 

--- a/examples/fluids/newtonianwave.yaml
+++ b/examples/fluids/newtonianwave.yaml
@@ -1,16 +1,18 @@
-problem: 'newtonian_wave'
+problem: newtonian_wave
 mu: 0 # Effectively solving Euler momentum equations
 
 dm_plex_box_faces: 40,40,1
-dm_plex_box_upper: 1,1,0.1
+dm_plex_box_upper: 1,1,0.025
 dm_plex_box_lower: 0,0,0
 dm_plex_dim: 3
 bc_freestream: 4,6,3,5
 bc_slip_z: 1,2
 
-velocity_freestream: 1,1,0
-temperature_freestream: 0.25
-pressure_freestream: 71.75
+freestream:
+  # riemann: hll # causes thermal bubble to reflect acoustic waves from boundary
+  velocity: 2,2,0
+  temperature: 0.25
+  pressure: 71.75
 g: 0,0,0
 
 epicenter: 0.33,0.75,0
@@ -18,11 +20,13 @@ amplitude: 2
 width: 0.05
 
 ts:
-  adapt_type: 'none'
+  adapt_type: none
   max_steps: 400
   dt: 3.6e-4
   type: alpha
   alpha_radius: 0.5
+  #monitor_solution: cgns:nwave.cgns
+  #monitor_solution_interval: 10
 
 implicit: true
 stab: supg

--- a/examples/fluids/qfunctions/freestream_bc.h
+++ b/examples/fluids/qfunctions/freestream_bc.h
@@ -138,8 +138,8 @@ CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Contact_Flux(
 
   StateConservative flux_left  = FluxInviscidDotNormal(gas, left, normal);
   StateConservative flux_right = FluxInviscidDotNormal(gas, right, normal);
-  StateConservative flux_star_left[5] = {0.};
-  StateConservative flux_star_right[5] = {0.};
+  StateConservative flux_star_left[5];
+  StateConservative flux_star_right[5];
   //StateConservative flux_star_left;
   //StateConservative flux_star_right;
   StateConservative RiemannFlux_HLLC;

--- a/examples/fluids/qfunctions/freestream_bc.h
+++ b/examples/fluids/qfunctions/freestream_bc.h
@@ -129,6 +129,103 @@ CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Flux(NewtonianIdealGa
   return RiemannFlux_HLL;
 }
 
+// HLLC Riemann solver (from Toro's book)
+CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Contact_Flux(
+  NewtonianIdealGasContext gas, State left, State right,
+  const CeedScalar normal[3]) {
+
+  const CeedScalar gamma = gas->cp / gas->cv;
+
+  StateConservative flux_left  = FluxInviscidDotNormal(gas, left, normal);
+  StateConservative flux_right = FluxInviscidDotNormal(gas, right, normal);
+  StateConservative flux_star_left[5] = {0.};
+  StateConservative flux_star_right[5] = {0.};
+  //StateConservative flux_star_left;
+  //StateConservative flux_star_right;
+  StateConservative RiemannFlux_HLLC;
+  //State star_left, star_right;
+
+
+  CeedScalar u_left = Dot3(left.Y.velocity, normal);
+  CeedScalar u_right = Dot3(right.Y.velocity, normal);
+
+  RoeWeights r = RoeSetup(left.U.density, right.U.density);
+  // Speed estimate
+  // Roe average eigenvalues for left and right non-linear waves
+  // Stability requires that these speed estimates are *at least*
+  // as fast as the physical wave speeds.
+  CeedScalar u_roe = RoeAverage(r, u_left, u_right);
+
+  CeedScalar H_left = (left.U.E_total + left.Y.pressure) / left.U.density;
+  CeedScalar H_right = (right.U.E_total + right.Y.pressure) / right.U.density;
+  CeedScalar H_roe = RoeAverage(r, H_left, H_right);
+  CeedScalar a_roe = sqrt((gamma - 1) * (H_roe - 0.5 * Square(u_roe)));
+
+  // Einfeldt (1988) justifies (and Toro's book repeats) that Roe speeds can be used here.
+  CeedScalar s_left = u_roe - a_roe;
+  CeedScalar s_right = u_roe + a_roe;
+  // Intermediate speed
+  CeedScalar s_star = (right.Y.pressure - left.Y.pressure +
+             left.U.density * u_left * (s_left - u_left) -
+             right.U.density * u_right * (s_right - u_right)) /
+             (left.U.density * (s_left - u_left) - right.U.density * (s_right - u_right));
+
+  // Left intermediate state
+  CeedScalar star_left[5] = {0.};
+  CeedScalar left_fact = left.U.density * ((s_left - u_left) / (s_left - s_star));
+  star_left[0] = left_fact * 1.0;
+  star_left[1] = left_fact * s_star;
+  star_left[2] = left_fact * left.Y.velocity[0];
+  star_left[3] = left_fact * left.Y.velocity[1];
+  star_left[4] = left_fact * (left.U.E_total / left.U.density) + (s_star - u_left) *
+                    (s_star + left.Y.pressure / (left.U.density * (s_left - u_left)));
+
+  //Right intermediate state
+  CeedScalar star_right[5] = {0.};
+  CeedScalar right_fact = right.U.density * ((s_right - u_right) / (s_right - s_star));
+  star_right[0] = right_fact * 1.0;
+  star_right[1] = right_fact * s_star;
+  star_right[2] = right_fact * right.Y.velocity[0];
+  star_right[3] = right_fact * right.Y.velocity[1];
+  star_right[4] = right_fact * (right.U.E_total / right.U.density) + (s_star - u_right) *
+                      (s_star + right.Y.pressure / (right.U.density * (s_right - u_right)));
+
+  // Left intermediate flux
+  flux_star_left[0].density = flux_left.density + s_left * (star_left[0] - left.U.density);
+  for (int i = 0; i < 3; i++){
+    flux_star_left[i+1].momentum = flux_left.momentum[i+1] + s_left * (star_left[i+1] - left.U.momentum[i+1]); //some issues
+  }
+  flux_star_left[4].E_total = flux_left.E_total + s_left * (star_left[4] - left.U.E_total);
+
+  // Right intermediate flux
+  flux_star_right[0].density = flux_right.density + s_right * (star_right[0] - right.U.density);
+  for (int i = 0; i < 3; i++){
+    flux_star_right[i+1].momentum = flux_right.momentum[i+1] + s_right * (star_right[i+1] - right.U.momentum[i+1]); //some issues
+  }
+  flux_star_right[4].E_total = flux_right.E_total + s_right * (star_right[4] - right.U.E_total);
+
+  // Compute HLLC flux
+  if (0 <= s_left) {
+    RiemannFlux_HLLC = flux_left;
+  } else if (s_left <= 0 <= s_star) {
+    RiemannFlux_HLLC.density = flux_star_left[0].density;
+    for (int i = 0; i < 3; i++){
+      RiemannFlux_HLLC.momentum[i+1] = flux_star_left[i+1].momentum;  // some issues here
+      }
+    RiemannFlux_HLLC.E_total = flux_star_left[4].E_total;
+  } else if (s_star <= 0 <= s_right) {
+    RiemannFlux_HLLC.density = flux_star_right[0].density;
+    for (int i = 0; i < 3; i++){
+      RiemannFlux_HLLC.momentum[i+1] = flux_star_right[i+1].momentum; // some issues here
+      }
+    RiemannFlux_HLLC.E_total = flux_star_right[4].E_total;
+  } else {
+    RiemannFlux_HLLC = flux_right;
+  }
+  // Return
+  return RiemannFlux_HLLC;
+}
+
 // *****************************************************************************
 // @brief Forward-mode Derivative of Harten Lax VanLeer (HLL) approximate Riemann solver.
 //

--- a/examples/fluids/qfunctions/freestream_bc.h
+++ b/examples/fluids/qfunctions/freestream_bc.h
@@ -103,6 +103,36 @@ CEED_QFUNCTION_HELPER void ComputeHLLSpeeds_Roe(NewtonianIdealGasContext gas, St
   *s_right = u_roe + a_roe;
 }
 
+CEED_QFUNCTION_HELPER void ComputeHLLSpeeds_Roe_fwd(NewtonianIdealGasContext gas, State left, State dleft, CeedScalar u_left, CeedScalar du_left,
+                                                    State right, State dright, CeedScalar u_right, CeedScalar du_right, CeedScalar *s_left,
+                                                    CeedScalar *ds_left, CeedScalar *s_right, CeedScalar *ds_right) {
+  const CeedScalar gamma = HeatCapacityRatio(gas);
+
+  RoeWeights r  = RoeSetup(left.U.density, right.U.density);
+  RoeWeights dr = RoeSetup_fwd(left.U.density, right.U.density, dleft.U.density, dright.U.density);
+  // Speed estimate
+  // Roe average eigenvalues for left and right non-linear waves
+  // Stability requires that these speed estimates are *at least*
+  // as fast as the physical wave speeds.
+  CeedScalar u_roe  = RoeAverage(r, u_left, u_right);
+  CeedScalar du_roe = RoeAverage_fwd(r, dr, u_left, u_right, du_left, du_right);
+
+  CeedScalar H_left   = TotalSpecificEnthalpy(gas, left);
+  CeedScalar H_right  = TotalSpecificEnthalpy(gas, right);
+  CeedScalar dH_left  = TotalSpecificEnthalpy_fwd(gas, left, dleft);
+  CeedScalar dH_right = TotalSpecificEnthalpy_fwd(gas, right, dright);
+
+  CeedScalar H_roe  = RoeAverage(r, H_left, H_right);
+  CeedScalar dH_roe = RoeAverage_fwd(r, dr, H_left, H_right, dH_left, dH_right);
+  CeedScalar a_roe  = sqrt((gamma - 1) * (H_roe - 0.5 * Square(u_roe)));
+  CeedScalar da_roe = 0.5 * (gamma - 1) / sqrt(H_roe) * dH_roe - 0.5 * sqrt(gamma - 1) * u_roe / sqrt(H_roe - 0.5 * Square(u_roe)) * du_roe;
+
+  *s_left   = u_roe - a_roe;
+  *ds_left  = du_roe - da_roe;
+  *s_right  = u_roe + a_roe;
+  *ds_right = du_roe + da_roe;
+}
+
 // *****************************************************************************
 // @brief Harten Lax VanLeer (HLL) approximate Riemann solver.
 // Taking in two states (left, right) and returns RiemannFlux_HLL
@@ -134,19 +164,92 @@ CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Flux(NewtonianIdealGa
   }
 }
 
+// *****************************************************************************
+// @brief Forward-mode Derivative of Harten Lax VanLeer (HLL) approximate Riemann solver.
+//
+// @param gas    NewtonianIdealGasContext for the fluid
+// @param left   Fluid state of the domain interior (the current solution)
+// @param right  Fluid state of the domain exterior (free stream conditions)
+// @param dleft  Derivative of fluid state of the domain interior (the current solution)
+// @param dright Derivative of fluid state of the domain exterior (free stream conditions)
+// @param normal Normalized, outward facing boundary normal vector
+// *****************************************************************************
+CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Flux_fwd(NewtonianIdealGasContext gas, State left, State dleft, State right, State dright,
+                                                                    const CeedScalar normal[3]) {
+  StateConservative flux_left   = FluxInviscidDotNormal(gas, left, normal);
+  StateConservative flux_right  = FluxInviscidDotNormal(gas, right, normal);
+  StateConservative dflux_left  = FluxInviscidDotNormal_fwd(gas, left, dleft, normal);
+  StateConservative dflux_right = FluxInviscidDotNormal_fwd(gas, right, dright, normal);
+
+  CeedScalar u_left   = Dot3(left.Y.velocity, normal);
+  CeedScalar u_right  = Dot3(right.Y.velocity, normal);
+  CeedScalar du_left  = Dot3(dleft.Y.velocity, normal);
+  CeedScalar du_right = Dot3(dright.Y.velocity, normal);
+
+  CeedScalar s_left, ds_left, s_right, ds_right;
+  ComputeHLLSpeeds_Roe_fwd(gas, left, dleft, u_left, du_left, right, dright, u_right, du_right, &s_left, &ds_left, &s_right, &ds_right);
+
+  if (0 <= s_left) {
+    return dflux_left;
+  } else if (s_right <= 0) {
+    return dflux_right;
+  } else {
+    return Flux_HLL_fwd(left, right, dleft, dright, flux_left, flux_right, dflux_left, dflux_right, s_left, s_right, ds_left, ds_right);
+  }
+}
+
 CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLLC_Star(NewtonianIdealGasContext gas, State side, StateConservative F_side,
                                                               const CeedScalar normal[3], CeedScalar u_side, CeedScalar s_side, CeedScalar s_star) {
-  CeedScalar        fact = side.U.density * ((s_side - u_side) / (s_side - s_star));
+  CeedScalar fact  = side.U.density * (s_side - u_side) / (s_side - s_star);
+  CeedScalar denom = side.U.density * (s_side - u_side);
+  // U_* = fact * star
   StateConservative star = {
-      fact * 1.0,
+      1.0,
       {
-              fact * (side.Y.velocity[0] + (s_star - u_side) * normal[0]),
-              fact * (side.Y.velocity[1] + (s_star - u_side) * normal[1]),
-              fact * (side.Y.velocity[2] + (s_star - u_side) * normal[2]),
-              },
-      fact * (side.U.E_total / side.U.density) + (s_star - u_side) * (s_star + side.Y.pressure / (side.U.density * (s_side - u_side))),
+        side.Y.velocity[0] + (s_star - u_side) * normal[0],
+        side.Y.velocity[1] + (s_star - u_side) * normal[1],
+        side.Y.velocity[2] + (s_star - u_side) * normal[2],
+        },
+      side.U.E_total / side.U.density + (s_star - u_side) * (s_star + side.Y.pressure / denom),
   };
-  return StateConservativeAXPBYPCZ(1, F_side, s_side, star, -s_side, side.U);
+  return StateConservativeAXPBYPCZ(1, F_side, s_side * fact, star, -s_side, side.U);
+}
+
+CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLLC_Star_fwd(NewtonianIdealGasContext gas, State side, State dside, StateConservative F_side,
+                                                                  StateConservative dF_side, const CeedScalar normal[3], CeedScalar u_side,
+                                                                  CeedScalar du_side, CeedScalar s_side, CeedScalar ds_side, CeedScalar s_star,
+                                                                  CeedScalar ds_star) {
+  CeedScalar fact  = side.U.density * (s_side - u_side) / (s_side - s_star);
+  CeedScalar dfact = (side.U.density * (ds_side - du_side) + dside.U.density * (s_side - u_side)) / (s_side - s_star)  //
+                     - fact / (s_side - s_star) * (ds_side - ds_star);
+  CeedScalar denom  = side.U.density * (s_side - u_side);
+  CeedScalar ddenom = side.U.density * (ds_side - du_side) + dside.U.density * (s_side - u_side);
+
+  StateConservative star = {
+      1.0,
+      {
+        side.Y.velocity[0] + (s_star - u_side) * normal[0],
+        side.Y.velocity[1] + (s_star - u_side) * normal[1],
+        side.Y.velocity[2] + (s_star - u_side) * normal[2],
+        },
+      side.U.E_total / side.U.density  //
+          + (s_star - u_side) * (s_star + side.Y.pressure / denom),
+  };
+  StateConservative dstar = {
+      0.,
+      {
+        dside.Y.velocity[0] + (ds_star - du_side) * normal[0],
+        dside.Y.velocity[1] + (ds_star - du_side) * normal[1],
+        dside.Y.velocity[2] + (ds_star - du_side) * normal[2],
+        },
+      dside.U.E_total / side.U.density - side.U.E_total / Square(side.U.density) * dside.U.density  //
+          + (ds_star - du_side) * (s_star + side.Y.pressure / denom)  //
+          + (s_star - u_side) * (ds_star + dside.Y.pressure / denom - side.Y.pressure / Square(denom) * ddenom)  //,
+  };
+
+  const CeedScalar        a[] = {1, ds_side * fact + s_side * dfact, s_side * fact, -ds_side, -s_side};
+  const StateConservative U[] = {dF_side, star, dstar, side.U, dside.U};
+  return StateConservativeMult(5, a, U);
 }
 
 // HLLC Riemann solver (from Toro's book)
@@ -161,9 +264,10 @@ CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Contact_Flux(Newtonia
   ComputeHLLSpeeds_Roe(gas, left, u_left, right, u_right, &s_left, &s_right);
 
   // Contact wave speed; Toro (10.37)
-  CeedScalar s_star =
-      (right.Y.pressure - left.Y.pressure + left.U.density * u_left * (s_left - u_left) - right.U.density * u_right * (s_right - u_right)) /
-      (left.U.density * (s_left - u_left) - right.U.density * (s_right - u_right));
+  CeedScalar rhou_left = left.U.density * u_left, rhou_right = right.U.density * u_right;
+  CeedScalar numer  = right.Y.pressure - left.Y.pressure + rhou_left * (s_left - u_left) - rhou_right * (s_right - u_right);
+  CeedScalar denom  = left.U.density * (s_left - u_left) - right.U.density * (s_right - u_right);
+  CeedScalar s_star = numer / denom;
 
   // Compute HLLC flux
   if (0 <= s_left) {
@@ -177,20 +281,8 @@ CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Contact_Flux(Newtonia
   }
 }
 
-// *****************************************************************************
-// @brief Forward-mode Derivative of Harten Lax VanLeer (HLL) approximate Riemann solver.
-//
-// @param gas    NewtonianIdealGasContext for the fluid
-// @param left   Fluid state of the domain interior (the current solution)
-// @param right  Fluid state of the domain exterior (free stream conditions)
-// @param dleft  Derivative of fluid state of the domain interior (the current solution)
-// @param dright Derivative of fluid state of the domain exterior (free stream conditions)
-// @param normal Normalized, outward facing boundary normal vector
-// *****************************************************************************
-CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Flux_fwd(NewtonianIdealGasContext gas, State left, State right, State dleft, State dright,
-                                                                    const CeedScalar normal[3]) {
-  const CeedScalar gamma = HeatCapacityRatio(gas);
-
+CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Contact_Flux_fwd(NewtonianIdealGasContext gas, State left, State dleft, State right,
+                                                                            State dright, const CeedScalar normal[3]) {
   StateConservative flux_left   = FluxInviscidDotNormal(gas, left, normal);
   StateConservative flux_right  = FluxInviscidDotNormal(gas, right, normal);
   StateConservative dflux_left  = FluxInviscidDotNormal_fwd(gas, left, dleft, normal);
@@ -201,41 +293,34 @@ CEED_QFUNCTION_HELPER StateConservative Harten_Lax_VanLeer_Flux_fwd(NewtonianIde
   CeedScalar du_left  = Dot3(dleft.Y.velocity, normal);
   CeedScalar du_right = Dot3(dright.Y.velocity, normal);
 
-  RoeWeights r  = RoeSetup(left.U.density, right.U.density);
-  RoeWeights dr = RoeSetup_fwd(left.U.density, right.U.density, dleft.U.density, dright.U.density);
-  // Speed estimate
-  // Roe average eigenvalues for left and right non-linear waves
-  // Stability requires that these speed estimates are *at least*
-  // as fast as the physical wave speeds.
-  CeedScalar u_roe  = RoeAverage(r, u_left, u_right);
-  CeedScalar du_roe = RoeAverage_fwd(r, dr, u_left, u_right, du_left, du_right);
+  CeedScalar s_left, ds_left, s_right, ds_right;
+  ComputeHLLSpeeds_Roe_fwd(gas, left, dleft, u_left, du_left, right, dright, u_right, du_right, &s_left, &ds_left, &s_right, &ds_right);
 
-  CeedScalar H_left   = TotalSpecificEnthalpy(gas, left);
-  CeedScalar H_right  = TotalSpecificEnthalpy(gas, right);
-  CeedScalar dH_left  = TotalSpecificEnthalpy_fwd(gas, left, dleft);
-  CeedScalar dH_right = TotalSpecificEnthalpy_fwd(gas, right, dright);
+  // Contact wave speed; Toro (10.37)
+  CeedScalar rhou_left = left.U.density * u_left, drhou_left = left.U.density * du_left + dleft.U.density * u_left;
+  CeedScalar rhou_right = right.U.density * u_right, drhou_right = right.U.density * du_right + dright.U.density * u_right;
+  CeedScalar numer = right.Y.pressure - left.Y.pressure  //
+                     + rhou_left * (s_left - u_left)     //
+                     - rhou_right * (s_right - u_right);
+  CeedScalar dnumer = dright.Y.pressure - dleft.Y.pressure                                //
+                      + rhou_left * (ds_left - du_left) + drhou_left * (s_left - u_left)  //
+                      - rhou_right * (ds_right - du_right) - drhou_right * (s_right - u_right);
+  CeedScalar denom  = left.U.density * (s_left - u_left) - right.U.density * (s_right - u_right);
+  CeedScalar ddenom = left.U.density * (ds_left - du_left) + dleft.U.density * (s_left - u_left)  //
+                      - right.U.density * (ds_right - du_right) - dright.U.density * (s_right - u_right);
+  CeedScalar s_star  = numer / denom;
+  CeedScalar ds_star = dnumer / denom - numer / Square(denom) * ddenom;
 
-  CeedScalar H_roe  = RoeAverage(r, H_left, H_right);
-  CeedScalar dH_roe = RoeAverage_fwd(r, dr, H_left, H_right, dH_left, dH_right);
-  CeedScalar a_roe  = sqrt((gamma - 1) * (H_roe - 0.5 * Square(u_roe)));
-  CeedScalar da_roe = 0.5 * (gamma - 1) / sqrt(H_roe) * dH_roe - 0.5 * sqrt(gamma - 1) * u_roe / sqrt(H_roe - 0.5 * Square(u_roe)) * du_roe;
-
-  // Einfeldt (1988) justifies (and Toro's book repeats) that Roe speeds can be used here.
-  CeedScalar s_left   = u_roe - a_roe;
-  CeedScalar s_right  = u_roe + a_roe;
-  CeedScalar ds_left  = du_roe - da_roe;
-  CeedScalar ds_right = du_roe + da_roe;
-
-  // Compute HLL flux
-  StateConservative dRiemannFlux_HLL;
+  // Compute HLLC flux
   if (0 <= s_left) {
-    dRiemannFlux_HLL = dflux_left;
-  } else if (s_right <= 0) {
-    dRiemannFlux_HLL = dflux_right;
+    return dflux_left;
+  } else if (0 <= s_star) {
+    return RiemannFlux_HLLC_Star_fwd(gas, left, dleft, flux_left, dflux_left, normal, u_left, du_left, s_left, ds_left, s_star, ds_star);
+  } else if (0 <= s_right) {
+    return RiemannFlux_HLLC_Star_fwd(gas, right, dright, flux_right, dflux_right, normal, u_right, du_right, s_right, ds_right, s_star, ds_star);
   } else {
-    dRiemannFlux_HLL = Flux_HLL_fwd(left, right, dleft, dright, flux_left, flux_right, dflux_left, dflux_right, s_left, s_right, ds_left, ds_right);
+    return dflux_right;
   }
-  return dRiemannFlux_HLL;
 }
 
 // *****************************************************************************
@@ -263,7 +348,7 @@ CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *con
     // ---- Normal vector
     const CeedScalar norm[3] = {q_data_sur[1][i], q_data_sur[2][i], q_data_sur[3][i]};
 
-    StateConservative HLL_flux = Harten_Lax_VanLeer_Flux(newt_ctx, s, context->S_infty, norm);
+    StateConservative HLL_flux = Harten_Lax_VanLeer_Contact_Flux(newt_ctx, s, context->S_infty, norm);
     CeedScalar        Flux[5];
     UnpackState_U(HLL_flux, Flux);
     for (CeedInt j = 0; j < 5; j++) v[j][i] = -wdetJb * Flux[j];
@@ -306,7 +391,7 @@ CEED_QFUNCTION_HELPER int Freestream_Jacobian(void *ctx, CeedInt Q, const CeedSc
     State s  = StateFromQi(newt_ctx, qi, x_i);
     State ds = StateFromQi_fwd(newt_ctx, s, dqi, x_i, dx_i);
 
-    StateConservative dHLL_flux = Harten_Lax_VanLeer_Flux_fwd(newt_ctx, s, context->S_infty, ds, dS_infty, norm);
+    StateConservative dHLL_flux = Harten_Lax_VanLeer_Contact_Flux_fwd(newt_ctx, s, ds, context->S_infty, dS_infty, norm);
     CeedScalar        Flux[5];
     UnpackState_U(dHLL_flux, Flux);
     for (CeedInt j = 0; j < 5; j++) v[j][i] = -wdetJb * Flux[j];

--- a/examples/fluids/qfunctions/newtonian_state.h
+++ b/examples/fluids/qfunctions/newtonian_state.h
@@ -132,11 +132,14 @@ CEED_QFUNCTION_HELPER StateConservative StateConservativeFromPrimitive_fwd(Newto
   return dU;
 }
 
-CEED_QFUNCTION_HELPER StateConservative StateConservativeAXPBY(CeedScalar a, StateConservative X, CeedScalar b, StateConservative Y) {
-  StateConservative R;
-  R.density = a * X.density + b * Y.density;
-  for (int i = 0; i < 3; i++) R.momentum[i] = a * X.momentum[i] + b * Y.momentum[i];
-  R.E_total = a * X.E_total + b * Y.E_total;
+// linear combination of n states
+CEED_QFUNCTION_HELPER StateConservative StateConservativeMult(CeedInt n, const CeedScalar a[], const StateConservative X[]) {
+  StateConservative R = {0};
+  for (CeedInt i = 0; i < n; i++) {
+    R.density += a[i] * X[i].density;
+    for (int j = 0; j < 3; j++) R.momentum[j] += a[i] * X[i].momentum[j];
+    R.E_total += a[i] * X[i].E_total;
+  }
   return R;
 }
 

--- a/examples/fluids/qfunctions/newtonian_state.h
+++ b/examples/fluids/qfunctions/newtonian_state.h
@@ -132,6 +132,23 @@ CEED_QFUNCTION_HELPER StateConservative StateConservativeFromPrimitive_fwd(Newto
   return dU;
 }
 
+CEED_QFUNCTION_HELPER StateConservative StateConservativeAXPBY(CeedScalar a, StateConservative X, CeedScalar b, StateConservative Y) {
+  StateConservative R;
+  R.density = a * X.density + b * Y.density;
+  for (int i = 0; i < 3; i++) R.momentum[i] = a * X.momentum[i] + b * Y.momentum[i];
+  R.E_total = a * X.E_total + b * Y.E_total;
+  return R;
+}
+
+CEED_QFUNCTION_HELPER StateConservative StateConservativeAXPBYPCZ(CeedScalar a, StateConservative X, CeedScalar b, StateConservative Y, CeedScalar c,
+                                                                  StateConservative Z) {
+  StateConservative R;
+  R.density = a * X.density + b * Y.density + c * Z.density;
+  for (int i = 0; i < 3; i++) R.momentum[i] = a * X.momentum[i] + b * Y.momentum[i] + c * Z.momentum[i];
+  R.E_total = a * X.E_total + b * Y.E_total + c * Z.E_total;
+  return R;
+}
+
 // Function pointer types for generic state array -> State struct functions
 typedef State (*StateFromQi_t)(NewtonianIdealGasContext gas, const CeedScalar qi[5], const CeedScalar x[3]);
 typedef State (*StateFromQi_fwd_t)(NewtonianIdealGasContext gas, State s, const CeedScalar dqi[5], const CeedScalar x[3], const CeedScalar dx[3]);


### PR DESCRIPTION
This allows both the shock and thermal bubble to exit pretty cleanly.

[nwave-hllc.webm](https://user-images.githubusercontent.com/3303/202583981-1a99fd81-b987-4da5-9152-d289a12213b1.webm)

@jrwrigh I'm just using HLL for the Jacobian and I didn't refactor the HLL Jacobian yet (it can be simplified in terms of new helpers). Maybe you can look at the code and make a choice of what you think is maintainable and correct.

@AdelekeBankole is traveling right now so unless he comments, we should clean this up and merge it so @jrwrigh's coming tests use this instead of HLL.

For comparison, here is the same setup with HLL.

[nwave-hll.webm](https://user-images.githubusercontent.com/3303/202585139-a5d05e5a-5670-4abb-bdd7-e5f9d261796e.webm)
