### PR TITLE
Add CeedCheck macro to reduce repetition

### DIFF
--- a/backends/avx/ceed-avx-blocked.c
+++ b/backends/avx/ceed-avx-blocked.c
@@ -16,11 +16,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Avx(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/avx") && strcmp(resource, "/cpu/self/avx/blocked")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "AVX backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/avx") || !strcmp(resource, "/cpu/self/avx/blocked"), ceed,
+            CEED_ERROR_BACKEND, "AVX backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/avx/ceed-avx-serial.c
+++ b/backends/avx/ceed-avx-serial.c
@@ -16,11 +16,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Avx(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/avx/serial")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "AVX backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/avx/serial"), ceed, CEED_ERROR_BACKEND,
+            "AVX backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -419,11 +419,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(CeedOperator o
   CeedCallBackend(CeedOperatorSetup_Blocked(op));
 
   // Check for identity
-  if (impl->is_identity_qf) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!impl->is_identity_qf, ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
 
   // Input Evecs and Restriction
   CeedCallBackend(CeedOperatorSetupInputs_Blocked(num_input_fields, qf_input_fields, op_input_fields, NULL, true, e_data_full, impl, request));
@@ -467,11 +463,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Blocked(CeedOperator o
   }
 
   // Check sizes
-  if (!num_active_in || !num_active_out) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(num_active_in > 0 && num_active_out > 0, ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
 
   // Setup Lvec
   if (!l_vec) {

--- a/backends/blocked/ceed-blocked.c
+++ b/backends/blocked/ceed-blocked.c
@@ -16,11 +16,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 CEED_INTERN int CeedInit_Blocked(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/ref/blocked")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Blocked backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/ref/blocked"), ceed, CEED_ERROR_BACKEND,
+            "Blocked backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/ceed-backend-weak.c
+++ b/backends/ceed-backend-weak.c
@@ -12,9 +12,7 @@
 // LCOV_EXCL_START
 // This function provides improved error messages for uncompiled backends
 static int CeedInit_Weak(const char *resource, Ceed ceed) {
-  return CeedError(ceed, CEED_ERROR_UNSUPPORTED,
-                   "Backend not currently compiled: %s\n"
-                   "Consult the installation instructions to compile this backend",
+  return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend not currently compiled: %s\nConsult the installation instructions to compile this backend",
                    resource);
 }
 

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -61,10 +61,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
     CeedEvalMode eval_mode_in, eval_mode_out;
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[0], &eval_mode_in));
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[0], &eval_mode_out));
-    if (eval_mode_in == CEED_EVAL_NONE && eval_mode_out == CEED_EVAL_NONE)
-      // LCOV_EXCL_START
-      return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement restriction only identity operators");
-    // LCOV_EXCL_STOP
+    CeedCheck(eval_mode_in != CEED_EVAL_NONE || eval_mode_out != CEED_EVAL_NONE, ceed, CEED_ERROR_BACKEND,
+              "Backend does not implement restriction only identity operators");
   }
 
   ostringstream code;
@@ -124,15 +122,10 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       CeedCallBackend(CeedBasisGetDimension(basis, &dim));
       bool isTensor;
       CeedCallBackend(CeedBasisIsTensor(basis, &isTensor));
-      if (isTensor) {
-        CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
-        CeedCallBackend(CeedBasisGetNumNodes1D(basis, &P_1d));
-        if (P_1d > data->max_P_1d) data->max_P_1d = P_1d;
-      } else {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(isTensor, ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
+      CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
+      CeedCallBackend(CeedBasisGetNumNodes1D(basis, &P_1d));
+      if (P_1d > data->max_P_1d) data->max_P_1d = P_1d;
     }
   }
   // Check output bases for Q_1d, dim as well
@@ -148,13 +141,8 @@ extern "C" int CeedCudaGenOperatorBuild(CeedOperator op) {
       CeedCallBackend(CeedBasisGetDimension(basis, &dim));
       bool isTensor;
       CeedCallBackend(CeedBasisIsTensor(basis, &isTensor));
-      if (isTensor) {
-        CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
-      } else {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(isTensor, ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
+      CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
     }
   }
   data->dim  = dim;

--- a/backends/cuda-gen/ceed-cuda-gen-qfunction.c
+++ b/backends/cuda-gen/ceed-cuda-gen-qfunction.c
@@ -50,11 +50,7 @@ int CeedQFunctionCreate_Cuda_gen(CeedQFunction qf) {
   CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &data->q_function_source));
   CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
-  if (!data->q_function_source) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "/gpu/cuda/gen backend requires QFunction source code file");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(data->q_function_source, ceed, CEED_ERROR_UNSUPPORTED, "/gpu/cuda/gen backend requires QFunction source code file");
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Apply", CeedQFunctionApply_Cuda_gen));
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Destroy", CeedQFunctionDestroy_Cuda_gen));

--- a/backends/cuda-gen/ceed-cuda-gen.c
+++ b/backends/cuda-gen/ceed-cuda-gen.c
@@ -19,11 +19,8 @@
 static int CeedInit_Cuda_gen(const char *resource, Ceed ceed) {
   char *resource_root;
   CeedCallBackend(CeedCudaGetResourceRoot(ceed, resource, &resource_root));
-  if (strcmp(resource_root, "/gpu/cuda") && strcmp(resource_root, "/gpu/cuda/gen")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cuda backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource_root, "/gpu/cuda") || !strcmp(resource_root, "/gpu/cuda/gen"), ceed, CEED_ERROR_BACKEND,
+            "Cuda backend cannot use resource: %s", resource);
   CeedCallBackend(CeedFree(&resource_root));
 
   Ceed_Cuda *data;

--- a/backends/cuda-ref/ceed-cuda-ref-basis.c
+++ b/backends/cuda-ref/ceed-cuda-ref-basis.c
@@ -31,9 +31,8 @@ int CeedBasisApply_Cuda(CeedBasis basis, const CeedInt num_elem, CeedTransposeMo
   // Read vectors
   const CeedScalar *d_u;
   CeedScalar       *d_v;
-  if (eval_mode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
-  }
+  if (u != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
+  else CeedCheck(eval_mode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
   CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
 
   // Clear v for transpose operation

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -164,7 +164,7 @@ static int CeedOperatorSetupFields_Cuda(CeedQFunction qf, CeedOperator op, bool 
         CeedCallBackend(CeedOperatorFieldGetBasis(opfields[i], &basis));
         q_size = (CeedSize)numelements * Q;
         CeedCallBackend(CeedVectorCreate(ceed, q_size, &qvecs[i]));
-        CeedCallBackend(CeedBasisApply(basis, numelements, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, NULL, qvecs[i]));
+        CeedCallBackend(CeedBasisApply(basis, numelements, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, CEED_VECTOR_NONE, qvecs[i]));
         break;
       case CEED_EVAL_DIV:
         break;  // TODO: Not implemented
@@ -463,11 +463,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op, 
   // Check for identity
   bool identityqf;
   CeedCallBackend(CeedQFunctionIsIdentity(qf, &identityqf));
-  if (identityqf) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!identityqf, ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
 
   // Input Evecs and Restriction
   CeedCallBackend(CeedOperatorSetupInputs_Cuda(numinputfields, qfinputfields, opinputfields, NULL, true, edata, impl, request));
@@ -511,11 +507,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op, 
   }
 
   // Check sizes
-  if (!numactivein || !numactiveout) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(numactivein > 0 && numactiveout > 0, ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
 
   // Build objects if needed
   if (build_objects) {
@@ -651,11 +643,8 @@ static inline int CeedOperatorAssembleDiagonalSetup_Cuda(CeedOperator op, const 
       CeedCallBackend(CeedBasisGetNumComponents(basisin, &ncomp));
       CeedCallBackend(CeedBasisGetDimension(basisin, &dim));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(opfields[i], &rstr));
-      if (rstrin && rstrin != rstr) {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator diagonal assembly");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(!rstrin || rstrin == rstr, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement multi-field non-composite operator diagonal assembly");
       rstrin = rstr;
       CeedEvalMode emode;
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qffields[i], &emode));
@@ -693,11 +682,8 @@ static inline int CeedOperatorAssembleDiagonalSetup_Cuda(CeedOperator op, const 
       CeedElemRestriction rstr;
       CeedCallBackend(CeedOperatorFieldGetBasis(opfields[i], &basisout));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(opfields[i], &rstr));
-      if (rstrout && rstrout != rstr) {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator diagonal assembly");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(!rstrout || rstrout == rstr, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement multi-field non-composite operator diagonal assembly");
       rstrout = rstr;
       CeedEvalMode emode;
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qffields[i], &emode));
@@ -951,11 +937,7 @@ static int CeedSingleOperatorAssembleSetup_Cuda(CeedOperator op) {
     if (vec == CEED_VECTOR_ACTIVE) {
       CeedCallBackend(CeedOperatorFieldGetBasis(output_fields[i], &basis_out));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr_out));
-      if (rstr_out && rstr_out != rstr_in) {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator assembly");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(!rstr_out || rstr_out == rstr_in, ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator assembly");
       CeedEvalMode eval_mode;
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
       if (eval_mode != CEED_EVAL_NONE) {
@@ -972,12 +954,7 @@ static int CeedSingleOperatorAssembleSetup_Cuda(CeedOperator op) {
       }
     }
   }
-
-  if (num_emode_in == 0 || num_emode_out == 0) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(num_emode_in > 0 && num_emode_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
 
   CeedInt nelem, ncomp;
   CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &nelem));

--- a/backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp
@@ -30,11 +30,7 @@ extern "C" int CeedCudaBuildQFunction(CeedQFunction qf) {
   // QFunction is built
   if (data->QFunction) return CEED_ERROR_SUCCESS;
 
-  if (!data->qfunction_source) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No QFunction source or CUfunction provided.");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(data->qfunction_source, ceed, CEED_ERROR_BACKEND, "No QFunction source or CUfunction provided.");
 
   // QFunction kernel generation
   CeedInt             num_input_fields, num_output_fields, size;

--- a/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
@@ -23,11 +23,7 @@ static inline int CeedQFunctionContextSyncH2D_Cuda(const CeedQFunctionContext ct
   CeedQFunctionContext_Cuda *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  if (!impl->h_data) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->h_data, ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
 
   size_t ctxsize;
   CeedCallBackend(CeedQFunctionContextGetContextSize(ctx, &ctxsize));
@@ -55,11 +51,7 @@ static inline int CeedQFunctionContextSyncD2H_Cuda(const CeedQFunctionContext ct
   CeedQFunctionContext_Cuda *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  if (!impl->d_data) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->d_data, ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
 
   size_t ctxsize;
   CeedCallBackend(CeedQFunctionContextGetContextSize(ctx, &ctxsize));

--- a/backends/cuda-ref/ceed-cuda-ref.c
+++ b/backends/cuda-ref/ceed-cuda-ref.c
@@ -41,11 +41,7 @@ int CeedCudaGetCublasHandle(Ceed ceed, cublasHandle_t *handle) {
 static int CeedInit_Cuda(const char *resource, Ceed ceed) {
   char *resource_root;
   CeedCallBackend(CeedCudaGetResourceRoot(ceed, resource, &resource_root));
-  if (strcmp(resource_root, "/gpu/cuda/ref")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cuda backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource_root, "/gpu/cuda/ref"), ceed, CEED_ERROR_BACKEND, "Cuda backend cannot use resource: %s", resource);
   CeedCallBackend(CeedFree(&resource_root));
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -124,7 +124,7 @@ CEED_INTERN int CeedBasisApplyElems_Cuda(CeedBasis basis, const CeedInt num_elem
 CEED_INTERN int CeedQFunctionApplyElems_Cuda(CeedQFunction qf, const CeedInt Q, const CeedVector *const u, const CeedVector *v);
 
 CEED_INTERN int CeedBasisCreateTensorH1_Cuda(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
-                                             const CeedScalar *qref_1d, const CeedScalar *qweight_1d, CeedBasis basis);
+                                             const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);
 
 CEED_INTERN int CeedBasisCreateH1_Cuda(CeedElemTopology, CeedInt, CeedInt, CeedInt, const CeedScalar *, const CeedScalar *, const CeedScalar *,
                                        const CeedScalar *, CeedBasis);

--- a/backends/cuda-ref/ceed-cuda-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-restriction.c
@@ -259,55 +259,60 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType m_type, CeedCopyMode copy_mode, c
   CeedCallBackend(CeedElemRestrictionSetELayout(r, layout));
 
   // Set up device indices/offset arrays
-  if (m_type == CEED_MEM_HOST) {
-    switch (copy_mode) {
-      case CEED_OWN_POINTER:
-        impl->h_ind_allocated = (CeedInt *)indices;
-        impl->h_ind           = (CeedInt *)indices;
-        break;
-      case CEED_USE_POINTER:
-        impl->h_ind = (CeedInt *)indices;
-        break;
-      case CEED_COPY_VALUES:
-        if (indices != NULL) {
-          CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-          memcpy(impl->h_ind_allocated, indices, elem_size * num_elem * sizeof(CeedInt));
-          impl->h_ind = impl->h_ind_allocated;
-        }
-        break;
+  switch (m_type) {
+    case CEED_MEM_HOST: {
+      switch (copy_mode) {
+        case CEED_OWN_POINTER:
+          impl->h_ind_allocated = (CeedInt *)indices;
+          impl->h_ind           = (CeedInt *)indices;
+          break;
+        case CEED_USE_POINTER:
+          impl->h_ind = (CeedInt *)indices;
+          break;
+        case CEED_COPY_VALUES:
+          if (indices != NULL) {
+            CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
+            memcpy(impl->h_ind_allocated, indices, elem_size * num_elem * sizeof(CeedInt));
+            impl->h_ind = impl->h_ind_allocated;
+          }
+          break;
+      }
+      if (indices != NULL) {
+        CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
+        impl->d_ind_allocated = impl->d_ind;  // We own the device memory
+        CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyHostToDevice));
+        CeedCallBackend(CeedElemRestrictionOffset_Cuda(r, indices));
+      }
+      break;
     }
-    if (indices != NULL) {
-      CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-      impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-      CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyHostToDevice));
-      CeedCallBackend(CeedElemRestrictionOffset_Cuda(r, indices));
+    case CEED_MEM_DEVICE: {
+      switch (copy_mode) {
+        case CEED_COPY_VALUES:
+          if (indices != NULL) {
+            CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
+            impl->d_ind_allocated = impl->d_ind;  // We own the device memory
+            CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyDeviceToDevice));
+          }
+          break;
+        case CEED_OWN_POINTER:
+          impl->d_ind           = (CeedInt *)indices;
+          impl->d_ind_allocated = impl->d_ind;
+          break;
+        case CEED_USE_POINTER:
+          impl->d_ind = (CeedInt *)indices;
+      }
+      if (indices != NULL) {
+        CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
+        CeedCallCuda(ceed, cudaMemcpy(impl->h_ind_allocated, impl->d_ind, elem_size * num_elem * sizeof(CeedInt), cudaMemcpyDeviceToHost));
+        impl->h_ind = impl->h_ind_allocated;
+        CeedCallBackend(CeedElemRestrictionOffset_Cuda(r, indices));
+      }
+      break;
     }
-  } else if (m_type == CEED_MEM_DEVICE) {
-    switch (copy_mode) {
-      case CEED_COPY_VALUES:
-        if (indices != NULL) {
-          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-          impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-          CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyDeviceToDevice));
-        }
-        break;
-      case CEED_OWN_POINTER:
-        impl->d_ind           = (CeedInt *)indices;
-        impl->d_ind_allocated = impl->d_ind;
-        break;
-      case CEED_USE_POINTER:
-        impl->d_ind = (CeedInt *)indices;
-    }
-    if (indices != NULL) {
-      CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-      CeedCallCuda(ceed, cudaMemcpy(impl->h_ind_allocated, impl->d_ind, elem_size * num_elem * sizeof(CeedInt), cudaMemcpyDeviceToHost));
-      impl->h_ind = impl->h_ind_allocated;
-      CeedCallBackend(CeedElemRestrictionOffset_Cuda(r, indices));
-    }
-  } else {
     // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
-    // LCOV_EXCL_STOP
+    default:
+      return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
+      // LCOV_EXCL_STOP
   }
 
   // Compile CUDA kernels

