### PR TITLE
Fix leak in memcheck multiple read only vec access

### DIFF
--- a/backends/memcheck/ceed-memcheck-vector.c
+++ b/backends/memcheck/ceed-memcheck-vector.c
@@ -144,8 +144,10 @@ static int CeedVectorGetArrayRead_Memcheck(CeedVector vec, CeedMemType mem_type,
   CeedCallBackend(CeedVectorGetArray_Memcheck(vec, mem_type, (CeedScalar **)array));
 
   // Make copy to verify no write occurred
-  CeedCallBackend(CeedCalloc(length, &impl->array_read_only_copy));
-  memcpy(impl->array_read_only_copy, *array, length * sizeof((*array)[0]));
+  if (!impl->array_read_only_copy) {
+    CeedCallBackend(CeedCalloc(length, &impl->array_read_only_copy));
+    memcpy(impl->array_read_only_copy, *array, length * sizeof((*array)[0]));
+  }
 
   return CEED_ERROR_SUCCESS;
 }


### PR DESCRIPTION
I think we want to keep this access pattern, but it does mean the memcheck backend check only runs once all references have been returned. I don't think this is a big deal, as usually a vector only has one reader at a time.
