### PR TITLE
fluids restart: set step number

### DIFF
--- a/examples/fluids/qfunctions/newtonian_state.h
+++ b/examples/fluids/qfunctions/newtonian_state.h
@@ -210,9 +210,6 @@ CEED_QFUNCTION_HELPER State StateFromY_fwd(NewtonianIdealGasContext gas, State s
   return ds;
 }
 
-// Function pointer types for State struct -> generic state array
-typedef void (*StateToQi_t)(NewtonianIdealGasContext gas, const State input, CeedScalar qi[5]);
-
 CEED_QFUNCTION_HELPER void FluxInviscid(NewtonianIdealGasContext gas, State s, StateConservative Flux[3]) {
   for (CeedInt i = 0; i < 3; i++) {
     Flux[i].density = s.U.momentum[i];

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -484,18 +484,21 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
     PetscCall(PetscViewerBinaryRead(viewer, &time, 1, &count, PETSC_REAL));
     PetscCall(PetscViewerDestroy(&viewer));
     PetscCall(TSSetTime(*ts, time * user->units->second));
+    PetscCall(TSSetStepNumber(*ts, app_ctx->cont_steps));
   }
   if (!app_ctx->test_mode) {
     PetscCall(TSMonitorSet(*ts, TSMonitor_NS, user, NULL));
   }
 
   // Solve
-  PetscScalar start_time;
+  PetscReal start_time;
+  PetscInt  start_step;
   PetscCall(TSGetTime(*ts, &start_time));
+  PetscCall(TSGetStepNumber(*ts, &start_step));
 
   PetscPreLoadBegin(PETSC_FALSE, "Fluids Solve");
   PetscCall(TSSetTime(*ts, start_time));
-  PetscCall(TSSetStepNumber(*ts, 0));
+  PetscCall(TSSetStepNumber(*ts, start_step));
   if (PetscPreLoadingOn) {
     // LCOV_EXCL_START
     SNES      snes;


### PR DESCRIPTION
@KennethEJansen I think this addresses the step numbering issue. The TS will report global step numbers. Just note that `-ts_max_steps` is global, not just with respect to this run.