### PR TITLE
fluids: Compatability for PETSc w/ 64bit ints

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
     }
     // Mesh
     const PetscInt num_comp_q = 5;
-    CeedInt        glob_dofs, owned_dofs;
+    PetscInt       glob_dofs, owned_dofs;
     PetscInt       glob_nodes, local_nodes;
     const CeedInt  num_P = app_ctx->degree + 1, num_Q = num_P + app_ctx->q_extra;
     // -- Get global size

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -415,6 +415,9 @@ PetscErrorCode PHASTADatFileGetNRows(const MPI_Comm comm, const char path[PETSC_
 
 PetscErrorCode PHASTADatFileReadToArrayReal(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscReal array[]);
 
+PetscErrorCode IntArrayC2P(PetscInt num_entries, CeedInt **array_ceed, PetscInt **array_petsc);
+PetscErrorCode IntArrayP2C(PetscInt num_entries, PetscInt **array_petsc, CeedInt **array_ceed);
+
 // -----------------------------------------------------------------------------
 // Turbulence Statistics Collection Functions
 // -----------------------------------------------------------------------------

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -277,9 +277,7 @@ struct ProblemData_private {
   CeedScalar           dm_scale;
   ProblemQFunctionSpec setup_vol, setup_sur, ics, apply_vol_rhs, apply_vol_ifunction, apply_vol_ijacobian, apply_inflow, apply_outflow,
       apply_freestream, apply_inflow_jacobian, apply_outflow_jacobian, apply_freestream_jacobian;
-  bool non_zero_time;
-  PetscErrorCode (*bc)(PetscInt, PetscReal, const PetscReal[], PetscInt, PetscScalar[], void *);
-  void     *bc_ctx;
+  bool      non_zero_time;
   PetscBool bc_from_ics, use_strong_bc_ceed;
   PetscErrorCode (*print_info)(ProblemData *, AppCtx);
 };

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -397,7 +397,9 @@ PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q);
 PetscErrorCode SetBCsFromICs_NS(DM dm, Vec Q, Vec Q_loc);
 
 // Versioning token for binary checkpoints
-extern const PetscInt FLUIDS_FILE_TOKEN;
+extern const PetscInt32 FLUIDS_FILE_TOKEN;  // for backwards compatibility
+extern const PetscInt32 FLUIDS_FILE_TOKEN_32;
+extern const PetscInt32 FLUIDS_FILE_TOKEN_64;
 
 // Create appropriate mass qfunction based on number of components N
 PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, CeedQFunction *qf);

--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -51,8 +51,6 @@ PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *ctx, SimpleBC bc)
   problem->apply_vol_ifunction.qfunction_loc = IFunction_Advection_loc;
   problem->apply_inflow.qfunction            = Advection_InOutFlow;
   problem->apply_inflow.qfunction_loc        = Advection_InOutFlow_loc;
-  problem->bc                                = Exact_Advection;
-  problem->bc_ctx                            = setup_context;
   problem->non_zero_time                     = PETSC_FALSE;
   problem->print_info                        = PRINT_ADVECTION;
 

