### PR TITLE
Consistency with Ceed*Refrence and Ceed*ReferenceCopy

### DIFF
--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -151,9 +151,7 @@ static int CeedOperatorSetup_Blocked(CeedOperator op) {
     if (in_mode == CEED_EVAL_NONE && out_mode == CEED_EVAL_NONE) {
       impl->is_identity_restr_op = true;
     } else {
-      CeedCallBackend(CeedVectorDestroy(&impl->q_vecs_out[0]));
-      impl->q_vecs_out[0] = impl->q_vecs_in[0];
-      CeedCallBackend(CeedVectorAddReference(impl->q_vecs_in[0]));
+      CeedCallBackend(CeedVectorReferenceCopy(impl->q_vecs_in[0], &impl->q_vecs_out[0]));
     }
   }
 

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -160,9 +160,7 @@ static int CeedOperatorSetup_Opt(CeedOperator op) {
     if (in_mode == CEED_EVAL_NONE && out_mode == CEED_EVAL_NONE) {
       impl->is_identity_restr_op = true;
     } else {
-      CeedCallBackend(CeedVectorDestroy(&impl->q_vecs_out[0]));
-      impl->q_vecs_out[0] = impl->q_vecs_in[0];
-      CeedCallBackend(CeedVectorAddReference(impl->q_vecs_in[0]));
+      CeedCallBackend(CeedVectorReferenceCopy(impl->q_vecs_in[0], &impl->q_vecs_out[0]));
     }
   }
 

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -125,9 +125,7 @@ static int CeedOperatorSetup_Ref(CeedOperator op) {
     if (in_mode == CEED_EVAL_NONE && out_mode == CEED_EVAL_NONE) {
       impl->is_identity_restr_op = true;
     } else {
-      CeedCallBackend(CeedVectorDestroy(&impl->q_vecs_out[0]));
-      impl->q_vecs_out[0] = impl->q_vecs_in[0];
-      CeedCallBackend(CeedVectorAddReference(impl->q_vecs_in[0]));
+      CeedCallBackend(CeedVectorReferenceCopy(impl->q_vecs_in[0], &impl->q_vecs_out[0]));
     }
   }
 

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -159,7 +159,6 @@ CEED_EXTERN int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array);
 CEED_EXTERN int CeedVectorHasBorrowedArrayOfType(CeedVector vec, CeedMemType mem_type, bool *has_borrowed_array_of_type);
 CEED_EXTERN int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array);
 CEED_EXTERN int CeedVectorGetState(CeedVector vec, uint64_t *state);
-CEED_EXTERN int CeedVectorAddReference(CeedVector vec);
 CEED_EXTERN int CeedVectorGetData(CeedVector vec, void *data);
 CEED_EXTERN int CeedVectorSetData(CeedVector vec, void *data);
 CEED_EXTERN int CeedVectorReference(CeedVector vec);

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -909,8 +909,7 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt num_comp, CeedInt P_
   CeedElemTopology topo = dim == 1 ? CEED_TOPOLOGY_LINE : dim == 2 ? CEED_TOPOLOGY_QUAD : CEED_TOPOLOGY_HEX;
 
   CeedCall(CeedCalloc(1, basis));
-  (*basis)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*basis)->ceed));
   (*basis)->ref_count       = 1;
   (*basis)->is_tensor_basis = true;
   (*basis)->dim             = dim;
@@ -1045,12 +1044,10 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, CeedIn
   CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
   CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
 
-  CeedCall(CeedCalloc(1, basis));
-
   CeedCall(CeedBasisGetTopologyDimension(topo, &dim));
 
-  (*basis)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedCalloc(1, basis));
+  CeedCall(CeedReferenceCopy(ceed, &(*basis)->ceed));
   (*basis)->ref_count       = 1;
   (*basis)->is_tensor_basis = false;
   (*basis)->dim             = dim;
@@ -1106,12 +1103,10 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Ceed
   CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
   CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
 
-  CeedCall(CeedCalloc(1, basis));
-
   CeedCall(CeedBasisGetTopologyDimension(topo, &dim));
 
