### PR TITLE
fluids: Move to local Vec storage and petsc-ops

### DIFF
--- a/examples/fluids/include/petsc_ops.h
+++ b/examples/fluids/include/petsc_ops.h
@@ -25,6 +25,7 @@ PetscErrorCode OperatorApplyContextCreate(DM dm_x, DM dm_y, Ceed ceed, CeedOpera
 PetscErrorCode OperatorApplyContextDestroy(OperatorApplyContext op_apply_ctx);
 PetscErrorCode MatGetDiag_Ceed(Mat A, Vec D);
 PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y);
+PetscErrorCode CreateMatShell_Ceed(OperatorApplyContext ctx, Mat *mat);
 
 PetscErrorCode VecP2C(Vec X_petsc, PetscMemType *mem_type, CeedVector x_ceed);
 PetscErrorCode VecC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc);

--- a/examples/fluids/include/petsc_ops.h
+++ b/examples/fluids/include/petsc_ops.h
@@ -38,6 +38,7 @@ VecType        DMReturnVecType(DM dm);
 PetscErrorCode ApplyCeedOperatorGlobalToGlobal(Vec X, Vec Y, OperatorApplyContext ctx);
 PetscErrorCode ApplyCeedOperatorGlobalToLocal(Vec X, Vec Y_loc, OperatorApplyContext ctx);
 PetscErrorCode ApplyCeedOperatorLocalToGlobal(Vec X_loc, Vec Y, OperatorApplyContext ctx);
+PetscErrorCode ApplyCeedOperatorLocalToLocal(Vec X_loc, Vec Y_loc, OperatorApplyContext ctx);
 PetscErrorCode ApplyAddCeedOperatorLocalToLocal(Vec X_loc, Vec Y_loc, OperatorApplyContext ctx);
 
 #endif  // petsc_ops_h

--- a/examples/fluids/include/petsc_ops.h
+++ b/examples/fluids/include/petsc_ops.h
@@ -31,6 +31,8 @@ PetscErrorCode VecC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc);
 PetscErrorCode VecReadP2C(Vec X_petsc, PetscMemType *mem_type, CeedVector x_ceed);
 PetscErrorCode VecReadC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc);
 PetscErrorCode VecCopyP2C(Vec X_petsc, CeedVector x_ceed);
+PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, MPI_Comm comm, Vec *input, Vec *output);
+VecType        DMReturnVecType(DM dm);
 
 PetscErrorCode ApplyCeedOperatorGlobalToGlobal(Vec X, Vec Y, OperatorApplyContext ctx);
 PetscErrorCode ApplyCeedOperatorGlobalToLocal(Vec X, Vec Y_loc, OperatorApplyContext ctx);

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -155,16 +155,7 @@ int main(int argc, char **argv) {
   }
 
   // ---------------------------------------------------------------------------
-  // Set up libCEED
-  // ---------------------------------------------------------------------------
-  // -- Set up libCEED objects
-  PetscCall(SetupLibceed(ceed, ceed_data, dm, user, app_ctx, problem, bc));
-
-  if (app_ctx->turb_spanstats_enable) PetscCall(SetupStatsCollection(ceed, user, ceed_data, problem));
-  if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SGS_DD_ModelSetup(ceed, user, ceed_data, problem));
-
-  // ---------------------------------------------------------------------------
-  // Set up ICs
+  // Create solution vectors
   // ---------------------------------------------------------------------------
   // -- Set up global state vector Q
   Vec Q;
@@ -176,6 +167,18 @@ int main(int argc, char **argv) {
   PetscCall(DMCreateLocalVector(dm, &user->Q_dot_loc));
   PetscCall(VecZeroEntries(user->Q_dot_loc));
 
+  // ---------------------------------------------------------------------------
+  // Set up libCEED
+  // ---------------------------------------------------------------------------
+  // -- Set up libCEED objects
+  PetscCall(SetupLibceed(ceed, ceed_data, dm, user, app_ctx, problem, bc));
+
+  if (app_ctx->turb_spanstats_enable) PetscCall(SetupStatsCollection(ceed, user, ceed_data, problem));
+  if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SGS_DD_ModelSetup(ceed, user, ceed_data, problem));
+
+  // ---------------------------------------------------------------------------
+  // Set up ICs
+  // ---------------------------------------------------------------------------
   // -- Fix multiplicity for ICs
   PetscCall(ICs_FixMultiplicity(dm, ceed_data, user, user->Q_loc, Q, 0.0));
 
