### PR TITLE
Error in CI on clang-tidy errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,3 @@
 Checks: "clang-diagnostic-*,clang-analyzer-*,readability-inconsistent-declaration-parameter-name"
 HeaderFilterRegex: .*
+WarningsAsErrors: "clang-diagnostic-*,clang-analyzer-*,readability-inconsistent-declaration-parameter-name"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,8 @@ noether-cpu:
     - make -k -j$NPROC_CPU BACKENDS="$BACKENDS_CPU" JUNIT_BATCH="cpu" junit search=nek NEK5K_DIR=$NEK5K_DIR
 # Clang-tidy
     - echo "-------------- clang-tidy ----------" && clang-tidy --version
-    - TIDY_OPTS="-fix-errors" make -j$NPROC_CPU tidy && git diff --color=always --exit-code
+    - export OCCA_DIR= && make lib -j$NPROC_CPU
+    - make -j$NPROC_CPU tidy
 # Report status
     - touch .SUCCESS
   after_script:


### PR DESCRIPTION
Previously `clang-tidy` errors would not generate CI failures. This PR fixes that.

See the similar change tested and deployed in Ratel:
https://gitlab.com/micromorph/ratel/-/merge_requests/486