--- a/examples/fluids/problems/advection2d.c
+++ b/examples/fluids/problems/advection2d.c
@@ -49,8 +49,6 @@ PetscErrorCode NS_ADVECTION2D(ProblemData *problem, DM dm, void *ctx, SimpleBC b
   problem->apply_vol_ifunction.qfunction_loc = IFunction_Advection2d_loc;
   problem->apply_inflow.qfunction            = Advection2d_InOutFlow;
   problem->apply_inflow.qfunction_loc        = Advection2d_InOutFlow_loc;
-  problem->bc                                = Exact_Advection2d;
-  problem->bc_ctx                            = setup_context;
   problem->non_zero_time                     = PETSC_TRUE;
   problem->print_info                        = PRINT_ADVECTION2D;
 

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -111,7 +111,7 @@ PetscErrorCode ComputeChebyshevCoefficients(BlasiusContext blasius) {
 }
 
 static PetscErrorCode GetYNodeLocs(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscReal **pynodes, PetscInt *nynodes) {
-  PetscInt       ndims, dims[2];
+  int            ndims, dims[2];
   FILE          *fp;
   const PetscInt char_array_len = 512;
   char           line[char_array_len];
@@ -132,8 +132,7 @@ static PetscErrorCode GetYNodeLocs(const MPI_Comm comm, const char path[PETSC_MA
     PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
     PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
     PetscCheck(ndims == dims[1], comm, PETSC_ERR_FILE_UNEXPECTED,
-               "Line %" PetscInt_FMT " of %s does not contain correct number of columns (%" PetscInt_FMT " instead of %" PetscInt_FMT ")", i, path,
-               ndims, dims[1]);
+               "Line %" PetscInt_FMT " of %s does not contain correct number of columns (%d instead of %d)", i, path, ndims, dims[1]);
 
     node_locs[i] = (PetscReal)atof(array[0]);
   }
@@ -207,11 +206,12 @@ static PetscErrorCode ModifyMesh(MPI_Comm comm, DM dm, PetscInt dim, PetscReal g
     *node_locs = temp_node_locs;
   } else {
     PetscCheck(*num_node_locs >= faces[1] + 1, comm, PETSC_ERR_FILE_UNEXPECTED,
-               "The y_node_locs_path has too few locations; There are %d + 1 nodes, but only %d locations given", faces[1] + 1, *num_node_locs);
+               "The y_node_locs_path has too few locations; There are %" PetscInt_FMT " + 1 nodes, but only %" PetscInt_FMT " locations given",
+               faces[1] + 1, *num_node_locs);
     if (*num_node_locs > faces[1] + 1) {
       PetscCall(PetscPrintf(comm,
-                            "WARNING: y_node_locs_path has more locations (%d) "
-                            "than the mesh has nodes (%d). This maybe unintended.\n",
+                            "WARNING: y_node_locs_path has more locations (%" PetscInt_FMT ") "
+                            "than the mesh has nodes (%" PetscInt_FMT "). This maybe unintended.\n",
                             *num_node_locs, faces[1] + 1));
     }
     PetscScalar max_y = (*node_locs)[faces[1]];
@@ -252,7 +252,7 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
   CeedScalar T_wall                               = 288.;         // K
   CeedScalar delta0                               = 4.2e-3;       // m
   CeedScalar P0                                   = 1.01e5;       // Pa
-  CeedInt    N                                    = 20;           // Number of Chebyshev terms
+  PetscInt   N                                    = 20;           // Number of Chebyshev terms
   PetscBool  weakT                                = PETSC_FALSE;  // weak density or temperature
   PetscReal  mesh_refine_height                   = 5.9e-4;       // m
   PetscReal  mesh_growth                          = 1.08;         // [-]

--- a/examples/fluids/problems/eulervortex.c
+++ b/examples/fluids/problems/eulervortex.c
@@ -50,8 +50,6 @@ PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *ctx, SimpleBC 
   problem->apply_inflow.qfunction_loc        = TravelingVortex_Inflow_loc;
   problem->apply_outflow.qfunction           = Euler_Outflow;
   problem->apply_outflow.qfunction_loc       = Euler_Outflow_loc;
-  problem->bc                                = Exact_Euler;
-  problem->bc_ctx                            = euler_ctx;
   problem->non_zero_time                     = PETSC_TRUE;
   problem->print_info                        = PRINT_EULER_VORTEX;
 

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -91,8 +91,6 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx, SimpleBC 
   problem->setup_vol.qfunction_loc = Setup_loc;
   problem->setup_sur.qfunction     = SetupBoundary;
   problem->setup_sur.qfunction_loc = SetupBoundary_loc;
-  problem->bc                      = NULL;
-  problem->bc_ctx                  = NULL;
   problem->non_zero_time           = PETSC_FALSE;
   problem->print_info              = PRINT_NEWTONIAN;
 

--- a/examples/fluids/problems/sgs_dd_model.c
+++ b/examples/fluids/problems/sgs_dd_model.c
@@ -66,7 +66,8 @@ PetscErrorCode SGS_DD_ModelSetupNodalEvaluation(Ceed ceed, User user, CeedData c
   SGS_DD_Data         sgs_dd_data = user->sgs_dd_data;
   CeedQFunction       qf_multiplicity, qf_sgs_dd_nodal;
   CeedOperator        op_multiplicity, op_sgs_dd_nodal;
-  CeedInt             num_elem, elem_size, num_comp_q, dim, num_qpts_1d, num_comp_grad_velo, num_comp_x, num_comp_grid_aniso;
+  CeedInt             num_elem, elem_size, num_comp_q, num_qpts_1d, num_comp_grad_velo, num_comp_x, num_comp_grid_aniso;
+  PetscInt            dim;
   CeedVector          multiplicity, inv_multiplicity;
   CeedElemRestriction elem_restr_inv_multiplicity, elem_restr_grad_velo, elem_restr_sgs;
 
@@ -160,7 +161,8 @@ PetscErrorCode SGS_DD_ModelSetupNodalEvaluation(Ceed ceed, User user, CeedData c
 // @brief Create CeedOperator to compute SGS contribution to the residual
 PetscErrorCode SGS_ModelSetupNodalIFunction(Ceed ceed, User user, CeedData ceed_data, SGS_DD_ModelSetupData sgs_dd_setup_data) {
   SGS_DD_Data   sgs_dd_data = user->sgs_dd_data;
-  CeedInt       dim, num_comp_q, num_comp_qd, num_comp_x, num_qpts_1d, num_nodes_1d;
+  CeedInt       num_comp_q, num_comp_qd, num_comp_x, num_qpts_1d, num_nodes_1d;
+  PetscInt      dim;
   CeedQFunction qf_sgs_apply;
   CeedOperator  op_sgs_apply;
   CeedBasis     basis_sgs;

--- a/examples/fluids/problems/shocktube.c
+++ b/examples/fluids/problems/shocktube.c
@@ -47,8 +47,6 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc)
   problem->apply_vol_rhs.qfunction_loc       = EulerShockTube_loc;
   problem->apply_vol_ifunction.qfunction     = NULL;
   problem->apply_vol_ifunction.qfunction_loc = NULL;
-  problem->bc                                = Exact_ShockTube;
-  problem->bc_ctx                            = setup_context;
   problem->non_zero_time                     = PETSC_FALSE;
   problem->print_info                        = PRINT_SHOCKTUBE;
 

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -61,7 +61,8 @@ PetscErrorCode CalcCholeskyDecomp(MPI_Comm comm, PetscInt nprofs, const CeedScal
  * @param[in,out] stg_ctx STGShur14Context where the data will be loaded into
  */
 static PetscErrorCode ReadSTGInflow(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], STGShur14Context stg_ctx) {
-  PetscInt       ndims, dims[2];
+  PetscInt       dims[2];
+  int            ndims;
   FILE          *fp;
   const PetscInt char_array_len = 512;
   char           line[char_array_len];
@@ -81,8 +82,7 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm, const char path[PETSC_M
     PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
     PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
     PetscCheck(ndims == dims[1], comm, PETSC_ERR_FILE_UNEXPECTED,
-               "Line %" PetscInt_FMT " of %s does not have correct number of columns (%" PetscInt_FMT " instead of %" PetscInt_FMT ")", i, path,
-               ndims, dims[1]);
+               "Line %" PetscInt_FMT " of %s does not have correct number of columns (%d instead of %" PetscInt_FMT ")", i, path, ndims, dims[1]);
 
     wall_dist[i] = (CeedScalar)atof(array[0]);
     ubar[0][i]   = (CeedScalar)atof(array[1]);
@@ -119,7 +119,8 @@ static PetscErrorCode ReadSTGInflow(const MPI_Comm comm, const char path[PETSC_M
  * @param[in,out] stg_ctx STGShur14Context where the data will be loaded into
  */
 static PetscErrorCode ReadSTGRand(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], STGShur14Context stg_ctx) {
-  PetscInt       ndims, dims[2];
+  PetscInt       dims[2];
+  int            ndims;
   FILE          *fp;
   const PetscInt char_array_len = 512;
   char           line[char_array_len];
@@ -136,8 +137,7 @@ static PetscErrorCode ReadSTGRand(const MPI_Comm comm, const char path[PETSC_MAX
     PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
     PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
     PetscCheck(ndims == dims[1], comm, PETSC_ERR_FILE_UNEXPECTED,
-               "Line %" PetscInt_FMT " of %s does not have correct number of columns (%" PetscInt_FMT " instead of %" PetscInt_FMT ")", i, path,
-               ndims, dims[1]);
+               "Line %" PetscInt_FMT " of %s does not have correct number of columns (%d instead of %" PetscInt_FMT ")", i, path, ndims, dims[1]);
 
     d[0][i]     = (CeedScalar)atof(array[0]);
     d[1][i]     = (CeedScalar)atof(array[1]);
@@ -173,8 +173,8 @@ PetscErrorCode GetSTGContextData(const MPI_Comm comm, const DM dm, char stg_infl
   PetscCall(PHASTADatFileGetNRows(comm, stg_rand_path, &nmodes));
   PetscCall(PHASTADatFileGetNRows(comm, stg_inflow_path, &nprofs));
   PetscCheck(nmodes < STG_NMODES_MAX, comm, PETSC_ERR_SUP,
-             "Number of wavemodes in %s (%" PetscInt_FMT ") exceeds STG_NMODES_MAX (%" PetscInt_FMT "). Change size of STG_NMODES_MAX and recompile",
-             stg_rand_path, nmodes, STG_NMODES_MAX);
+             "Number of wavemodes in %s (%" PetscInt_FMT ") exceeds STG_NMODES_MAX (%d). Change size of STG_NMODES_MAX and recompile", stg_rand_path,
+             nmodes, STG_NMODES_MAX);
 
   {
     STGShur14Context temp_ctx;

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -17,7 +17,8 @@
 PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData ceed_data, CeedQFunctionContext diff_filter_qfctx) {
   DiffFilterData diff_filter = user->diff_filter;
   DM             dm_filter   = diff_filter->dm_filter;
-  CeedInt        num_comp_q, num_comp_qd, dim, num_qpts_1d, num_nodes_1d, num_comp_x;
+  CeedInt        num_comp_q, num_comp_qd, num_qpts_1d, num_nodes_1d, num_comp_x;
+  PetscInt       dim;
 
   PetscFunctionBeginUser;
   PetscCall(DMGetDimension(user->dm, &dim));
@@ -81,7 +82,8 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
     CeedOperator         op_lhs;
     OperatorApplyContext mat_ctx;
     Mat                  mat_lhs;
-    CeedInt              num_comp_qd, dim, num_comp_grid_aniso;
+    CeedInt              num_comp_qd;
+    PetscInt             dim, num_comp_grid_aniso;
     CeedElemRestriction  elem_restr_grid_aniso;
     CeedVector           grid_aniso_ceed;
 
@@ -113,7 +115,8 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
           CeedQFunctionCreateInterior(ceed, 1, DifferentialFilter_LHS_11, DifferentialFilter_LHS_11_loc, &qf_lhs);
           break;
         default:
-          SETERRQ(PetscObjectComm((PetscObject)user->dm), PETSC_ERR_SUP, "Differential filtering not available for (%d) components", num_comp_filter);
+          SETERRQ(PetscObjectComm((PetscObject)user->dm), PETSC_ERR_SUP, "Differential filtering not available for (%" PetscInt_FMT ") components",
+                  num_comp_filter);
       }
 
       CeedQFunctionSetContext(qf_lhs, diff_filter_qfctx);

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -53,26 +53,22 @@ PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, SimpleBC bc
     PetscCall(DMPlexLabelComplete(dm, label));
     // Set wall BCs
     if (bc->num_wall > 0) {
-      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "wall", label, bc->num_wall, bc->walls, 0, bc->num_comps, bc->wall_comps,
-                              (void (*)(void))problem->bc, NULL, problem->bc_ctx, NULL));
+      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "wall", label, bc->num_wall, bc->walls, 0, bc->num_comps, bc->wall_comps, NULL, NULL, NULL, NULL));
     }
     // Set slip BCs in the x direction
     if (bc->num_slip[0] > 0) {
       PetscInt comps[1] = {1};
-      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipx", label, bc->num_slip[0], bc->slips[0], 0, 1, comps, (void (*)(void))NULL, NULL,
-                              problem->bc_ctx, NULL));
+      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipx", label, bc->num_slip[0], bc->slips[0], 0, 1, comps, NULL, NULL, NULL, NULL));
     }
     // Set slip BCs in the y direction
     if (bc->num_slip[1] > 0) {
       PetscInt comps[1] = {2};
-      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipy", label, bc->num_slip[1], bc->slips[1], 0, 1, comps, (void (*)(void))NULL, NULL,
-                              problem->bc_ctx, NULL));
+      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipy", label, bc->num_slip[1], bc->slips[1], 0, 1, comps, NULL, NULL, NULL, NULL));
     }
     // Set slip BCs in the z direction
     if (bc->num_slip[2] > 0) {
       PetscInt comps[1] = {3};
-      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipz", label, bc->num_slip[2], bc->slips[2], 0, 1, comps, (void (*)(void))NULL, NULL,
-                              problem->bc_ctx, NULL));
+      PetscCall(DMAddBoundary(dm, DM_BC_ESSENTIAL, "slipz", label, bc->num_slip[2], bc->slips[2], 0, 1, comps, NULL, NULL, NULL, NULL));
     }
     {
       PetscBool use_strongstg = PETSC_FALSE;

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -365,8 +365,8 @@ PetscErrorCode WriteOutput(User user, Vec Q, PetscInt step_no, PetscScalar time)
   }
   PetscCall(PetscViewerBinaryOpen(user->comm, file_path, FILE_MODE_WRITE, &viewer));
 
