### PR TITLE
fluids: Use ContextGetDouble for time and dt label updates

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -168,7 +168,7 @@ struct User_private {
   CeedVector   q_ceed, q_dot_ceed, g_ceed, coo_values_amat, coo_values_pmat, x_ceed;
   CeedOperator op_rhs_vol, op_rhs, op_ifunction_vol, op_ifunction, op_ijacobian, op_dirichlet;
   bool         matrices_set_up;
-  CeedScalar   time, dt, time_bc_set;
+  CeedScalar   time_bc_set;
   Span_Stats   spanstats;
 };
 


### PR DESCRIPTION
Instead of using `user->{time,dt}` to keep track of what data is set in the QFContext labels (used for determining when to update the labels), use the `CeedOperatorGetContextDoubleRead` and friends to get the label data directly.