### PR TITLE
fluids: Add generic L2 projection function

### DIFF
--- a/examples/fluids/include/matops.h
+++ b/examples/fluids/include/matops.h
@@ -29,4 +29,9 @@ PetscErrorCode MatGetDiag_Ceed(Mat A, Vec D);
 PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, MatopApplyContext op_apply_ctx);
 PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y);
 
+PetscErrorCode VecP2C(Vec X_petsc, PetscMemType *mem_type, CeedVector x_ceed);
+PetscErrorCode VecC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc);
+PetscErrorCode VecReadP2C(Vec X_petsc, PetscMemType *mem_type, CeedVector x_ceed);
+PetscErrorCode VecReadC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc);
+
 #endif  // matops_h

--- a/examples/fluids/include/matops.h
+++ b/examples/fluids/include/matops.h
@@ -15,14 +15,14 @@
 // Data for PETSc Matshell
 typedef struct OperatorApplyContext_ *MatopApplyContext;
 struct OperatorApplyContext_ {
-  DM           dm;
+  DM           dm_x, dm_y;
   Vec          X_loc, Y_loc;
   CeedVector   x_ceed, y_ceed;
   CeedOperator op;
   Ceed         ceed;
 };
 
-PetscErrorCode MatopApplyContextCreate(DM dm, Ceed ceed, CeedOperator op_apply, CeedVector x_ceed, CeedVector y_ceed, Vec X_loc,
+PetscErrorCode MatopApplyContextCreate(DM dm_x, DM dm_y, Ceed ceed, CeedOperator op_apply, CeedVector x_ceed, CeedVector y_ceed, Vec X_loc, Vec Y_loc,
                                        MatopApplyContext *op_apply_ctx);
 PetscErrorCode MatopApplyContextDestroy(MatopApplyContext op_apply_ctx);
 PetscErrorCode MatGetDiag_Ceed(Mat A, Vec D);

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -147,7 +147,6 @@ typedef struct {
   PetscInt              num_comp_stats;
   CeedVector            child_stats, parent_stats;  // collocated statistics data
   CeedVector            rhs_ceed;
-  Vec                   M_inv;       // Lumped Mass matrix inverse
   KSP                   ksp;         // For the L^2 projection solve
   CeedScalar            span_width;  // spanwise width of the child domain
   PetscBool             do_mms_test;

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -355,6 +355,8 @@ extern const PetscInt FLUIDS_FILE_TOKEN;
 // Create appropriate mass qfunction based on number of components N
 PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, CeedQFunction *qf);
 
+PetscErrorCode ComputeL2Projection(Vec source_vec, Vec target_vec, MatopApplyContext rhs_matop_ctx, KSP ksp);
+
 PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree, SimpleBC bc);
 
 PetscErrorCode SetupStatsCollection(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);

