### PR TITLE
fluids: checkpoint interval

### DIFF
--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -64,16 +64,32 @@ The following options are common among all problem types:
   - Number of extra quadrature points
   - `0`
 
-* - `-viz_refine`
-  - Use regular refinement for visualization
-  - `0`
+* - `-ts_monitor_solution`
+  - PETSc output format, such as `cgns:output-%d.cgns` (requires PETSc `--download-cgns`)
+  -
 
-* - `-output_freq`
-  - Frequency of output, in number of steps. `0` has no output, `-1` outputs final state only
+* - `-ts_monitor_solution_interval`
+  - Number of time steps between visualization output frames.
+  - `1`
+
+* - `-viewer_cgns_batch_size`
+  - Number of frames written per CGNS file if the CGNS file name includes a format specifier (`%d`).
+  - `20`
+
+* - `-checkpoint_interval`
+  - Number of steps between writing binary checkpoints. `0` has no output, `-1` outputs final state only
   - `10`
 
+* - `-checkpoint_vtk`
+  - Checkpoints include VTK (`*.vtu`) files for visualization. Consider `-ts_monitor_solution`instead.
+  - `false`
+
+* - `-viz_refine`
+  - Use regular refinement for VTK visualization
+  - `0`
+
 * - `-output_dir`
-  - Output directory
+  - Output directory for binary checkpoints and VTK files (if enabled).
   - `.`
 
 * - `-output_add_stepnum2bin`

--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -105,7 +105,7 @@ The following options are common among all problem types:
   - `[output_dir]/ns-solution.bin`
 
 * - `-continue_time_filename`
-  - Path to time stamp binary file from which to continue from
+  - Path to time stamp binary file (only for legacy checkpoints)
   - `[output_dir]/ns-time.bin`
 
 * - `-bc_wall`

--- a/examples/fluids/blasius.yaml
+++ b/examples/fluids/blasius.yaml
@@ -6,7 +6,9 @@ ts:
   type: 'beuler'
   dt: 0.2e-5
   max_time: 1.0e-3