--- a/backends/cuda-ref/ceed-cuda-vector.c
+++ b/backends/cuda-ref/ceed-cuda-vector.c
@@ -46,11 +46,7 @@ static inline int CeedVectorSyncH2D_Cuda(const CeedVector vec) {
   CeedVector_Cuda *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  if (!impl->h_array) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->h_array, ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
 
   CeedSize length;
   CeedCallBackend(CeedVectorGetLength(vec, &length));
@@ -79,11 +75,7 @@ static inline int CeedVectorSyncD2H_Cuda(const CeedVector vec) {
   CeedVector_Cuda *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  if (!impl->d_array) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->d_array, ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
 
   if (impl->h_array_borrowed) {
     impl->h_array = impl->h_array_borrowed;

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -42,9 +42,8 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt num_elem, Ce
   // Read vectors
   const CeedScalar *d_u;
   CeedScalar       *d_v;
-  if (eval_mode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
-  }
+  if (u != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
+  else CeedCheck(eval_mode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
   CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
 
   // Apply basis operation

--- a/backends/cuda-shared/ceed-cuda-shared.c
+++ b/backends/cuda-shared/ceed-cuda-shared.c
@@ -20,11 +20,7 @@
 static int CeedInit_Cuda_shared(const char *resource, Ceed ceed) {
   char *resource_root;
   CeedCallBackend(CeedCudaGetResourceRoot(ceed, resource, &resource_root));
-  if (strcmp(resource_root, "/gpu/cuda/shared")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cuda backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource_root, "/gpu/cuda/shared"), ceed, CEED_ERROR_BACKEND, "Cuda backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   Ceed_Cuda *data;

--- a/backends/cuda/ceed-cuda-common.h
+++ b/backends/cuda/ceed-cuda-common.h
@@ -38,13 +38,13 @@
   do {                          \
     int ierr_q_ = __VA_ARGS__;  \
     CeedChk_Cu(ceed, ierr_q_);  \
-  } while (0);
+  } while (0)
 
 #define CeedCallCublas(ceed, ...)  \
   do {                             \
     int ierr_q_ = __VA_ARGS__;     \
     CeedChk_Cublas(ceed, ierr_q_); \
-  } while (0);
+  } while (0)
 
 #define CASE(name) \
   case name:       \

--- a/backends/cuda/ceed-cuda-compile.cpp
+++ b/backends/cuda/ceed-cuda-compile.cpp
@@ -30,7 +30,7 @@
   do {                            \
     int ierr_q_ = __VA_ARGS__;    \
     CeedChk_Nvrtc(ceed, ierr_q_); \
-  } while (0);
+  } while (0)
 
 //------------------------------------------------------------------------------
 // Compile CUDA kernel

--- a/backends/cuda/ceed-cuda-compile.h
+++ b/backends/cuda/ceed-cuda-compile.h
@@ -21,7 +21,7 @@ CEED_INTERN int CeedGetKernelCuda(Ceed ceed, CUmodule module, const char *name, 
 
 CEED_INTERN int CeedRunKernelCuda(Ceed ceed, CUfunction kernel, const int grid_size, const int block_size, void **args);
 
-CEED_INTERN int CeedRunKernelAutoblockCuda(Ceed ceed, CUfunction kernel, size_t size, void **args);
+CEED_INTERN int CeedRunKernelAutoblockCuda(Ceed ceed, CUfunction kernel, size_t points, void **args);
 
 CEED_INTERN int CeedRunKernelDimCuda(Ceed ceed, CUfunction kernel, const int grid_size, const int block_size_x, const int block_size_y,
                                      const int block_size_z, void **args);

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -83,10 +83,8 @@ extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
     CeedEvalMode eval_mode_in, eval_mode_out;
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[0], &eval_mode_in));
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[0], &eval_mode_out));
-    if (eval_mode_in == CEED_EVAL_NONE && eval_mode_out == CEED_EVAL_NONE)
-      // LCOV_EXCL_START
-      return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement restriction only identity operators");
-    // LCOV_EXCL_STOP
+    CeedCheck(eval_mode_in != CEED_EVAL_NONE || eval_mode_out != CEED_EVAL_NONE, ceed, CEED_ERROR_BACKEND,
+              "Backend does not implement restriction only identity operators");
   }
 
   ostringstream code;
@@ -127,15 +125,10 @@ extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
       CeedCallBackend(CeedBasisGetDimension(basis, &dim));
       bool isTensor;
       CeedCallBackend(CeedBasisIsTensor(basis, &isTensor));
-      if (isTensor) {
-        CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
-        CeedCallBackend(CeedBasisGetNumNodes1D(basis, &P_1d));
-        if (P_1d > data->max_P_1d) data->max_P_1d = P_1d;
-      } else {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(isTensor, ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
+      CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
+      CeedCallBackend(CeedBasisGetNumNodes1D(basis, &P_1d));
+      if (P_1d > data->max_P_1d) data->max_P_1d = P_1d;
     }
   }
   // Check output bases for Q_1d, dim as well
@@ -151,13 +144,8 @@ extern "C" int CeedHipGenOperatorBuild(CeedOperator op) {
       CeedCallBackend(CeedBasisGetDimension(basis, &dim));
       bool isTensor;
       CeedCallBackend(CeedBasisIsTensor(basis, &isTensor));
-      if (isTensor) {
-        CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
-      } else {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(isTensor, ceed, CEED_ERROR_BACKEND, "Backend does not implement operators with non-tensor basis");
+      CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
     }
   }
   data->dim  = dim;

--- a/backends/hip-gen/ceed-hip-gen-qfunction.c
+++ b/backends/hip-gen/ceed-hip-gen-qfunction.c
@@ -50,11 +50,7 @@ int CeedQFunctionCreate_Hip_gen(CeedQFunction qf) {
   CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &data->q_function_source));
   CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
-  if (!data->q_function_source) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "/gpu/hip/gen backend requires QFunction source code file");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(data->q_function_source, ceed, CEED_ERROR_UNSUPPORTED, "/gpu/hip/gen backend requires QFunction source code file");
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Apply", CeedQFunctionApply_Hip_gen));
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Destroy", CeedQFunctionDestroy_Hip_gen));

--- a/backends/hip-gen/ceed-hip-gen.c
+++ b/backends/hip-gen/ceed-hip-gen.c
@@ -19,11 +19,8 @@
 static int CeedInit_Hip_gen(const char *resource, Ceed ceed) {
   char *resource_root;
   CeedCallBackend(CeedHipGetResourceRoot(ceed, resource, &resource_root));
-  if (strcmp(resource_root, "/gpu/hip") && strcmp(resource_root, "/gpu/hip/gen")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Hip backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource_root, "/gpu/hip") || !strcmp(resource_root, "/gpu/hip/gen"), ceed, CEED_ERROR_BACKEND,
+            "Hip backend cannot use resource: %s", resource);
   CeedCallBackend(CeedFree(&resource_root));
 
   Ceed_Hip *data;

--- a/backends/hip-ref/ceed-hip-ref-basis.c
+++ b/backends/hip-ref/ceed-hip-ref-basis.c
@@ -30,9 +30,8 @@ int CeedBasisApply_Hip(CeedBasis basis, const CeedInt num_elem, CeedTransposeMod
   // Read vectors
   const CeedScalar *d_u;
   CeedScalar       *d_v;
-  if (eval_mode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
-  }
+  if (u != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
+  else CeedCheck(eval_mode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
   CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
 
   // Clear v for transpose operation
@@ -202,7 +201,7 @@ static int CeedBasisDestroyNonTensor_Hip(CeedBasis basis) {
 // Create tensor
 //------------------------------------------------------------------------------
 int CeedBasisCreateTensorH1_Hip(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
-                                const CeedScalar *qref1d, const CeedScalar *q_weight_1d, CeedBasis basis) {
+                                const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis) {
   Ceed ceed;
   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
   CeedBasis_Hip *data;

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -163,7 +163,7 @@ static int CeedOperatorSetupFields_Hip(CeedQFunction qf, CeedOperator op, bool i
         CeedCallBackend(CeedOperatorFieldGetBasis(opfields[i], &basis));
         q_size = (CeedSize)numelements * Q;
         CeedCallBackend(CeedVectorCreate(ceed, q_size, &qvecs[i]));
-        CeedCallBackend(CeedBasisApply(basis, numelements, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, NULL, qvecs[i]));
+        CeedCallBackend(CeedBasisApply(basis, numelements, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, CEED_VECTOR_NONE, qvecs[i]));
         break;
       case CEED_EVAL_DIV:
         break;  // TODO: Not implemented
@@ -462,11 +462,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
   // Check for identity
   bool identityqf;
   CeedCallBackend(CeedQFunctionIsIdentity(qf, &identityqf));
-  if (identityqf) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!identityqf, ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
 
   // Input Evecs and Restriction
   CeedCallBackend(CeedOperatorSetupInputs_Hip(numinputfields, qfinputfields, opinputfields, NULL, true, edata, impl, request));
@@ -510,11 +506,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
   }
 
   // Check sizes
-  if (!numactivein || !numactiveout) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(numactivein > 0 && numactiveout > 0, ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
 
   // Build objects if needed
   if (build_objects) {
@@ -650,11 +642,8 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, const b
       CeedCallBackend(CeedBasisGetNumComponents(basisin, &ncomp));
       CeedCallBackend(CeedBasisGetDimension(basisin, &dim));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(opfields[i], &rstr));
-      if (rstrin && rstrin != rstr) {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator diagonal assembly");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(!rstrin || rstrin == rstr, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement multi-field non-composite operator diagonal assembly");
       rstrin = rstr;
       CeedEvalMode emode;
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qffields[i], &emode));
@@ -692,11 +681,8 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, const b
       CeedElemRestriction rstr;
       CeedCallBackend(CeedOperatorFieldGetBasis(opfields[i], &basisout));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(opfields[i], &rstr));
-      if (rstrout && rstrout != rstr) {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator diagonal assembly");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(!rstrout || rstrout == rstr, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement multi-field non-composite operator diagonal assembly");
       rstrout = rstr;
       CeedEvalMode emode;
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qffields[i], &emode));
@@ -950,11 +936,7 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op) {
     if (vec == CEED_VECTOR_ACTIVE) {
       CeedCallBackend(CeedOperatorFieldGetBasis(output_fields[i], &basis_out));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr_out));
