### PR TITLE
Always NULL object on Ceed*Destroy

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -158,6 +158,23 @@ int main(int argc, char **argv) {
     PetscCall(SetupStatsCollection(ceed, user, ceed_data, problem));
   }
 
+  // Destroy QFunction contexts after using
+  // ToDo: Simplify tracked libCEED objects, smaller struct
+  {
+    CeedQFunctionContextDestroy(&problem->apply_inflow_jacobian.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_inflow_jacobian.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_outflow_jacobian.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_outflow_jacobian.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_freestream_jacobian.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_freestream_jacobian.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->setup_sur.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->setup_vol.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->ics.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_vol_rhs.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_vol_ifunction.qfunction_context);
+    CeedQFunctionContextDestroy(&problem->apply_vol_ijacobian.qfunction_context);
+  }
+
   // ---------------------------------------------------------------------------
   // Set up ICs
   // ---------------------------------------------------------------------------
@@ -314,17 +331,6 @@ int main(int argc, char **argv) {
   CeedVectorDestroy(&user->coo_values_amat);
   CeedVectorDestroy(&user->coo_values_pmat);
 
-  // -- QFunctions
-  CeedQFunctionDestroy(&ceed_data->qf_setup_vol);
-  CeedQFunctionDestroy(&ceed_data->qf_ics);
-  CeedQFunctionDestroy(&ceed_data->qf_rhs_vol);
-  CeedQFunctionDestroy(&ceed_data->qf_ifunction_vol);
-  CeedQFunctionDestroy(&ceed_data->qf_setup_sur);
-  CeedQFunctionDestroy(&ceed_data->qf_apply_inflow);
-  CeedQFunctionDestroy(&ceed_data->qf_apply_inflow_jacobian);
-  CeedQFunctionDestroy(&ceed_data->qf_apply_freestream);
-  CeedQFunctionDestroy(&ceed_data->qf_apply_freestream_jacobian);
-
   // -- Bases
   CeedBasisDestroy(&ceed_data->basis_q);
   CeedBasisDestroy(&ceed_data->basis_x);
@@ -336,6 +342,17 @@ int main(int argc, char **argv) {
   CeedElemRestrictionDestroy(&ceed_data->elem_restr_q);
   CeedElemRestrictionDestroy(&ceed_data->elem_restr_x);
   CeedElemRestrictionDestroy(&ceed_data->elem_restr_qd_i);
+
+  // -- QFunctions
+  CeedQFunctionDestroy(&ceed_data->qf_setup_vol);
+  CeedQFunctionDestroy(&ceed_data->qf_ics);
+  CeedQFunctionDestroy(&ceed_data->qf_rhs_vol);
+  CeedQFunctionDestroy(&ceed_data->qf_ifunction_vol);
+  CeedQFunctionDestroy(&ceed_data->qf_setup_sur);
+  CeedQFunctionDestroy(&ceed_data->qf_apply_inflow);
+  CeedQFunctionDestroy(&ceed_data->qf_apply_inflow_jacobian);
+  CeedQFunctionDestroy(&ceed_data->qf_apply_freestream);
+  CeedQFunctionDestroy(&ceed_data->qf_apply_freestream_jacobian);
 
   // -- Operators
   CeedOperatorDestroy(&ceed_data->op_setup_vol);

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -185,7 +185,6 @@ PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_
   if (apply_bc.qfunction) {
     CeedQFunctionCreateInterior(ceed, 1, apply_bc.qfunction, apply_bc.qfunction_loc, qf_apply_bc);
     CeedQFunctionSetContext(*qf_apply_bc, apply_bc.qfunction_context);
-    CeedQFunctionContextDestroy(&apply_bc.qfunction_context);
     CeedQFunctionAddInput(*qf_apply_bc, "q", num_comp_q, CEED_EVAL_INTERP);
     CeedQFunctionAddInput(*qf_apply_bc, "Grad_q", num_comp_q * dim_sur, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(*qf_apply_bc, "surface qdata", q_data_size_sur, CEED_EVAL_NONE);
@@ -196,7 +195,6 @@ PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_
   if (apply_bc_jacobian.qfunction) {
     CeedQFunctionCreateInterior(ceed, 1, apply_bc_jacobian.qfunction, apply_bc_jacobian.qfunction_loc, qf_apply_bc_jacobian);
     CeedQFunctionSetContext(*qf_apply_bc_jacobian, apply_bc_jacobian.qfunction_context);
-    CeedQFunctionContextDestroy(&apply_bc_jacobian.qfunction_context);
     CeedQFunctionAddInput(*qf_apply_bc_jacobian, "dq", num_comp_q, CEED_EVAL_INTERP);
     CeedQFunctionAddInput(*qf_apply_bc_jacobian, "Grad_dq", num_comp_q * dim_sur, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(*qf_apply_bc_jacobian, "surface qdata", q_data_size_sur, CEED_EVAL_NONE);
@@ -246,7 +244,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   CeedQFunctionCreateInterior(ceed, 1, problem->setup_vol.qfunction, problem->setup_vol.qfunction_loc, &ceed_data->qf_setup_vol);
   if (problem->setup_vol.qfunction_context) {
     CeedQFunctionSetContext(ceed_data->qf_setup_vol, problem->setup_vol.qfunction_context);
-    CeedQFunctionContextDestroy(&problem->setup_vol.qfunction_context);
   }
   CeedQFunctionAddInput(ceed_data->qf_setup_vol, "dx", num_comp_x * dim, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(ceed_data->qf_setup_vol, "weight", 1, CEED_EVAL_WEIGHT);
@@ -255,7 +252,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   // -- Create QFunction for ICs
   CeedQFunctionCreateInterior(ceed, 1, problem->ics.qfunction, problem->ics.qfunction_loc, &ceed_data->qf_ics);
   CeedQFunctionSetContext(ceed_data->qf_ics, problem->ics.qfunction_context);
-  CeedQFunctionContextDestroy(&problem->ics.qfunction_context);
   CeedQFunctionAddInput(ceed_data->qf_ics, "x", num_comp_x, CEED_EVAL_INTERP);
   CeedQFunctionAddInput(ceed_data->qf_ics, "qdata", q_data_size_vol, CEED_EVAL_NONE);
   CeedQFunctionAddOutput(ceed_data->qf_ics, "q0", num_comp_q, CEED_EVAL_NONE);
@@ -264,7 +260,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   if (problem->apply_vol_rhs.qfunction) {
     CeedQFunctionCreateInterior(ceed, 1, problem->apply_vol_rhs.qfunction, problem->apply_vol_rhs.qfunction_loc, &ceed_data->qf_rhs_vol);
     CeedQFunctionSetContext(ceed_data->qf_rhs_vol, problem->apply_vol_rhs.qfunction_context);
-    CeedQFunctionContextDestroy(&problem->apply_vol_rhs.qfunction_context);
     CeedQFunctionAddInput(ceed_data->qf_rhs_vol, "q", num_comp_q, CEED_EVAL_INTERP);
     CeedQFunctionAddInput(ceed_data->qf_rhs_vol, "Grad_q", num_comp_q * dim, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(ceed_data->qf_rhs_vol, "qdata", q_data_size_vol, CEED_EVAL_NONE);
@@ -278,7 +273,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     CeedQFunctionCreateInterior(ceed, 1, problem->apply_vol_ifunction.qfunction, problem->apply_vol_ifunction.qfunction_loc,
                                 &ceed_data->qf_ifunction_vol);
     CeedQFunctionSetContext(ceed_data->qf_ifunction_vol, problem->apply_vol_ifunction.qfunction_context);
-    CeedQFunctionContextDestroy(&problem->apply_vol_ifunction.qfunction_context);
     CeedQFunctionAddInput(ceed_data->qf_ifunction_vol, "q", num_comp_q, CEED_EVAL_INTERP);
     CeedQFunctionAddInput(ceed_data->qf_ifunction_vol, "Grad_q", num_comp_q * dim, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(ceed_data->qf_ifunction_vol, "q dot", num_comp_q, CEED_EVAL_INTERP);
@@ -293,7 +287,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   if (problem->apply_vol_ijacobian.qfunction) {
     CeedQFunctionCreateInterior(ceed, 1, problem->apply_vol_ijacobian.qfunction, problem->apply_vol_ijacobian.qfunction_loc, &qf_ijacobian_vol);
     CeedQFunctionSetContext(qf_ijacobian_vol, problem->apply_vol_ijacobian.qfunction_context);
-    CeedQFunctionContextDestroy(&problem->apply_vol_ijacobian.qfunction_context);
     CeedQFunctionAddInput(qf_ijacobian_vol, "dq", num_comp_q, CEED_EVAL_INTERP);
     CeedQFunctionAddInput(qf_ijacobian_vol, "Grad_dq", num_comp_q * dim, CEED_EVAL_GRAD);
     CeedQFunctionAddInput(qf_ijacobian_vol, "qdata", q_data_size_vol, CEED_EVAL_NONE);
@@ -413,7 +406,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   CeedQFunctionCreateInterior(ceed, 1, problem->setup_sur.qfunction, problem->setup_sur.qfunction_loc, &ceed_data->qf_setup_sur);
   if (problem->setup_sur.qfunction_context) {
     CeedQFunctionSetContext(ceed_data->qf_setup_sur, problem->setup_sur.qfunction_context);
-    CeedQFunctionContextDestroy(&problem->setup_sur.qfunction_context);
   }
   CeedQFunctionAddInput(ceed_data->qf_setup_sur, "dx", num_comp_x * dim_sur, CEED_EVAL_GRAD);
   CeedQFunctionAddInput(ceed_data->qf_setup_sur, "weight", 1, CEED_EVAL_WEIGHT);

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -1404,7 +1404,10 @@ int CeedBasisGetDiv(CeedBasis basis, const CeedScalar **div) {
   @ref User
 **/
 int CeedBasisDestroy(CeedBasis *basis) {
-  if (!*basis || --(*basis)->ref_count > 0) return CEED_ERROR_SUCCESS;
+  if (!*basis || --(*basis)->ref_count > 0) {
+    *basis = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if ((*basis)->Destroy) CeedCall((*basis)->Destroy(*basis));
   if ((*basis)->contract) CeedCall(CeedTensorContractDestroy(&(*basis)->contract));
   CeedCall(CeedFree(&(*basis)->interp));

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -989,7 +989,10 @@ int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream) {
   @ref User
 **/
 int CeedElemRestrictionDestroy(CeedElemRestriction *rstr) {
-  if (!*rstr || --(*rstr)->ref_count > 0) return CEED_ERROR_SUCCESS;
+  if (!*rstr || --(*rstr)->ref_count > 0) {
+    *rstr = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if ((*rstr)->num_readers) {
     // LCOV_EXCL_START
     return CeedError((*rstr)->ceed, CEED_ERROR_ACCESS, "Cannot destroy CeedElemRestriction, a process has read access to the offset data");

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1731,7 +1731,10 @@ int CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedReq
   @ref User
 **/
 int CeedOperatorDestroy(CeedOperator *op) {
-  if (!*op || --(*op)->ref_count > 0) return CEED_ERROR_SUCCESS;
+  if (!*op || --(*op)->ref_count > 0) {
+    *op = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if ((*op)->Destroy) CeedCall((*op)->Destroy(*op));
   CeedCall(CeedDestroy(&(*op)->ceed));
   // Free fields

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -1075,8 +1075,10 @@ int CeedQFunctionAssemblyDataGetObjects(CeedQFunctionAssemblyData data, CeedVect
   @ref Backend
 **/
 int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data) {
-  if (!*data || --(*data)->ref_count > 0) return CEED_ERROR_SUCCESS;
-
+  if (!*data || --(*data)->ref_count > 0) {
+    *data = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   CeedCall(CeedDestroy(&(*data)->ceed));
   CeedCall(CeedVectorDestroy(&(*data)->vec));
   CeedCall(CeedElemRestrictionDestroy(&(*data)->rstr));
@@ -1491,8 +1493,10 @@ int CeedOperatorAssemblyDataGetElemRestrictions(CeedOperatorAssemblyData data, C
   @ref Backend
 **/
 int CeedOperatorAssemblyDataDestroy(CeedOperatorAssemblyData *data) {
-  if (!*data) return CEED_ERROR_SUCCESS;
-
+  if (!*data) {
+    *data = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   CeedCall(CeedDestroy(&(*data)->ceed));
   for (CeedInt b = 0; b < (*data)->num_active_bases; b++) {
     CeedCall(CeedBasisDestroy(&(*data)->active_bases[b]));

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -1024,7 +1024,10 @@ int CeedQFunctionApply(CeedQFunction qf, CeedInt Q, CeedVector *u, CeedVector *v
   @ref User
 **/
 int CeedQFunctionDestroy(CeedQFunction *qf) {
-  if (!*qf || --(*qf)->ref_count > 0) return CEED_ERROR_SUCCESS;
+  if (!*qf || --(*qf)->ref_count > 0) {
+    *qf = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   // Backend destroy
   if ((*qf)->Destroy) {
     CeedCall((*qf)->Destroy(*qf));

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -942,8 +942,10 @@ int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_m
   @ref User
 **/
 int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx) {
-  if (!*ctx || --(*ctx)->ref_count > 0) return CEED_ERROR_SUCCESS;
-
+  if (!*ctx || --(*ctx)->ref_count > 0) {
+    *ctx = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if ((*ctx) && ((*ctx)->state % 2) == 1) {
     // LCOV_EXCL_START
     return CeedError((*ctx)->ceed, 1, "Cannot destroy CeedQFunctionContext, the access lock is in use");

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -150,7 +150,10 @@ int CeedTensorContractReference(CeedTensorContract contract) {
   @ref Backend
 **/
 int CeedTensorContractDestroy(CeedTensorContract *contract) {
-  if (!*contract || --(*contract)->ref_count > 0) return CEED_ERROR_SUCCESS;
+  if (!*contract || --(*contract)->ref_count > 0) {
+    *contract = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if ((*contract)->Destroy) {
     CeedCall((*contract)->Destroy(*contract));
   }

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -889,8 +889,10 @@ int CeedVectorGetLength(CeedVector vec, CeedSize *length) {
   @ref User
 **/
 int CeedVectorDestroy(CeedVector *vec) {
-  if (!*vec || --(*vec)->ref_count > 0) return CEED_ERROR_SUCCESS;
-
+  if (!*vec || --(*vec)->ref_count > 0) {
+    *vec = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if (((*vec)->state % 2) == 1) {
     return CeedError((*vec)->ceed, CEED_ERROR_ACCESS, "Cannot destroy CeedVector, the writable access lock is in use");
   }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1038,7 +1038,10 @@ int CeedView(Ceed ceed, FILE *stream) {
   @ref User
 **/
 int CeedDestroy(Ceed *ceed) {
-  if (!*ceed || --(*ceed)->ref_count > 0) return CEED_ERROR_SUCCESS;
+  if (!*ceed || --(*ceed)->ref_count > 0) {
+    *ceed = NULL;
+    return CEED_ERROR_SUCCESS;
+  }
   if ((*ceed)->delegate) CeedCall(CeedDestroy(&(*ceed)->delegate));
 
   if ((*ceed)->obj_delegate_count > 0) {


### PR DESCRIPTION
Currently, if an Ceed* object is referenced elsewhere, the caller could be left with a valid reference to a Ceed* object after calling `Ceed*Destroy`. This can lead to confusing bugs if the order of control flow is changed.