### PR TITLE
Add CeedOperatorGetContext

### DIFF
--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -116,12 +116,12 @@ CEED_INTERN int CeedFree(void *p);
   do {                         \
     int ierr_q_ = __VA_ARGS__; \
     CeedChk(ierr_q_);          \
-  } while (0);
+  } while (0)
 #define CeedCallBackend(...)   \
   do {                         \
     int ierr_q_ = __VA_ARGS__; \
     CeedChkBackend(ierr_q_);   \
-  } while (0);
+  } while (0)
 
 /* Note that CeedMalloc and CeedCalloc will, generally, return pointers with different memory alignments:
    CeedMalloc returns pointers aligned at CEED_ALIGN bytes, while CeedCalloc uses the alignment of calloc. */

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -507,6 +507,7 @@ CEED_EXTERN int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed);
 CEED_EXTERN int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem);
 CEED_EXTERN int CeedOperatorGetNumQuadraturePoints(CeedOperator op, CeedInt *num_qpts);
 CEED_EXTERN int CeedOperatorGetFlopsEstimate(CeedOperator op, CeedSize *flops);
+CEED_EXTERN int CeedOperatorGetContext(CeedOperator op, CeedQFunctionContext *ctx);
 CEED_EXTERN int CeedOperatorContextGetFieldLabel(CeedOperator op, const char *field_name, CeedContextFieldLabel *field_label);
 CEED_EXTERN int CeedOperatorContextSetDouble(CeedOperator op, CeedContextFieldLabel field_label, double *values);
 CEED_EXTERN int CeedOperatorContextGetDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const double **values);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1426,6 +1426,30 @@ int CeedOperatorGetFlopsEstimate(CeedOperator op, CeedSize *flops) {
 }
 
 /**
+  @brief Get CeedQFunction global context for a CeedOperator.
+           Note: The caller is responsible for destroying `ctx` returned from this function via `CeedQFunctionContextDestroy()`.
+           Note: If the value of `ctx` passed into this function is non-NULL, then it is assumed that `ctx` is a valid pointer to a
+             CeedQFunctionContext. This CeedQFunctionContext will be destroyed if `ctx` is the only reference to this CeedQFunctionContext.
+
+  @param[in]  qf  CeedQFunction
+  @param[out] ctx Variable to store CeedQFunctionContext
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedOperatorGetContext(CeedOperator op, CeedQFunctionContext *ctx) {
+  bool is_composite;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  if (is_composite) return CeedError(op->ceed, CEED_ERROR_INCOMPATIBLE, "Cannot retrieve QFunctionContext for composite operator");
+
+  if (op->qf->ctx) CeedCall(CeedQFunctionContextReferenceCopy(op->qf->ctx, ctx));
+  else *ctx = NULL;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Get label for a registered QFunctionContext field, or `NULL` if no field has been registered with this `field_name`.
 
   @param[in]  op          CeedOperator

--- a/tests/t525-operator.c
+++ b/tests/t525-operator.c
@@ -104,6 +104,18 @@ int main(int argc, char **argv) {
   CeedOperatorContextGetFieldLabel(op_composite, "bad", &bad_label);
   if (bad_label) printf("Incorrect context label returned\n");
 
+  {
+    // Check getting reference to QFunctionContext
+    CeedQFunctionContext ctx_copy = NULL;
+
+    CeedOperatorGetContext(op_sub_1, &ctx_copy);
+    if (ctx_copy != qf_ctx_sub_1) printf("Incorrect QFunctionContext retrieved");
+
+    CeedOperatorGetContext(op_sub_2, &ctx_copy);  // Destroys reference to qf_ctx_sub_1
+    if (ctx_copy != qf_ctx_sub_2) printf("Incorrect QFunctionContext retrieved");
+    CeedQFunctionContextDestroy(&ctx_copy);  // Cleanup to prevent leak
+  }
+
   CeedQFunctionContextDestroy(&qf_ctx_sub_1);
   CeedQFunctionContextDestroy(&qf_ctx_sub_2);
   CeedQFunctionDestroy(&qf_sub_1);


### PR DESCRIPTION
Adding `CeedOperatorGetContext` provides more ways to get at the context data without dragging around a big struct