### PR TITLE
Fluids: Decompose SGS DD input and output processing

### DIFF
--- a/examples/fluids/qfunctions/sgs_dd_model.h
+++ b/examples/fluids/qfunctions/sgs_dd_model.h
@@ -6,7 +6,7 @@
 // This file is part of CEED:  http://github.com/ceed
 
 /// @file
-/// Structs and helper functions for data-driven subgrid-stress modeling
+/// Structs and helper functions to evaluate data-driven subgrid-stress modeling
 /// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
 /// correction models for data-informed Reynolds stress closure' 2022
 
@@ -17,6 +17,7 @@
 
 #include "newtonian_state.h"
 #include "newtonian_types.h"
+#include "sgs_dd_utils.h"
 #include "utils.h"
 #include "utils_eigensolver_jacobi.h"
 
@@ -37,20 +38,6 @@ struct SGS_DD_ModelContext_ {
   CeedScalar data[1];
 };
 
-// @brief Calculate the inverse of the multiplicity, reducing to a single component
-CEED_QFUNCTION(InverseMultiplicity)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar(*multiplicity)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
-  CeedScalar(*inv_multiplicity)               = (CeedScalar(*))out[0];
-
-  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) inv_multiplicity[i] = 1.0 / multiplicity[0][i];
-  return 0;
-}
-
-// @brief Calculate Frobenius norm of velocity gradient from eigenframe quantities
-CEED_QFUNCTION_HELPER CeedScalar VelocityGradientMagnitude(const CeedScalar strain_sframe[3], const CeedScalar vorticity_sframe[3]) {
-  return sqrt(Dot3(strain_sframe, strain_sframe) + 0.5 * Dot3(vorticity_sframe, vorticity_sframe));
-};
-
 // @brief Denormalize outputs using min-max (de-)normalization
 CEED_QFUNCTION_HELPER void DenormalizeDDOutputs(CeedScalar output[6], const CeedScalar (*new_bounds)[2], const CeedScalar old_bounds[6][2]) {
   CeedScalar bounds_ratio;
@@ -58,22 +45,6 @@ CEED_QFUNCTION_HELPER void DenormalizeDDOutputs(CeedScalar output[6], const Ceed
     bounds_ratio = (new_bounds[i][1] - new_bounds[i][0]) / (old_bounds[i][1] - old_bounds[i][0]);
     output[i]    = bounds_ratio * (output[i] - old_bounds[i][1]) + new_bounds[i][1];
   }
-}
-
-// @brief Change the order of basis vectors so that they align with vector and obey right-hand rule
-// @details The e_1 and e_3 basis vectors are the closest aligned to the vector. The e_2 is set via  e_3 x e_1
-// The basis vectors are assumed to form the rows of the basis matrix.
-CEED_QFUNCTION_HELPER void OrientBasisWithVector(CeedScalar basis[3][3], const CeedScalar vector[3]) {
-  CeedScalar alignment[3] = {0.}, cross[3];
-
-  MatVec3(basis, vector, CEED_NOTRANSPOSE, alignment);
-
-  if (alignment[0] < 0) ScaleN(basis[0], -1, 3);
-  if (alignment[2] < 0) ScaleN(basis[2], -1, 3);
-
-  Cross3(basis[2], basis[0], cross);
-  CeedScalar basis_1_orientation = Dot3(cross, basis[1]);
-  if (basis_1_orientation < 0) ScaleN(basis[1], -1, 3);
 }
 
 CEED_QFUNCTION_HELPER void LeakyReLU(CeedScalar *x, const CeedScalar alpha, const CeedInt N) {
@@ -96,53 +67,6 @@ CEED_QFUNCTION_HELPER void DataDrivenInference(const CeedScalar *inputs, CeedSca
   LeakyReLU(V, alpha, num_neurons);
   CopyN(bias2, outputs, num_outputs);
   MatVecNM(weight2, V, num_outputs, num_neurons, CEED_NOTRANSPOSE, outputs);
-}
-
-/**
- * @brief Compute model inputs for anisotropic data-driven model
- *
- * @param[in]  grad_velo_aniso     Gradient of velocity in physical (anisotropic) coordinates
- * @param[in]  km_A_ij             Anisotropy tensor, in Kelvin-Mandel notation
- * @param[in]  delta               Length used to create anisotropy tensor
- * @param[in]  viscosity           Kinematic viscosity
- * @param[out] eigenvectors        Eigenvectors of the (anisotropic) velocity gradient
- * @param[out] inputs              Data-driven model inputs
- * @param[out] grad_velo_magnitude Frobenius norm of the velocity gradient
- */
-CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropicInputs(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,
-                                                          const CeedScalar viscosity, CeedScalar eigenvectors[3][3], CeedScalar inputs[6], CeedScalar *grad_velo_magnitude) {
-  CeedScalar strain_sframe[3] = {0.}, vorticity_sframe[3] = {0.};
-  CeedScalar A_ij[3][3] = {{0.}}, grad_velo_iso[3][3] = {{0.}};
-
-  // -- Transform physical, anisotropic velocity gradient to isotropic
-  KMUnpack(km_A_ij, A_ij);
-  MatMat3(grad_velo_aniso, A_ij, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, grad_velo_iso);
-
-  {  // -- Get Eigenframe
-    CeedScalar kmstrain_iso[6], strain_iso[3][3];
-    CeedInt    work_vector[3] = {0};
-    KMStrainRate(grad_velo_iso, kmstrain_iso);
-    KMUnpack(kmstrain_iso, strain_iso);
-    Diagonalize3(strain_iso, strain_sframe, eigenvectors, work_vector, SORT_DECREASING_EVALS, true, 5);
-  }
-
-  {  // -- Get vorticity in S-frame
-    CeedScalar rotation_iso[3][3];
-    RotationRate(grad_velo_iso, rotation_iso);
-    CeedScalar vorticity_iso[3] = {-2 * rotation_iso[1][2], 2 * rotation_iso[0][2], -2 * rotation_iso[0][1]};
-    OrientBasisWithVector(eigenvectors, vorticity_iso);
-    MatVec3(eigenvectors, vorticity_iso, CEED_NOTRANSPOSE, vorticity_sframe);
-  }
-
-  // -- Calculate DD model inputs
-  *grad_velo_magnitude = VelocityGradientMagnitude(strain_sframe, vorticity_sframe);
-  inputs[0] = strain_sframe[0];
-  inputs[1] = strain_sframe[1];
-  inputs[2] = strain_sframe[2];
-  inputs[3] = vorticity_sframe[0];
-  inputs[4] = vorticity_sframe[1];
-  inputs[5] = viscosity / Square(delta);
-  ScaleN(inputs, 1 / (*grad_velo_magnitude + CEED_EPSILON), 6);
 }
 
 CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropic(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,

--- a/examples/fluids/qfunctions/sgs_dd_model.h
+++ b/examples/fluids/qfunctions/sgs_dd_model.h
@@ -98,15 +98,24 @@ CEED_QFUNCTION_HELPER void DataDrivenInference(const CeedScalar *inputs, CeedSca
   MatVecNM(weight2, V, num_outputs, num_neurons, CEED_NOTRANSPOSE, outputs);
 }
 
-CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropic(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,
-                                                    const CeedScalar viscosity, CeedScalar kmsgs_stress[6], SGS_DDModelContext sgsdd_ctx) {
-  CeedScalar strain_sframe[3] = {0.}, vorticity_sframe[3] = {0.}, eigenvectors[3][3];
+/**
+ * @brief Compute model inputs for anisotropic data-driven model
+ *
+ * @param[in]  grad_velo_aniso     Gradient of velocity in physical (anisotropic) coordinates
+ * @param[in]  km_A_ij             Anisotropy tensor, in Kelvin-Mandel notation
+ * @param[in]  delta               Length used to create anisotropy tensor
+ * @param[in]  viscosity           Kinematic viscosity
+ * @param[out] eigenvectors        Eigenvectors of the (anisotropic) velocity gradient
+ * @param[out] inputs              Data-driven model inputs
+ * @param[out] grad_velo_magnitude Frobenius norm of the velocity gradient
+ */
+CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropicInputs(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,
+                                                          const CeedScalar viscosity, CeedScalar eigenvectors[3][3], CeedScalar inputs[6], CeedScalar *grad_velo_magnitude) {
+  CeedScalar strain_sframe[3] = {0.}, vorticity_sframe[3] = {0.};
   CeedScalar A_ij[3][3] = {{0.}}, grad_velo_iso[3][3] = {{0.}};
 
-  // -- Unpack anisotropy tensor
-  KMUnpack(km_A_ij, A_ij);
-
   // -- Transform physical, anisotropic velocity gradient to isotropic
+  KMUnpack(km_A_ij, A_ij);
   MatMat3(grad_velo_aniso, A_ij, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, grad_velo_iso);
 
   {  // -- Get Eigenframe
@@ -125,12 +134,23 @@ CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropic(const CeedScalar grad_velo_a
     MatVec3(eigenvectors, vorticity_iso, CEED_NOTRANSPOSE, vorticity_sframe);
   }
 
-  // -- Setup DD model inputs
-  const CeedScalar grad_velo_magnitude = VelocityGradientMagnitude(strain_sframe, vorticity_sframe);
-  CeedScalar inputs[6] = {strain_sframe[0], strain_sframe[1], strain_sframe[2], vorticity_sframe[0], vorticity_sframe[1], viscosity / Square(delta)};
-  ScaleN(inputs, 1 / (grad_velo_magnitude + CEED_EPSILON), 6);
+  // -- Calculate DD model inputs
+  *grad_velo_magnitude = VelocityGradientMagnitude(strain_sframe, vorticity_sframe);
+  inputs[0] = strain_sframe[0];
+  inputs[1] = strain_sframe[1];
+  inputs[2] = strain_sframe[2];
+  inputs[3] = vorticity_sframe[0];
+  inputs[4] = vorticity_sframe[1];
+  inputs[5] = viscosity / Square(delta);
+  ScaleN(inputs, 1 / (*grad_velo_magnitude + CEED_EPSILON), 6);
+}
 
-  CeedScalar sgs_sframe_sym[6] = {0.};
+CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropic(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,
+                                                    const CeedScalar viscosity, CeedScalar kmsgs_stress[6], SGS_DDModelContext sgsdd_ctx) {
+  CeedScalar inputs[6], grad_velo_magnitude, eigenvectors[3][3], sgs_sframe_sym[6] = {0.};
+
+  ComputeSGS_DDAnisotropicInputs(grad_velo_aniso, km_A_ij, delta, viscosity, eigenvectors, inputs, &grad_velo_magnitude);
+
   DataDrivenInference(inputs, sgs_sframe_sym, sgsdd_ctx);
 
   CeedScalar old_bounds[6][2] = {{0}};

--- a/examples/fluids/qfunctions/sgs_dd_utils.h
+++ b/examples/fluids/qfunctions/sgs_dd_utils.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Structs and helper functions for data-driven subgrid-stress modeling
+/// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
+/// correction models for data-informed Reynolds stress closure' 2022
+
+#ifndef sgs_dd_utils_h
+#define sgs_dd_utils_h
+
+#include <ceed.h>
+
+#include "newtonian_state.h"
+#include "newtonian_types.h"
+#include "utils.h"
+#include "utils_eigensolver_jacobi.h"
+
+// @brief Calculate the inverse of the multiplicity, reducing to a single component
+CEED_QFUNCTION(InverseMultiplicity)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  const CeedScalar(*multiplicity)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
+  CeedScalar(*inv_multiplicity)               = (CeedScalar(*))out[0];
+
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) inv_multiplicity[i] = 1.0 / multiplicity[0][i];
+  return 0;
+}
+
+// @brief Calculate Frobenius norm of velocity gradient from eigenframe quantities
+CEED_QFUNCTION_HELPER CeedScalar VelocityGradientMagnitude(const CeedScalar strain_sframe[3], const CeedScalar vorticity_sframe[3]) {
+  return sqrt(Dot3(strain_sframe, strain_sframe) + 0.5 * Dot3(vorticity_sframe, vorticity_sframe));
+};
+
+// @brief Change the order of basis vectors so that they align with vector and obey right-hand rule
+// @details The e_1 and e_3 basis vectors are the closest aligned to the vector. The e_2 is set via  e_3 x e_1
+// The basis vectors are assumed to form the rows of the basis matrix.
+CEED_QFUNCTION_HELPER void OrientBasisWithVector(CeedScalar basis[3][3], const CeedScalar vector[3]) {
+  CeedScalar alignment[3] = {0.}, cross[3];
+
+  MatVec3(basis, vector, CEED_NOTRANSPOSE, alignment);
+
+  if (alignment[0] < 0) ScaleN(basis[0], -1, 3);
+  if (alignment[2] < 0) ScaleN(basis[2], -1, 3);
+
+  Cross3(basis[2], basis[0], cross);
+  CeedScalar basis_1_orientation = Dot3(cross, basis[1]);
+  if (basis_1_orientation < 0) ScaleN(basis[1], -1, 3);
+}
+
+/**
+ * @brief Compute model inputs for anisotropic data-driven model
+ *
+ * @param[in]  grad_velo_aniso     Gradient of velocity in physical (anisotropic) coordinates
+ * @param[in]  km_A_ij             Anisotropy tensor, in Kelvin-Mandel notation
+ * @param[in]  delta               Length used to create anisotropy tensor
+ * @param[in]  viscosity           Kinematic viscosity
+ * @param[out] eigenvectors        Eigenvectors of the (anisotropic) velocity gradient
+ * @param[out] inputs              Data-driven model inputs
+ * @param[out] grad_velo_magnitude Frobenius norm of the velocity gradient
+ */
+CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropicInputs(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,
+                                                          const CeedScalar viscosity, CeedScalar eigenvectors[3][3], CeedScalar inputs[6],
+                                                          CeedScalar *grad_velo_magnitude) {
+  CeedScalar strain_sframe[3] = {0.}, vorticity_sframe[3] = {0.};
+  CeedScalar A_ij[3][3] = {{0.}}, grad_velo_iso[3][3] = {{0.}};
+
+  // -- Transform physical, anisotropic velocity gradient to isotropic
+  KMUnpack(km_A_ij, A_ij);
+  MatMat3(grad_velo_aniso, A_ij, CEED_NOTRANSPOSE, CEED_NOTRANSPOSE, grad_velo_iso);
+
+  {  // -- Get Eigenframe
+    CeedScalar kmstrain_iso[6], strain_iso[3][3];
+    CeedInt    work_vector[3] = {0};
+    KMStrainRate(grad_velo_iso, kmstrain_iso);
+    KMUnpack(kmstrain_iso, strain_iso);
+    Diagonalize3(strain_iso, strain_sframe, eigenvectors, work_vector, SORT_DECREASING_EVALS, true, 5);
+  }
+
+  {  // -- Get vorticity in S-frame
+    CeedScalar rotation_iso[3][3];
+    RotationRate(grad_velo_iso, rotation_iso);
+    CeedScalar vorticity_iso[3] = {-2 * rotation_iso[1][2], 2 * rotation_iso[0][2], -2 * rotation_iso[0][1]};
+    OrientBasisWithVector(eigenvectors, vorticity_iso);
+    MatVec3(eigenvectors, vorticity_iso, CEED_NOTRANSPOSE, vorticity_sframe);
+  }
+
+  // -- Calculate DD model inputs
+  *grad_velo_magnitude = VelocityGradientMagnitude(strain_sframe, vorticity_sframe);
+  inputs[0]            = strain_sframe[0];
+  inputs[1]            = strain_sframe[1];
+  inputs[2]            = strain_sframe[2];
+  inputs[3]            = vorticity_sframe[0];
+  inputs[4]            = vorticity_sframe[1];
+  inputs[5]            = viscosity / Square(delta);
+  ScaleN(inputs, 1 / (*grad_velo_magnitude + CEED_EPSILON), 6);
+}
+
+#endif  // sgs_dd_utils_h


### PR DESCRIPTION
- Extract out the SGS DD input and output processing (ie. the rotation to/from S-frame and un-dimensionalizing)
    - This is particularly useful for _in situ_ ML training and for incorporating external inference libraries (rather than computing the neural network manually).
    
#1203 depends on this PR