### PR TITLE
Fluids: Move to state enum for state functions

### DIFF
--- a/examples/fluids/problems/freestream_bc.c
+++ b/examples/fluids/problems/freestream_bc.c
@@ -16,10 +16,6 @@
 #include "../navierstokes.h"
 #include "../qfunctions/newtonian_types.h"
 
-typedef enum {
-  RIEMANN_HLL,
-  RIEMANN_HLLC,
-} RiemannSolverType;
 static const char *const RiemannSolverTypes[] = {"hll", "hllc", "RiemannSolverTypes", "RIEMANN_", NULL};
 
 PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference) {
@@ -27,7 +23,7 @@ PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, Newtoni
   MPI_Comm             comm = user->comm;
   FreestreamContext    freestream_ctx;
   CeedQFunctionContext freestream_context;
-  RiemannSolverType    riemann = RIEMANN_HLLC;
+  RiemannFluxType      riemann = RIEMANN_HLLC;
   PetscFunctionBeginUser;
   PetscScalar meter  = user->units->meter;
   PetscScalar second = user->units->second;

--- a/examples/fluids/qfunctions/freestream_bc.h
+++ b/examples/fluids/qfunctions/freestream_bc.h
@@ -12,8 +12,8 @@
 #include "newtonian_state.h"
 #include "newtonian_types.h"
 
-typedef StateConservative (*RiemannFluxFunction)(NewtonianIdealGasContext, State, State, const CeedScalar[3]);
-typedef StateConservative (*RiemannFluxFwdFunction)(NewtonianIdealGasContext, State, State, State, State, const CeedScalar[3]);
+enum RiemannFluxType_ { RIEMANN_HLL, RIEMANN_HLLC };
+typedef enum RiemannFluxType_ RiemannFluxType;
 
 typedef struct {
   CeedScalar left, right;
@@ -335,8 +335,8 @@ CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLLC_fwd(NewtonianIdealGasCo
 // *****************************************************************************
 // Freestream Boundary Condition
 // *****************************************************************************
-CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateFromQi_t StateFromQi,
-                                     StateFromQi_fwd_t StateFromQi_fwd, RiemannFluxFunction RiemannFlux) {
+CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateVariable state_var,
+                                     RiemannFluxType flux_type) {
   const CeedScalar(*q)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*q_data_sur)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];
   const CeedScalar(*x)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[3];
@@ -351,14 +351,22 @@ CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *con
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
     const CeedScalar qi[5]  = {q[0][i], q[1][i], q[2][i], q[3][i], q[4][i]};
-    State            s      = StateFromQi(newt_ctx, qi, x_i);
+    State            s      = StateFromQ(newt_ctx, qi, x_i, state_var);
 
     const CeedScalar wdetJb = (is_implicit ? -1. : 1.) * q_data_sur[0][i];
     // ---- Normal vector
     const CeedScalar norm[3] = {q_data_sur[1][i], q_data_sur[2][i], q_data_sur[3][i]};
 
-    StateConservative flux = RiemannFlux(newt_ctx, s, context->S_infty, norm);
-    CeedScalar        Flux[5];
+    StateConservative flux;
+    switch (flux_type) {
+      case RIEMANN_HLL:
+        flux = RiemannFlux_HLL(newt_ctx, s, context->S_infty, norm);
+        break;
+      case RIEMANN_HLLC:
+        flux = RiemannFlux_HLLC(newt_ctx, s, context->S_infty, norm);
+        break;
+    }
+    CeedScalar Flux[5];
     UnpackState_U(flux, Flux);
     for (CeedInt j = 0; j < 5; j++) v[j][i] = -wdetJb * Flux[j];
 
@@ -368,23 +376,23 @@ CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *con
 }
 
 CEED_QFUNCTION(Freestream_Conserv_HLL)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream(ctx, Q, in, out, StateFromU, StateFromU_fwd, RiemannFlux_HLL);
+  return Freestream(ctx, Q, in, out, STATEVAR_CONSERVATIVE, RIEMANN_HLL);
 }
 
 CEED_QFUNCTION(Freestream_Prim_HLL)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream(ctx, Q, in, out, StateFromY, StateFromY_fwd, RiemannFlux_HLL);
