### PR TITLE
Temporary Altair doc fix

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,4 +1,4 @@
-altair>=4.1
+altair>=4.1,<5.0
 breathe>=4.30
 myst-parser[linkify]>=0.14.0
 sphinx-hoverxref>=0.3b1


### PR DESCRIPTION
This PR fixes the doc builds by temporarily pinning Altair < 5.0 until Sphinx is updated