-  (*basis)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedCalloc(1, basis));
+  CeedCall(CeedReferenceCopy(ceed, &(*basis)->ceed));
   (*basis)->ref_count       = 1;
   (*basis)->is_tensor_basis = false;
   (*basis)->dim             = dim;
@@ -1168,13 +1163,11 @@ int CeedBasisCreateHcurl(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Cee
   CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
   CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
 
-  CeedCall(CeedCalloc(1, basis));
-
   CeedCall(CeedBasisGetTopologyDimension(topo, &dim));
   curl_comp = (dim < 3) ? 1 : dim;
 
-  (*basis)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedCalloc(1, basis));
+  CeedCall(CeedReferenceCopy(ceed, &(*basis)->ceed));
   (*basis)->ref_count       = 1;
   (*basis)->is_tensor_basis = false;
   (*basis)->dim             = dim;

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -360,8 +360,7 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size, Ce
   CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(1, rstr));
-  (*rstr)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
   (*rstr)->ref_count   = 1;
   (*rstr)->num_elem    = num_elem;
   (*rstr)->elem_size   = elem_size;
@@ -416,8 +415,7 @@ int CeedElemRestrictionCreateOriented(Ceed ceed, CeedInt num_elem, CeedInt elem_
   CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(1, rstr));
-  (*rstr)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
   (*rstr)->ref_count   = 1;
   (*rstr)->num_elem    = num_elem;
   (*rstr)->elem_size   = elem_size;
@@ -464,8 +462,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
 
   CeedCall(CeedCalloc(1, rstr));
-  (*rstr)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
   (*rstr)->ref_count   = 1;
   (*rstr)->num_elem    = num_elem;
   (*rstr)->elem_size   = elem_size;
@@ -525,13 +522,11 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
   CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
 
-  CeedCall(CeedCalloc(1, rstr));
-
   CeedCall(CeedCalloc(num_blk * blk_size * elem_size, &blk_offsets));
   CeedCall(CeedPermutePadOffsets(offsets, blk_offsets, num_blk, num_elem, blk_size, elem_size));
 
-  (*rstr)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedCalloc(1, rstr));
+  CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
   (*rstr)->ref_count   = 1;
   (*rstr)->num_elem    = num_elem;
   (*rstr)->elem_size   = elem_size;
@@ -585,9 +580,7 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem, CeedInt
   CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
 
   CeedCall(CeedCalloc(1, rstr));
-
-  (*rstr)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
   (*rstr)->ref_count   = 1;
   (*rstr)->num_elem    = num_elem;
   (*rstr)->elem_size   = elem_size;

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -535,22 +535,15 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, CeedQFunc
   }
 
   CeedCheck(qf && qf != CEED_QFUNCTION_NONE, ceed, CEED_ERROR_MINOR, "Operator must have a valid QFunction.");
+
   CeedCall(CeedCalloc(1, op));
-  (*op)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*op)->ceed));
   (*op)->ref_count   = 1;
-  (*op)->qf          = qf;
   (*op)->input_size  = -1;
   (*op)->output_size = -1;
-  CeedCall(CeedQFunctionReference(qf));
-  if (dqf && dqf != CEED_QFUNCTION_NONE) {
-    (*op)->dqf = dqf;
-    CeedCall(CeedQFunctionReference(dqf));
-  }
-  if (dqfT && dqfT != CEED_QFUNCTION_NONE) {
-    (*op)->dqfT = dqfT;
-    CeedCall(CeedQFunctionReference(dqfT));
-  }
+  CeedCall(CeedQFunctionReferenceCopy(qf, &(*op)->qf));
+  if (dqf && dqf != CEED_QFUNCTION_NONE) CeedCall(CeedQFunctionReferenceCopy(dqf, &(*op)->dqf));
+  if (dqfT && dqfT != CEED_QFUNCTION_NONE) CeedCall(CeedQFunctionReferenceCopy(dqfT, &(*op)->dqfT));
   CeedCall(CeedQFunctionAssemblyDataCreate(ceed, &(*op)->qf_assembled));
   CeedCall(CeedCalloc(CEED_FIELD_MAX, &(*op)->input_fields));
   CeedCall(CeedCalloc(CEED_FIELD_MAX, &(*op)->output_fields));