-  PetscInt token = FLUIDS_FILE_TOKEN;
-  PetscCall(PetscViewerBinaryWrite(viewer, &token, 1, PETSC_INT));
+  PetscInt32 token = PetscDefined(USE_64BIT_INDICES) ? FLUIDS_FILE_TOKEN_64 : FLUIDS_FILE_TOKEN_32;
+  PetscCall(PetscViewerBinaryWrite(viewer, &token, 1, PETSC_INT32));
   PetscCall(PetscViewerBinaryWrite(viewer, &step_no, 1, PETSC_INT));
   time /= user->units->second;  // Dimensionalize time back
   PetscCall(PetscViewerBinaryWrite(viewer, &time, 1, PETSC_REAL));

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -217,29 +217,32 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
 
 static PetscErrorCode FormPreallocation(User user, PetscBool pbdiagonal, Mat J, CeedVector *coo_values) {
   PetscCount ncoo;
-  PetscInt  *rows, *cols;
+  PetscInt  *rows_petsc, *cols_petsc;
 
   PetscFunctionBeginUser;
   if (pbdiagonal) {
     CeedSize l_size;
     CeedOperatorGetActiveVectorLengths(user->op_ijacobian, &l_size, NULL);
-    ncoo = l_size * 5;
-    rows = malloc(ncoo * sizeof(rows[0]));
-    cols = malloc(ncoo * sizeof(cols[0]));
+    ncoo       = l_size * 5;
+    rows_petsc = malloc(ncoo * sizeof(rows_petsc));
+    cols_petsc = malloc(ncoo * sizeof(cols_petsc));
     for (PetscCount n = 0; n < l_size / 5; n++) {
       for (PetscInt i = 0; i < 5; i++) {
         for (PetscInt j = 0; j < 5; j++) {
-          rows[(n * 5 + i) * 5 + j] = n * 5 + i;
-          cols[(n * 5 + i) * 5 + j] = n * 5 + j;
+          rows_petsc[(n * 5 + i) * 5 + j] = n * 5 + i;
+          cols_petsc[(n * 5 + i) * 5 + j] = n * 5 + j;
         }
       }
     }
   } else {
-    PetscCall(CeedOperatorLinearAssembleSymbolic(user->op_ijacobian, &ncoo, &rows, &cols));
+    CeedInt *rows_ceed, *cols_ceed;
+    PetscCall(CeedOperatorLinearAssembleSymbolic(user->op_ijacobian, &ncoo, &rows_ceed, &cols_ceed));
+    PetscCall(IntArrayC2P(ncoo, &rows_ceed, &rows_petsc));
+    PetscCall(IntArrayC2P(ncoo, &cols_ceed, &cols_petsc));
   }
-  PetscCall(MatSetPreallocationCOOLocal(J, ncoo, rows, cols));
-  free(rows);
-  free(cols);
+  PetscCall(MatSetPreallocationCOOLocal(J, ncoo, rows_petsc, cols_petsc));
+  free(rows_petsc);
+  free(cols_petsc);
   CeedVectorCreate(user->ceed, ncoo, coo_values);
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -144,7 +144,7 @@ PetscErrorCode GetQuadratureCoords(Ceed ceed, DM dm, CeedElemRestriction elem_re
   CeedElemRestriction  elem_restr_qx;
   CeedQFunction        qf_quad_coords;
   CeedOperator         op_quad_coords;
-  PetscInt             num_comp_x, loc_num_elem, num_elem_qpts;
+  CeedInt              num_comp_x, loc_num_elem, num_elem_qpts;
   OperatorApplyContext op_quad_coords_ctx;
 
   PetscFunctionBeginUser;
@@ -176,9 +176,10 @@ PetscErrorCode GetQuadratureCoords(Ceed ceed, DM dm, CeedElemRestriction elem_re
 }
 
 PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem, SpanStatsSetupData *stats_data) {
-  DM      dm = user->spanstats.dm;
-  CeedInt dim, P, Q, num_comp_x, num_comp_stats = user->spanstats.num_comp_stats;
-  Vec     X_loc;
+  DM       dm = user->spanstats.dm;
+  PetscInt dim;
+  CeedInt  P, Q, num_comp_x, num_comp_stats = user->spanstats.num_comp_stats;
+  Vec      X_loc;
   PetscFunctionBeginUser;
 
   PetscCall(PetscNew(stats_data));
@@ -236,7 +237,8 @@ PetscErrorCode SpanStatsSetupDataDestroy(SpanStatsSetupData data) {
 
 // Create PetscSF for child-to-parent communication
 PetscErrorCode CreateStatsSF(Ceed ceed, CeedData ceed_data, SpanStatsSetupData stats_data, DM parentdm, DM childdm, PetscSF *statssf) {
-  PetscInt child_num_qpnts, parent_num_qpnts, num_comp_x;
+  PetscInt child_num_qpnts, parent_num_qpnts;
+  CeedInt  num_comp_x;
   Vec      Child_qx_coords, Parent_qx_coords;
 
   PetscFunctionBeginUser;

--- a/examples/fluids/src/velocity_gradient_projection.c
+++ b/examples/fluids/src/velocity_gradient_projection.c
@@ -53,7 +53,8 @@ PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ce
   CeedQFunction        qf_rhs_assemble, qf_mass;
   CeedBasis            basis_grad_velo;
   CeedElemRestriction  elem_restr_grad_velo;
-  PetscInt             dim, num_comp_x, num_comp_q, q_data_size, num_qpts_1d, num_nodes_1d;
+  PetscInt             dim;
+  CeedInt              num_comp_x, num_comp_q, q_data_size, num_qpts_1d, num_nodes_1d;
 
   PetscFunctionBeginUser;
   PetscCall(PetscNew(&user->grad_velo_proj));


### PR DESCRIPTION
Makes fluids example compatible with PETSc builds using 64bit integers (ie. `--with-64-bit-indices=1`). 

Note: depends on [this PETSc MR](https://gitlab.com/petsc/petsc/-/merge_requests/6618) for `PetscInt32` support.