### PR TITLE
CI Rust: pin cargo-llvm-version@0.5.3 to avoid --doctests breakage

### DIFF
--- a/.github/workflows/rust-test-with-style.yml
+++ b/.github/workflows/rust-test-with-style.yml
@@ -20,8 +20,11 @@ jobs:
       with:
         # Note: nightly required for coverage of Doctests
         toolchain: nightly
+        components: llvm-tools-preview
     - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov@0.5.3
     - name: Rust test with coverage
       env:
         CC: ${{ matrix.compiler }}


### PR DESCRIPTION
First noticed here: https://github.com/CEED/libCEED/pull/1136#issuecomment-1376409002