-      if (rstr_out && rstr_out != rstr_in) {
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator assembly");
-        // LCOV_EXCL_STOP
-      }
+      CeedCheck(!rstr_out || rstr_out == rstr_in, ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator assembly");
       CeedEvalMode eval_mode;
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
       if (eval_mode != CEED_EVAL_NONE) {
@@ -972,11 +954,7 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op) {
     }
   }
 
-  if (num_emode_in == 0 || num_emode_out == 0) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(num_emode_in > 0 && num_emode_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
 
   CeedInt nelem, ncomp;
   CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &nelem));

--- a/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
+++ b/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
@@ -32,11 +32,7 @@ extern "C" int CeedHipBuildQFunction(CeedQFunction qf) {
   // QFunction is built
   if (data->QFunction) return CEED_ERROR_SUCCESS;
 
-  if (!data->qfunction_source) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No QFunction source or hipFunction_t provided.");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(data->qfunction_source, ceed, CEED_ERROR_BACKEND, "No QFunction source or hipFunction_t provided.");
 
   // QFunction kernel generation
   CeedInt             num_input_fields, num_output_fields, size;

--- a/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
+++ b/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
@@ -23,11 +23,7 @@ static inline int CeedQFunctionContextSyncH2D_Hip(const CeedQFunctionContext ctx
   CeedQFunctionContext_Hip *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  if (!impl->h_data) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->h_data, ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
 
   size_t ctxsize;
   CeedCallBackend(CeedQFunctionContextGetContextSize(ctx, &ctxsize));
@@ -55,11 +51,7 @@ static inline int CeedQFunctionContextSyncD2H_Hip(const CeedQFunctionContext ctx
   CeedQFunctionContext_Hip *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  if (!impl->d_data) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->d_data, ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
 
   size_t ctxsize;
   CeedCallBackend(CeedQFunctionContextGetContextSize(ctx, &ctxsize));

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -257,55 +257,60 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mtype, CeedCopyMode cmode, const C
   CeedCallBackend(CeedElemRestrictionSetELayout(r, layout));
 
   // Set up device indices/offset arrays
-  if (mtype == CEED_MEM_HOST) {
-    switch (cmode) {
-      case CEED_OWN_POINTER:
-        impl->h_ind_allocated = (CeedInt *)indices;
-        impl->h_ind           = (CeedInt *)indices;
-        break;
-      case CEED_USE_POINTER:
-        impl->h_ind = (CeedInt *)indices;
-        break;
-      case CEED_COPY_VALUES:
-        if (indices != NULL) {
-          CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-          memcpy(impl->h_ind_allocated, indices, elem_size * num_elem * sizeof(CeedInt));
-          impl->h_ind = impl->h_ind_allocated;
-        }
-        break;
+  switch (mtype) {
+    case CEED_MEM_HOST: {
+      switch (cmode) {
+        case CEED_OWN_POINTER:
+          impl->h_ind_allocated = (CeedInt *)indices;
+          impl->h_ind           = (CeedInt *)indices;
+          break;
+        case CEED_USE_POINTER:
+          impl->h_ind = (CeedInt *)indices;
+          break;
+        case CEED_COPY_VALUES:
+          if (indices != NULL) {
+            CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
+            memcpy(impl->h_ind_allocated, indices, elem_size * num_elem * sizeof(CeedInt));
+            impl->h_ind = impl->h_ind_allocated;
+          }
+          break;
+      }
+      if (indices != NULL) {
+        CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
+        impl->d_ind_allocated = impl->d_ind;  // We own the device memory
+        CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyHostToDevice));
+        CeedCallBackend(CeedElemRestrictionOffset_Hip(r, indices));
+      }
+      break;
     }
-    if (indices != NULL) {
-      CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-      impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-      CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyHostToDevice));
-      CeedCallBackend(CeedElemRestrictionOffset_Hip(r, indices));
+    case CEED_MEM_DEVICE: {
+      switch (cmode) {
+        case CEED_COPY_VALUES:
+          if (indices != NULL) {
+            CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
+            impl->d_ind_allocated = impl->d_ind;  // We own the device memory
+            CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyDeviceToDevice));
+          }
+          break;
+        case CEED_OWN_POINTER:
+          impl->d_ind           = (CeedInt *)indices;
+          impl->d_ind_allocated = impl->d_ind;
+          break;
+        case CEED_USE_POINTER:
+          impl->d_ind = (CeedInt *)indices;
+      }
+      if (indices != NULL) {
+        CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
+        CeedCallHip(ceed, hipMemcpy(impl->h_ind_allocated, impl->d_ind, elem_size * num_elem * sizeof(CeedInt), hipMemcpyDeviceToHost));
+        impl->h_ind = impl->h_ind_allocated;
+        CeedCallBackend(CeedElemRestrictionOffset_Hip(r, indices));
+      }
+      break;
     }
-  } else if (mtype == CEED_MEM_DEVICE) {
-    switch (cmode) {
-      case CEED_COPY_VALUES:
-        if (indices != NULL) {
-          CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-          impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-          CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyDeviceToDevice));
-        }
-        break;
-      case CEED_OWN_POINTER:
-        impl->d_ind           = (CeedInt *)indices;
-        impl->d_ind_allocated = impl->d_ind;
-        break;
-      case CEED_USE_POINTER:
-        impl->d_ind = (CeedInt *)indices;
-    }
-    if (indices != NULL) {
-      CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-      CeedCallHip(ceed, hipMemcpy(impl->h_ind_allocated, impl->d_ind, elem_size * num_elem * sizeof(CeedInt), hipMemcpyDeviceToHost));
-      impl->h_ind = impl->h_ind_allocated;
-      CeedCallBackend(CeedElemRestrictionOffset_Hip(r, indices));
-    }
-  } else {
     // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
-    // LCOV_EXCL_STOP
+    default:
+      return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
+      // LCOV_EXCL_STOP
   }
 
   // Compile HIP kernels

--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -49,11 +49,7 @@ static inline int CeedVectorSyncH2D_Hip(const CeedVector vec) {
   CeedCallBackend(CeedVectorGetLength(vec, &length));
   size_t bytes = length * sizeof(CeedScalar);
 
-  if (!impl->h_array) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->h_array, ceed, CEED_ERROR_BACKEND, "No valid host data to sync to device");
 
   if (impl->d_array_borrowed) {
     impl->d_array = impl->d_array_borrowed;
@@ -78,11 +74,7 @@ static inline int CeedVectorSyncD2H_Hip(const CeedVector vec) {
   CeedVector_Hip *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  if (!impl->d_array) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(impl->d_array, ceed, CEED_ERROR_BACKEND, "No valid device data to sync to host");
 
   if (impl->h_array_borrowed) {
     impl->h_array = impl->h_array_borrowed;

--- a/backends/hip-ref/ceed-hip-ref.c
+++ b/backends/hip-ref/ceed-hip-ref.c
@@ -40,11 +40,7 @@ int CeedHipGetHipblasHandle(Ceed ceed, hipblasHandle_t *handle) {
 static int CeedInit_Hip(const char *resource, Ceed ceed) {
   char *resource_root;
   CeedCallBackend(CeedHipGetResourceRoot(ceed, resource, &resource_root));
-  if (strcmp(resource_root, "/gpu/hip/ref")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Hip backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource_root, "/gpu/hip/ref"), ceed, CEED_ERROR_BACKEND, "Hip backend cannot use resource: %s", resource);
   CeedCallBackend(CeedFree(&resource_root));
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -124,8 +124,8 @@ CEED_INTERN int CeedBasisApplyElems_Hip(CeedBasis basis, const CeedInt nelem, Ce
 
 CEED_INTERN int CeedQFunctionApplyElems_Hip(CeedQFunction qf, const CeedInt Q, const CeedVector *const u, const CeedVector *v);
 
-CEED_INTERN int CeedBasisCreateTensorH1_Hip(CeedInt dim, CeedInt P1d, CeedInt Q1d, const CeedScalar *interp1d, const CeedScalar *grad1d,
-                                            const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);
+CEED_INTERN int CeedBasisCreateTensorH1_Hip(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
+                                            const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);
 
 CEED_INTERN int CeedBasisCreateH1_Hip(CeedElemTopology, CeedInt, CeedInt, CeedInt, const CeedScalar *, const CeedScalar *, const CeedScalar *,
                                       const CeedScalar *, CeedBasis);

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -100,9 +100,8 @@ int CeedBasisApplyTensor_Hip_shared(CeedBasis basis, const CeedInt num_elem, Cee
   // Read vectors
   const CeedScalar *d_u;
   CeedScalar       *d_v;
-  if (eval_mode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
-  }
+  if (u != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_DEVICE, &d_u));
+  else CeedCheck(eval_mode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
   CeedCallBackend(CeedVectorGetArrayWrite(v, CEED_MEM_DEVICE, &d_v));
 
   // Apply basis operation
@@ -257,7 +256,7 @@ static int CeedBasisDestroy_Hip_shared(CeedBasis basis) {
 // Create tensor basis
 //------------------------------------------------------------------------------
 int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
-                                       const CeedScalar *q_ref1d, const CeedScalar *q_weight_1d, CeedBasis basis) {
+                                       const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis) {
   Ceed ceed;
   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
   CeedBasis_Hip_shared *data;

--- a/backends/hip-shared/ceed-hip-shared.c
+++ b/backends/hip-shared/ceed-hip-shared.c
@@ -20,11 +20,7 @@
 static int CeedInit_Hip_shared(const char *resource, Ceed ceed) {
   char *resource_root;
   CeedCallBackend(CeedHipGetResourceRoot(ceed, resource, &resource_root));
-  if (strcmp(resource_root, "/gpu/hip/shared")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Hip backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource_root, "/gpu/hip/shared"), ceed, CEED_ERROR_BACKEND, "Hip backend cannot use resource: %s", resource);
   CeedCallBackend(CeedFree(&resource_root));
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -26,7 +26,7 @@ typedef struct {
   CeedScalar   *d_q_weight_1d;
 } CeedBasis_Hip_shared;
 
-CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P1d, CeedInt Q1d, const CeedScalar *interp1d, const CeedScalar *grad1d,
-                                                   const CeedScalar *qref1d, const CeedScalar *qweight1d, CeedBasis basis);
+CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
+                                                   const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);
 
 #endif  // _ceed_hip_shared_h

--- a/backends/hip/ceed-hip-common.h
+++ b/backends/hip/ceed-hip-common.h
@@ -41,13 +41,13 @@
   do {                                \
     hipError_t ierr_q_ = __VA_ARGS__; \
     CeedChk_Hip(ceed, ierr_q_);       \
-  } while (0);
+  } while (0)
 
 #define CeedCallHipblas(ceed, ...)         \
   do {                                     \
     hipblasStatus_t ierr_q_ = __VA_ARGS__; \
     CeedChk_Hipblas(ceed, ierr_q_);        \
-  } while (0);
+  } while (0)
 
 #define CASE(name) \
   case name:       \

--- a/backends/hip/ceed-hip-compile.cpp
+++ b/backends/hip/ceed-hip-compile.cpp
@@ -28,7 +28,7 @@
   do {                             \
     int ierr_q_ = __VA_ARGS__;     \
     CeedChk_hiprtc(ceed, ierr_q_); \
-  } while (0);
+  } while (0)
 
 //------------------------------------------------------------------------------
 // Compile HIP kernel

--- a/backends/magma/ceed-magma-basis.c
+++ b/backends/magma/ceed-magma-basis.c
@@ -34,16 +34,11 @@ CEED_INTERN "C"
   Ceed_Magma *data;
   CeedCallBackend(CeedGetData(ceed, &data));
 
-  const CeedScalar *u;
-  CeedScalar       *v;
-  if (emode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorGetArrayRead(U, CEED_MEM_DEVICE, &u));
-  } else if (emode != CEED_EVAL_WEIGHT) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
-    // LCOV_EXCL_STOP
-  }
-  CeedCallBackend(CeedVectorGetArrayWrite(V, CEED_MEM_DEVICE, &v));
+  const CeedScalar *du;
+  CeedScalar       *dv;
+  if (U != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(U, CEED_MEM_DEVICE, &du));
+  else CeedCheck(emode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
+  CeedCallBackend(CeedVectorGetArrayWrite(V, CEED_MEM_DEVICE, &dv));
 
   CeedBasis_Magma *impl;
   CeedCallBackend(CeedBasisGetData(basis, &impl));
@@ -58,9 +53,9 @@ CEED_INTERN "C"
     CeedSize length;
     CeedCallBackend(CeedVectorGetLength(V, &length));
     if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-      magmablas_slaset(MagmaFull, length, 1, 0., 0., (float *)v, length, data->queue);
+      magmablas_slaset(MagmaFull, length, 1, 0., 0., (float *)dv, length, data->queue);
     } else {
-      magmablas_dlaset(MagmaFull, length, 1, 0., 0., (double *)v, length, data->queue);
+      magmablas_dlaset(MagmaFull, length, 1, 0., 0., (double *)dv, length, data->queue);
     }
     ceed_magma_queue_sync(data->queue);
   }
@@ -83,7 +78,7 @@ CEED_INTERN "C"
       //       node                            node
 
       // ---  Define strides for NOTRANSPOSE mode: ---
-      // Input (u) is E-vector, output (v) is Q-vector
+      // Input (du) is E-vector, output (dv) is Q-vector
 
       // Element strides
       CeedInt u_elstride = eldofssize;
