### PR TITLE
doc: fix math in headers

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -199,6 +199,7 @@ latex_elements = {
     #
     "preamble": r"""
 \usepackage{amscd}
+\usepackage{cancel}
 \newcommand\bm[1]{\symbf{#1}}
 """
     + latex_macros,

--- a/examples/fluids/README.md
+++ b/examples/fluids/README.md
@@ -704,7 +704,7 @@ For the Density Current, Channel, and Blasius problems, the following common com
   - string
 
 * - `-diff_filter_wall_damping_constant`
-  - Constant for the wall-damping function. $\A^+$ for `van_driest` damping function.
+  - Constant for the wall-damping function. $A^+$ for `van_driest` damping function.
   - 25
   -
 

--- a/examples/fluids/index.md
+++ b/examples/fluids/index.md
@@ -377,7 +377,7 @@ $$
 
 The boundary integral resulting from integration-by-parts is crossed out, as we assume that $(\bm{D}\bm{\Delta})^2 = \bm{0} \Leftrightarrow \overline \phi = \phi$ at boundaries (this is reasonable at walls, but for convenience elsewhere).
 
-#### Filter width tensor $\bm{\Delta}$
+#### Filter width tensor, Δ
 For homogenous filtering, $\bm{\Delta}$ is defined as the identity matrix.
 
 :::{note}
@@ -441,7 +441,7 @@ $$
 \end{bmatrix}
 $$
 
-#### Filter kernel scaling, $\beta$
+#### Filter kernel scaling, β
 While we define $\bm{D}\bm{\Delta}$ to be of a certain physical filter width, the actual width of the implied filter kernel is quite larger than "normal" kernels.
 To account for this, we use $\beta$ to scale the filter tensor to the appropriate size, as is done in {cite}`bullExplicitFilteringExact2016`.
 To match the "size" of a normal kernel to our differential kernel, we attempt to have them match second order moments with respect to the prescribed filter width.


### PR DESCRIPTION
There is a bad hyperref/unicode-math interaction apparently resulting from how PDF bookmarks work. This replaces math in headers (section titles) with unicode Greek letters to fix doc-latexpdf.

https://tex.stackexchange.com/questions/570000/improper-alphabetic-constant-error-in-title-with-greek-bug-with-unicode-math-an