-output_freq: 10
+  #monitor_solution: cgns:blasius-%d.cgns
+  #monitor_solution_interval: 10
+checkpoint_interval: 10
 
 ## Linear Settings:
 degree: 1

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -89,13 +89,14 @@ struct AppCtx_private {
   MatType   amat_type;
   PetscBool pmat_pbdiagonal;
   // Post-processing arguments
-  PetscInt  output_freq;
+  PetscInt  checkpoint_interval;
   PetscInt  viz_refine;
   PetscInt  cont_steps;
   char      cont_file[PETSC_MAX_PATH_LEN];
   char      cont_time_file[PETSC_MAX_PATH_LEN];
   char      output_dir[PETSC_MAX_PATH_LEN];
   PetscBool add_stepnum2bin;
+  PetscBool checkpoint_vtk;
   // Problem type arguments
   PetscFunctionList problems;
   char              problem_name[PETSC_MAX_PATH_LEN];

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -92,6 +92,7 @@ struct AppCtx_private {
   PetscInt  checkpoint_interval;
   PetscInt  viz_refine;
   PetscInt  cont_steps;
+  PetscReal cont_time;
   char      cont_file[PETSC_MAX_PATH_LEN];
   char      cont_time_file[PETSC_MAX_PATH_LEN];
   char      output_dir[PETSC_MAX_PATH_LEN];
@@ -305,6 +306,9 @@ PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q);
 
 // Record boundary values from initial condition
 PetscErrorCode SetBCsFromICs_NS(DM dm, Vec Q, Vec Q_loc);
+
+// Versioning token for binary checkpoints
+extern const PetscInt FLUIDS_FILE_TOKEN;
 
 // -----------------------------------------------------------------------------
 // Boundary Condition Related Functions

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -58,8 +58,16 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
   app_ctx->viz_refine = 0;
   PetscCall(PetscOptionsInt("-viz_refine", "Regular refinement levels for visualization", NULL, app_ctx->viz_refine, &app_ctx->viz_refine, NULL));
 
-  app_ctx->output_freq = 10;
-  PetscCall(PetscOptionsInt("-output_freq", "Frequency of output, in number of steps", NULL, app_ctx->output_freq, &app_ctx->output_freq, NULL));
+  app_ctx->checkpoint_interval = 10;
+  app_ctx->checkpoint_vtk      = PETSC_FALSE;
+  PetscCall(PetscOptionsDeprecated("-output_freq", "-checkpoint_interval", "libCEED 0.11.1", "Use -checkpoint_vtk true to include VTK output"));
+  PetscCall(PetscOptionsInt("-output_freq", "Frequency of output, in number of steps", NULL, app_ctx->checkpoint_interval,
+                            &app_ctx->checkpoint_interval, &option_set));
+  if (option_set) app_ctx->checkpoint_vtk = PETSC_TRUE;
+  PetscCall(PetscOptionsInt("-checkpoint_interval", "Frequency of output, in number of steps", NULL, app_ctx->checkpoint_interval,
+                            &app_ctx->checkpoint_interval, NULL));
+  PetscCall(PetscOptionsBool("-checkpoint_vtk", "Include VTK (*.vtu) output at each binary checkpoint", NULL, app_ctx->checkpoint_vtk,
+                             &app_ctx->checkpoint_vtk, NULL));
 
   PetscCall(PetscOptionsBool("-output_add_stepnum2bin", "Add step number to the binary outputs", NULL, app_ctx->add_stepnum2bin,
                              &app_ctx->add_stepnum2bin, NULL));

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -82,6 +82,7 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
   PetscCall(PetscOptionsString("-continue_filename", "Filename to get initial condition from", NULL, app_ctx->cont_file, app_ctx->cont_file,
                                sizeof(app_ctx->cont_file), &option_set));
   if (!option_set) PetscCall(PetscSNPrintf(app_ctx->cont_file, sizeof app_ctx->cont_file, "%s/ns-solution.bin", app_ctx->output_dir));
+  if (option_set && app_ctx->cont_steps == 0) app_ctx->cont_steps = -1;  // Read time from file
 
   PetscCall(PetscStrcpy(app_ctx->cont_time_file, "[output_dir]/ns-time.bin"));
   PetscCall(PetscOptionsString("-continue_time_filename", "Filename to get initial condition time from", NULL, app_ctx->cont_time_file,

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -418,7 +418,9 @@ PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time, Vec Q, void
   PetscFunctionBeginUser;
 
   // Print every 'checkpoint_interval' steps
-  if (user->app_ctx->checkpoint_interval <= 0 || step_no % user->app_ctx->checkpoint_interval != 0) PetscFunctionReturn(0);
+  if (user->app_ctx->checkpoint_interval <= 0 || step_no % user->app_ctx->checkpoint_interval != 0 ||
+      (user->app_ctx->cont_steps == step_no && step_no != 0))
+    PetscFunctionReturn(0);
 
   PetscCall(WriteOutput(user, Q, step_no, time));
 

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -343,47 +343,47 @@ PetscErrorCode WriteOutput(User user, Vec Q, PetscInt step_no, PetscScalar time)
   PetscViewer viewer;
   PetscFunctionBeginUser;
 
-  // Set up output
-  PetscCall(DMGetLocalVector(user->dm, &Q_loc));
-  PetscCall(PetscObjectSetName((PetscObject)Q_loc, "StateVec"));
-  PetscCall(VecZeroEntries(Q_loc));
-  PetscCall(DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc));
+  if (user->app_ctx->checkpoint_vtk) {
+    // Set up output
+    PetscCall(DMGetLocalVector(user->dm, &Q_loc));
+    PetscCall(PetscObjectSetName((PetscObject)Q_loc, "StateVec"));
+    PetscCall(VecZeroEntries(Q_loc));
+    PetscCall(DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc));
 
-  // Output
-  PetscCall(
-      PetscSNPrintf(file_path, sizeof file_path, "%s/ns-%03" PetscInt_FMT ".vtu", user->app_ctx->output_dir, step_no + user->app_ctx->cont_steps));
+    // Output
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-%03" PetscInt_FMT ".vtu", user->app_ctx->output_dir, step_no));
 
-  PetscCall(PetscViewerVTKOpen(PetscObjectComm((PetscObject)Q), file_path, FILE_MODE_WRITE, &viewer));
-  PetscCall(VecView(Q_loc, viewer));
-  PetscCall(PetscViewerDestroy(&viewer));
-  if (user->dm_viz) {
-    Vec         Q_refined, Q_refined_loc;
-    char        file_path_refined[PETSC_MAX_PATH_LEN];
-    PetscViewer viewer_refined;
+    PetscCall(PetscViewerVTKOpen(PetscObjectComm((PetscObject)Q), file_path, FILE_MODE_WRITE, &viewer));
+    PetscCall(VecView(Q_loc, viewer));
+    PetscCall(PetscViewerDestroy(&viewer));
+    if (user->dm_viz) {
+      Vec         Q_refined, Q_refined_loc;
+      char        file_path_refined[PETSC_MAX_PATH_LEN];
+      PetscViewer viewer_refined;
 
-    PetscCall(DMGetGlobalVector(user->dm_viz, &Q_refined));
-    PetscCall(DMGetLocalVector(user->dm_viz, &Q_refined_loc));
-    PetscCall(PetscObjectSetName((PetscObject)Q_refined_loc, "Refined"));
+      PetscCall(DMGetGlobalVector(user->dm_viz, &Q_refined));
+      PetscCall(DMGetLocalVector(user->dm_viz, &Q_refined_loc));
+      PetscCall(PetscObjectSetName((PetscObject)Q_refined_loc, "Refined"));
 
-    PetscCall(MatInterpolate(user->interp_viz, Q, Q_refined));
-    PetscCall(VecZeroEntries(Q_refined_loc));
-    PetscCall(DMGlobalToLocal(user->dm_viz, Q_refined, INSERT_VALUES, Q_refined_loc));
+      PetscCall(MatInterpolate(user->interp_viz, Q, Q_refined));
+      PetscCall(VecZeroEntries(Q_refined_loc));
+      PetscCall(DMGlobalToLocal(user->dm_viz, Q_refined, INSERT_VALUES, Q_refined_loc));
 
-    PetscCall(PetscSNPrintf(file_path_refined, sizeof file_path_refined, "%s/nsrefined-%03" PetscInt_FMT ".vtu", user->app_ctx->output_dir,
-                            step_no + user->app_ctx->cont_steps));
+      PetscCall(
+          PetscSNPrintf(file_path_refined, sizeof file_path_refined, "%s/nsrefined-%03" PetscInt_FMT ".vtu", user->app_ctx->output_dir, step_no));
 
-    PetscCall(PetscViewerVTKOpen(PetscObjectComm((PetscObject)Q_refined), file_path_refined, FILE_MODE_WRITE, &viewer_refined));
-    PetscCall(VecView(Q_refined_loc, viewer_refined));
-    PetscCall(DMRestoreLocalVector(user->dm_viz, &Q_refined_loc));
-    PetscCall(DMRestoreGlobalVector(user->dm_viz, &Q_refined));
-    PetscCall(PetscViewerDestroy(&viewer_refined));
+      PetscCall(PetscViewerVTKOpen(PetscObjectComm((PetscObject)Q_refined), file_path_refined, FILE_MODE_WRITE, &viewer_refined));
+      PetscCall(VecView(Q_refined_loc, viewer_refined));
+      PetscCall(DMRestoreLocalVector(user->dm_viz, &Q_refined_loc));
+      PetscCall(DMRestoreGlobalVector(user->dm_viz, &Q_refined));
+      PetscCall(PetscViewerDestroy(&viewer_refined));
+    }
+    PetscCall(DMRestoreLocalVector(user->dm, &Q_loc));
   }
-  PetscCall(DMRestoreLocalVector(user->dm, &Q_loc));
 
   // Save data in a binary file for continuation of simulations
   if (user->app_ctx->add_stepnum2bin) {
-    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-solution-%" PetscInt_FMT ".bin", user->app_ctx->output_dir,
-                            step_no + user->app_ctx->cont_steps));
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-solution-%" PetscInt_FMT ".bin", user->app_ctx->output_dir, step_no));
   } else {
     PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-solution.bin", user->app_ctx->output_dir));
   }
