### PR TITLE
Julia: move identity test from release to development to fix path issue

### DIFF
--- a/julia/LibCEED.jl/test/runtests.jl
+++ b/julia/LibCEED.jl/test/runtests.jl
@@ -210,53 +210,6 @@ else
             end
         end
 
-        @testset "QFunction" begin
-            c = Ceed()
-
-            id = create_identity_qfunction(c, 1, EVAL_INTERP, EVAL_INTERP)
-            Q = 10
-            v = rand(CeedScalar, Q)
-            v1 = CeedVector(c, v)
-            v2 = CeedVector(c, Q)
-            apply!(id, Q, [v1], [v2])
-            @test @witharray(a = v2, a == v)
-
-            @interior_qf id2 = (c, (a, :in, EVAL_INTERP), (b, :out, EVAL_INTERP), b .= a)
-            v2[] = 0.0
-            apply!(id2, Q, [v1], [v2])
-            @test @witharray(a = v2, a == v)
-
-            ctxdata = CtxData(IOBuffer(), rand(CeedScalar, 3))
-            ctx = Context(c, ctxdata)
-            dim = 3
-            @interior_qf qf = (
-                c,
-                dim=dim,
-                ctxdata::CtxData,
-                (a, :in, EVAL_GRAD, dim),
-                (b, :in, EVAL_NONE),
-                (c, :out, EVAL_INTERP),
-                begin
-                    c[] = b*sum(a)
-                    show(ctxdata.io, MIME("text/plain"), ctxdata.x)
-                end,
-            )
-            set_context!(qf, ctx)
-            in_sz, out_sz = LibCEED.get_field_sizes(qf)
-            @test in_sz == [dim, 1]
-            @test out_sz == [1]
-            v1 = rand(CeedScalar, dim)
-            v2 = rand(CeedScalar, 1)
-            cv1 = CeedVector(c, v1)
-            cv2 = CeedVector(c, v2)
-            cv3 = CeedVector(c, 1)
-            apply!(qf, 1, [cv1, cv2], [cv3])
-            @test String(take!(ctxdata.io)) == showstr(ctxdata.x)
-            @test @witharray_read(v3 = cv3, v3[1] == v2[1]*sum(v1))
-
-            @test QFunctionNone()[] == LibCEED.C.CEED_QFUNCTION_NONE[]
-        end
-
         @testset "Operator" begin
             c = Ceed()
             @interior_qf id = (


### PR DESCRIPTION
I think this was a side-effect of fixing path handling for Ratel/installs that we didn't notice at the time. Anyway, it works as a dev test, but (now) not as a release test.