+  return Freestream(ctx, Q, in, out, STATEVAR_PRIMITIVE, RIEMANN_HLL);
 }
 
 CEED_QFUNCTION(Freestream_Conserv_HLLC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream(ctx, Q, in, out, StateFromU, StateFromU_fwd, RiemannFlux_HLLC);
+  return Freestream(ctx, Q, in, out, STATEVAR_CONSERVATIVE, RIEMANN_HLLC);
 }
 
 CEED_QFUNCTION(Freestream_Prim_HLLC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream(ctx, Q, in, out, StateFromY, StateFromY_fwd, RiemannFlux_HLLC);
+  return Freestream(ctx, Q, in, out, STATEVAR_PRIMITIVE, RIEMANN_HLLC);
 }
 
-CEED_QFUNCTION_HELPER int Freestream_Jacobian(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateFromQi_t StateFromQi,
-                                              StateFromQi_fwd_t StateFromQi_fwd, RiemannFluxFwdFunction RiemannFlux_fwd) {
+CEED_QFUNCTION_HELPER int Freestream_Jacobian(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateVariable state_var,
+                                              RiemannFluxType flux_type) {
   const CeedScalar(*dq)[CEED_Q_VLA]           = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*q_data_sur)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];
   const CeedScalar(*x)[CEED_Q_VLA]            = (const CeedScalar(*)[CEED_Q_VLA])in[3];
@@ -405,11 +413,19 @@ CEED_QFUNCTION_HELPER int Freestream_Jacobian(void *ctx, CeedInt Q, const CeedSc
     CeedScalar qi[5], dqi[5], dx_i[3] = {0.};
     for (int j = 0; j < 5; j++) qi[j] = jac_data_sur[j][i];
     for (int j = 0; j < 5; j++) dqi[j] = dq[j][i];
-    State s  = StateFromQi(newt_ctx, qi, x_i);
-    State ds = StateFromQi_fwd(newt_ctx, s, dqi, x_i, dx_i);
+    State s  = StateFromQ(newt_ctx, qi, x_i, state_var);
+    State ds = StateFromQ_fwd(newt_ctx, s, dqi, x_i, dx_i, state_var);
 
-    StateConservative dflux = RiemannFlux_fwd(newt_ctx, s, ds, context->S_infty, dS_infty, norm);
-    CeedScalar        dFlux[5];
+    StateConservative dflux;
+    switch (flux_type) {
+      case RIEMANN_HLL:
+        dflux = RiemannFlux_HLL_fwd(newt_ctx, s, ds, context->S_infty, dS_infty, norm);
+        break;
+      case RIEMANN_HLLC:
+        dflux = RiemannFlux_HLLC_fwd(newt_ctx, s, ds, context->S_infty, dS_infty, norm);
+        break;
+    }
+    CeedScalar dFlux[5];
     UnpackState_U(dflux, dFlux);
     for (CeedInt j = 0; j < 5; j++) v[j][i] = -wdetJb * dFlux[j];
   }
@@ -417,19 +433,19 @@ CEED_QFUNCTION_HELPER int Freestream_Jacobian(void *ctx, CeedInt Q, const CeedSc
 }
 
 CEED_QFUNCTION(Freestream_Jacobian_Conserv_HLL)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream_Jacobian(ctx, Q, in, out, StateFromU, StateFromU_fwd, RiemannFlux_HLL_fwd);
+  return Freestream_Jacobian(ctx, Q, in, out, STATEVAR_CONSERVATIVE, RIEMANN_HLL);
 }
 
 CEED_QFUNCTION(Freestream_Jacobian_Prim_HLL)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream_Jacobian(ctx, Q, in, out, StateFromY, StateFromY_fwd, RiemannFlux_HLL_fwd);
+  return Freestream_Jacobian(ctx, Q, in, out, STATEVAR_PRIMITIVE, RIEMANN_HLL);
 }
 
 CEED_QFUNCTION(Freestream_Jacobian_Conserv_HLLC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream_Jacobian(ctx, Q, in, out, StateFromU, StateFromU_fwd, RiemannFlux_HLLC_fwd);
+  return Freestream_Jacobian(ctx, Q, in, out, STATEVAR_CONSERVATIVE, RIEMANN_HLLC);
 }
 
 CEED_QFUNCTION(Freestream_Jacobian_Prim_HLLC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return Freestream_Jacobian(ctx, Q, in, out, StateFromY, StateFromY_fwd, RiemannFlux_HLLC_fwd);
+  return Freestream_Jacobian(ctx, Q, in, out, STATEVAR_PRIMITIVE, RIEMANN_HLLC);
 }
 
 // Note the identity