@@ -396,8 +396,7 @@ PetscErrorCode WriteOutput(User user, Vec Q, PetscInt step_no, PetscScalar time)
   // Dimensionalize time back
   time /= user->units->second;
   if (user->app_ctx->add_stepnum2bin) {
-    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-time-%" PetscInt_FMT ".bin", user->app_ctx->output_dir,
-                            step_no + user->app_ctx->cont_steps));
+    PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-time-%" PetscInt_FMT ".bin", user->app_ctx->output_dir, step_no));
   } else {
     PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/ns-time.bin", user->app_ctx->output_dir));
   }
@@ -418,8 +417,8 @@ PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time, Vec Q, void
   User user = ctx;
   PetscFunctionBeginUser;
 
-  // Print every 'output_freq' steps
-  if (user->app_ctx->output_freq <= 0 || step_no % user->app_ctx->output_freq != 0) PetscFunctionReturn(0);
+  // Print every 'checkpoint_interval' steps
+  if (user->app_ctx->checkpoint_interval <= 0 || step_no % user->app_ctx->checkpoint_interval != 0) PetscFunctionReturn(0);
 
   PetscCall(WriteOutput(user, Q, step_no, time));
 
@@ -524,7 +523,7 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
   *f_time = final_time;
 
   if (!app_ctx->test_mode) {
-    if (user->app_ctx->output_freq > 0 || user->app_ctx->output_freq == -1) {
+    if (user->app_ctx->checkpoint_interval > 0 || user->app_ctx->checkpoint_interval == -1) {
       PetscInt step_no;
       PetscCall(TSGetStepNumber(*ts, &step_no));
       PetscCall(WriteOutput(user, *Q, step_no, final_time));

--- a/examples/fluids/vortexshedding.yaml
+++ b/examples/fluids/vortexshedding.yaml
@@ -4,7 +4,7 @@ problem: newtonian
 implicit: true
 stab: supg
 
-output_freq: 10
+checkpoint_interval: 10
 
 ts:
   adapt_type: 'none'
@@ -12,6 +12,8 @@ ts:
   dt: .05
   max_steps: 2000
   alpha_radius: 0.5
+  #monitor_solution: cgns:vortexshedding-%d.cgns
+  #monitor_solution_interval: 10
 
 # Reference state is used for the initial condition, zero velocity by default.
 reference:


### PR DESCRIPTION
* Deprecate `output_freq`, but preserves existing behavior
* Add `checkpoint_interval` for binary checkpoints
* Use `-checkpoint_vtk` to include VTK output alongside binary checkpoints (as with now-deprecated `output_freq`)
* Write step number and time to `ns-solution.bin` checkpoint files; read on restart. So you can now
```yaml
continue_filename: ns-solution-40.bin
```
without any `continue: 40` or `continue_time_filename: ns-time-40.bin` part and it'll pick up correctly.
* If using default (`-output_add_stepnum2bin false`) names, one can use `-continue -1` to read `ns-solution.bin`, picking up the step number and time automatically. If a number is specified in `-continue`, we use it even if it's inconsistent with the value in the file. Note that `-continue 20` and `-continue_time_filename` (whatever the correct step number is) are still needed if reading a legacy checkpoint.

---
## Demo

On main (prior to this PR), I ran this to generate the first 20 time steps and create a (legacy) checkpoint.
```console
$ mpiexec -n 5 build/fluids-navierstokes -options_file examples/fluids/vortexshedding.yaml -{ts,snes}_monitor -ksp_converged_reason  -ts_max_steps 20 -output_dir v1
```

I updated to this branch and recompiled, running the next 20 time steps
```console
$ mpiexec -n 5 build/fluids-navierstokes -options_file examples/fluids/vortexshedding.yaml -{ts,snes}_monitor -ksp_converged_reason  -ts_max_steps 40 -output_dir v2 -continue 20 -continue_filename v1/ns-solution.bin -continue_time_filename v1/ns-time.bin
[...]
20 TS dt 0.05 time 1.
    0 SNES Function norm 1.810353133257e+01
    Linear solve converged due to CONVERGED_RTOL iterations 220
    1 SNES Function norm 2.359853698058e-02
    Linear solve converged due to CONVERGED_RTOL iterations 203
    2 SNES Function norm 5.154421628365e-05
    Linear solve converged due to CONVERGED_RTOL iterations 140
    3 SNES Function norm 3.932162726632e-07
[...]
```

Now I have a new-style checkpoint and can continue with just `-continue_filename`.
```console
$ mpiexec -n 5 build/fluids-navierstokes -options_file examples/fluids/vortexshedding.yaml -{ts,snes}_monitor -ksp_converged_reason  -ts_max_steps 60 -output_dir v3 -continue_filename v2/ns-solution.bin
[...]
40 TS dt 0.05 time 2.
    0 SNES Function norm 1.516668598843e+00
    Linear solve converged due to CONVERGED_RTOL iterations 166
    1 SNES Function norm 2.029586823076e-02
    Linear solve converged due to CONVERGED_RTOL iterations 197
    2 SNES Function norm 3.055918873916e-05
[...]
```