--- a/examples/fluids/src/dirichlet.c
+++ b/examples/fluids/src/dirichlet.c
@@ -131,7 +131,6 @@ PetscErrorCode DMPlexInsertBoundaryValues_StrongBCCeed(DM dm, PetscBool insert_e
                                                        Vec cell_geom_FVM, Vec grad_FVM) {
   Vec          boundary_mask;
   User         user;
-  PetscScalar *q;
   PetscMemType q_mem_type;
   PetscFunctionBeginUser;
 
@@ -147,15 +146,13 @@ PetscErrorCode DMPlexInsertBoundaryValues_StrongBCCeed(DM dm, PetscBool insert_e
   PetscCall(DMRestoreNamedLocalVector(dm, "boundary mask", &boundary_mask));
 
   // Setup libCEED vector
-  PetscCall(VecGetArrayAndMemType(Q_loc, &q, &q_mem_type));
-  CeedVectorSetArray(user->q_ceed, MemTypeP2C(q_mem_type), CEED_USE_POINTER, q);
+  PetscCall(VecP2C(Q_loc, &q_mem_type, user->q_ceed));
 
   // Apply libCEED operator
   CeedOperatorApplyAdd(user->op_dirichlet, CEED_VECTOR_NONE, user->q_ceed, CEED_REQUEST_IMMEDIATE);
 
   // Restore PETSc vectors
-  CeedVectorTakeArray(user->q_ceed, MemTypeP2C(q_mem_type), NULL);
-  PetscCall(VecRestoreArrayAndMemType(Q_loc, &q));
+  PetscCall(VecC2P(user->q_ceed, q_mem_type, Q_loc));
 
   PetscFunctionReturn(0);
 }

--- a/examples/fluids/src/matops.c
+++ b/examples/fluids/src/matops.c
@@ -63,20 +63,18 @@ PetscErrorCode MatopApplyContextDestroy(MatopApplyContext op_apply_ctx) {
 }
 
 // -----------------------------------------------------------------------------
-// This function returns the computed diagonal of the operator
+// Returns the computed diagonal of the operator
 // -----------------------------------------------------------------------------
 PetscErrorCode MatGetDiag_Ceed(Mat A, Vec D) {
   MatopApplyContext op_apply_ctx;
   Vec               Y_loc;
+  PetscScalar      *y;
+  PetscMemType      mem_type;
   PetscFunctionBeginUser;
 
   PetscCall(MatShellGetContext(A, &op_apply_ctx));
   if (op_apply_ctx->Y_loc) Y_loc = op_apply_ctx->Y_loc;
   else PetscCall(DMGetLocalVector(op_apply_ctx->dm, &Y_loc));
-
-  // Compute Diagonal via libCEED
-  PetscScalar *y;
-  PetscMemType mem_type;
 
   // -- Place PETSc vector in libCEED vector
   PetscCall(VecGetArrayAndMemType(Y_loc, &y, &mem_type));
@@ -137,7 +135,7 @@ PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, MatopApplyContext op_apply_ctx) {
 };
 
 // -----------------------------------------------------------------------------
-// This function wraps the libCEED operator for a MatShell
+// Wraps the libCEED operator for a MatShell
 // -----------------------------------------------------------------------------
 PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y) {
   MatopApplyContext op_apply_ctx;

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -27,17 +27,14 @@ PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_l
   CeedElemRestrictionCreateVector(ceed_data->elem_restr_q, &q0_ceed, NULL);
 
   // -- Place PETSc vector in CEED vector
-  CeedScalar  *q0;
   PetscMemType q0_mem_type;
-  PetscCall(VecGetArrayAndMemType(Q_loc, (PetscScalar **)&q0, &q0_mem_type));
-  CeedVectorSetArray(q0_ceed, MemTypeP2C(q0_mem_type), CEED_USE_POINTER, q0);
+  PetscCall(VecP2C(Q_loc, &q0_mem_type, q0_ceed));
 
   // -- Apply CEED Operator
   CeedOperatorApply(ceed_data->op_ics, ceed_data->x_coord, q0_ceed, CEED_REQUEST_IMMEDIATE);
 
   // -- Restore vectors
-  CeedVectorTakeArray(q0_ceed, MemTypeP2C(q0_mem_type), NULL);
-  PetscCall(VecRestoreArrayReadAndMemType(Q_loc, (const PetscScalar **)&q0));
+  PetscCall(VecC2P(q0_ceed, q0_mem_type, Q_loc));
 
   // -- Local-to-Global
   PetscCall(VecZeroEntries(Q));
@@ -51,19 +48,16 @@ PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_l
   CeedElemRestrictionCreateVector(ceed_data->elem_restr_q, &mult_vec, NULL);
 
   // -- Place PETSc vector in CEED vector
-  CeedScalar  *mult;
   PetscMemType m_mem_type;
   Vec          multiplicity_loc;
   PetscCall(DMGetLocalVector(dm, &multiplicity_loc));
-  PetscCall(VecGetArrayAndMemType(multiplicity_loc, (PetscScalar **)&mult, &m_mem_type));
-  CeedVectorSetArray(mult_vec, MemTypeP2C(m_mem_type), CEED_USE_POINTER, mult);
+  PetscCall(VecP2C(multiplicity_loc, &m_mem_type, mult_vec));
 
   // -- Get multiplicity
   CeedElemRestrictionGetMultiplicity(ceed_data->elem_restr_q, mult_vec);
 
   // -- Restore vectors
-  CeedVectorTakeArray(mult_vec, MemTypeP2C(m_mem_type), NULL);
-  PetscCall(VecRestoreArrayReadAndMemType(multiplicity_loc, (const PetscScalar **)&mult));
+  PetscCall(VecC2P(mult_vec, m_mem_type, multiplicity_loc));
 
   // -- Local-to-Global
   Vec multiplicity;

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -286,3 +286,21 @@ PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, Ce
   CeedQFunctionAddOutput(*qf, "v", N, CEED_EVAL_INTERP);
   PetscFunctionReturn(0);
 }
