### PR TITLE
Makefile: avoid creating null.d file (fix #1107)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ endif
 # AVX Backed
 AVX_STATUS = Disabled
 AVX_FLAG := $(if $(filter clang,$(CC_VENDOR)),+avx,-mavx)
-AVX := $(filter $(AVX_FLAG),$(shell $(CC) $(CFLAGS) -v -E -x c /dev/null 2>&1))
+AVX := $(filter $(AVX_FLAG),$(shell $(CC) $(CFLAGS:-M%=) -v -E -x c /dev/null 2>&1))
 AVX_BACKENDS = /cpu/self/avx/serial /cpu/self/avx/blocked
 ifneq ($(AVX),)
   AVX_STATUS = Enabled


### PR DESCRIPTION
The feature checks in the makefile used gcc -MMD -x c /dev/null, which generates a dependency file. We need to use $(CFLAGS) because that's where target/optimization options go, so filter out the -M arguments, which relate to generating dependencies.

Reported-by: Veselin Dobrev