### PR TITLE
operator: Get OperatorField by field name

### DIFF
--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -6,6 +6,9 @@ On this page we provide a summary of the main API changes, new features and exam
 
 ## Current `main` branch
 
+### New features
+- Added {c:func}`CeedOperatorGetFieldByName` to access a specific `CeedOperatorField` by its name
+
 (v0-11)=
 
 ## v0.11 (Dec 24, 2022)
@@ -20,7 +23,7 @@ On this page we provide a summary of the main API changes, new features and exam
 
 - Update `/cpu/self/memcheck/*` backends to help verify `CeedQFunctionContext` data sizes provided by user.
 - Improved support for $H(\text{div})$ bases.
-- Added `CeedInt_FMT` to support potential future use of larger interger sizes.
+- Added `CeedInt_FMT` to support potential future use of larger integer sizes.
 - Added `CEED_QFUNCTION_ATTR` for setting compiler attributes/pragmas to `CEED_QFUNCTION_HELPER` and `CEED_QFUNCTION`.
 - OCCA backend updated to latest OCCA release; DPC++ and OMP OCCA modes enabled.
 Due to a limitation of the OCCA parser, typedefs are required to use pointers to arrays in QFunctions with the OCCA backend.

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -518,6 +518,7 @@ CEED_EXTERN int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out
 CEED_EXTERN int CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
 CEED_EXTERN int CeedOperatorDestroy(CeedOperator *op);
 
+CEED_EXTERN int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOperatorField *op_field);
 CEED_EXTERN int CeedOperatorFieldGetName(CeedOperatorField op_field, char **field_name);
 CEED_EXTERN int CeedOperatorFieldGetElemRestriction(CeedOperatorField op_field, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedOperatorFieldGetBasis(CeedOperatorField op_field, CeedBasis *basis);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -873,6 +873,48 @@ int CeedOperatorGetFields(CeedOperator op, CeedInt *num_input_fields, CeedOperat
 }
 
 /**
+  @brief Get a CeedOperatorField of an CeedOperator from its name
+
+  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+
+  @param[in]  op         CeedOperator
+  @param[in]  field_name Name of desired CeedOperatorField
+  @param[out] op_field   CeedOperatorField corresponding to the name
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOperatorField *op_field) {
+  CeedInt            num_input_fields, num_output_fields;
+  CeedOperatorField *input_fields, *output_fields;
+  char              *name;
+  CeedCall(CeedOperatorGetFields(op, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
+
+  for (CeedInt i = 0; i < num_input_fields; i++) {
+    CeedCall(CeedOperatorFieldGetName(input_fields[i], &name));
+    if (!strcmp(name, field_name)) {
+      *op_field = input_fields[i];
+      return CEED_ERROR_SUCCESS;
+    }
+  }
+
+  for (CeedInt i = 0; i < num_output_fields; i++) {
+    CeedCall(CeedOperatorFieldGetName(output_fields[i], &name));
+    if (!strcmp(name, field_name)) {
+      *op_field = output_fields[i];
+      return CEED_ERROR_SUCCESS;
+    }
+  }
+
+  bool has_name = op->name;
+  // LCOV_EXCL_START
+  return CeedError(op->ceed, CEED_ERROR_MINOR, "The field \"%s\" not found in CeedOperator%s%s%s.\n", field_name, has_name ? " \"" : "",
+                   has_name ? op->name : "", has_name ? "\"" : "");
+  // LCOV_EXCL_STOP
+}
+
+/**
   @brief Get the name of a CeedOperatorField
 
   @param[in]  op_field    CeedOperatorField


### PR DESCRIPTION
Get a `CeedOperatorField` from a `CeedOperator` by the field's name.

Still need to actually test the code, but the prototype from 9a889ca works correctly.

- [ ] Update Release notes
- [x] Verify error message prints correctly
- [x] Double-check that it's working in this implementation