@@ -363,7 +366,7 @@ int main(int argc, char **argv) {
 
   // -- Operators
   CeedOperatorDestroy(&ceed_data->op_setup_vol);
-  CeedOperatorDestroy(&ceed_data->op_ics);
+  PetscCall(OperatorApplyContextDestroy(ceed_data->op_ics_ctx));
   CeedOperatorDestroy(&user->op_rhs_vol);
   CeedOperatorDestroy(&user->op_ifunction_vol);
   CeedOperatorDestroy(&user->op_rhs);

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -144,15 +144,9 @@ int main(int argc, char **argv) {
 
   // -- Set up DM
   PetscCall(SetUpDM(dm, problem, app_ctx->degree, bc, phys_ctx));
-  PetscCall(CreateStatsDM(user, problem, app_ctx->degree, bc));
-  app_ctx->wall_forces.num_wall = bc->num_wall;
-  PetscMalloc1(bc->num_wall, &app_ctx->wall_forces.walls);
-  PetscCall(PetscArraycpy(app_ctx->wall_forces.walls, bc->walls, bc->num_wall));
 
   // -- Refine DM for high-order viz
-  if (app_ctx->viz_refine) {
-    PetscCall(VizRefineDM(dm, user, problem, bc, phys_ctx));
-  }
+  if (app_ctx->viz_refine) PetscCall(VizRefineDM(dm, user, problem, bc, phys_ctx));
 
   // ---------------------------------------------------------------------------
   // Create solution vectors
@@ -172,9 +166,6 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   // -- Set up libCEED objects
   PetscCall(SetupLibceed(ceed, ceed_data, dm, user, app_ctx, problem, bc));
-
-  if (app_ctx->turb_spanstats_enable) PetscCall(SetupStatsCollection(ceed, user, ceed_data, problem));
-  if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SGS_DD_ModelSetup(ceed, user, ceed_data, problem));
 
   // ---------------------------------------------------------------------------
   // Set up ICs
@@ -311,7 +302,7 @@ int main(int argc, char **argv) {
   // Destroy libCEED objects
   // ---------------------------------------------------------------------------
 
-  PetscCall(DestroyStats(user, ceed_data));
+  PetscCall(TurbulenceStatisticsDestroy(user, ceed_data));
   PetscCall(NodalProjectionDataDestroy(user->grad_velo_proj));
   PetscCall(SGS_DD_DataDestroy(user->sgs_dd_data));
 

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
   {
     PetscErrorCode (*p)(ProblemData *, DM, void *, SimpleBC);
     PetscCall(PetscFunctionListFind(app_ctx->problems, app_ctx->problem_name, &p));
-    if (!p) SETERRQ(PETSC_COMM_SELF, 1, "Problem '%s' not found", app_ctx->problem_name);
+    PetscCheck(p, PETSC_COMM_SELF, 1, "Problem '%s' not found", app_ctx->problem_name);
     PetscCall((*p)(problem, dm, &user, bc));
   }
 

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -360,7 +360,7 @@ int main(int argc, char **argv) {
   PetscCall(OperatorApplyContextDestroy(ceed_data->op_ics_ctx));
   CeedOperatorDestroy(&user->op_rhs_vol);
   CeedOperatorDestroy(&user->op_ifunction_vol);
-  CeedOperatorDestroy(&user->op_rhs);
+  PetscCall(OperatorApplyContextDestroy(user->op_rhs_ctx));
   CeedOperatorDestroy(&user->op_ifunction);
   CeedOperatorDestroy(&user->op_ijacobian);
 

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -177,10 +177,10 @@ int main(int argc, char **argv) {
   // Set up lumped mass matrix
   // ---------------------------------------------------------------------------
   // -- Set up global mass vector
-  PetscCall(VecDuplicate(Q, &user->M));
+  PetscCall(VecDuplicate(Q, &user->M_inv));
 
   // -- Compute lumped mass matrix
-  PetscCall(ComputeLumpedMassMatrix(ceed, dm, ceed_data, user->M));
+  PetscCall(ComputeLumpedMassMatrix(ceed, dm, ceed_data, user->M_inv));
 
   // ---------------------------------------------------------------------------
   // Record boundary values from initial condition
@@ -372,7 +372,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   // -- Vectors
   PetscCall(VecDestroy(&Q));
-  PetscCall(VecDestroy(&user->M));
+  PetscCall(VecDestroy(&user->M_inv));
   PetscCall(VecDestroy(&user->Q_loc));
   PetscCall(VecDestroy(&user->Q_dot_loc));
 

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -175,22 +175,23 @@ typedef struct {
 
 // PETSc user data
 struct User_private {
-  MPI_Comm            comm;
-  DM                  dm;
-  DM                  dm_viz;
-  Mat                 interp_viz;
-  Ceed                ceed;
-  Units               units;
-  Vec                 M, Q_loc, Q_dot_loc;
-  Physics             phys;
-  AppCtx              app_ctx;
-  CeedVector          q_ceed, q_dot_ceed, g_ceed, coo_values_amat, coo_values_pmat, x_ceed;
-  CeedOperator        op_rhs_vol, op_rhs, op_ifunction_vol, op_ifunction, op_ijacobian, op_dirichlet;
-  bool                matrices_set_up;
-  CeedScalar          time_bc_set;
-  Span_Stats          spanstats;
-  NodalProjectionData grad_velo_proj;
-  SGS_DD_Data         sgs_dd_data;
+  MPI_Comm             comm;
+  DM                   dm;
+  DM                   dm_viz;
+  Mat                  interp_viz;
+  Ceed                 ceed;
+  Units                units;
+  Vec                  M, Q_loc, Q_dot_loc;
+  Physics              phys;
+  AppCtx               app_ctx;
+  CeedVector           q_ceed, q_dot_ceed, g_ceed, coo_values_amat, coo_values_pmat, x_ceed;
+  CeedOperator         op_rhs_vol, op_rhs, op_ifunction_vol, op_ifunction, op_ijacobian;
+  OperatorApplyContext op_dirichlet_ctx;
+  bool                 matrices_set_up;
+  CeedScalar           time_bc_set;
+  Span_Stats           spanstats;
+  NodalProjectionData  grad_velo_proj;
+  SGS_DD_Data          sgs_dd_data;
 };
 
 // Units

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -186,8 +186,8 @@ struct User_private {
   Physics              phys;
   AppCtx               app_ctx;
   CeedVector           q_ceed, q_dot_ceed, g_ceed, coo_values_amat, coo_values_pmat, x_ceed;
-  CeedOperator         op_rhs_vol, op_rhs, op_ifunction_vol, op_ifunction, op_ijacobian;
-  OperatorApplyContext op_strong_bc_ctx;
+  CeedOperator         op_rhs_vol, op_ifunction_vol, op_ifunction, op_ijacobian;
+  OperatorApplyContext op_rhs_ctx, op_strong_bc_ctx;
   bool                 matrices_set_up;
   CeedScalar           time_bc_set;
   Span_Stats           spanstats;

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -149,10 +149,9 @@ struct CeedData_private {
 typedef struct {
   DM                    dm;
   PetscSF               sf;  // For communicating child data to parents
-  CeedOperator          op_stats_collect, op_stats_proj;
+  OperatorApplyContext  op_stats_collect_ctx, op_proj_rhs_ctx;
   PetscInt              num_comp_stats;
-  CeedVector            child_stats, parent_stats;  // collocated statistics data
-  CeedVector            rhs_ceed;
+  Vec                   Child_Stats_loc, Parent_Stats_loc;
   KSP                   ksp;         // For the L^2 projection solve
   CeedScalar            span_width;  // spanwise width of the child domain
   PetscBool             do_mms_test;

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -186,7 +186,7 @@ struct User_private {
   AppCtx               app_ctx;
   CeedVector           q_ceed, q_dot_ceed, g_ceed, coo_values_amat, coo_values_pmat, x_ceed;
   CeedOperator         op_rhs_vol, op_rhs, op_ifunction_vol, op_ifunction, op_ijacobian;
-  OperatorApplyContext op_dirichlet_ctx;
+  OperatorApplyContext op_strong_bc_ctx;
   bool                 matrices_set_up;
   CeedScalar           time_bc_set;
   Span_Stats           spanstats;
@@ -254,7 +254,7 @@ struct ProblemData_private {
   bool non_zero_time;
   PetscErrorCode (*bc)(PetscInt, PetscReal, const PetscReal[], PetscInt, PetscScalar[], void *);
   void     *bc_ctx;
-  PetscBool bc_from_ics, use_dirichlet_ceed;
+  PetscBool bc_from_ics, use_strong_bc_ceed;
   PetscErrorCode (*print_info)(ProblemData *, AppCtx);
 };
 

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -392,10 +392,9 @@ PetscErrorCode PHASTADatFileReadToArrayReal(const MPI_Comm comm, const char path
 // Turbulence Statistics Collection Functions
 // -----------------------------------------------------------------------------
 
-PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree, SimpleBC bc);
-PetscErrorCode SetupStatsCollection(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
-PetscErrorCode TSMonitor_Statistics(TS ts, PetscInt steps, PetscReal solution_time, Vec Q, void *ctx);
-PetscErrorCode DestroyStats(User user, CeedData ceed_data);
+PetscErrorCode TurbulenceStatisticsSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
+PetscErrorCode TSMonitor_TurbulenceStatistics(TS ts, PetscInt steps, PetscReal solution_time, Vec Q, void *ctx);
+PetscErrorCode TurbulenceStatisticsDestroy(User user, CeedData ceed_data);
 
 // -----------------------------------------------------------------------------
 // Data-Driven Subgrid Stress (DD-SGS) Modeling Functions
@@ -414,7 +413,7 @@ PetscErrorCode GridAnisotropyTensorProjectionSetupApply(Ceed ceed, User user, Ce
 // -----------------------------------------------------------------------------
 
 // Setup StrongBCs that use QFunctions
-PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData *problem, SimpleBC bc, CeedInt Q_sur,
+PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData *problem, SimpleBC bc, CeedInt Q_sur,
                                   CeedInt q_data_size_sur);
 
 PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -138,11 +138,12 @@ struct AppCtx_private {
 
 // libCEED data struct
 struct CeedData_private {
-  CeedVector          x_coord, q_data;
-  CeedBasis           basis_x, basis_xc, basis_q, basis_x_sur, basis_q_sur, basis_xc_sur;
-  CeedElemRestriction elem_restr_x, elem_restr_q, elem_restr_qd_i;
-  CeedOperator        op_setup_vol, op_ics;
-  CeedQFunction       qf_setup_vol, qf_ics, qf_rhs_vol, qf_ifunction_vol, qf_setup_sur, qf_apply_inflow, qf_apply_inflow_jacobian, qf_apply_outflow,
+  CeedVector           x_coord, q_data;
+  CeedBasis            basis_x, basis_xc, basis_q, basis_x_sur, basis_q_sur, basis_xc_sur;
+  CeedElemRestriction  elem_restr_x, elem_restr_q, elem_restr_qd_i;
+  CeedOperator         op_setup_vol;
+  OperatorApplyContext op_ics_ctx;
+  CeedQFunction        qf_setup_vol, qf_ics, qf_rhs_vol, qf_ifunction_vol, qf_setup_sur, qf_apply_inflow, qf_apply_inflow_jacobian, qf_apply_outflow,
       qf_apply_outflow_jacobian, qf_apply_freestream, qf_apply_freestream_jacobian;
 };
 

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -182,7 +182,7 @@ struct User_private {
   Mat                  interp_viz;
   Ceed                 ceed;
   Units                units;
-  Vec                  M, Q_loc, Q_dot_loc;
+  Vec                  M_inv, Q_loc, Q_dot_loc;
   Physics              phys;
   AppCtx               app_ctx;
   CeedVector           q_ceed, q_dot_ceed, g_ceed, coo_values_amat, coo_values_pmat, x_ceed;

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -204,9 +204,8 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx, SimpleBC 
   if (stab == STAB_SUPG && !implicit) {
     PetscCall(PetscPrintf(comm, "Warning! Use -stab supg only with -implicit\n"));
   }
-  if (state_var == STATEVAR_PRIMITIVE && !implicit) {
-    SETERRQ(comm, PETSC_ERR_SUP, "RHSFunction is not provided for primitive variables (use -state_var primitive only with -implicit)\n");
-  }
+  PetscCheck(!(state_var == STATEVAR_PRIMITIVE && !implicit), comm, PETSC_ERR_SUP,
+             "RHSFunction is not provided for primitive variables (use -state_var primitive only with -implicit)\n");
 
   PetscCall(PetscOptionsScalar("-idl_decay_time", "Characteristic timescale of the pressure deviance decay. The timestep is good starting point",
                                NULL, idl_decay_time, &idl_decay_time, &idl_enable));

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -292,7 +292,7 @@ PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem, 
 
   if (use_stgstrong) {
     // Use default boundary integral QF (BoundaryIntegral) in newtonian.h
-    problem->use_dirichlet_ceed = PETSC_TRUE;
+    problem->use_strong_bc_ceed = PETSC_TRUE;
     problem->bc_from_ics        = PETSC_FALSE;
   } else {
     problem->apply_inflow.qfunction              = STGShur14_Inflow;

--- a/examples/fluids/qfunctions/freestream_bc.h
+++ b/examples/fluids/qfunctions/freestream_bc.h
@@ -145,10 +145,12 @@ CEED_QFUNCTION_HELPER void ComputeHLLSpeeds_Roe_fwd(NewtonianIdealGasContext gas
 // Taking in two states (left, right) and returns RiemannFlux_HLL.
 // The left and right states are specified from the perspective of an outward-facing normal vector pointing left to right.
 //
-// @param gas    NewtonianIdealGasContext for the fluid
-// @param left   Fluid state of the domain interior (the current solution)
-// @param right  Fluid state of the domain exterior (free stream conditions)
-// @param normal Normalized, outward facing boundary normal vector
+// @param[in] gas    NewtonianIdealGasContext for the fluid
+// @param[in] left   Fluid state of the domain interior (the current solution)
+// @param[in] right  Fluid state of the domain exterior (free stream conditions)
+// @param[in] normal Normalized, outward facing boundary normal vector
+//
+// @return StateConservative with HLL Riemann Flux
 // *****************************************************************************
 CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLL(NewtonianIdealGasContext gas, State left, State right, const CeedScalar normal[3]) {
   StateConservative flux_left  = FluxInviscidDotNormal(gas, left, normal);
@@ -179,6 +181,8 @@ CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLL(NewtonianIdealGasContext
 // @param dleft  Derivative of fluid state of the domain interior (the current solution)
 // @param dright Derivative of fluid state of the domain exterior (free stream conditions)
 // @param normal Normalized, outward facing boundary normal vector
+//
+// @return StateConservative with derivative of HLL Riemann Flux
 // *****************************************************************************
 CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLL_fwd(NewtonianIdealGasContext gas, State left, State dleft, State right, State dright,
                                                             const CeedScalar normal[3]) {

--- a/examples/fluids/qfunctions/strong_boundary_conditions.h
+++ b/examples/fluids/qfunctions/strong_boundary_conditions.h
@@ -5,12 +5,12 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef dirichlet_boundary_h
-#define dirichlet_boundary_h
+#ifndef strong_boundary_conditions_h
+#define strong_boundary_conditions_h
 
 #include <ceed.h>
 
-CEED_QFUNCTION(SetupDirichletBC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+CEED_QFUNCTION(SetupStrongBC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
   const CeedScalar(*coords)[CEED_Q_VLA]       = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*multiplicity)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
@@ -26,4 +26,4 @@ CEED_QFUNCTION(SetupDirichletBC)(void *ctx, CeedInt Q, const CeedScalar *const *
   return 0;
 }
 
-#endif  // dirichlet_boundary_h
+#endif  // strong_boundary_conditions_h

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -143,9 +143,8 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
     for (PetscInt c = 0; c < 3; c++) {
       for (PetscInt s = 0; s < bc->num_slip[c]; s++) {
         for (PetscInt w = 0; w < bc->num_wall; w++) {
-          if (bc->slips[c][s] == bc->walls[w]) {
-            SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONG, "Boundary condition already set on face %" PetscInt_FMT "!\n", bc->walls[w]);
-          }
+          PetscCheck(bc->slips[c][s] != bc->walls[w], PETSC_COMM_SELF, PETSC_ERR_ARG_WRONG,
+                     "Boundary condition already set on face %" PetscInt_FMT "!\n", bc->walls[w]);
         }
       }
     }

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -149,6 +149,9 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
       }
     }
   }
+  app_ctx->wall_forces.num_wall = bc->num_wall;
+  PetscMalloc1(bc->num_wall, &app_ctx->wall_forces.walls);
+  PetscCall(PetscArraycpy(app_ctx->wall_forces.walls, bc->walls, bc->num_wall));
 
   // Inflow BCs
   bc->num_inflow = 16;

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -21,7 +21,7 @@ PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_l
   // ---------------------------------------------------------------------------
   // Update time for evaluation
   // ---------------------------------------------------------------------------
-  if (user->phys->ics_time_label) CeedOperatorSetContextDouble(ceed_data->op_ics, user->phys->ics_time_label, &time);
+  if (user->phys->ics_time_label) CeedOperatorSetContextDouble(ceed_data->op_ics_ctx->op, user->phys->ics_time_label, &time);
 
   // ---------------------------------------------------------------------------
   // ICs
@@ -31,18 +31,7 @@ PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_l
   CeedElemRestrictionCreateVector(ceed_data->elem_restr_q, &q0_ceed, NULL);
 
   // -- Place PETSc vector in CEED vector
-  PetscMemType q0_mem_type;
-  PetscCall(VecP2C(Q_loc, &q0_mem_type, q0_ceed));
-
-  // -- Apply CEED Operator
-  CeedOperatorApply(ceed_data->op_ics, ceed_data->x_coord, q0_ceed, CEED_REQUEST_IMMEDIATE);
-
-  // -- Restore vectors
-  PetscCall(VecC2P(q0_ceed, q0_mem_type, Q_loc));
-
-  // -- Local-to-Global
-  PetscCall(VecZeroEntries(Q));
-  PetscCall(DMLocalToGlobal(dm, Q_loc, ADD_VALUES, Q));
+  PetscCall(ApplyCeedOperatorLocalToGlobal(NULL, Q, ceed_data->op_ics_ctx));
 
   // ---------------------------------------------------------------------------
   // Fix multiplicity for output of ICs

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -254,35 +254,27 @@ int FreeContextPetsc(void *data) {
 
 // Return mass qfunction specification for number of components N
 PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, CeedQFunction *qf) {
-  CeedQFunctionUser qfunction_ptr;
-  const char       *qfunction_loc;
   PetscFunctionBeginUser;
 
   switch (N) {
     case 1:
-      qfunction_ptr = Mass_1;
-      qfunction_loc = Mass_1_loc;
+      CeedQFunctionCreateInterior(ceed, 1, Mass_1, Mass_1_loc, qf);
       break;
     case 5:
-      qfunction_ptr = Mass_5;
-      qfunction_loc = Mass_5_loc;
+      CeedQFunctionCreateInterior(ceed, 1, Mass_5, Mass_5_loc, qf);
       break;
     case 7:
-      qfunction_ptr = Mass_7;
-      qfunction_loc = Mass_7_loc;
+      CeedQFunctionCreateInterior(ceed, 1, Mass_7, Mass_7_loc, qf);
       break;
     case 9:
-      qfunction_ptr = Mass_9;
-      qfunction_loc = Mass_9_loc;
+      CeedQFunctionCreateInterior(ceed, 1, Mass_9, Mass_9_loc, qf);
       break;
     case 22:
-      qfunction_ptr = Mass_22;
-      qfunction_loc = Mass_22_loc;
+      CeedQFunctionCreateInterior(ceed, 1, Mass_22, Mass_22_loc, qf);
       break;
     default:
-      SETERRQ(PETSC_COMM_WORLD, -1, "Could not find mass qfunction of size %d", N);
+      SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "Could not find mass qfunction of size %d", N);
   }
-  CeedQFunctionCreateInterior(ceed, 1, qfunction_ptr, qfunction_loc, qf);
 
   CeedQFunctionAddInput(*qf, "u", N, CEED_EVAL_INTERP);
   CeedQFunctionAddInput(*qf, "qdata", q_data_size, CEED_EVAL_NONE);

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -89,7 +89,7 @@ PetscErrorCode DMPlexInsertBoundaryValues_NS(DM dm, PetscBool insert_essential, 
   Vec Qbc, boundary_mask;
   PetscFunctionBegin;
 
-  // Mask (zero) Dirichlet entries
+  // Mask (zero) Strong BC entries
   PetscCall(DMGetNamedLocalVector(dm, "boundary mask", &boundary_mask));
   PetscCall(VecPointwiseMult(Q_loc, Q_loc, boundary_mask));
   PetscCall(DMRestoreNamedLocalVector(dm, "boundary mask", &boundary_mask));

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -357,9 +357,7 @@ PetscErrorCode PHASTADatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_
   PetscCall(PetscFOpen(comm, path, "r", fp));
   PetscCall(PetscSynchronizedFGets(comm, *fp, char_array_len, line));
   PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
-  if (ndims != 2) {
-    SETERRQ(comm, -1, "Found %" PetscInt_FMT " dimensions instead of 2 on the first line of %s", ndims, path);
-  }
+  PetscCheck(ndims == 2, comm, PETSC_ERR_FILE_UNEXPECTED, "Found %" PetscInt_FMT " dimensions instead of 2 on the first line of %s", ndims, path);
 
   for (PetscInt i = 0; i < ndims; i++) dims[i] = atoi(array[i]);
   PetscCall(PetscStrToArrayDestroy(ndims, array));
@@ -402,10 +400,9 @@ PetscErrorCode PHASTADatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC
   for (PetscInt i = 0; i < dims[0]; i++) {
     PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
     PetscCall(PetscStrToArray(line, ' ', &ndims, &row_array));
-    if (ndims < dims[1]) {
-      SETERRQ(comm, -1, "Line %" PetscInt_FMT " of %s does not contain enough columns (%" PetscInt_FMT " instead of %" PetscInt_FMT ")", i, path,
-              ndims, dims[1]);
-    }
+    PetscCheck(ndims == dims[1], comm, PETSC_ERR_FILE_UNEXPECTED,
+               "Line %" PetscInt_FMT " of %s does not contain enough columns (%" PetscInt_FMT " instead of %" PetscInt_FMT ")", i, path, ndims,
+               dims[1]);
 
     for (PetscInt j = 0; j < dims[1]; j++) {
       array[i * dims[1] + j] = (PetscReal)atof(row_array[j]);

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -302,14 +302,14 @@ PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, MP
 /**
  * @brief Apply FEM Operator defined by `OperatorApplyContext` to various input and output vectors
  *
- * @param X             Input global `Vec`, maybe `NULL`
- * @param X_loc         Input local `Vec`, maybe `NULL`
- * @param x_ceed        Input `CeedVector`, maybe `CEED_VECTOR_NONE`
- * @param y_ceed        Output `CeedVector`, maybe `CEED_VECTOR_NONE`
- * @param Y_loc         Output local `Vec`, maybe `NULL`
- * @param Y             Output global `Vec`, maybe `NULL`
- * @param ctx           Context for the operator apply
- * @param use_apply_add Whether to use `CeedOperatorApply` or `CeedOperatorApplyAdd`
+ * @param[in]     X             Input global `Vec`, maybe `NULL`
+ * @param[in]     X_loc         Input local `Vec`, maybe `NULL`
+ * @param[in]     x_ceed        Input `CeedVector`, maybe `CEED_VECTOR_NONE`
+ * @param[in,out] y_ceed        Output `CeedVector`, maybe `CEED_VECTOR_NONE`
+ * @param[in,out] Y_loc         Output local `Vec`, maybe `NULL`
+ * @param[in,out] Y             Output global `Vec`, maybe `NULL`
+ * @param[in]     ctx           Context for the operator apply
+ * @param[in]     use_apply_add Whether to use `CeedOperatorApply` or `CeedOperatorApplyAdd`
  */
 PetscErrorCode ApplyCeedOperator_Core(Vec X, Vec X_loc, CeedVector x_ceed, CeedVector y_ceed, Vec Y_loc, Vec Y, OperatorApplyContext ctx,
                                       bool use_apply_add) {

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -357,6 +357,12 @@ PetscErrorCode ApplyCeedOperatorGlobalToLocal(Vec X, Vec Y_loc, OperatorApplyCon
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode ApplyCeedOperatorLocalToLocal(Vec X_loc, Vec Y_loc, OperatorApplyContext ctx) {
+  PetscFunctionBeginUser;
+  PetscCall(ApplyCeedOperator_Core(NULL, X_loc, ctx->x_ceed, ctx->y_ceed, Y_loc, NULL, ctx, false));
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode ApplyAddCeedOperatorLocalToLocal(Vec X_loc, Vec Y_loc, OperatorApplyContext ctx) {
   PetscFunctionBeginUser;
   PetscCall(ApplyCeedOperator_Core(NULL, X_loc, ctx->x_ceed, ctx->y_ceed, Y_loc, NULL, ctx, true));

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -12,6 +12,32 @@
 
 #include "../navierstokes.h"
 
+// @brief Get information about a DM's local vector
+PetscErrorCode DMGetLocalVectorInfo(DM dm, PetscInt *local_size, PetscInt *global_size, VecType *vec_type) {
+  Vec V_loc;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMGetLocalVector(dm, &V_loc));
+  if (local_size) PetscCall(VecGetLocalSize(V_loc, local_size));
+  if (global_size) PetscCall(VecGetSize(V_loc, global_size));
+  if (vec_type) PetscCall(VecGetType(V_loc, vec_type));
+  PetscCall(DMRestoreLocalVector(dm, &V_loc));
+  PetscFunctionReturn(0);
+}
+
+// @brief Get information about a DM's global vector
+PetscErrorCode DMGetGlobalVectorInfo(DM dm, PetscInt *local_size, PetscInt *global_size, VecType *vec_type) {
+  Vec V;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMGetGlobalVector(dm, &V));
+  if (local_size) PetscCall(VecGetLocalSize(V, local_size));
+  if (global_size) PetscCall(VecGetSize(V, global_size));
+  if (vec_type) PetscCall(VecGetType(V, vec_type));
+  PetscCall(DMRestoreGlobalVector(dm, &V));
+  PetscFunctionReturn(0);
+}
+
 /**
  * @brief Create OperatorApplyContext struct for applying FEM operator in a PETSc context
  *

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -63,16 +63,41 @@ PetscErrorCode OperatorApplyContextCreate(DM dm_x, DM dm_y, Ceed ceed, CeedOpera
   PetscFunctionBeginUser;
   CeedOperatorGetActiveVectorLengths(op_apply, &x_size, &y_size);
   {  // Verify sizes
-    PetscInt X_size, Y_size;
+    PetscInt X_size, Y_size, dm_X_size, dm_Y_size;
+    CeedSize x_ceed_size, y_ceed_size;
+    if (dm_x) PetscCall(DMGetLocalVectorInfo(dm_x, &dm_X_size, NULL, NULL));
+    if (dm_y) PetscCall(DMGetLocalVectorInfo(dm_y, &dm_Y_size, NULL, NULL));
     if (X_loc) {
       PetscCall(VecGetLocalSize(X_loc, &X_size));
       PetscCheck(X_size == x_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
                  "X_loc (%" PetscInt_FMT ") not correct size for CeedOperator active input size (%" CeedSize_FMT ")", X_size, x_size);
+      if (dm_x)
+        PetscCheck(X_size == dm_X_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
+                   "X_loc size (%" PetscInt_FMT ") does not match dm_x local vector size (%" PetscInt_FMT ")", X_size, dm_X_size);
     }
     if (Y_loc) {
       PetscCall(VecGetLocalSize(Y_loc, &Y_size));
       PetscCheck(Y_size == y_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
                  "Y_loc (%" PetscInt_FMT ") not correct size for CeedOperator active output size (%" CeedSize_FMT ")", Y_size, y_size);
+      if (dm_y)
+        PetscCheck(Y_size == dm_Y_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
+                   "Y_loc size (%" PetscInt_FMT ") does not match dm_y local vector size (%" PetscInt_FMT ")", Y_size, dm_Y_size);
+    }
+    if (x_ceed && x_ceed != CEED_VECTOR_NONE) {
+      CeedVectorGetLength(x_ceed, &x_ceed_size);
+      PetscCheck(x_size >= 0 ? x_ceed_size == x_size : true, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
+                 "x_ceed (%" CeedSize_FMT ") not correct size for CeedOperator active input size (%" CeedSize_FMT ")", x_ceed_size, x_size);
+      if (dm_x)
+        PetscCheck(x_ceed_size == dm_X_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
+                   "x_ceed size (%" CeedSize_FMT ") does not match dm_x local vector size (%" PetscInt_FMT ")", x_ceed_size, dm_X_size);
+    }
+    if (y_ceed && y_ceed != CEED_VECTOR_NONE) {
+      CeedVectorGetLength(y_ceed, &y_ceed_size);
+      PetscCheck(y_ceed_size == y_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
+                 "y_ceed (%" CeedSize_FMT ") not correct size for CeedOperator active input size (%" CeedSize_FMT ")", y_ceed_size, y_size);
+      if (dm_y)
+        PetscCheck(y_ceed_size == dm_Y_size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ,
+                   "y_ceed size (%" CeedSize_FMT ") does not match dm_y local vector size (%" PetscInt_FMT ")", y_ceed_size, dm_Y_size);
     }
   }
 

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -449,8 +449,7 @@ PetscErrorCode CreateMatShell_Ceed(OperatorApplyContext ctx, Mat *mat) {
   VecType  X_vec_type, Y_vec_type;
 
   PetscFunctionBeginUser;
-
-  PetscCheck(comm_x == comm_y, PETSC_COMM_WORLD, PETSC_ERR_ARG_NOTSAMECOMM, "Input and output comm must be the same");
+  PetscCheck(comm_x == comm_y, PETSC_COMM_WORLD, PETSC_ERR_ARG_NOTSAMECOMM, "Input and output DM must have the same comm");
 
   PetscCall(DMGetGlobalVectorInfo(ctx->dm_x, &X_loc_size, &X_size, &X_vec_type));
   PetscCall(DMGetGlobalVectorInfo(ctx->dm_y, &Y_loc_size, &Y_size, &Y_vec_type));

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -77,10 +77,7 @@ PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, SimpleBC bc
     {
       PetscBool use_strongstg = PETSC_FALSE;
       PetscCall(PetscOptionsGetBool(NULL, NULL, "-stg_strong", &use_strongstg, NULL));
-
-      if (use_strongstg) {
-        PetscCall(SetupStrongSTG(dm, bc, problem, phys));
-      }
+      if (use_strongstg) PetscCall(SetupStrongSTG(dm, bc, problem, phys));
     }
 
     PetscCall(DMPlexSetClosurePermutationTensor(dm, PETSC_DETERMINE, NULL));

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -336,11 +336,14 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   CeedOperatorSetField(ceed_data->op_setup_vol, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
 
   // -- Create CEED operator for ICs
-  CeedOperatorCreate(ceed, ceed_data->qf_ics, NULL, NULL, &ceed_data->op_ics);
-  CeedOperatorSetField(ceed_data->op_ics, "x", ceed_data->elem_restr_x, ceed_data->basis_xc, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(ceed_data->op_ics, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, ceed_data->q_data);
-  CeedOperatorSetField(ceed_data->op_ics, "q0", ceed_data->elem_restr_q, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-  CeedOperatorGetContextFieldLabel(ceed_data->op_ics, "evaluation time", &user->phys->ics_time_label);
+  CeedOperator op_ics;
+  CeedOperatorCreate(ceed, ceed_data->qf_ics, NULL, NULL, &op_ics);
+  CeedOperatorSetField(op_ics, "x", ceed_data->elem_restr_x, ceed_data->basis_xc, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_ics, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, ceed_data->q_data);
+  CeedOperatorSetField(op_ics, "q0", ceed_data->elem_restr_q, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+  CeedOperatorGetContextFieldLabel(op_ics, "evaluation time", &user->phys->ics_time_label);
+  PetscCall(OperatorApplyContextCreate(NULL, dm, user->ceed, op_ics, ceed_data->x_coord, NULL, NULL, user->Q_loc, &ceed_data->op_ics_ctx));
+  CeedOperatorDestroy(&op_ics);
 
   // Create CEED operator for RHS
   if (ceed_data->qf_rhs_vol) {

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -437,10 +437,12 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     if (user->op_ijacobian) {
       CeedOperatorGetContextFieldLabel(user->op_ijacobian, "ijacobian time shift", &user->phys->ijacobian_time_shift_label);
     }
-    if (problem->use_strong_bc_ceed) {
-      PetscCall(SetupStrongBC_Ceed(ceed, ceed_data, dm, user, app_ctx, problem, bc, Q_sur, q_data_size_sur));
-    }
+    if (problem->use_strong_bc_ceed) PetscCall(SetupStrongBC_Ceed(ceed, ceed_data, dm, user, problem, bc, Q_sur, q_data_size_sur));
+    if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SGS_DD_ModelSetup(ceed, user, ceed_data, problem));
   }
+
+  if (app_ctx->turb_spanstats_enable) PetscCall(TurbulenceStatisticsSetup(ceed, user, ceed_data, problem));
+
   CeedElemRestrictionDestroy(&elem_restr_jd_i);
   CeedOperatorDestroy(&op_ijacobian_vol);
   CeedVectorDestroy(&jac_data);

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -429,8 +429,11 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
 
   // -- Create and apply CEED Composite Operator for the entire domain
   if (!user->phys->implicit) {  // RHS
-    PetscCall(CreateOperatorForDomain(ceed, dm, bc, ceed_data, user->phys, user->op_rhs_vol, NULL, height, P_sur, Q_sur, q_data_size_sur, 0,
-                                      &user->op_rhs, NULL));
+    CeedOperator op_rhs;
+    PetscCall(CreateOperatorForDomain(ceed, dm, bc, ceed_data, user->phys, user->op_rhs_vol, NULL, height, P_sur, Q_sur, q_data_size_sur, 0, &op_rhs,
+                                      NULL));
+    PetscCall(OperatorApplyContextCreate(dm, dm, ceed, op_rhs, user->q_ceed, user->g_ceed, user->Q_loc, NULL, &user->op_rhs_ctx));
+    CeedOperatorDestroy(&op_rhs);
   } else {  // IFunction
     PetscCall(CreateOperatorForDomain(ceed, dm, bc, ceed_data, user->phys, user->op_ifunction_vol, op_ijacobian_vol, height, P_sur, Q_sur,
                                       q_data_size_sur, jac_data_size_sur, &user->op_ifunction, op_ijacobian_vol ? &user->op_ijacobian : NULL));

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -434,7 +434,7 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     if (user->op_ijacobian) {
       CeedOperatorGetContextFieldLabel(user->op_ijacobian, "ijacobian time shift", &user->phys->ijacobian_time_shift_label);
     }
-    if (problem->use_dirichlet_ceed) {
+    if (problem->use_strong_bc_ceed) {
       PetscCall(SetupStrongBC_Ceed(ceed, ceed_data, dm, user, app_ctx, problem, bc, Q_sur, q_data_size_sur));
     }
   }

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -539,7 +539,7 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
       }
     }
   } else {
-    if (!user->op_rhs) SETERRQ(comm, PETSC_ERR_ARG_NULL, "Problem does not provide RHSFunction");
+    PetscCheck(user->op_rhs, comm, PETSC_ERR_ARG_NULL, "Problem does not provide RHSFunction");
     PetscCall(TSSetType(*ts, TSRK));
     PetscCall(TSRKSetType(*ts, TSRK5F));
     PetscCall(TSSetRHSFunction(*ts, NULL, RHS_NS, &user));

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -108,7 +108,7 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   PetscCall(ApplyCeedOperatorGlobalToGlobal(Q, G, user->op_rhs_ctx));
 
   // Inverse of the lumped mass matrix (M is Minv)
-  PetscCall(VecPointwiseMult(G, G, user->M));
+  PetscCall(VecPointwiseMult(G, G, user->M_inv));
 
   PetscFunctionReturn(0);
 }

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -510,7 +510,7 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
     PetscCall(TSMonitorSet(*ts, TSMonitor_WallForce, user, NULL));
   }
   if (app_ctx->turb_spanstats_enable) {
-    PetscCall(TSMonitorSet(*ts, TSMonitor_Statistics, user, NULL));
+    PetscCall(TSMonitorSet(*ts, TSMonitor_TurbulenceStatistics, user, NULL));
     CeedScalar previous_time = app_ctx->cont_time * user->units->second;
     CeedOperatorSetContextDouble(user->spanstats.op_stats_collect_ctx->op, user->spanstats.previous_time_label, &previous_time);
   }

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -582,7 +582,7 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
   if (app_ctx->turb_spanstats_enable) {
     PetscCall(TSMonitorSet(*ts, TSMonitor_Statistics, user, NULL));
     CeedScalar previous_time = app_ctx->cont_time * user->units->second;
-    CeedOperatorSetContextDouble(user->spanstats.op_stats_collect, user->spanstats.previous_time_label, &previous_time);
+    CeedOperatorSetContextDouble(user->spanstats.op_stats_collect_ctx->op, user->spanstats.previous_time_label, &previous_time);
   }
 
   // Solve

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -248,7 +248,7 @@ static PetscErrorCode FormSetValues(User user, PetscBool pbdiagonal, Mat J, Ceed
   PetscFunctionBeginUser;
   PetscCall(MatGetType(J, &mat_type));
   if (strstr(mat_type, "kokkos") || strstr(mat_type, "cusparse")) mem_type = CEED_MEM_DEVICE;
-  if (user->app_ctx->pmat_pbdiagonal) {
+  if (pbdiagonal) {
     CeedOperatorLinearAssemblePointBlockDiagonal(user->op_ijacobian, coo_values, CEED_REQUEST_IMMEDIATE);
   } else {
     CeedOperatorLinearAssemble(user->op_ijacobian, coo_values);

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -5,21 +5,22 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
+#include "../qfunctions/strong_boundary_conditions.h"
+
 #include <ceed.h>
 #include <petscdmplex.h>
 
 #include "../navierstokes.h"
 #include "../problems/stg_shur14.h"
-#include "../qfunctions/dirichlet_boundary.h"
 
 PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, AppCtx app_ctx, ProblemData *problem, SimpleBC bc, Physics phys,
-                                   CeedInt Q_sur, CeedInt q_data_size_sur, CeedOperator op_dirichlet) {
+                                   CeedInt Q_sur, CeedInt q_data_size_sur, CeedOperator op_strong_bc) {
   CeedInt             num_comp_x = problem->dim, num_comp_q = 5, num_elem, elem_size, stg_data_size = 1;
   CeedVector          multiplicity, x_stored, scale_stored, q_data_sur, stg_data;
   CeedBasis           basis_x_to_q_sur;
   CeedElemRestriction elem_restr_x_sur, elem_restr_q_sur, elem_restr_x_stored, elem_restr_scale, elem_restr_qd_sur, elem_restr_stgdata;
   CeedQFunction       qf_setup, qf_strongbc, qf_stgdata;
-  CeedOperator        op_setup, op_dirichlet_sub, op_setup_sur, op_stgdata;
+  CeedOperator        op_setup, op_strong_bc_sub, op_setup_sur, op_stgdata;
   DMLabel             domain_label;
 
   PetscFunctionBeginUser;
@@ -30,7 +31,7 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, AppCtx 
   PetscCall(CeedBasisCreateProjection(ceed_data->basis_x_sur, ceed_data->basis_q_sur, &basis_x_to_q_sur));
 
   // Setup QFunction
-  CeedQFunctionCreateInterior(ceed, 1, SetupDirichletBC, SetupDirichletBC_loc, &qf_setup);
+  CeedQFunctionCreateInterior(ceed, 1, SetupStrongBC, SetupStrongBC_loc, &qf_setup);
   CeedQFunctionAddInput(qf_setup, "x", num_comp_x, CEED_EVAL_INTERP);
   CeedQFunctionAddInput(qf_setup, "multiplicity", num_comp_q, CEED_EVAL_NONE);
   CeedQFunctionAddOutput(qf_setup, "x stored", num_comp_x, CEED_EVAL_NONE);
@@ -90,18 +91,18 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, AppCtx 
 
     // -- Setup BC QFunctions
     SetupStrongSTG_QF(ceed, problem, num_comp_x, num_comp_q, stg_data_size, q_data_size_sur, &qf_strongbc);
-    CeedOperatorCreate(ceed, qf_strongbc, NULL, NULL, &op_dirichlet_sub);
-    CeedOperatorSetName(op_dirichlet_sub, "Strong STG");
+    CeedOperatorCreate(ceed, qf_strongbc, NULL, NULL, &op_strong_bc_sub);
+    CeedOperatorSetName(op_strong_bc_sub, "Strong STG");
 
-    CeedOperatorSetField(op_dirichlet_sub, "surface qdata", elem_restr_qd_sur, CEED_BASIS_COLLOCATED, q_data_sur);
-    CeedOperatorSetField(op_dirichlet_sub, "x", elem_restr_x_stored, CEED_BASIS_COLLOCATED, x_stored);
-    CeedOperatorSetField(op_dirichlet_sub, "scale", elem_restr_scale, CEED_BASIS_COLLOCATED, scale_stored);
-    CeedOperatorSetField(op_dirichlet_sub, "stg data", elem_restr_stgdata, CEED_BASIS_COLLOCATED, stg_data);
-    CeedOperatorSetField(op_dirichlet_sub, "q", elem_restr_q_sur, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetNumQuadraturePoints(op_dirichlet_sub, elem_size);
+    CeedOperatorSetField(op_strong_bc_sub, "surface qdata", elem_restr_qd_sur, CEED_BASIS_COLLOCATED, q_data_sur);
+    CeedOperatorSetField(op_strong_bc_sub, "x", elem_restr_x_stored, CEED_BASIS_COLLOCATED, x_stored);
+    CeedOperatorSetField(op_strong_bc_sub, "scale", elem_restr_scale, CEED_BASIS_COLLOCATED, scale_stored);
+    CeedOperatorSetField(op_strong_bc_sub, "stg data", elem_restr_stgdata, CEED_BASIS_COLLOCATED, stg_data);
+    CeedOperatorSetField(op_strong_bc_sub, "q", elem_restr_q_sur, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+    CeedOperatorSetNumQuadraturePoints(op_strong_bc_sub, elem_size);
 
     // -- Add to composite operator
-    CeedCompositeOperatorAddSub(op_dirichlet, op_dirichlet_sub);
+    CeedCompositeOperatorAddSub(op_strong_bc, op_strong_bc_sub);
 
     CeedVectorDestroy(&q_data_sur);
     CeedVectorDestroy(&multiplicity);
@@ -117,12 +118,12 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, AppCtx 
     CeedQFunctionDestroy(&qf_strongbc);
     CeedQFunctionDestroy(&qf_stgdata);
     CeedOperatorDestroy(&op_setup_sur);
-    CeedOperatorDestroy(&op_dirichlet_sub);
+    CeedOperatorDestroy(&op_strong_bc_sub);
     CeedOperatorDestroy(&op_setup);
     CeedOperatorDestroy(&op_stgdata);
   }
 
-  CeedOperatorGetContextFieldLabel(op_dirichlet, "solution time", &phys->stg_solution_time_label);
+  CeedOperatorGetContextFieldLabel(op_strong_bc, "solution time", &phys->stg_solution_time_label);
 
   CeedBasisDestroy(&basis_x_to_q_sur);
   CeedQFunctionDestroy(&qf_setup);
@@ -139,22 +140,22 @@ PetscErrorCode DMPlexInsertBoundaryValues_StrongBCCeed(DM dm, PetscBool insert_e
   PetscCall(DMGetApplicationContext(dm, &user));
 
   if (user->phys->stg_solution_time_label) {
-    CeedOperatorSetContextDouble(user->op_dirichlet_ctx->op, user->phys->stg_solution_time_label, &time);
+    CeedOperatorSetContextDouble(user->op_strong_bc_ctx->op, user->phys->stg_solution_time_label, &time);
   }
 
-  // Mask Dirichlet entries
+  // Mask Strong BC entries
   PetscCall(DMGetNamedLocalVector(dm, "boundary mask", &boundary_mask));
   PetscCall(VecPointwiseMult(Q_loc, Q_loc, boundary_mask));
   PetscCall(DMRestoreNamedLocalVector(dm, "boundary mask", &boundary_mask));
 
-  PetscCall(ApplyAddCeedOperatorLocalToLocal(NULL, Q_loc, user->op_dirichlet_ctx));
+  PetscCall(ApplyAddCeedOperatorLocalToLocal(NULL, Q_loc, user->op_strong_bc_ctx));
 
   PetscFunctionReturn(0);
 }
 
 PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData *problem, SimpleBC bc, CeedInt Q_sur,
                                   CeedInt q_data_size_sur) {
-  CeedOperator op_dirichlet;
+  CeedOperator op_strong_bc;
 
   PetscFunctionBeginUser;
   {
@@ -169,17 +170,17 @@ PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User use
     PetscCall(DMRestoreGlobalVector(dm, &global_vec));
   }
 
-  CeedCompositeOperatorCreate(ceed, &op_dirichlet);
+  CeedCompositeOperatorCreate(ceed, &op_strong_bc);
   {
     PetscBool use_strongstg = PETSC_FALSE;
     PetscCall(PetscOptionsGetBool(NULL, NULL, "-stg_strong", &use_strongstg, NULL));
 
     if (use_strongstg) {
-      PetscCall(SetupStrongSTG_Ceed(ceed, ceed_data, dm, app_ctx, problem, bc, user->phys, Q_sur, q_data_size_sur, op_dirichlet));
+      PetscCall(SetupStrongSTG_Ceed(ceed, ceed_data, dm, app_ctx, problem, bc, user->phys, Q_sur, q_data_size_sur, op_strong_bc));
     }
   }
 
-  PetscCall(OperatorApplyContextCreate(NULL, NULL, ceed, op_dirichlet, CEED_VECTOR_NONE, NULL, NULL, NULL, &user->op_dirichlet_ctx));
+  PetscCall(OperatorApplyContextCreate(NULL, NULL, ceed, op_strong_bc, CEED_VECTOR_NONE, NULL, NULL, NULL, &user->op_strong_bc_ctx));
 
   PetscCall(PetscObjectComposeFunction((PetscObject)dm, "DMPlexInsertBoundaryValues_C", DMPlexInsertBoundaryValues_StrongBCCeed));
   PetscFunctionReturn(0);

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -13,8 +13,8 @@
 #include "../navierstokes.h"
 #include "../problems/stg_shur14.h"
 
-PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, AppCtx app_ctx, ProblemData *problem, SimpleBC bc, Physics phys,
-                                   CeedInt Q_sur, CeedInt q_data_size_sur, CeedOperator op_strong_bc) {
+PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, ProblemData *problem, SimpleBC bc, Physics phys, CeedInt Q_sur,
+                                   CeedInt q_data_size_sur, CeedOperator op_strong_bc) {
   CeedInt             num_comp_x = problem->dim, num_comp_q = 5, num_elem, elem_size, stg_data_size = 1;
   CeedVector          multiplicity, x_stored, scale_stored, q_data_sur, stg_data;
   CeedBasis           basis_x_to_q_sur;
@@ -153,7 +153,7 @@ PetscErrorCode DMPlexInsertBoundaryValues_StrongBCCeed(DM dm, PetscBool insert_e
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData *problem, SimpleBC bc, CeedInt Q_sur,
+PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData *problem, SimpleBC bc, CeedInt Q_sur,
                                   CeedInt q_data_size_sur) {
   CeedOperator op_strong_bc;
 
@@ -176,7 +176,7 @@ PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User use
     PetscCall(PetscOptionsGetBool(NULL, NULL, "-stg_strong", &use_strongstg, NULL));
 
     if (use_strongstg) {
-      PetscCall(SetupStrongSTG_Ceed(ceed, ceed_data, dm, app_ctx, problem, bc, user->phys, Q_sur, q_data_size_sur, op_strong_bc));
+      PetscCall(SetupStrongSTG_Ceed(ceed, ceed_data, dm, problem, bc, user->phys, Q_sur, q_data_size_sur, op_strong_bc));
     }
   }
 


### PR DESCRIPTION
- Move everything possible over to petsc-ops
- Any continually change data shifted to use Petsc Vec
   -  (Mainly geared at turbulence spanwise statistics)
- Switch IJacobian to use petsc-ops
- Add `CreateMatShell_Ceed` for creating `Mat`
- Move feature-specific setup from `navierstokes.c` to somewhere else (mostly `src/setuplibceed.c`)
- Small cleanups/improvements

Depends on #1149 


Closes #1142 