### PR TITLE
Fix HIP include order

### DIFF
--- a/backends/hip/ceed-hip-common.h
+++ b/backends/hip/ceed-hip-common.h
@@ -10,12 +10,13 @@
 
 #include <ceed.h>
 #include <ceed/backend.h>
+#include <hip/hip_runtime.h>
+
 #if (HIP_VERSION >= 50200000)
 #include <hipblas/hipblas.h>  // IWYU pragma: export
 #else
 #include <hipblas.h>  // IWYU pragma: export
 #endif
-#include <hip/hip_runtime.h>
 
 #define QUOTE(...) #__VA_ARGS__
 


### PR DESCRIPTION
This out of order include was triggering the warning for the header `hipblas.h`