@@ -458,8 +474,7 @@ CEED_QFUNCTION_HELPER CeedScalar Softplus_fwd(CeedScalar x, CeedScalar dx, CeedS
 // keep it outflow. These parameters have been finnicky in practice and provide
 // little or no benefit in the tests we've run thus far, thus we recommend
 // skipping this feature and just allowing recirculation.
-CEED_QFUNCTION_HELPER int RiemannOutflow(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateFromQi_t StateFromQi,
-                                         StateFromQi_fwd_t StateFromQi_fwd) {
+CEED_QFUNCTION_HELPER int RiemannOutflow(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateVariable state_var) {
   // Inputs
   const CeedScalar(*q)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*Grad_q)[5][CEED_Q_VLA]  = (const CeedScalar(*)[5][CEED_Q_VLA])in[1];
@@ -479,7 +494,7 @@ CEED_QFUNCTION_HELPER int RiemannOutflow(void *ctx, CeedInt Q, const CeedScalar 
     const CeedScalar x_i[3]   = {x[0][i], x[1][i], x[2][i]};
     const CeedScalar norm[3]  = {q_data_sur[1][i], q_data_sur[2][i], q_data_sur[3][i]};
     const CeedScalar qi[5]    = {q[0][i], q[1][i], q[2][i], q[3][i], q[4][i]};
-    const State      s_int    = StateFromQi(gas, qi, x_i);
+    State            s_int    = StateFromQ(gas, qi, x_i, state_var);
     StatePrimitive   y_ext    = s_int.Y;
     y_ext.pressure            = outflow->pressure;
     y_ext.temperature         = outflow->temperature;
@@ -505,7 +520,7 @@ CEED_QFUNCTION_HELPER int RiemannOutflow(void *ctx, CeedInt Q, const CeedScalar 
       CeedScalar dx_i[3] = {0}, dqi[5];
       for (CeedInt k = 0; k < 5; k++) dqi[k] = Grad_q[0][k][i] * dXdx[0][j] + Grad_q[1][k][i] * dXdx[1][j];
       dx_i[j]   = 1.;
-      grad_s[j] = StateFromQi_fwd(gas, s_int, dqi, x_i, dx_i);
+      grad_s[j] = StateFromQ_fwd(gas, s_int, dqi, x_i, dx_i, state_var);
     }
 
     CeedScalar strain_rate[6], kmstress[6], stress[3][3], Fe[3];
@@ -529,18 +544,18 @@ CEED_QFUNCTION_HELPER int RiemannOutflow(void *ctx, CeedInt Q, const CeedScalar 
 }
 
 CEED_QFUNCTION(RiemannOutflow_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return RiemannOutflow(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return RiemannOutflow(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(RiemannOutflow_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return RiemannOutflow(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return RiemannOutflow(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 
 // *****************************************************************************
 // Jacobian for Riemann pressure/temperature outflow boundary condition
 // *****************************************************************************
 CEED_QFUNCTION_HELPER int RiemannOutflow_Jacobian(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out,
-                                                  StateFromQi_t StateFromQi, StateFromQi_fwd_t StateFromQi_fwd) {
+                                                  StateVariable state_var) {
   // Inputs
   const CeedScalar(*dq)[CEED_Q_VLA]           = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*Grad_dq)[5][CEED_Q_VLA]   = (const CeedScalar(*)[5][CEED_Q_VLA])in[1];
@@ -571,8 +586,8 @@ CEED_QFUNCTION_HELPER int RiemannOutflow_Jacobian(void *ctx, CeedInt Q, const Ce
     for (int j = 0; j < 6; j++) kmstress[j] = jac_data_sur[5 + j][i];
     for (int j = 0; j < 5; j++) dqi[j] = dq[j][i];
 
-    State          s_int  = StateFromQi(gas, qi, x_i);
-    State          ds_int = StateFromQi_fwd(gas, s_int, dqi, x_i, dx_i);
+    State          s_int  = StateFromQ(gas, qi, x_i, state_var);
+    const State    ds_int = StateFromQ_fwd(gas, s_int, dqi, x_i, dx_i, state_var);
     StatePrimitive y_ext = s_int.Y, dy_ext = ds_int.Y;
     y_ext.pressure             = outflow->pressure;
     y_ext.temperature          = outflow->temperature;
@@ -595,7 +610,7 @@ CEED_QFUNCTION_HELPER int RiemannOutflow_Jacobian(void *ctx, CeedInt Q, const Ce
       CeedScalar dx_i[3] = {0}, dqi_j[5];
       for (CeedInt k = 0; k < 5; k++) dqi_j[k] = Grad_dq[0][k][i] * dXdx[0][j] + Grad_dq[1][k][i] * dXdx[1][j];
       dx_i[j]    = 1.;
-      grad_ds[j] = StateFromQi_fwd(gas, s_int, dqi_j, x_i, dx_i);
+      grad_ds[j] = StateFromQ_fwd(gas, s_int, dqi_j, x_i, dx_i, state_var);
     }
 
     CeedScalar dstrain_rate[6], dkmstress[6], stress[3][3], dstress[3][3], dFe[3];
@@ -616,11 +631,11 @@ CEED_QFUNCTION_HELPER int RiemannOutflow_Jacobian(void *ctx, CeedInt Q, const Ce
 }
 
 CEED_QFUNCTION(RiemannOutflow_Jacobian_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return RiemannOutflow_Jacobian(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return RiemannOutflow_Jacobian(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(RiemannOutflow_Jacobian_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return RiemannOutflow_Jacobian(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return RiemannOutflow_Jacobian(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 
 // *****************************************************************************
@@ -630,8 +645,7 @@ CEED_QFUNCTION(RiemannOutflow_Jacobian_Prim)(void *ctx, CeedInt Q, const CeedSca
 // will crash if outflow ever becomes an inflow, as occurs with strong
 // acoustics, vortices, etc.
 // *****************************************************************************
-CEED_QFUNCTION_HELPER int PressureOutflow(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateFromQi_t StateFromQi,
-                                          StateFromQi_fwd_t StateFromQi_fwd) {
+CEED_QFUNCTION_HELPER int PressureOutflow(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateVariable state_var) {
   // Inputs
   const CeedScalar(*q)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*Grad_q)[5][CEED_Q_VLA]  = (const CeedScalar(*)[5][CEED_Q_VLA])in[1];
@@ -652,7 +666,7 @@ CEED_QFUNCTION_HELPER int PressureOutflow(void *ctx, CeedInt Q, const CeedScalar
     // -- Interp in
     const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
     const CeedScalar qi[5]  = {q[0][i], q[1][i], q[2][i], q[3][i], q[4][i]};
-    State            s      = StateFromQi(gas, qi, x_i);
+    State            s      = StateFromQ(gas, qi, x_i, state_var);
     s.Y.pressure            = outflow->pressure;
 
     // -- Interp-to-Interp q_data
@@ -674,7 +688,7 @@ CEED_QFUNCTION_HELPER int PressureOutflow(void *ctx, CeedInt Q, const CeedScalar
       CeedScalar dx_i[3] = {0}, dqi[5];
       for (CeedInt k = 0; k < 5; k++) dqi[k] = Grad_q[0][k][i] * dXdx[0][j] + Grad_q[1][k][i] * dXdx[1][j];
       dx_i[j]   = 1.;
-      grad_s[j] = StateFromQi_fwd(gas, s, dqi, x_i, dx_i);
+      grad_s[j] = StateFromQ_fwd(gas, s, dqi, x_i, dx_i, state_var);
     }
 
     CeedScalar strain_rate[6], kmstress[6], stress[3][3], Fe[3];
@@ -699,18 +713,18 @@ CEED_QFUNCTION_HELPER int PressureOutflow(void *ctx, CeedInt Q, const CeedScalar
 }
 
 CEED_QFUNCTION(PressureOutflow_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return PressureOutflow(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return PressureOutflow(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(PressureOutflow_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return PressureOutflow(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return PressureOutflow(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 
 // *****************************************************************************
 // Jacobian for weak-pressure outflow boundary condition
 // *****************************************************************************
 CEED_QFUNCTION_HELPER int PressureOutflow_Jacobian(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out,
-                                                   StateFromQi_t StateFromQi, StateFromQi_fwd_t StateFromQi_fwd) {
+                                                   StateVariable state_var) {
   // Inputs
   const CeedScalar(*dq)[CEED_Q_VLA]           = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*Grad_dq)[5][CEED_Q_VLA]   = (const CeedScalar(*)[5][CEED_Q_VLA])in[1];
@@ -740,8 +754,8 @@ CEED_QFUNCTION_HELPER int PressureOutflow_Jacobian(void *ctx, CeedInt Q, const C
     for (int j = 0; j < 6; j++) kmstress[j] = jac_data_sur[5 + j][i];
     for (int j = 0; j < 5; j++) dqi[j] = dq[j][i];
 
-    State s       = StateFromQi(gas, qi, x_i);
-    State ds      = StateFromQi_fwd(gas, s, dqi, x_i, dx_i);
+    State s       = StateFromQ(gas, qi, x_i, state_var);
+    State ds      = StateFromQ_fwd(gas, s, dqi, x_i, dx_i, state_var);
     s.Y.pressure  = outflow->pressure;
     ds.Y.pressure = 0.;
 
@@ -750,7 +764,7 @@ CEED_QFUNCTION_HELPER int PressureOutflow_Jacobian(void *ctx, CeedInt Q, const C
       CeedScalar dx_i[3] = {0}, dqi_j[5];
       for (CeedInt k = 0; k < 5; k++) dqi_j[k] = Grad_dq[0][k][i] * dXdx[0][j] + Grad_dq[1][k][i] * dXdx[1][j];
       dx_i[j]    = 1.;
-      grad_ds[j] = StateFromQi_fwd(gas, s, dqi_j, x_i, dx_i);
+      grad_ds[j] = StateFromQ_fwd(gas, s, dqi_j, x_i, dx_i, state_var);
     }
 
     CeedScalar dstrain_rate[6], dkmstress[6], stress[3][3], dstress[3][3], dFe[3];
@@ -772,9 +786,9 @@ CEED_QFUNCTION_HELPER int PressureOutflow_Jacobian(void *ctx, CeedInt Q, const C
 }
 
 CEED_QFUNCTION(PressureOutflow_Jacobian_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return PressureOutflow_Jacobian(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return PressureOutflow_Jacobian(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(PressureOutflow_Jacobian_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return PressureOutflow_Jacobian(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return PressureOutflow_Jacobian(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }

--- a/examples/fluids/qfunctions/gaussianwave.h
+++ b/examples/fluids/qfunctions/gaussianwave.h
@@ -23,7 +23,7 @@ struct GaussianWaveContext_ {
   struct NewtonianIdealGasContext_ newt_ctx;
 };
 
-CEED_QFUNCTION_HELPER int IC_GaussianWave(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateToQi_t StateToQi) {
+CEED_QFUNCTION_HELPER int IC_GaussianWave(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateVariable state_var) {
   const CeedScalar(*X)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
 
   CeedScalar(*q0)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
@@ -55,7 +55,7 @@ CEED_QFUNCTION_HELPER int IC_GaussianWave(void *ctx, CeedInt Q, const CeedScalar
     U[4] = S_infty.Y.pressure / (gamma - 1) * perturbation + e_kinetic;
 
     State initCond = StateFromU(newt_ctx, U, x);
-    StateToQi(newt_ctx, initCond, qi);
+    StateToQ(newt_ctx, initCond, qi, state_var);
 
     for (CeedInt j = 0; j < 5; j++) q0[j][i] = qi[j];
   }
@@ -64,9 +64,9 @@ CEED_QFUNCTION_HELPER int IC_GaussianWave(void *ctx, CeedInt Q, const CeedScalar
 }
 
 CEED_QFUNCTION(IC_GaussianWave_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return IC_GaussianWave(ctx, Q, in, out, StateToU);
+  return IC_GaussianWave(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(IC_GaussianWave_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return IC_GaussianWave(ctx, Q, in, out, StateToY);
+  return IC_GaussianWave(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }

--- a/examples/fluids/qfunctions/sgs_dd_model.h
+++ b/examples/fluids/qfunctions/sgs_dd_model.h
@@ -158,7 +158,7 @@ CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropic(const CeedScalar grad_velo_a
 
 // @brief Calculate subgrid stress at nodes using anisotropic data-driven model
 CEED_QFUNCTION_HELPER int ComputeSGS_DDAnisotropicNodal(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out,
-                                                        StateFromQi_t StateFromQi) {
+                                                        StateVariable state_var) {
   const CeedScalar(*q)[CEED_Q_VLA]            = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*x)[CEED_Q_VLA]            = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*grad_velo)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[2];
@@ -179,7 +179,7 @@ CEED_QFUNCTION_HELPER int ComputeSGS_DDAnisotropicNodal(void *ctx, CeedInt Q, co
     };
     const CeedScalar km_A_ij[6] = {A_ij_delta[0][i], A_ij_delta[1][i], A_ij_delta[2][i], A_ij_delta[3][i], A_ij_delta[4][i], A_ij_delta[5][i]};
     const CeedScalar delta      = A_ij_delta[6][i];
-    const State      s          = StateFromQi(gas, qi, x_i);
+    const State      s          = StateFromQ(gas, qi, x_i, state_var);
     CeedScalar       km_sgs[6];
 
     ComputeSGS_DDAnisotropic(grad_velo_aniso, km_A_ij, delta, gas->mu / s.U.density, km_sgs, sgsdd_ctx);
@@ -190,11 +190,11 @@ CEED_QFUNCTION_HELPER int ComputeSGS_DDAnisotropicNodal(void *ctx, CeedInt Q, co
 }
 
 CEED_QFUNCTION(ComputeSGS_DDAnisotropicNodal_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return ComputeSGS_DDAnisotropicNodal(ctx, Q, in, out, StateFromY);
+  return ComputeSGS_DDAnisotropicNodal(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 
 CEED_QFUNCTION(ComputeSGS_DDAnisotropicNodal_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return ComputeSGS_DDAnisotropicNodal(ctx, Q, in, out, StateFromU);
+  return ComputeSGS_DDAnisotropicNodal(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 // @brief Adds subgrid stress to residual (during IFunction evaluation)
@@ -211,7 +211,7 @@ CEED_QFUNCTION_HELPER int FluxSubgridStress(const StatePrimitive Y, const CeedSc
 }
 
 CEED_QFUNCTION_HELPER int IFunction_NodalSubgridStress(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out,
-                                                       StateFromQi_t StateFromQi, StateFromQi_fwd_t StateFromQi_fwd) {
+                                                       StateVariable state_var) {
   const CeedScalar(*q)[CEED_Q_VLA]      = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*x)[CEED_Q_VLA]      = (const CeedScalar(*)[CEED_Q_VLA])in[2];
@@ -224,7 +224,7 @@ CEED_QFUNCTION_HELPER int IFunction_NodalSubgridStress(void *ctx, CeedInt Q, con
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     const CeedScalar qi[5]  = {q[0][i], q[1][i], q[2][i], q[3][i], q[4][i]};
     const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
-    const State      s      = StateFromQi(gas, qi, x_i);
+    const State      s      = StateFromQ(gas, qi, x_i, state_var);
 
     const CeedScalar wdetJ      = q_data[0][i];
     const CeedScalar dXdx[3][3] = {
@@ -247,11 +247,11 @@ CEED_QFUNCTION_HELPER int IFunction_NodalSubgridStress(void *ctx, CeedInt Q, con
 }
 
 CEED_QFUNCTION(IFunction_NodalSubgridStress_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return IFunction_NodalSubgridStress(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return IFunction_NodalSubgridStress(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(IFunction_NodalSubgridStress_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return IFunction_NodalSubgridStress(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return IFunction_NodalSubgridStress(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 
 #endif  // sgs_dd_model_h

--- a/examples/fluids/qfunctions/turb_spanstats.h
+++ b/examples/fluids/qfunctions/turb_spanstats.h
@@ -11,8 +11,7 @@
 #include "turb_stats_types.h"
 #include "utils.h"
 
-CEED_QFUNCTION_HELPER int ChildStatsCollection(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateFromQi_t StateFromQi,
-                                               StateFromQi_fwd_t StateFromQi_fwd) {
+CEED_QFUNCTION_HELPER int ChildStatsCollection(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out, StateVariable state_var) {
   const CeedScalar(*q)[CEED_Q_VLA]      = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*x)[CEED_Q_VLA]      = (const CeedScalar(*)[CEED_Q_VLA])in[2];
@@ -27,7 +26,7 @@ CEED_QFUNCTION_HELPER int ChildStatsCollection(void *ctx, CeedInt Q, const CeedS
 
     const CeedScalar qi[5]  = {q[0][i], q[1][i], q[2][i], q[3][i], q[4][i]};
     const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
-    const State      s      = StateFromQi(gas, qi, x_i);
+    const State      s      = StateFromQ(gas, qi, x_i, state_var);
 
     v[TURB_MEAN_DENSITY][i]                    = wdetJ * s.U.density;
     v[TURB_MEAN_PRESSURE][i]                   = wdetJ * s.Y.pressure;
@@ -56,11 +55,11 @@ CEED_QFUNCTION_HELPER int ChildStatsCollection(void *ctx, CeedInt Q, const CeedS
 }
 
 CEED_QFUNCTION(ChildStatsCollection_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return ChildStatsCollection(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return ChildStatsCollection(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(ChildStatsCollection_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return ChildStatsCollection(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return ChildStatsCollection(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 
 // QFunctions for testing

--- a/examples/fluids/qfunctions/utils.h
+++ b/examples/fluids/qfunctions/utils.h
@@ -51,7 +51,7 @@ CEED_QFUNCTION_HELPER CeedScalar DotN(const CeedScalar *u, const CeedScalar *v, 
 }
 
 // @brief Dot product of 3 element vectors
-CEED_QFUNCTION_HELPER CeedScalar Dot3(const CeedScalar u[3], const CeedScalar v[3]) { return u[0] * v[0] + u[1] * v[1] + u[2] * v[2]; }
+CEED_QFUNCTION_HELPER CeedScalar Dot3(const CeedScalar *u, const CeedScalar *v) { return u[0] * v[0] + u[1] * v[1] + u[2] * v[2]; }
 
 // @brief Cross product of vectors with 3 elements
 CEED_QFUNCTION_HELPER void Cross3(const CeedScalar u[3], const CeedScalar v[3], CeedScalar w[3]) {

--- a/examples/fluids/qfunctions/velocity_gradient_projection.h
+++ b/examples/fluids/qfunctions/velocity_gradient_projection.h
@@ -15,7 +15,7 @@
 #include "utils.h"
 
 CEED_QFUNCTION_HELPER int VelocityGradientProjectionRHS(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out,
-                                                        StateFromQi_t StateFromQi, StateFromQi_fwd_t StateFromQi_fwd) {
+                                                        StateVariable state_var) {
   const CeedScalar(*q)[CEED_Q_VLA]         = (const CeedScalar(*)[CEED_Q_VLA])in[0];
   const CeedScalar(*Grad_q)[5][CEED_Q_VLA] = (const CeedScalar(*)[5][CEED_Q_VLA])in[1];
   const CeedScalar(*q_data)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[2];
@@ -34,7 +34,7 @@ CEED_QFUNCTION_HELPER int VelocityGradientProjectionRHS(void *ctx, CeedInt Q, co
         {q_data[7][i], q_data[8][i], q_data[9][i]}
     };
 
-    const State s = StateFromQi(context, qi, x_i);
+    const State s = StateFromQ(context, qi, x_i, state_var);
     State       grad_s[3];
     for (CeedInt j = 0; j < 3; j++) {
       CeedScalar dx_i[3] = {0}, dqi[5];
@@ -42,7 +42,7 @@ CEED_QFUNCTION_HELPER int VelocityGradientProjectionRHS(void *ctx, CeedInt Q, co
         dqi[k] = Grad_q[0][k][i] * dXdx[0][j] + Grad_q[1][k][i] * dXdx[1][j] + Grad_q[2][k][i] * dXdx[2][j];
       }
       dx_i[j]   = 1.;
-      grad_s[j] = StateFromQi_fwd(context, s, dqi, x_i, dx_i);
+      grad_s[j] = StateFromQ_fwd(context, s, dqi, x_i, dx_i, state_var);
     }
 
     CeedScalar grad_velocity[3][3];
@@ -58,10 +58,10 @@ CEED_QFUNCTION_HELPER int VelocityGradientProjectionRHS(void *ctx, CeedInt Q, co
 }
 
 CEED_QFUNCTION(VelocityGradientProjectionRHS_Conserv)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return VelocityGradientProjectionRHS(ctx, Q, in, out, StateFromU, StateFromU_fwd);
+  return VelocityGradientProjectionRHS(ctx, Q, in, out, STATEVAR_CONSERVATIVE);
 }
 
 CEED_QFUNCTION(VelocityGradientProjectionRHS_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  return VelocityGradientProjectionRHS(ctx, Q, in, out, StateFromY, StateFromY_fwd);
+  return VelocityGradientProjectionRHS(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
 #endif  // velocity_gradient_projection_h


### PR DESCRIPTION
Instead of using function pointers to convert generic state vectors to `State` structs, use enums passed to a function. This is done to increase backend compatibility (particularly with SYCL/OpenCL).