@@ -94,7 +89,7 @@ CEED_INTERN "C"
 
       // ---  Swap strides for TRANSPOSE mode: ---
       if (tmode == CEED_TRANSPOSE) {
-        // Input (u) is Q-vector, output (v) is E-vector
+        // Input (du) is Q-vector, output (dv) is E-vector
         // Element strides
         v_elstride = eldofssize;
         u_elstride = elquadsize;
@@ -130,7 +125,7 @@ CEED_INTERN "C"
                                P * Q * Q));  // rU needs P^2xP, the intermediate output needs max(P^2xQ,PQ^2)
       }
       CeedInt grid   = (nelem + ntcol - 1) / ntcol;
-      void   *args[] = {&impl->dinterp1d, &u, &u_elstride, &u_compstride, &v, &v_elstride, &v_compstride, &nelem};
+      void   *args[] = {&impl->dinterp1d, &du, &u_elstride, &u_compstride, &dv, &v_elstride, &v_compstride, &nelem};
 
       if (tmode == CEED_TRANSPOSE) {
         CeedCallBackend(CeedRunKernelDimSharedMagma(ceed, impl->magma_interp_tr, grid, nthreads, ntcol, 1, shmem, args));
@@ -141,9 +136,9 @@ CEED_INTERN "C"
     case CEED_EVAL_GRAD: {
       CeedInt P = P1d, Q = Q1d;
       // In CEED_NOTRANSPOSE mode:
-      // u is (P^dim x nc), column-major layout (nc = ncomp)
-      // v is (Q^dim x nc x dim), column-major layout (nc = ncomp)
-      // In CEED_TRANSPOSE mode, the sizes of u and v are switched.
+      // du is (P^dim x nc), column-major layout (nc = ncomp)
+      // dv is (Q^dim x nc x dim), column-major layout (nc = ncomp)
+      // In CEED_TRANSPOSE mode, the sizes of du and dv are switched.
       if (tmode == CEED_TRANSPOSE) {
         P = Q1d, Q = P1d;
       }
@@ -159,7 +154,7 @@ CEED_INTERN "C"
       //       node                            node
 
       // ---  Define strides for NOTRANSPOSE mode: ---
-      // Input (u) is E-vector, output (v) is Q-vector
+      // Input (du) is E-vector, output (dv) is Q-vector
 
       // Element strides
       CeedInt u_elstride = eldofssize;
@@ -173,7 +168,7 @@ CEED_INTERN "C"
 
       // ---  Swap strides for TRANSPOSE mode: ---
       if (tmode == CEED_TRANSPOSE) {
-        // Input (u) is Q-vector, output (v) is E-vector
+        // Input (du) is Q-vector, output (dv) is E-vector
         // Element strides
         v_elstride = eldofssize;
         u_elstride = elquadsize;
@@ -212,7 +207,7 @@ CEED_INTERN "C"
                               (P * P * Q) + (P * Q * Q));  // rU needs P^2xP, the intermediate outputs need (P^2.Q + P.Q^2)
       }
       CeedInt grid   = (nelem + ntcol - 1) / ntcol;
-      void   *args[] = {&impl->dinterp1d, &impl->dgrad1d, &u,           &u_elstride, &u_compstride, &u_dimstride, &v,
+      void   *args[] = {&impl->dinterp1d, &impl->dgrad1d, &du,          &u_elstride, &u_compstride, &u_dimstride, &dv,
                         &v_elstride,      &v_compstride,  &v_dimstride, &nelem};
 
       if (tmode == CEED_TRANSPOSE) {
@@ -222,10 +217,7 @@ CEED_INTERN "C"
       }
     } break;
     case CEED_EVAL_WEIGHT: {
-      if (tmode == CEED_TRANSPOSE)
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
-      // LCOV_EXCL_STOP
+      CeedCheck(tmode != CEED_TRANSPOSE, ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
       CeedInt Q          = Q1d;
       CeedInt eldofssize = CeedIntPow(Q, dim);
       CeedInt nthreads   = 1;
@@ -250,7 +242,7 @@ CEED_INTERN "C"
           shmem += sizeof(CeedScalar) * Q;  // for dqweight1d
       }
       CeedInt grid   = (nelem + ntcol - 1) / ntcol;
-      void   *args[] = {&impl->dqweight1d, &v, &eldofssize, &nelem};
+      void   *args[] = {&impl->dqweight1d, &dv, &eldofssize, &nelem};
 
       CeedCallBackend(CeedRunKernelDimSharedMagma(ceed, impl->magma_weight, grid, nthreads, ntcol, 1, shmem, args));
     } break;
@@ -268,9 +260,9 @@ CEED_INTERN "C"
   ceed_magma_queue_sync(data->queue);
 
   if (emode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorRestoreArrayRead(U, &u));
+    CeedCallBackend(CeedVectorRestoreArrayRead(U, &du));
   }
-  CeedCallBackend(CeedVectorRestoreArray(V, &v));
+  CeedCallBackend(CeedVectorRestoreArray(V, &dv));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -294,13 +286,8 @@ CEED_INTERN "C"
   CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis, &nqpt));
   const CeedScalar *du;
   CeedScalar       *dv;
