### PR TITLE
No ctx access after restoring

### DIFF
--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -376,6 +376,7 @@ int CeedQFunctionRestoreContextData(CeedQFunction qf, void *data) {
       CeedCall(CeedQFunctionContextRestoreDataRead(ctx, data));
     }
   }
+  *(void **)data = NULL;
   return CEED_ERROR_SUCCESS;
 }
 
@@ -456,6 +457,7 @@ int CeedQFunctionRestoreInnerContextData(CeedQFunction qf, void *data) {
       CeedCall(CeedQFunctionContextRestoreDataRead(ctx, data));
     }
   }
+  *(void **)data = NULL;
   return CEED_ERROR_SUCCESS;
 }
 


### PR DESCRIPTION
Bug found by @rezgarshakeri - QFunctionContext data should not be accessible after restoring