@@ -580,17 +573,14 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
   }
 
   CeedCall(CeedCalloc(1, op));
-  (*op)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*op)->ceed));
   (*op)->ref_count    = 1;
   (*op)->is_composite = true;
   CeedCall(CeedCalloc(CEED_COMPOSITE_MAX, &(*op)->sub_operators));
   (*op)->input_size  = -1;
   (*op)->output_size = -1;
 
-  if (ceed->CompositeOperatorCreate) {
-    CeedCall(ceed->CompositeOperatorCreate(*op));
-  }
+  if (ceed->CompositeOperatorCreate) CeedCall(ceed->CompositeOperatorCreate(*op));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -588,8 +588,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length, CeedQFunctionUser
             "Provided path to source does not include function name. Provided: \"%s\"\nRequired: \"\\abs_path\\file.h:function_name\"", source);
 
   CeedCall(CeedCalloc(1, qf));
-  (*qf)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*qf)->ceed));
   (*qf)->ref_count           = 1;
   (*qf)->vec_length          = vec_length;
   (*qf)->is_identity         = false;
@@ -857,9 +856,7 @@ int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedEvalMode *eva
 int CeedQFunctionSetContext(CeedQFunction qf, CeedQFunctionContext ctx) {
   CeedCall(CeedQFunctionContextDestroy(&qf->ctx));
   qf->ctx = ctx;
-  if (ctx) {
-    CeedCall(CeedQFunctionContextReference(ctx));
-  }
+  if (ctx) CeedCall(CeedQFunctionContextReference(ctx));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -487,8 +487,7 @@ int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
   }
 
   CeedCall(CeedCalloc(1, ctx));
-  (*ctx)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*ctx)->ceed));
   (*ctx)->ref_count = 1;
   CeedCall(ceed->QFunctionContextCreate(*ctx));
   return CEED_ERROR_SUCCESS;

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -41,9 +41,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedBasis basis, CeedTensorContract *con
   }
 
   CeedCall(CeedCalloc(1, contract));
-
-  (*contract)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*contract)->ceed));
   CeedCall(ceed->TensorContractCreate(basis, *contract));
   return CEED_ERROR_SUCCESS;
 }

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -88,20 +88,6 @@ int CeedVectorGetState(CeedVector vec, uint64_t *state) {
 }
 
 /**
-  @brief Add a reference to a CeedVector
-
-  @param[in,out] vec CeedVector to increment reference counter
-
-  @return An error code: 0 - success, otherwise - failure
-
-  @ref Backend
-**/
-int CeedVectorAddReference(CeedVector vec) {
-  vec->ref_count++;
-  return CEED_ERROR_SUCCESS;
-}
-
-/**
   @brief Get the backend data of a CeedVector
 
   @param[in]  vec  CeedVector to retrieve state
@@ -175,8 +161,7 @@ int CeedVectorCreate(Ceed ceed, CeedSize length, CeedVector *vec) {
   }
 
   CeedCall(CeedCalloc(1, vec));
-  (*vec)->ceed = ceed;
-  CeedCall(CeedReference(ceed));
+  CeedCall(CeedReferenceCopy(ceed, &(*vec)->ceed));
   (*vec)->ref_count = 1;
   (*vec)->length    = length;
   (*vec)->state     = 0;

--- a/julia/LibCEED.jl/src/generated/libceed_bindings.jl
+++ b/julia/LibCEED.jl/src/generated/libceed_bindings.jl
@@ -940,10 +940,6 @@ function CeedVectorGetState(vec, state)
     ccall((:CeedVectorGetState, libceed), Cint, (CeedVector, Ptr{UInt64}), vec, state)
 end
 
-function CeedVectorAddReference(vec)
-    ccall((:CeedVectorAddReference, libceed), Cint, (CeedVector,), vec)
-end
-
 function CeedVectorGetData(vec, data)
     ccall((:CeedVectorGetData, libceed), Cint, (CeedVector, Ptr{Cvoid}), vec, data)
 end


### PR DESCRIPTION
I noticed that we have some legacy patterns from before `Ceed*ReferenceCopy` existed. Updated here.

Note: This MR has no functional changes