-  if (emode != CEED_EVAL_WEIGHT) {
-    CeedCallBackend(CeedVectorGetArrayRead(U, CEED_MEM_DEVICE, &du));
-  } else if (emode != CEED_EVAL_WEIGHT) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
-    // LCOV_EXCL_STOP
-  }
+  if (U != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(U, CEED_MEM_DEVICE, &du));
+  else CeedCheck(emode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
   CeedCallBackend(CeedVectorGetArrayWrite(V, CEED_MEM_DEVICE, &dv));
 
   CeedBasisNonTensor_Magma *impl;
@@ -398,10 +385,7 @@ CEED_INTERN "C"
     } break;
 
     case CEED_EVAL_WEIGHT: {
-      if (tmode == CEED_TRANSPOSE)
-        // LCOV_EXCL_START
-        return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
-      // LCOV_EXCL_STOP
+      CeedCheck(tmode != CEED_TRANSPOSE, ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
 
       int elemsPerBlock = 1;  // basis->Q1d < 7 ? optElems[basis->Q1d] : 1;
       int grid          = nelem / elemsPerBlock + ((nelem / elemsPerBlock * elemsPerBlock < nelem) ? 1 : 0);

--- a/backends/magma/ceed-magma-det.c
+++ b/backends/magma/ceed-magma-det.c
@@ -12,13 +12,10 @@
 
 #include "ceed-magma.h"
 
-CEED_INTERN int CeedInit_Magma_Det(const char *resource, Ceed ceed) {
+static int CeedInit_Magma_Det(const char *resource, Ceed ceed) {
   const int nrc = 18;  // number of characters in resource
-  if (strncmp(resource, "/gpu/cuda/magma/det", nrc) && strncmp(resource, "/gpu/hip/magma/det", nrc)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Magma backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strncmp(resource, "/gpu/cuda/magma/det", nrc) || !strncmp(resource, "/gpu/hip/magma/det", nrc), ceed, CEED_ERROR_BACKEND,
+            "Magma backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   Ceed_Magma *data;

--- a/backends/magma/ceed-magma-restriction.c
+++ b/backends/magma/ceed-magma-restriction.c
@@ -112,9 +112,9 @@ static int CeedElemRestrictionApply_Magma(CeedElemRestriction r, CeedTransposeMo
 
 int CeedElemRestrictionApplyBlock_Magma(CeedElemRestriction r, CeedInt block, CeedTransposeMode tmode, CeedVector u, CeedVector v,
                                         CeedRequest *request) {
+  // LCOV_EXCL_START
   Ceed ceed;
   CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  // LCOV_EXCL_START
   return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement blocked restrictions");
   // LCOV_EXCL_STOP
 }
@@ -180,60 +180,68 @@ int CeedElemRestrictionCreate_Magma(CeedMemType mtype, CeedCopyMode cmode, const
   impl->own_     = OWNED_NONE;
   impl->down_    = 0;
 
-  if (mtype == CEED_MEM_HOST) {
-    // memory is on the host; own_ = 0
-    switch (cmode) {
-      case CEED_COPY_VALUES:
-        impl->own_ = OWNED_PINNED;
+  switch (mtype) {
+    case CEED_MEM_HOST: {
+      // memory is on the host; own_ = 0
+      switch (cmode) {
+        case CEED_COPY_VALUES:
+          impl->own_ = OWNED_PINNED;
 
-        if (offsets != NULL) {
+          if (offsets != NULL) {
+            CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
+            CeedCallBackend(magma_malloc_pinned((void **)&impl->offsets, size * sizeof(CeedInt)));
+            memcpy(impl->offsets, offsets, size * sizeof(CeedInt));
+
+            magma_setvector(size, sizeof(CeedInt), offsets, 1, impl->doffsets, 1, data->queue);
+          }
+          break;
+        case CEED_OWN_POINTER:
+          impl->own_ = OWNED_UNPINNED;
+
+          if (offsets != NULL) {
+            CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
+            impl->offsets = (CeedInt *)offsets;
+
+            magma_setvector(size, sizeof(CeedInt), offsets, 1, impl->doffsets, 1, data->queue);
+          }
+          break;
+        case CEED_USE_POINTER:
+          if (offsets != NULL) {
+            CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
+            magma_setvector(size, sizeof(CeedInt), offsets, 1, impl->doffsets, 1, data->queue);
+          }
+          impl->down_   = 1;
+          impl->offsets = (CeedInt *)offsets;
+      }
+      break;
+    }
+    case CEED_MEM_DEVICE: {
+      // memory is on the device; own = 0
+      switch (cmode) {
+        case CEED_COPY_VALUES:
           CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
           CeedCallBackend(magma_malloc_pinned((void **)&impl->offsets, size * sizeof(CeedInt)));
-          memcpy(impl->offsets, offsets, size * sizeof(CeedInt));
+          impl->own_ = OWNED_PINNED;
 
-          magma_setvector(size, sizeof(CeedInt), offsets, 1, impl->doffsets, 1, data->queue);
-        }
-        break;
-      case CEED_OWN_POINTER:
-        impl->own_ = OWNED_UNPINNED;
+          if (offsets) magma_getvector(size, sizeof(CeedInt), impl->doffsets, 1, (void *)offsets, 1, data->queue);
+          break;
+        case CEED_OWN_POINTER:
+          impl->doffsets = (CeedInt *)offsets;
+          CeedCallBackend(magma_malloc_pinned((void **)&impl->offsets, size * sizeof(CeedInt)));
+          impl->own_ = OWNED_PINNED;
 
-        if (offsets != NULL) {
-          CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
-          impl->offsets = (CeedInt *)offsets;
-
-          magma_setvector(size, sizeof(CeedInt), offsets, 1, impl->doffsets, 1, data->queue);
-        }
-        break;
-      case CEED_USE_POINTER:
-        if (offsets != NULL) {
-          CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
-          magma_setvector(size, sizeof(CeedInt), offsets, 1, impl->doffsets, 1, data->queue);
-        }
-        impl->down_   = 1;
-        impl->offsets = (CeedInt *)offsets;
+          break;
+        case CEED_USE_POINTER:
+          impl->doffsets = (CeedInt *)offsets;
+          impl->offsets  = NULL;
+      }
+      break;
     }
-  } else if (mtype == CEED_MEM_DEVICE) {
-    // memory is on the device; own = 0
-    switch (cmode) {
-      case CEED_COPY_VALUES:
-        CeedCallBackend(magma_malloc((void **)&impl->doffsets, size * sizeof(CeedInt)));
-        CeedCallBackend(magma_malloc_pinned((void **)&impl->offsets, size * sizeof(CeedInt)));
-        impl->own_ = OWNED_PINNED;
-
-        if (offsets) magma_getvector(size, sizeof(CeedInt), impl->doffsets, 1, (void *)offsets, 1, data->queue);
-        break;
-      case CEED_OWN_POINTER:
-        impl->doffsets = (CeedInt *)offsets;
-        CeedCallBackend(magma_malloc_pinned((void **)&impl->offsets, size * sizeof(CeedInt)));
-        impl->own_ = OWNED_PINNED;
-
-        break;
-      case CEED_USE_POINTER:
-        impl->doffsets = (CeedInt *)offsets;
-        impl->offsets  = NULL;
-    }
-
-  } else return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
+    // LCOV_EXCL_START
+    default:
+      return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
+      // LCOV_EXCL_STOP
+  }
   // Compile kernels
   char *magma_common_path;
   char *restriction_kernel_path, *restriction_kernel_source;
@@ -273,9 +281,5 @@ int CeedElemRestrictionCreate_Magma(CeedMemType mtype, CeedCopyMode cmode, const
 int CeedElemRestrictionCreateBlocked_Magma(const CeedMemType mtype, const CeedCopyMode cmode, const CeedInt *offsets, const CeedElemRestriction r) {
   Ceed ceed;
   CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  // LCOV_EXCL_START
   return CeedError(ceed, CEED_ERROR_BACKEND, "Backend does not implement blocked restrictions");
-  // LCOV_EXCL_STOP
-
-  return CEED_ERROR_SUCCESS;
 }

--- a/backends/magma/ceed-magma.c
+++ b/backends/magma/ceed-magma.c
@@ -23,18 +23,11 @@ static int CeedDestroy_Magma(Ceed ceed) {
 static int CeedInit_Magma(const char *resource, Ceed ceed) {
   int       ierr;
   const int nrc = 14;  // number of characters in resource
-  if (strncmp(resource, "/gpu/cuda/magma", nrc) && strncmp(resource, "/gpu/hip/magma", nrc)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Magma backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strncmp(resource, "/gpu/cuda/magma", nrc) || !strncmp(resource, "/gpu/hip/magma", nrc), ceed, CEED_ERROR_BACKEND,
+            "Magma backend cannot use resource: %s", resource);
 
   ierr = magma_init();
-  if (ierr) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "error in magma_init(): %d\n", ierr);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ierr == 0, ceed, CEED_ERROR_BACKEND, "error in magma_init(): %d\n", ierr);
 
   Ceed_Magma *data;
   CeedCallBackend(CeedCalloc(sizeof(Ceed_Magma), &data));

--- a/backends/magma/ceed-magma.h
+++ b/backends/magma/ceed-magma.h
@@ -139,8 +139,6 @@ CEED_INTERN int CeedElemRestrictionCreate_Magma(CeedMemType mtype, CeedCopyMode 
 CEED_INTERN int CeedElemRestrictionCreateBlocked_Magma(const CeedMemType mtype, const CeedCopyMode cmode, const CeedInt *offsets,
                                                        const CeedElemRestriction res);
 
-CEED_INTERN int CeedOperatorCreate_Magma(CeedOperator op);
-
 // comment the line below to use the default magma_is_devptr function
 #define magma_is_devptr magma_isdevptr
 

--- a/backends/memcheck/ceed-memcheck-blocked.c
+++ b/backends/memcheck/ceed-memcheck-blocked.c
@@ -15,11 +15,7 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self/memcheck/blocked")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Valgrind Memcheck backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self/memcheck/blocked"), ceed, CEED_ERROR_BACKEND, "Valgrind Memcheck backend cannot use resource: %s", resource);
 
   // Create reference Ceed that implementation will be dispatched through unless overridden
   Ceed ceed_ref;

--- a/backends/memcheck/ceed-memcheck-qfunctioncontext.c
+++ b/backends/memcheck/ceed-memcheck-qfunctioncontext.c
@@ -59,11 +59,7 @@ static int CeedQFunctionContextSetData_Memcheck(CeedQFunctionContext ctx, CeedMe
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
 
   CeedCallBackend(CeedFree(&impl->data_allocated));
   CeedCallBackend(CeedFree(&impl->data_owned));
@@ -102,11 +98,7 @@ static int CeedQFunctionContextTakeData_Memcheck(CeedQFunctionContext ctx, CeedM
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   *(void **)data      = impl->data_borrowed;
   impl->data_borrowed = NULL;
@@ -126,11 +118,7 @@ static int CeedQFunctionContextGetData_Memcheck(CeedQFunctionContext ctx, CeedMe
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   *(void **)data = impl->data;
 
@@ -187,11 +175,8 @@ static int CeedQFunctionContextRestoreDataRead_Memcheck(CeedQFunctionContext ctx
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (memcmp(impl->data, impl->data_read_only_copy, ctx_size)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Context data changed while accessed in read-only mode");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!memcmp(impl->data, impl->data_read_only_copy, ctx_size), ceed, CEED_ERROR_BACKEND,
+            "Context data changed while accessed in read-only mode");
 
   CeedCallBackend(CeedFree(&impl->data_read_only_copy));
 
@@ -210,11 +195,7 @@ static int CeedQFunctionContextDataDestroy_Memcheck(CeedQFunctionContext ctx) {
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (data_destroy_mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only destroy HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(data_destroy_mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only destroy HOST memory for this backend");
 
   if (data_destroy_function) {
     CeedCallBackend(data_destroy_function(impl->data_borrowed ? impl->data_borrowed : impl->data_owned));

--- a/backends/memcheck/ceed-memcheck-serial.c
+++ b/backends/memcheck/ceed-memcheck-serial.c
@@ -15,11 +15,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Memcheck(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self/memcheck") && strcmp(resource, "/cpu/self/memcheck/serial")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Valgrind Memcheck backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self/memcheck") || !strcmp(resource, "/cpu/self/memcheck/serial"), ceed, CEED_ERROR_BACKEND,
+            "Valgrind Memcheck backend cannot use resource: %s", resource);
 
   // Create reference Ceed that implementation will be dispatched through unless overridden
   Ceed ceed_ref;

--- a/backends/memcheck/ceed-memcheck-vector.c
+++ b/backends/memcheck/ceed-memcheck-vector.c
@@ -60,11 +60,7 @@ static int CeedVectorSetArray_Memcheck(CeedVector vec, CeedMemType mem_type, Cee
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
 
   CeedCallBackend(CeedFree(&impl->array_allocated));
   CeedCallBackend(CeedFree(&impl->array_owned));
@@ -107,11 +103,7 @@ static int CeedVectorTakeArray_Memcheck(CeedVector vec, CeedMemType mem_type, Ce
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   (*array)             = impl->array_borrowed;
   impl->array_borrowed = NULL;
@@ -131,11 +123,7 @@ static int CeedVectorGetArray_Memcheck(CeedVector vec, CeedMemType mem_type, Cee
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   *array = impl->array;
 
@@ -213,11 +201,8 @@ static int CeedVectorRestoreArrayRead_Memcheck(CeedVector vec) {
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (memcmp(impl->array, impl->array_read_only_copy, length * sizeof(impl->array[0]))) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Array data changed while accessed in read-only mode");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!memcmp(impl->array, impl->array_read_only_copy, length * sizeof(impl->array[0])), ceed, CEED_ERROR_BACKEND,
+            "Array data changed while accessed in read-only mode");
 
   CeedCallBackend(CeedFree(&impl->array_read_only_copy));
 

--- a/backends/opt/ceed-opt-blocked.c
+++ b/backends/opt/ceed-opt-blocked.c
@@ -27,11 +27,8 @@ static int CeedDestroy_Opt(Ceed ceed) {
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Opt_Blocked(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/opt") && strcmp(resource, "/cpu/self/opt/blocked")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Opt backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/opt") || !strcmp(resource, "/cpu/self/opt/blocked"), ceed,
+            CEED_ERROR_BACKEND, "Opt backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -294,9 +294,7 @@ static inline int CeedOperatorOutputBasis_Opt(CeedInt e, CeedInt Q, CeedQFunctio
       case CEED_EVAL_WEIGHT: {
         Ceed ceed;
         CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
-        return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "CEED_EVAL_WEIGHT cannot be an output "
-                         "evaluation mode");
+        return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
         // LCOV_EXCL_STOP
       }
     }
@@ -434,11 +432,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Opt(CeedOperator op, b
   CeedCallBackend(CeedOperatorSetup_Opt(op));
 
   // Check for identity
-  if (impl->is_identity_qf) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Assembling identity qfunctions not supported");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!impl->is_identity_qf, ceed, CEED_ERROR_BACKEND, "Assembling identity qfunctions not supported");
 
   // Input Evecs and Restriction
   CeedCallBackend(CeedOperatorSetupInputs_Opt(num_input_fields, qf_input_fields, op_input_fields, NULL, e_data, impl, request));
@@ -482,11 +476,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Opt(CeedOperator op, b
   }
 
   // Check sizes
-  if (!num_active_in || !num_active_out) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(num_active_in > 0 && num_active_out > 0, ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
 
   // Setup l_vec
   if (!l_vec) {
@@ -636,11 +626,7 @@ int CeedOperatorCreate_Opt(CeedOperator op) {
   CeedCallBackend(CeedCalloc(1, &impl));
   CeedCallBackend(CeedOperatorSetData(op, impl));
 
-  if (blk_size != 1 && blk_size != 8) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Opt backend cannot use blocksize: %" CeedInt_FMT, blk_size);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(blk_size == 1 || blk_size == 8, ceed, CEED_ERROR_BACKEND, "Opt backend cannot use blocksize: %" CeedInt_FMT, blk_size);
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleQFunction", CeedOperatorLinearAssembleQFunction_Opt));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleQFunctionUpdate", CeedOperatorLinearAssembleQFunctionUpdate_Opt));

--- a/backends/opt/ceed-opt-serial.c
+++ b/backends/opt/ceed-opt-serial.c
@@ -27,11 +27,8 @@ static int CeedDestroy_Opt(Ceed ceed) {
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Opt_Serial(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/opt/serial")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Opt backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/opt/serial"), ceed, CEED_ERROR_BACKEND,
+            "Opt backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -30,13 +30,8 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem, CeedTransposeMo
   const CeedInt     add = (t_mode == CEED_TRANSPOSE);
   const CeedScalar *u;
   CeedScalar       *v;
-  if (U != CEED_VECTOR_NONE) {
-    CeedCallBackend(CeedVectorGetArrayRead(U, CEED_MEM_HOST, &u));
-  } else if (eval_mode != CEED_EVAL_WEIGHT) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
-    // LCOV_EXCL_STOP
-  }
+  if (U != CEED_VECTOR_NONE) CeedCallBackend(CeedVectorGetArrayRead(U, CEED_MEM_HOST, &u));
+  else CeedCheck(eval_mode == CEED_EVAL_WEIGHT, ceed, CEED_ERROR_BACKEND, "An input vector is required for this CeedEvalMode");
   CeedCallBackend(CeedVectorGetArrayWrite(V, CEED_MEM_HOST, &v));
 
   // Clear v if operating in transpose
@@ -157,11 +152,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem, CeedTransposeMo
       } break;
       // Retrieve interpolation weights
       case CEED_EVAL_WEIGHT: {
-        if (t_mode == CEED_TRANSPOSE) {
-          // LCOV_EXCL_START
-          return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
-          // LCOV_EXCL_STOP
-        }
+        CeedCheck(t_mode == CEED_NOTRANSPOSE, ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
         CeedInt           Q = Q_1d;
         const CeedScalar *q_weight_1d;
         CeedCallBackend(CeedBasisGetQWeights(basis, &q_weight_1d));
@@ -219,11 +210,7 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem, CeedTransposeMo
       } break;
       // Retrieve interpolation weights
       case CEED_EVAL_WEIGHT: {
-        if (t_mode == CEED_TRANSPOSE) {
-          // LCOV_EXCL_START
-          return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
-          // LCOV_EXCL_STOP
-        }
+        CeedCheck(t_mode == CEED_NOTRANSPOSE, ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT incompatible with CEED_TRANSPOSE");
         const CeedScalar *q_weight;
         CeedCallBackend(CeedBasisGetQWeights(basis, &q_weight));
         for (CeedInt i = 0; i < num_qpts; i++) {

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -252,9 +252,7 @@ static inline int CeedOperatorOutputBasis_Ref(CeedInt e, CeedInt Q, CeedQFunctio
       case CEED_EVAL_WEIGHT: {
         Ceed ceed;
         CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
-        return CeedError(ceed, CEED_ERROR_BACKEND,
-                         "CEED_EVAL_WEIGHT cannot be an output "
-                         "evaluation mode");
+        return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
         // LCOV_EXCL_STOP
       }
     }
@@ -400,11 +398,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Ref(CeedOperator op, b
   CeedCallBackend(CeedOperatorSetup_Ref(op));
 
   // Check for identity
-  if (impl->is_identity_qf) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!impl->is_identity_qf, ceed, CEED_ERROR_BACKEND, "Assembling identity QFunctions not supported");
 
   // Input Evecs and Restriction
   CeedCallBackend(CeedOperatorSetupInputs_Ref(num_input_fields, qf_input_fields, op_input_fields, NULL, true, e_data_full, impl, request));
@@ -448,11 +442,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Ref(CeedOperator op, b
   }
 
   // Check sizes
-  if (!num_active_in || !num_active_out) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(num_active_in > 0 && num_active_out > 0, ceed, CEED_ERROR_BACKEND, "Cannot assemble QFunction without active inputs and outputs");
 
   // Build objects if needed
   if (build_objects) {

--- a/backends/ref/ceed-ref-qfunctioncontext.c
+++ b/backends/ref/ceed-ref-qfunctioncontext.c
@@ -58,11 +58,7 @@ static int CeedQFunctionContextSetData_Ref(CeedQFunctionContext ctx, CeedMemType
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
 
   CeedCallBackend(CeedFree(&impl->data_owned));
   switch (copy_mode) {
@@ -93,11 +89,7 @@ static int CeedQFunctionContextTakeData_Ref(CeedQFunctionContext ctx, CeedMemTyp
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   *(void **)data      = impl->data;
   impl->data_borrowed = NULL;
@@ -115,11 +107,7 @@ static int CeedQFunctionContextGetData_Ref(CeedQFunctionContext ctx, CeedMemType
   Ceed ceed;
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   *(void **)data = impl->data;
 

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -249,11 +249,7 @@ static int CeedElemRestrictionGetOffsets_Ref(CeedElemRestriction rstr, CeedMemTy
   Ceed ceed;
   CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide to HOST memory");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide to HOST memory");
 
   *offsets = impl->offsets;
   return CEED_ERROR_SUCCESS;
@@ -287,11 +283,7 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
   Ceed ceed;
   CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST supported");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Only MemType = HOST supported");
   CeedCallBackend(CeedCalloc(1, &impl));
 
   // Offsets data
@@ -312,12 +304,8 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
       CeedCallBackend(CeedElemRestrictionGetLVectorSize(r, &l_size));
 
       for (CeedInt i = 0; i < num_elem * elem_size; i++) {
-        if (offsets[i] < 0 || l_size <= offsets[i] + (num_comp - 1) * comp_stride) {
-          // LCOV_EXCL_START
-          return CeedError(ceed, CEED_ERROR_BACKEND, "Restriction offset %" CeedInt_FMT " (%" CeedInt_FMT ") out of range [0, %" CeedInt_FMT "]", i,
-                           offsets[i], l_size);
-          // LCOV_EXCL_STOP
-        }
+        CeedCheck(offsets[i] >= 0 && offsets[i] + (num_comp - 1) * comp_stride < l_size, ceed, CEED_ERROR_BACKEND,
+                  "Restriction offset %" CeedInt_FMT " (%" CeedInt_FMT ") out of range [0, %" CeedInt_FMT "]", i, offsets[i], l_size);
       }
     }
 

--- a/backends/ref/ceed-ref-vector.c
+++ b/backends/ref/ceed-ref-vector.c
@@ -58,11 +58,7 @@ static int CeedVectorSetArray_Ref(CeedVector vec, CeedMemType mem_type, CeedCopy
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
 
   switch (copy_mode) {
     case CEED_COPY_VALUES:
@@ -96,11 +92,7 @@ static int CeedVectorTakeArray_Ref(CeedVector vec, CeedMemType mem_type, CeedSca
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   (*array)             = impl->array_borrowed;
   impl->array_borrowed = NULL;
@@ -118,11 +110,7 @@ static int CeedVectorGetArrayCore_Ref(CeedVector vec, CeedMemType mem_type, Ceed
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
-  if (mem_type != CEED_MEM_HOST) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Can only provide HOST memory for this backend");
 
   *array = impl->array;
 

--- a/backends/ref/ceed-ref.c
+++ b/backends/ref/ceed-ref.c
@@ -15,11 +15,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Ref(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/ref") && strcmp(resource, "/cpu/self/ref/serial")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "Ref backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/ref") || !strcmp(resource, "/cpu/self/ref/serial"), ceed,
+            CEED_ERROR_BACKEND, "Ref backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "Ceed", ceed, "VectorCreate", CeedVectorCreate_Ref));

--- a/backends/xsmm/ceed-xsmm-blocked.c
+++ b/backends/xsmm/ceed-xsmm-blocked.c
@@ -16,11 +16,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Xsmm_Blocked(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/xsmm") && strcmp(resource, "/cpu/self/xsmm/blocked")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "blocked libXSMM backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/xsmm") || !strcmp(resource, "/cpu/self/xsmm/blocked"), ceed,
+            CEED_ERROR_BACKEND, "blocked libXSMM backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/xsmm/ceed-xsmm-serial.c
+++ b/backends/xsmm/ceed-xsmm-serial.c
@@ -16,11 +16,8 @@
 // Backend Init
 //------------------------------------------------------------------------------
 static int CeedInit_Xsmm_Serial(const char *resource, Ceed ceed) {
-  if (strcmp(resource, "/cpu/self") && strcmp(resource, "/cpu/self/xsmm/serial")) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_BACKEND, "serial libXSMM backend cannot use resource: %s", resource);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(resource, "/cpu/self") || !strcmp(resource, "/cpu/self/xsmm/serial"), ceed, CEED_ERROR_BACKEND,
+            "serial libXSMM backend cannot use resource: %s", resource);
   CeedCallBackend(CeedSetDeterministic(ceed, true));
 
   // Create reference Ceed that implementation will be dispatched through unless overridden

--- a/backends/xsmm/ceed-xsmm-tensor-f32.c
+++ b/backends/xsmm/ceed-xsmm-tensor-f32.c
@@ -106,10 +106,7 @@ int CeedTensorContractCreate_f32_Xsmm(CeedBasis basis, CeedTensorContract contra
                 float alpha = 1.0, beta = 1.0;
                 if (!add) beta = 0.0;
                 libxsmm_smmfunction kernel = libxsmm_smmdispatch(C, J, B, NULL, NULL, NULL, &alpha, &beta, &flags, NULL);
-                if (!kernel)
-                  // LCOV_EXCL_START
-                  return CeedError(ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
-                // LCOV_EXCL_STOP
+                CeedCheck(kernel, ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
                 // Add kernel to hash table
                 kh_value(impl->lookup_f32, k) = kernel;
               }
@@ -139,10 +136,7 @@ int CeedTensorContractCreate_f32_Xsmm(CeedBasis basis, CeedTensorContract contra
               float alpha = 1.0, beta = 1.0;
               if (!add) beta = 0.0;
               libxsmm_smmfunction kernel = libxsmm_smmdispatch(C, J, B, NULL, NULL, NULL, &alpha, &beta, &flags, NULL);
-              if (!kernel)
-                // LCOV_EXCL_START
-                return CeedError(ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
-              // LCOV_EXCL_STOP
+              CeedCheck(kernel, ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
               // Add kernel to hash table
               kh_value(impl->lookup_f32, k) = kernel;
             }

--- a/backends/xsmm/ceed-xsmm-tensor-f64.c
+++ b/backends/xsmm/ceed-xsmm-tensor-f64.c
@@ -106,10 +106,7 @@ int CeedTensorContractCreate_f64_Xsmm(CeedBasis basis, CeedTensorContract contra
                 double alpha = 1.0, beta = 1.0;
                 if (!add) beta = 0.0;
                 libxsmm_dmmfunction kernel = libxsmm_dmmdispatch(C, J, B, NULL, NULL, NULL, &alpha, &beta, &flags, NULL);
-                if (!kernel)
-                  // LCOV_EXCL_START
-                  return CeedError(ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
-                // LCOV_EXCL_STOP
+                CeedCheck(kernel, ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
                 // Add kernel to hash table
                 kh_value(impl->lookup_f64, k) = kernel;
               }
@@ -139,10 +136,7 @@ int CeedTensorContractCreate_f64_Xsmm(CeedBasis basis, CeedTensorContract contra
               double alpha = 1.0, beta = 1.0;
               if (!add) beta = 0.0;
               libxsmm_dmmfunction kernel = libxsmm_dmmdispatch(C, J, B, NULL, NULL, NULL, &alpha, &beta, &flags, NULL);
-              if (!kernel)
-                // LCOV_EXCL_START
-                return CeedError(ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
-              // LCOV_EXCL_STOP
+              CeedCheck(kernel, ceed, CEED_ERROR_BACKEND, "LIBXSMM kernel failed to build.");
               // Add kernel to hash table
               kh_value(impl->lookup_f64, k) = kernel;
             }

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -17,11 +17,7 @@
 static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Identity";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // QFunction fields 'input' and 'output' with requested emodes added by the library rather than being added here
 

--- a/gallery/mass-vector/ceed-vectormassapply.c
+++ b/gallery/mass-vector/ceed-vectormassapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Vector3MassApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Vector3MassApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt num_comp = 3;

--- a/gallery/mass/ceed-mass1dbuild.c
+++ b/gallery/mass/ceed-mass1dbuild.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Mass1DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Mass1DBuild";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 1;

--- a/gallery/mass/ceed-mass2dbuild.c
+++ b/gallery/mass/ceed-mass2dbuild.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Mass2DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Mass2DBuild";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 2;

--- a/gallery/mass/ceed-mass3dbuild.c
+++ b/gallery/mass/ceed-mass3dbuild.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Mass3DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Mass3DBuild";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 3;

--- a/gallery/mass/ceed-massapply.c
+++ b/gallery/mass/ceed-massapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_MassApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "MassApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   CeedCall(CeedQFunctionAddInput(qf, "u", 1, CEED_EVAL_INTERP));

--- a/gallery/poisson-vector/ceed-vectorpoisson1dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson1dapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Vector3Poisson1DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Vector3Poisson1DApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 1, num_comp = 3;

--- a/gallery/poisson-vector/ceed-vectorpoisson2dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson2dapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Vector3Poisson2DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Vector3Poisson2DApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 2, num_comp = 3;

--- a/gallery/poisson-vector/ceed-vectorpoisson3dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson3dapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Vector3Poisson3DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Vector3Poisson3DApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 3, num_comp = 3;

--- a/gallery/poisson/ceed-poisson1dapply.c
+++ b/gallery/poisson/ceed-poisson1dapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Poisson1DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Poisson1DApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 1;

--- a/gallery/poisson/ceed-poisson1dbuild.c
+++ b/gallery/poisson/ceed-poisson1dbuild.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Poisson1DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Poisson1DBuild";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 1;

--- a/gallery/poisson/ceed-poisson2dapply.c
+++ b/gallery/poisson/ceed-poisson2dapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Poisson2DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Poisson2DApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 2;

--- a/gallery/poisson/ceed-poisson2dbuild.c
+++ b/gallery/poisson/ceed-poisson2dbuild.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Poisson2DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Poisson2DBuild";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 2;

--- a/gallery/poisson/ceed-poisson3dapply.c
+++ b/gallery/poisson/ceed-poisson3dapply.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Poisson3DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Poisson3DApply";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 3;

--- a/gallery/poisson/ceed-poisson3dbuild.c
+++ b/gallery/poisson/ceed-poisson3dbuild.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Poisson3DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Poisson3DBuild";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // Add QFunction fields
   const CeedInt dim = 3;

--- a/gallery/scale/ceed-scale.c
+++ b/gallery/scale/ceed-scale.c
@@ -16,11 +16,7 @@
 static int CeedQFunctionInit_Scale(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
   const char *name = "Scale";
-  if (strcmp(name, requested)) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(!strcmp(name, requested), ceed, CEED_ERROR_UNSUPPORTED, "QFunction '%s' does not match requested name: %s", name, requested);
 
   // QFunction fields 'input' and 'output' with requested emodes added by the library rather than being added here
 

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -123,6 +123,13 @@ CEED_INTERN int CeedFree(void *p);
     CeedChkBackend(ierr_q_);   \
   } while (0)
 
+#define CeedCheck(cond, ceed, ecode, ...)         \
+  do {                                            \
+    if (!(cond)) {                                \
+      return CeedError(ceed, ecode, __VA_ARGS__); \
+    }                                             \
+  } while (0)
+
 /* Note that CeedMalloc and CeedCalloc will, generally, return pointers with different memory alignments:
    CeedMalloc returns pointers aligned at CEED_ALIGN bytes, while CeedCalloc uses the alignment of calloc. */
 #define CeedMalloc(n, p) CeedMallocArray((n), sizeof(**(p)), p)

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -86,11 +86,7 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, c
 
   // Read file to temporary buffer
   source_file = fopen(source_file_path, "rb");
-  if (!source_file) {
-    // LCOV_EXCL_START
-    return CeedError(ceed, CEED_ERROR_MAJOR, "Couldn't open source file: %s", source_file_path);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(source_file, ceed, CEED_ERROR_MAJOR, "Couldn't open source file: %s", source_file_path);
   // -- Compute size of source
   fseek(source_file, 0L, SEEK_END);
   file_size = ftell(source_file);
@@ -247,12 +243,7 @@ int CeedPathConcatenate(Ceed ceed, const char *base_file_path, const char *relat
 **/
 int CeedGetJitRelativePath(const char *absolute_file_path, const char **relative_file_path) {
   *(relative_file_path) = strstr(absolute_file_path, "ceed/jit-source");
-
-  if (!*relative_file_path) {
-    // LCOV_EXCL_START
-    return CeedError(NULL, CEED_ERROR_MAJOR, "Couldn't find relative path including 'ceed/jit-source' for: %s", absolute_file_path);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(*relative_file_path, NULL, CEED_ERROR_MAJOR, "Couldn't find relative path including 'ceed/jit-source' for: %s", absolute_file_path);
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -61,11 +61,7 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx, const char *fi
   // Check for duplicate
   CeedInt field_index = -1;
   CeedCall(CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index));
-  if (field_index != -1) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" already registered", field_name);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(field_index == -1, ctx->ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" already registered", field_name);
 
   // Allocate space for field data
   if (ctx->num_fields == 0) {
@@ -151,14 +147,8 @@ int CeedQFunctionContextGetCeed(CeedQFunctionContext ctx, Ceed *ceed) {
   @ref Backend
 **/
 int CeedQFunctionContextHasValidData(CeedQFunctionContext ctx, bool *has_valid_data) {
-  if (!ctx->HasValidData) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasValidData");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(ctx->HasValidData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasValidData");
   CeedCall(ctx->HasValidData(ctx, has_valid_data));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -174,14 +164,8 @@ int CeedQFunctionContextHasValidData(CeedQFunctionContext ctx, bool *has_valid_d
   @ref Backend
 **/
 int CeedQFunctionContextHasBorrowedDataOfType(CeedQFunctionContext ctx, CeedMemType mem_type, bool *has_borrowed_data_of_type) {
-  if (!ctx->HasBorrowedDataOfType) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasBorrowedDataOfType");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(ctx->HasBorrowedDataOfType, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasBorrowedDataOfType");
   CeedCall(ctx->HasBorrowedDataOfType(ctx, mem_type, has_borrowed_data_of_type));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -268,12 +252,9 @@ int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx, const char *fiel
 **/
 int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type, void *values) {
   // Check field type
-  if (field_label->type != field_type) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" registered as %s, not registered as %s",
-                     field_label->name, CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(field_label->type == field_type, ctx->ceed, CEED_ERROR_UNSUPPORTED,
+            "QFunctionContext field with name \"%s\" registered as %s, not registered as %s", field_label->name,
+            CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
 
   char *data;
   CeedCall(CeedQFunctionContextGetData(ctx, CEED_MEM_HOST, &data));
@@ -299,12 +280,9 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx, CeedContextFieldLab
 int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type,
                                        size_t *num_values, void *values) {
   // Check field type
-  if (field_label->type != field_type) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" registered as %s, not registered as %s",
-                     field_label->name, CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(field_label->type == field_type, ctx->ceed, CEED_ERROR_UNSUPPORTED,
+            "QFunctionContext field with name \"%s\" registered as %s, not registered as %s", field_label->name,
+            CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
 
   char *data;
   CeedCall(CeedQFunctionContextGetDataRead(ctx, CEED_MEM_HOST, &data));
@@ -336,12 +314,9 @@ int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFiel
 int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type,
                                            void *values) {
   // Check field type
-  if (field_label->type != field_type) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" registered as %s, not registered as %s",
-                     field_label->name, CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(field_label->type == field_type, ctx->ceed, CEED_ERROR_UNSUPPORTED,
+            "QFunctionContext field with name \"%s\" registered as %s, not registered as %s", field_label->name,
+            CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
 
   CeedCall(CeedQFunctionContextRestoreDataRead(ctx, values));
 
@@ -360,14 +335,8 @@ int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContext
   @ref Backend
 **/
 int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, double *values) {
-  if (!field_label) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, values));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -384,14 +353,8 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabe
   @ref Backend
 **/
 int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const double **values) {
-  if (!field_label) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, num_values, values));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -407,14 +370,8 @@ int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextField
   @ref Backend
 **/
 int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const double **values) {
-  if (!field_label) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, values));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -430,14 +387,8 @@ int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextF
   @ref Backend
 **/
 int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int *values) {
-  if (!field_label) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_INT32, values));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -454,14 +405,8 @@ int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel
   @ref Backend
 **/
 int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const int **values) {
-  if (!field_label) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT32, num_values, values));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -477,14 +422,8 @@ int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldL
   @ref Backend
 **/
 int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int **values) {
-  if (!field_label) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT32, values));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -540,14 +479,9 @@ int CeedQFunctionContextReference(CeedQFunctionContext ctx) {
 int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
   if (!ceed->QFunctionContextCreate) {
     Ceed delegate;
+
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "Context"));
-
-    if (!delegate) {
-      // LCOV_EXCL_START
-      return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support ContextCreate");
-      // LCOV_EXCL_STOP
-    }
-
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support ContextCreate");
     CeedCall(CeedQFunctionContextCreate(delegate, ctx));
     return CEED_ERROR_SUCCESS;
   }
@@ -597,16 +531,8 @@ int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx, CeedQFunctionCon
   @ref User
 **/
 int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, CeedCopyMode copy_mode, size_t size, void *data) {
-  if (!ctx->SetData) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support ContextSetData");
-    // LCOV_EXCL_STOP
-  }
-  if (ctx->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ctx->SetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support ContextSetData");
+  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextDestroyData(ctx));
   ctx->ctx_size = size;
@@ -631,31 +557,15 @@ int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 int CeedQFunctionContextTakeData(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
   bool has_valid_data = true;
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
-  if (!has_valid_data) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to take, must set data");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to take, must set data");
 
-  if (!ctx->TakeData) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TakeData");
-    // LCOV_EXCL_STOP
-  }
-  if (ctx->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ctx->TakeData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TakeData");
+  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   bool has_borrowed_data_of_type = true;
   CeedCall(CeedQFunctionContextHasBorrowedDataOfType(ctx, mem_type, &has_borrowed_data_of_type));
-  if (!has_borrowed_data_of_type) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no borrowed %s data, must set data with CeedQFunctionContextSetData",
-                     CeedMemTypes[mem_type]);
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_borrowed_data_of_type, ctx->ceed, CEED_ERROR_BACKEND,
+            "CeedQFunctionContext has no borrowed %s data, must set data with CeedQFunctionContextSetData", CeedMemTypes[mem_type]);
 
   void *temp_data = NULL;
   CeedCall(ctx->TakeData(ctx, mem_type, &temp_data));
@@ -680,29 +590,13 @@ space. Pairing get/restore allows the Context to track access.
   @ref User
 **/
 int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
-  if (!ctx->GetData) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetData");
-    // LCOV_EXCL_STOP
-  }
-  if (ctx->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
-  if (ctx->num_readers > 0) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, a process has read access");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ctx->GetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetData");
+  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
+  CeedCheck(ctx->num_readers == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, a process has read access");
 
   bool has_valid_data = true;
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
-  if (!has_valid_data) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
 
   CeedCall(ctx->GetData(ctx, mem_type, data));
   ctx->state++;
@@ -726,24 +620,12 @@ memory space. Pairing get/restore allows the Context to track access.
   @ref User
 **/
 int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
-  if (!ctx->GetDataRead) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetDataRead");
-    // LCOV_EXCL_STOP
-  }
-  if (ctx->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ctx->GetDataRead, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetDataRead");
+  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   bool has_valid_data = true;
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
-  if (!has_valid_data) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
 
   CeedCall(ctx->GetDataRead(ctx, mem_type, data));
   ctx->num_readers++;
@@ -761,15 +643,9 @@ int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_ty
   @ref User
 **/
 int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
-  if (ctx->state % 2 != 1) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ctx->state % 2 == 1, ctx->ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
 
-  if (ctx->RestoreData) {
-    CeedCall(ctx->RestoreData(ctx));
-  }
+  if (ctx->RestoreData) CeedCall(ctx->RestoreData(ctx));
   *(void **)data = NULL;
   ctx->state++;
   return CEED_ERROR_SUCCESS;
@@ -786,16 +662,10 @@ int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
   @ref User
 **/
 int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data) {
-  if (ctx->num_readers == 0) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ctx->num_readers > 0, ctx->ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
 
   ctx->num_readers--;
-  if (ctx->num_readers == 0 && ctx->RestoreDataRead) {
-    CeedCall(ctx->RestoreDataRead(ctx));
-  }
+  if (ctx->num_readers == 0 && ctx->RestoreDataRead) CeedCall(ctx->RestoreDataRead(ctx));
   *(void **)data = NULL;
 
   return CEED_ERROR_SUCCESS;
@@ -924,11 +794,7 @@ int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream) {
   @ref User
 **/
 int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_mem_type, CeedQFunctionContextDataDestroyUser f) {
-  if (!f) {
-    // LCOV_EXCL_START
-    return CeedError(ctx->ceed, 1, "Must provide valid callback function for destroying user data");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(f, ctx->ceed, 1, "Must provide valid callback function for destroying user data");
   ctx->data_destroy_mem_type = f_mem_type;
   ctx->data_destroy_function = f;
   return CEED_ERROR_SUCCESS;
@@ -948,11 +814,7 @@ int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx) {
     *ctx = NULL;
     return CEED_ERROR_SUCCESS;
   }
-  if ((*ctx) && ((*ctx)->state % 2) == 1) {
-    // LCOV_EXCL_START
-    return CeedError((*ctx)->ceed, 1, "Cannot destroy CeedQFunctionContext, the access lock is in use");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(((*ctx)->state % 2) == 0, (*ctx)->ceed, 1, "Cannot destroy CeedQFunctionContext, the access lock is in use");
 
   CeedCall(CeedQFunctionContextDestroyData(*ctx));
   if ((*ctx)->Destroy) CeedCall((*ctx)->Destroy(*ctx));

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -33,14 +33,9 @@
 int CeedTensorContractCreate(Ceed ceed, CeedBasis basis, CeedTensorContract *contract) {
   if (!ceed->TensorContractCreate) {
     Ceed delegate;
+
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "TensorContract"));
-
-    if (!delegate) {
-      // LCOV_EXCL_START
-      return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TensorContractCreate");
-      // LCOV_EXCL_STOP
-    }
-
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TensorContractCreate");
     CeedCall(CeedTensorContractCreate(delegate, basis, contract));
     return CEED_ERROR_SUCCESS;
   }

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -50,14 +50,8 @@ const CeedVector CEED_VECTOR_NONE = &ceed_vector_none;
   @ref Backend
 **/
 int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array) {
-  if (!vec->HasValidArray) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasValidArray");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(vec->HasValidArray, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasValidArray");
   CeedCall(vec->HasValidArray(vec, has_valid_array));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -73,14 +67,8 @@ int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array) {
   @ref Backend
 **/
 int CeedVectorHasBorrowedArrayOfType(CeedVector vec, CeedMemType mem_type, bool *has_borrowed_array_of_type) {
-  if (!vec->HasBorrowedArrayOfType) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasBorrowedArrayOfType");
-    // LCOV_EXCL_STOP
-  }
-
+  CeedCheck(vec->HasBorrowedArrayOfType, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasBorrowedArrayOfType");
   CeedCall(vec->HasBorrowedArrayOfType(vec, mem_type, has_borrowed_array_of_type));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -179,14 +167,9 @@ int CeedVectorReference(CeedVector vec) {
 int CeedVectorCreate(Ceed ceed, CeedSize length, CeedVector *vec) {
   if (!ceed->VectorCreate) {
     Ceed delegate;
+
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "Vector"));
-
-    if (!delegate) {
-      // LCOV_EXCL_START
-      return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support VectorCreate");
-      // LCOV_EXCL_STOP
-    }
-
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support VectorCreate");
     CeedCall(CeedVectorCreate(delegate, length, vec));
     return CEED_ERROR_SUCCESS;
   }
@@ -274,17 +257,9 @@ int CeedVectorCopy(CeedVector vec, CeedVector vec_copy) {
   @ref User
 **/
 int CeedVectorSetArray(CeedVector vec, CeedMemType mem_type, CeedCopyMode copy_mode, CeedScalar *array) {
-  if (!vec->SetArray) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support VectorSetArray");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->state % 2 == 1) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
-  }
-  if (vec->num_readers > 0) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
-  }
+  CeedCheck(vec->SetArray, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support VectorSetArray");
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
+  CeedCheck(vec->num_readers == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
 
   CeedCall(vec->SetArray(vec, mem_type, copy_mode, array));
   vec->state += 2;
@@ -302,16 +277,8 @@ int CeedVectorSetArray(CeedVector vec, CeedMemType mem_type, CeedCopyMode copy_m
   @ref User
 **/
 int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
-  if (vec->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->num_readers > 0) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
+  CeedCheck(vec->num_readers == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
 
   if (vec->SetValue) {
     CeedCall(vec->SetValue(vec, value));
@@ -338,9 +305,7 @@ int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
   @ref User
 **/
 int CeedVectorSyncArray(CeedVector vec, CeedMemType mem_type) {
-  if (vec->state % 2 == 1) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot sync CeedVector, the access lock is already in use");
-  }
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot sync CeedVector, the access lock is already in use");
 
   if (vec->SyncArray) {
     CeedCall(vec->SyncArray(vec, mem_type));
@@ -367,36 +332,20 @@ int CeedVectorSyncArray(CeedVector vec, CeedMemType mem_type) {
   @ref User
 **/
 int CeedVectorTakeArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array) {
-  if (vec->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot take CeedVector array, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->num_readers > 0) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot take CeedVector array, a process has read access");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot take CeedVector array, the access lock is already in use");
+  CeedCheck(vec->num_readers == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot take CeedVector array, a process has read access");
 
   CeedScalar *temp_array = NULL;
   if (vec->length > 0) {
     bool has_borrowed_array_of_type = true;
     CeedCall(CeedVectorHasBorrowedArrayOfType(vec, mem_type, &has_borrowed_array_of_type));
-    if (!has_borrowed_array_of_type) {
-      // LCOV_EXCL_START
-      return CeedError(vec->ceed, CEED_ERROR_BACKEND, "CeedVector has no borrowed %s array, must set array with CeedVectorSetArray",
-                       CeedMemTypes[mem_type]);
-      // LCOV_EXCL_STOP
-    }
+    CeedCheck(has_borrowed_array_of_type, vec->ceed, CEED_ERROR_BACKEND,
+              "CeedVector has no borrowed %s array, must set array with CeedVectorSetArray", CeedMemTypes[mem_type]);
 
     bool has_valid_array = true;
     CeedCall(CeedVectorHasValidArray(vec, &has_valid_array));
-    if (!has_valid_array) {
-      // LCOV_EXCL_START
-      return CeedError(vec->ceed, CEED_ERROR_BACKEND,
-                       "CeedVector has no valid data to take, must set data with CeedVectorSetValue or CeedVectorSetArray");
-      // LCOV_EXCL_STOP
-    }
+    CeedCheck(has_valid_array, vec->ceed, CEED_ERROR_BACKEND,
+              "CeedVector has no valid data to take, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
     CeedCall(vec->TakeArray(vec, mem_type, &temp_array));
   }
@@ -421,26 +370,14 @@ int CeedVectorTakeArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array
   @ref User
 **/
 int CeedVectorGetArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array) {
-  if (!vec->GetArray) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArray");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->state % 2 == 1) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
-  }
-  if (vec->num_readers > 0) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
-  }
+  CeedCheck(vec->GetArray, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArray");
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
+  CeedCheck(vec->num_readers == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
 
   bool has_valid_array = true;
   CeedCall(CeedVectorHasValidArray(vec, &has_valid_array));
-  if (!has_valid_array) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_BACKEND,
-                     "CeedVector has no valid data to read, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array, vec->ceed, CEED_ERROR_BACKEND,
+            "CeedVector has no valid data to read, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   CeedCall(vec->GetArray(vec, mem_type, array));
   vec->state++;
@@ -461,24 +398,14 @@ int CeedVectorGetArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array)
   @ref User
 **/
 int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mem_type, const CeedScalar **array) {
-  if (!vec->GetArrayRead) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArrayRead");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->state % 2 == 1) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector read-only array access, the access lock is already in use");
-  }
+  CeedCheck(vec->GetArrayRead, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArrayRead");
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector read-only array access, the access lock is already in use");
 
   if (vec->length > 0) {
     bool has_valid_array = true;
     CeedCall(CeedVectorHasValidArray(vec, &has_valid_array));
-    if (!has_valid_array) {
-      // LCOV_EXCL_START
-      return CeedError(vec->ceed, CEED_ERROR_BACKEND,
-                       "CeedVector has no valid data to read, must set data with CeedVectorSetValue or CeedVectorSetArray");
-      // LCOV_EXCL_STOP
-    }
+    CeedCheck(has_valid_array, vec->ceed, CEED_ERROR_BACKEND,
+              "CeedVector has no valid data to read, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
     CeedCall(vec->GetArrayRead(vec, mem_type, array));
   } else {
@@ -502,21 +429,9 @@ int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mem_type, const CeedScala
   @ref User
 **/
 int CeedVectorGetArrayWrite(CeedVector vec, CeedMemType mem_type, CeedScalar **array) {
-  if (!vec->GetArrayWrite) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArrayWrite");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->state % 2 == 1) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
-    // LCOV_EXCL_STOP
-  }
-  if (vec->num_readers > 0) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(vec->GetArrayWrite, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArrayWrite");
+  CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
+  CeedCheck(vec->num_readers == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
 
   CeedCall(vec->GetArrayWrite(vec, mem_type, array));
   vec->state++;
@@ -534,9 +449,7 @@ int CeedVectorGetArrayWrite(CeedVector vec, CeedMemType mem_type, CeedScalar **a
   @ref User
 **/
 int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
-  if (vec->state % 2 != 1) {
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot restore CeedVector array access, access was not granted");
-  }
+  CeedCheck(vec->state % 2 == 1, vec->ceed, CEED_ERROR_ACCESS, "Cannot restore CeedVector array access, access was not granted");
   if (vec->RestoreArray) CeedCall(vec->RestoreArray(vec));
   *array = NULL;
   vec->state++;
@@ -554,11 +467,7 @@ int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
   @ref User
 **/
 int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
-  if (vec->num_readers == 0) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_ACCESS, "Cannot restore CeedVector array read access, access was not granted");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(vec->num_readers > 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot restore CeedVector array read access, access was not granted");
 
   vec->num_readers--;
   if (vec->num_readers == 0 && vec->RestoreArrayRead) CeedCall(vec->RestoreArrayRead(vec));
@@ -585,12 +494,8 @@ duplicated or hanging nodes.
 int CeedVectorNorm(CeedVector vec, CeedNormType norm_type, CeedScalar *norm) {
   bool has_valid_array = true;
   CeedCall(CeedVectorHasValidArray(vec, &has_valid_array));
-  if (!has_valid_array) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_BACKEND,
-                     "CeedVector has no valid data to compute norm, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array, vec->ceed, CEED_ERROR_BACKEND,
+            "CeedVector has no valid data to compute norm, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   // Backend impl for GPU, if added
   if (vec->Norm) {
@@ -641,12 +546,8 @@ int CeedVectorScale(CeedVector x, CeedScalar alpha) {
 
   bool has_valid_array = true;
   CeedCall(CeedVectorHasValidArray(x, &has_valid_array));
-  if (!has_valid_array) {
-    // LCOV_EXCL_START
-    return CeedError(x->ceed, CEED_ERROR_BACKEND,
-                     "CeedVector has no valid data to scale, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array, x->ceed, CEED_ERROR_BACKEND,
+            "CeedVector has no valid data to scale, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   CeedCall(CeedVectorGetLength(x, &n_x));
 
@@ -679,39 +580,21 @@ int CeedVectorAXPY(CeedVector y, CeedScalar alpha, CeedVector x) {
 
   CeedCall(CeedVectorGetLength(y, &n_y));
   CeedCall(CeedVectorGetLength(x, &n_x));
-  if (n_x != n_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot add vector of different lengths");
-    // LCOV_EXCL_STOP
-  }
-  if (x == y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot use same vector for x and y in CeedVectorAXPY");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(n_x == n_y, y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot add vector of different lengths");
+  CeedCheck(x != y, y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot use same vector for x and y in CeedVectorAXPY");
 
   bool has_valid_array_x = true, has_valid_array_y = true;
   CeedCall(CeedVectorHasValidArray(x, &has_valid_array_x));
-  if (!has_valid_array_x) {
-    // LCOV_EXCL_START
-    return CeedError(x->ceed, CEED_ERROR_BACKEND, "CeedVector x has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array_x, x->ceed, CEED_ERROR_BACKEND,
+            "CeedVector x has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
   CeedCall(CeedVectorHasValidArray(y, &has_valid_array_y));
-  if (!has_valid_array_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_BACKEND, "CeedVector y has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array_y, y->ceed, CEED_ERROR_BACKEND,
+            "CeedVector y has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   Ceed ceed_parent_x, ceed_parent_y;
   CeedCall(CeedGetParent(x->ceed, &ceed_parent_x));
   CeedCall(CeedGetParent(y->ceed, &ceed_parent_y));
-  if (ceed_parent_x != ceed_parent_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_INCOMPATIBLE, "Vectors x and y must be created by the same Ceed context");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ceed_parent_x == ceed_parent_y, y->ceed, CEED_ERROR_INCOMPATIBLE, "Vectors x and y must be created by the same Ceed context");
 
   // Backend implementation
   if (y->AXPY) {
@@ -753,39 +636,21 @@ int CeedVectorAXPBY(CeedVector y, CeedScalar alpha, CeedScalar beta, CeedVector 
 
   CeedCall(CeedVectorGetLength(y, &n_y));
   CeedCall(CeedVectorGetLength(x, &n_x));
-  if (n_x != n_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot add vector of different lengths");
-    // LCOV_EXCL_STOP
-  }
-  if (x == y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot use same vector for x and y in CeedVectorAXPBY");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(n_x == n_y, y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot add vector of different lengths");
+  CeedCheck(x != y, y->ceed, CEED_ERROR_UNSUPPORTED, "Cannot use same vector for x and y in CeedVectorAXPBY");
 
   bool has_valid_array_x = true, has_valid_array_y = true;
   CeedCall(CeedVectorHasValidArray(x, &has_valid_array_x));
-  if (!has_valid_array_x) {
-    // LCOV_EXCL_START
-    return CeedError(x->ceed, CEED_ERROR_BACKEND, "CeedVector x has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array_x, x->ceed, CEED_ERROR_BACKEND,
+            "CeedVector x has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
   CeedCall(CeedVectorHasValidArray(y, &has_valid_array_y));
-  if (!has_valid_array_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_BACKEND, "CeedVector y has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array_y, y->ceed, CEED_ERROR_BACKEND,
+            "CeedVector y has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   Ceed ceed_parent_x, ceed_parent_y;
   CeedCall(CeedGetParent(x->ceed, &ceed_parent_x));
   CeedCall(CeedGetParent(y->ceed, &ceed_parent_y));
-  if (ceed_parent_x != ceed_parent_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_INCOMPATIBLE, "Vectors x and y must be created by the same Ceed context");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ceed_parent_x == ceed_parent_y, y->ceed, CEED_ERROR_INCOMPATIBLE, "Vectors x and y must be created by the same Ceed context");
 
   // Backend implementation
   if (y->AXPBY) {
@@ -828,35 +693,22 @@ int CeedVectorPointwiseMult(CeedVector w, CeedVector x, CeedVector y) {
   CeedCall(CeedVectorGetLength(w, &n_w));
   CeedCall(CeedVectorGetLength(x, &n_x));
   CeedCall(CeedVectorGetLength(y, &n_y));
-  if (n_w != n_x || n_w != n_y) {
-    // LCOV_EXCL_START
-    return CeedError(w->ceed, CEED_ERROR_UNSUPPORTED, "Cannot multiply vectors of different lengths");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(n_w == n_x && n_w == n_y, w->ceed, CEED_ERROR_UNSUPPORTED, "Cannot multiply vectors of different lengths");
 
   Ceed ceed_parent_w, ceed_parent_x, ceed_parent_y;
   CeedCall(CeedGetParent(w->ceed, &ceed_parent_w));
   CeedCall(CeedGetParent(x->ceed, &ceed_parent_x));
   CeedCall(CeedGetParent(y->ceed, &ceed_parent_y));
-  if ((ceed_parent_w != ceed_parent_x) || (ceed_parent_w != ceed_parent_y)) {
-    // LCOV_EXCL_START
-    return CeedError(w->ceed, CEED_ERROR_INCOMPATIBLE, "Vectors w, x, and y must be created by the same Ceed context");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(ceed_parent_w == ceed_parent_x && ceed_parent_w == ceed_parent_y, w->ceed, CEED_ERROR_INCOMPATIBLE,
+            "Vectors w, x, and y must be created by the same Ceed context");
 
   bool has_valid_array_x = true, has_valid_array_y = true;
   CeedCall(CeedVectorHasValidArray(x, &has_valid_array_x));
-  if (!has_valid_array_x) {
-    // LCOV_EXCL_START
-    return CeedError(x->ceed, CEED_ERROR_BACKEND, "CeedVector x has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array_x, x->ceed, CEED_ERROR_BACKEND,
+            "CeedVector x has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
   CeedCall(CeedVectorHasValidArray(y, &has_valid_array_y));
-  if (!has_valid_array_y) {
-    // LCOV_EXCL_START
-    return CeedError(y->ceed, CEED_ERROR_BACKEND, "CeedVector y has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array_y, y->ceed, CEED_ERROR_BACKEND,
+            "CeedVector y has no valid data, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   // Backend implementation
   if (w->PointwiseMult) {
@@ -906,19 +758,11 @@ int CeedVectorReciprocal(CeedVector vec) {
   bool has_valid_array = true;
   CeedCall(CeedVectorHasValidArray(vec, &has_valid_array));
 
-  if (!has_valid_array) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_BACKEND,
-                     "CeedVector has no valid data to compute reciprocal, must set data with CeedVectorSetValue or CeedVectorSetArray");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(has_valid_array, vec->ceed, CEED_ERROR_BACKEND,
+            "CeedVector has no valid data to compute reciprocal, must set data with CeedVectorSetValue or CeedVectorSetArray");
 
   // Check if vector data set
-  if (!vec->state) {
-    // LCOV_EXCL_START
-    return CeedError(vec->ceed, CEED_ERROR_INCOMPLETE, "CeedVector must have data set to take reciprocal");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck(vec->state > 0, vec->ceed, CEED_ERROR_INCOMPLETE, "CeedVector must have data set to take reciprocal");
 
   // Backend impl for GPU, if added
   if (vec->Reciprocal) {
@@ -959,7 +803,7 @@ int CeedVectorViewRange(CeedVector vec, CeedSize start, CeedSize stop, CeedInt s
   const CeedScalar *x;
   char              fmt[1024];
 
-  if (step == 0) return CeedError(vec->ceed, CEED_ERROR_MINOR, "View range 'step' must be nonzero");
+  CeedCheck(step != 0, vec->ceed, CEED_ERROR_MINOR, "View range 'step' must be nonzero");
 
   fprintf(stream, "CeedVector length %ld\n", (long)vec->length);
   if (start != 0 || stop != vec->length || step != 1) {
@@ -1037,14 +881,8 @@ int CeedVectorDestroy(CeedVector *vec) {
     *vec = NULL;
     return CEED_ERROR_SUCCESS;
   }
-  if (((*vec)->state % 2) == 1) {
-    return CeedError((*vec)->ceed, CEED_ERROR_ACCESS, "Cannot destroy CeedVector, the writable access lock is in use");
-  }
-  if ((*vec)->num_readers > 0) {
-    // LCOV_EXCL_START
-    return CeedError((*vec)->ceed, CEED_ERROR_ACCESS, "Cannot destroy CeedVector, a process has read access");
-    // LCOV_EXCL_STOP
-  }
+  CeedCheck((*vec)->state % 2 == 0, (*vec)->ceed, CEED_ERROR_ACCESS, "Cannot destroy CeedVector, the writable access lock is in use");
+  CeedCheck((*vec)->num_readers == 0, (*vec)->ceed, CEED_ERROR_ACCESS, "Cannot destroy CeedVector, a process has read access");
 
   if ((*vec)->Destroy) CeedCall((*vec)->Destroy(*vec));
 

--- a/tests/t300-basis.c
+++ b/tests/t300-basis.c
@@ -10,9 +10,7 @@ int main(int argc, char **argv) {
   CeedInit(argv[1], &ceed);
 
   // Test skipped if using single precision
-  if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-    return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Test not implemented in single precision\n");
-  }
+  if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Test not implemented in single precision\n");
 
   CeedBasisCreateTensorH1Lagrange(ceed, 1, 1, 4, 4, CEED_GAUSS_LOBATTO, &basis);
   CeedBasisView(basis, stdout);


### PR DESCRIPTION
I added `CeedCheck` macro similar to the `PetscCheck` macro to reduce repeated code and `LCOV_ECXL_[START,STOP]` floating around. Dropped ~1,339 lines of repetition.