+
+/* @brief L^2 Projection of a source FEM function to a target FEM space
+ *
+ * To solve system using a lumped mass matrix, pass a KSP object with ksp_type=preonly, pc_type=jacobi, pc_jacobi_type=rowsum.
+ *
+ * @param[in]  source_vec    Global Vec of the source FEM function. NULL indicates using rhs_matop_ctx->X_loc
+ * @param[out] target_vec    Global Vec of the target (result) FEM function. NULL indicates using rhs_matop_ctx->Y_loc
+ * @param[in]  rhs_matop_ctx MatopApplyContext for performing the RHS evaluation
+ * @param[in]  ksp           KSP for solving the consistent projection problem
+ */
+PetscErrorCode ComputeL2Projection(Vec source_vec, Vec target_vec, MatopApplyContext rhs_matop_ctx, KSP ksp) {
+  PetscFunctionBeginUser;
+
+  PetscCall(ApplyLocal_Ceed(source_vec, target_vec, rhs_matop_ctx));
+  PetscCall(KSPSolve(ksp, target_vec, target_vec));
+
+  PetscFunctionReturn(0);
+}

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -37,18 +37,15 @@ PetscErrorCode ComputeLumpedMassMatrix(Ceed ceed, DM dm, CeedData ceed_data, Vec
   CeedOperatorSetField(op_mass, "v", ceed_data->elem_restr_q, ceed_data->basis_q, CEED_VECTOR_ACTIVE);
 
   // Place PETSc vector in CEED vector
-  CeedScalar  *m;
   PetscMemType m_mem_type;
   PetscCall(DMGetLocalVector(dm, &M_loc));
-  PetscCall(VecGetArrayAndMemType(M_loc, (PetscScalar **)&m, &m_mem_type));
-  CeedVectorSetArray(m_ceed, MemTypeP2C(m_mem_type), CEED_USE_POINTER, m);
+  PetscCall(VecP2C(M_loc, &m_mem_type, m_ceed));
 
   // Apply CEED Operator
   CeedOperatorApply(op_mass, ones_vec, m_ceed, CEED_REQUEST_IMMEDIATE);
 
   // Restore vectors
-  CeedVectorTakeArray(m_ceed, MemTypeP2C(m_mem_type), NULL);
-  PetscCall(VecRestoreArrayReadAndMemType(M_loc, (const PetscScalar **)&m));
+  PetscCall(VecC2P(m_ceed, m_mem_type, M_loc));
 
   // Local-to-Global
   PetscCall(VecZeroEntries(M));
@@ -94,7 +91,7 @@ PetscErrorCode UpdateContextLabel(PetscScalar *previous_value, PetscScalar updat
 //   This function takes in a state vector Q and writes into G
 PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   User         user = *(User *)user_data;
-  PetscScalar *q, *g, dt;
+  PetscScalar  dt;
   Vec          Q_loc = user->Q_loc, G_loc;
   PetscMemType q_mem_type, g_mem_type;
   PetscFunctionBeginUser;
@@ -112,19 +109,15 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   PetscCall(DMGlobalToLocal(user->dm, Q, INSERT_VALUES, Q_loc));
 
   // Place PETSc vectors in CEED vectors
-  PetscCall(VecGetArrayReadAndMemType(Q_loc, (const PetscScalar **)&q, &q_mem_type));
-  PetscCall(VecGetArrayAndMemType(G_loc, &g, &g_mem_type));
-  CeedVectorSetArray(user->q_ceed, MemTypeP2C(q_mem_type), CEED_USE_POINTER, q);
-  CeedVectorSetArray(user->g_ceed, MemTypeP2C(g_mem_type), CEED_USE_POINTER, g);
+  PetscCall(VecReadP2C(Q_loc, &q_mem_type, user->q_ceed));
+  PetscCall(VecP2C(G_loc, &g_mem_type, user->g_ceed));
 
   // Apply CEED operator
   CeedOperatorApply(user->op_rhs, user->q_ceed, user->g_ceed, CEED_REQUEST_IMMEDIATE);
 
   // Restore vectors
-  CeedVectorTakeArray(user->q_ceed, MemTypeP2C(q_mem_type), NULL);
-  CeedVectorTakeArray(user->g_ceed, MemTypeP2C(g_mem_type), NULL);
-  PetscCall(VecRestoreArrayReadAndMemType(Q_loc, (const PetscScalar **)&q));
-  PetscCall(VecRestoreArrayAndMemType(G_loc, &g));
+  PetscCall(VecReadC2P(user->q_ceed, q_mem_type, Q_loc));
+  PetscCall(VecC2P(user->g_ceed, g_mem_type, G_loc));
 
   // Local-to-Global
   PetscCall(VecZeroEntries(G));
@@ -182,11 +175,10 @@ static PetscErrorCode Surface_Forces_NS(DM dm, Vec G_loc, PetscInt num_walls, co
 
 // Implicit time-stepper function setup
 PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *user_data) {
-  User               user = *(User *)user_data;
-  const PetscScalar *q, *q_dot;
-  PetscScalar       *g, dt;
-  Vec                Q_loc = user->Q_loc, Q_dot_loc = user->Q_dot_loc, G_loc;
-  PetscMemType       q_mem_type, q_dot_mem_type, g_mem_type;
+  User         user = *(User *)user_data;
+  PetscScalar  dt;
+  Vec          Q_loc = user->Q_loc, Q_dot_loc = user->Q_dot_loc, G_loc;
+  PetscMemType q_mem_type, q_dot_mem_type, g_mem_type;
   PetscFunctionBeginUser;
 
   // Get local vectors
@@ -205,23 +197,17 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
   PetscCall(DMGlobalToLocalEnd(user->dm, Q_dot, INSERT_VALUES, Q_dot_loc));
 
   // Place PETSc vectors in CEED vectors
-  PetscCall(VecGetArrayReadAndMemType(Q_loc, &q, &q_mem_type));
-  PetscCall(VecGetArrayReadAndMemType(Q_dot_loc, &q_dot, &q_dot_mem_type));
-  PetscCall(VecGetArrayAndMemType(G_loc, &g, &g_mem_type));
-  CeedVectorSetArray(user->q_ceed, MemTypeP2C(q_mem_type), CEED_USE_POINTER, (PetscScalar *)q);
-  CeedVectorSetArray(user->q_dot_ceed, MemTypeP2C(q_dot_mem_type), CEED_USE_POINTER, (PetscScalar *)q_dot);
-  CeedVectorSetArray(user->g_ceed, MemTypeP2C(g_mem_type), CEED_USE_POINTER, g);
+  PetscCall(VecReadP2C(Q_loc, &q_mem_type, user->q_ceed));
+  PetscCall(VecReadP2C(Q_dot_loc, &q_dot_mem_type, user->q_dot_ceed));
+  PetscCall(VecP2C(G_loc, &g_mem_type, user->g_ceed));
 
   // Apply CEED operator
   CeedOperatorApply(user->op_ifunction, user->q_ceed, user->g_ceed, CEED_REQUEST_IMMEDIATE);
 
   // Restore vectors
-  CeedVectorTakeArray(user->q_ceed, MemTypeP2C(q_mem_type), NULL);
-  CeedVectorTakeArray(user->q_dot_ceed, MemTypeP2C(q_dot_mem_type), NULL);
-  CeedVectorTakeArray(user->g_ceed, MemTypeP2C(g_mem_type), NULL);
-  PetscCall(VecRestoreArrayReadAndMemType(Q_loc, &q));
-  PetscCall(VecRestoreArrayReadAndMemType(Q_dot_loc, &q_dot));
-  PetscCall(VecRestoreArrayAndMemType(G_loc, &g));
+  PetscCall(VecReadC2P(user->q_ceed, q_mem_type, Q_loc));
+  PetscCall(VecReadC2P(user->q_dot_ceed, q_dot_mem_type, Q_dot_loc));
+  PetscCall(VecC2P(user->g_ceed, g_mem_type, G_loc));
 
   // Local-to-Global
   PetscCall(VecZeroEntries(G));

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -9,17 +9,8 @@
 
 #include "../qfunctions/turb_spanstats.h"
 
-#include <petscsf.h>
-
 #include "../include/matops.h"
 #include "../navierstokes.h"
-#include "ceed/ceed.h"
-#include "petscerror.h"
-#include "petsclog.h"
-#include "petscmat.h"
-#include "petscsys.h"
-#include "petscvec.h"
-#include "petscviewer.h"
 
 typedef struct {
   CeedElemRestriction elem_restr_parent_x, elem_restr_parent_stats, elem_restr_parent_qd, elem_restr_parent_colloc, elem_restr_child_colloc;
@@ -85,7 +76,7 @@ PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree, S
   PetscCall(PetscObjectSetName((PetscObject)user->spanstats.dm, "Spanwise_Stats"));
   PetscCall(DMSetOptionsPrefix(user->spanstats.dm, "turbulence_spanstats_"));
   PetscCall(DMSetFromOptions(user->spanstats.dm));
-  PetscCall(DMViewFromOptions(user->spanstats.dm, NULL, "-dm_view"));  // -spanstats_dm_view
+  PetscCall(DMViewFromOptions(user->spanstats.dm, NULL, "-dm_view"));
 
   // Create FE space for parent DM
   PetscCall(PetscFECreateLagrange(PETSC_COMM_SELF, problem->dim - 1, user->spanstats.num_comp_stats, PETSC_FALSE, degree, PETSC_DECIDE, &fe));

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -331,7 +331,7 @@ PetscErrorCode SetupL2ProjectionStats(Ceed ceed, User user, CeedData ceed_data, 
 
     CeedElemRestrictionCreateVector(stats_data->elem_restr_parent_stats, &x_ceed, NULL);
     CeedElemRestrictionCreateVector(stats_data->elem_restr_parent_stats, &y_ceed, NULL);
-    PetscCall(MatopApplyContextCreate(user->spanstats.dm, user->ceed, op_mass, x_ceed, y_ceed, NULL, &M_ctx));
+    PetscCall(MatopApplyContextCreate(user->spanstats.dm, user->spanstats.dm, user->ceed, op_mass, x_ceed, y_ceed, NULL, NULL, &M_ctx));
     CeedVectorDestroy(&x_ceed);
     CeedVectorDestroy(&y_ceed);
 
@@ -463,7 +463,8 @@ PetscErrorCode SetupMMSErrorChecking(Ceed ceed, User user, CeedData ceed_data, S
 
   CeedElemRestrictionCreateVector(stats_data->elem_restr_parent_stats, &x_ceed, NULL);
   CeedElemRestrictionCreateVector(stats_data->elem_restr_parent_stats, &y_ceed, NULL);
-  PetscCall(MatopApplyContextCreate(user->spanstats.dm, user->ceed, op_error, x_ceed, y_ceed, NULL, &user->spanstats.mms_error_ctx));
+  PetscCall(MatopApplyContextCreate(user->spanstats.dm, user->spanstats.dm, user->ceed, op_error, x_ceed, y_ceed, NULL, NULL,
+                                    &user->spanstats.mms_error_ctx));
 
   CeedOperatorDestroy(&op_error);
   CeedQFunctionDestroy(&qf_error);


### PR DESCRIPTION
- Adds a function `ComputeL2Projection`, which should be able to handle generic L2 projection problems.
- Updated `ApplyLocal_Ceed` to handle collocated ceed vector inputs and outputs
   - Assumes that the `x_ceed` and/or `y_ceed` already has the necessary data to be applied to the operator
- Implemented `ComputeL2Projection` for the spanwise statistics processing function
