### PR TITLE
CeedVector/Preconditioning: fix CeedInt loop vars to CeedSize

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -462,6 +462,7 @@ static int CeedVectorNorm_Cuda(CeedVector vec, CeedNormType type, CeedScalar *no
   CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &d_array));
   switch (type) {
     case CEED_NORM_1: {
+      *norm = 0.0;
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
 #if CUDA_VERSION >= 12000  // We have CUDA 12, and can use 64-bit integers
         CeedCallCublas(ceed, cublasSasum_64(handle, (int64_t)length, (float *)d_array, 1, (float *)norm));

--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -277,18 +277,18 @@ static int CeedVectorSetArray_Cuda(const CeedVector vec, const CeedMemType mem_t
 //------------------------------------------------------------------------------
 // Set host array to value
 //------------------------------------------------------------------------------
-static int CeedHostSetValue_Cuda(CeedScalar *h_array, CeedInt length, CeedScalar val) {
-  for (int i = 0; i < length; i++) h_array[i] = val;
+static int CeedHostSetValue_Cuda(CeedScalar *h_array, CeedSize length, CeedScalar val) {
+  for (CeedSize i = 0; i < length; i++) h_array[i] = val;
   return CEED_ERROR_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
 // Set device array to value (impl in .cu file)
 //------------------------------------------------------------------------------
-int CeedDeviceSetValue_Cuda(CeedScalar *d_array, CeedInt length, CeedScalar val);
+int CeedDeviceSetValue_Cuda(CeedScalar *d_array, CeedSize length, CeedScalar val);
 
 //------------------------------------------------------------------------------
-// Set a vector to a value,
+// Set a vector to a value
 //------------------------------------------------------------------------------
 static int CeedVectorSetValue_Cuda(CeedVector vec, CeedScalar val) {
   Ceed ceed;
@@ -449,36 +449,128 @@ static int CeedVectorNorm_Cuda(CeedVector vec, CeedNormType type, CeedScalar *no
   cublasHandle_t handle;
   CeedCallBackend(CeedGetCublasHandle_Cuda(ceed, &handle));
 
+#if CUDA_VERSION < 12000
+  // With CUDA 12, we can use the 64-bit integer interface. Prior to that,
+  // we need to check if the vector is too long to handle with int32,
+  // and if so, divide it into subsections for repeated cuBLAS calls
+  CeedSize num_calls = length / INT_MAX;
+  if (length % INT_MAX > 0) num_calls += 1;
+#endif
+
   // Compute norm
   const CeedScalar *d_array;
   CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &d_array));
   switch (type) {
     case CEED_NORM_1: {
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-        CeedCallCublas(ceed, cublasSasum(handle, length, (float *)d_array, 1, (float *)norm));
+#if CUDA_VERSION >= 12000  // We have CUDA 12, and can use 64-bit integers
+        CeedCallCublas(ceed, cublasSasum_64(handle, (int64_t)length, (float *)d_array, 1, (float *)norm));
+#else
+        float  sub_norm = 0.0;
+        float *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallCublas(ceed, cublasSasum(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &sub_norm));
+          *norm += sub_norm;
+        }
+#endif
       } else {
-        CeedCallCublas(ceed, cublasDasum(handle, length, (double *)d_array, 1, (double *)norm));
+#if CUDA_VERSION >= 12000
+        CeedCallCublas(ceed, cublasDasum_64(handle, (int64_t)length, (double *)d_array, 1, (double *)norm));
+#else
+        double  sub_norm = 0.0;
+        double *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallCublas(ceed, cublasDasum(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &sub_norm));
+          *norm += sub_norm;
+        }
+#endif
       }
       break;
     }
     case CEED_NORM_2: {
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-        CeedCallCublas(ceed, cublasSnrm2(handle, length, (float *)d_array, 1, (float *)norm));
+#if CUDA_VERSION >= 12000
+        CeedCallCublas(ceed, cublasSnrm2_64(handle, (int64_t)length, (float *)d_array, 1, (float *)norm));
+#else
+        float  sub_norm = 0.0, norm_sum = 0.0;
+        float *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallCublas(ceed, cublasSnrm2(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &sub_norm));
+          norm_sum += sub_norm * sub_norm;
+        }
+        *norm            = sqrt(norm_sum);
+#endif
       } else {
-        CeedCallCublas(ceed, cublasDnrm2(handle, length, (double *)d_array, 1, (double *)norm));
+#if CUDA_VERSION >= 12000
+        CeedCallCublas(ceed, cublasDnrm2_64(handle, (int64_t)length, (double *)d_array, 1, (double *)norm));
+#else
+        double  sub_norm = 0.0, norm_sum = 0.0;
+        double *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallCublas(ceed, cublasDnrm2(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &sub_norm));
+          norm_sum += sub_norm * sub_norm;
+        }
+        *norm = sqrt(norm_sum);
+#endif
       }
       break;
     }
     case CEED_NORM_MAX: {
-      CeedInt indx;
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-        CeedCallCublas(ceed, cublasIsamax(handle, length, (float *)d_array, 1, &indx));
+#if CUDA_VERSION >= 12000
+        int64_t indx;
+        CeedCallCublas(ceed, cublasIsamax_64(handle, (int64_t)length, (float *)d_array, 1, &indx));
+        CeedScalar normNoAbs;
+        CeedCallCuda(ceed, cudaMemcpy(&normNoAbs, impl->d_array + indx - 1, sizeof(CeedScalar), cudaMemcpyDeviceToHost));
+        *norm = fabs(normNoAbs);
+#else
+        CeedInt indx;
+        float   sub_max = 0.0, current_max = 0.0;
+        float  *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallCublas(ceed, cublasIsamax(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &indx));
+          CeedCallCuda(ceed, cudaMemcpy(&sub_max, d_array_start + indx - 1, sizeof(CeedScalar), cudaMemcpyDeviceToHost));
+          if (fabs(sub_max) > current_max) current_max = fabs(sub_max);
+        }
+        *norm = current_max;
+#endif
       } else {
-        CeedCallCublas(ceed, cublasIdamax(handle, length, (double *)d_array, 1, &indx));
+#if CUDA_VERSION >= 12000
+        int64_t indx;
+        CeedCallCublas(ceed, cublasIdamax_64(handle, (int64_t)length, (double *)d_array, 1, &indx));
+        CeedScalar normNoAbs;
+        CeedCallCuda(ceed, cudaMemcpy(&normNoAbs, impl->d_array + indx - 1, sizeof(CeedScalar), cudaMemcpyDeviceToHost));
+        *norm = fabs(normNoAbs);
+#else
+        CeedInt indx;
+        double  sub_max = 0.0, current_max = 0.0;
+        double *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallCublas(ceed, cublasIdamax(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &indx));
+          CeedCallCuda(ceed, cudaMemcpy(&sub_max, d_array_start + indx - 1, sizeof(CeedScalar), cudaMemcpyDeviceToHost));
+          if (fabs(sub_max) > current_max) current_max = fabs(sub_max);
+        }
+        *norm = current_max;
+#endif
       }
-      CeedScalar normNoAbs;
-      CeedCallCuda(ceed, cudaMemcpy(&normNoAbs, impl->d_array + indx - 1, sizeof(CeedScalar), cudaMemcpyDeviceToHost));
-      *norm = fabs(normNoAbs);
       break;
     }
   }
@@ -490,8 +582,8 @@ static int CeedVectorNorm_Cuda(CeedVector vec, CeedNormType type, CeedScalar *no
 //------------------------------------------------------------------------------
 // Take reciprocal of a vector on host
 //------------------------------------------------------------------------------
-static int CeedHostReciprocal_Cuda(CeedScalar *h_array, CeedInt length) {
-  for (int i = 0; i < length; i++) {
+static int CeedHostReciprocal_Cuda(CeedScalar *h_array, CeedSize length) {
+  for (CeedSize i = 0; i < length; i++) {
     if (fabs(h_array[i]) > CEED_EPSILON) h_array[i] = 1. / h_array[i];
   }
   return CEED_ERROR_SUCCESS;
@@ -500,7 +592,7 @@ static int CeedHostReciprocal_Cuda(CeedScalar *h_array, CeedInt length) {
 //------------------------------------------------------------------------------
 // Take reciprocal of a vector on device (impl in .cu file)
 //------------------------------------------------------------------------------
-int CeedDeviceReciprocal_Cuda(CeedScalar *d_array, CeedInt length);
+int CeedDeviceReciprocal_Cuda(CeedScalar *d_array, CeedSize length);
 
 //------------------------------------------------------------------------------
 // Take reciprocal of a vector
@@ -523,15 +615,15 @@ static int CeedVectorReciprocal_Cuda(CeedVector vec) {
 //------------------------------------------------------------------------------
 // Compute x = alpha x on the host
 //------------------------------------------------------------------------------
-static int CeedHostScale_Cuda(CeedScalar *x_array, CeedScalar alpha, CeedInt length) {
-  for (int i = 0; i < length; i++) x_array[i] *= alpha;
+static int CeedHostScale_Cuda(CeedScalar *x_array, CeedScalar alpha, CeedSize length) {
+  for (CeedSize i = 0; i < length; i++) x_array[i] *= alpha;
   return CEED_ERROR_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
 // Compute x = alpha x on device (impl in .cu file)
 //------------------------------------------------------------------------------
-int CeedDeviceScale_Cuda(CeedScalar *x_array, CeedScalar alpha, CeedInt length);
+int CeedDeviceScale_Cuda(CeedScalar *x_array, CeedScalar alpha, CeedSize length);
 
 //------------------------------------------------------------------------------
 // Compute x = alpha x
@@ -554,15 +646,15 @@ static int CeedVectorScale_Cuda(CeedVector x, CeedScalar alpha) {
 //------------------------------------------------------------------------------
 // Compute y = alpha x + y on the host
 //------------------------------------------------------------------------------
-static int CeedHostAXPY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedInt length) {
-  for (int i = 0; i < length; i++) y_array[i] += alpha * x_array[i];
+static int CeedHostAXPY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedSize length) {
+  for (CeedSize i = 0; i < length; i++) y_array[i] += alpha * x_array[i];
   return CEED_ERROR_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
 // Compute y = alpha x + y on device (impl in .cu file)
 //------------------------------------------------------------------------------
-int CeedDeviceAXPY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedInt length);
+int CeedDeviceAXPY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedSize length);
 
 //------------------------------------------------------------------------------
 // Compute y = alpha x + y
@@ -592,15 +684,15 @@ static int CeedVectorAXPY_Cuda(CeedVector y, CeedScalar alpha, CeedVector x) {
 //------------------------------------------------------------------------------
 // Compute y = alpha x + beta y on the host
 //------------------------------------------------------------------------------
-static int CeedHostAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedInt length) {
-  for (int i = 0; i < length; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
+static int CeedHostAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedSize length) {
+  for (CeedSize i = 0; i < length; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
   return CEED_ERROR_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
 // Compute y = alpha x + beta y on device (impl in .cu file)
 //------------------------------------------------------------------------------
-int CeedDeviceAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedInt length);
+int CeedDeviceAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedSize length);
 
 //------------------------------------------------------------------------------
 // Compute y = alpha x + beta y
@@ -630,15 +722,15 @@ static int CeedVectorAXPBY_Cuda(CeedVector y, CeedScalar alpha, CeedScalar beta,
 //------------------------------------------------------------------------------
 // Compute the pointwise multiplication w = x .* y on the host
 //------------------------------------------------------------------------------
-static int CeedHostPointwiseMult_Cuda(CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedInt length) {
-  for (int i = 0; i < length; i++) w_array[i] = x_array[i] * y_array[i];
+static int CeedHostPointwiseMult_Cuda(CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedSize length) {
+  for (CeedSize i = 0; i < length; i++) w_array[i] = x_array[i] * y_array[i];
   return CEED_ERROR_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
 // Compute the pointwise multiplication w = x .* y on device (impl in .cu file)
 //------------------------------------------------------------------------------
-int CeedDevicePointwiseMult_Cuda(CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedInt length);
+int CeedDevicePointwiseMult_Cuda(CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedSize length);
 
 //------------------------------------------------------------------------------
 // Compute the pointwise multiplication w = x .* y

--- a/backends/cuda-ref/kernels/cuda-ref-vector.cu
+++ b/backends/cuda-ref/kernels/cuda-ref-vector.cu
@@ -11,9 +11,9 @@
 //------------------------------------------------------------------------------
 // Kernel for set value on device
 //------------------------------------------------------------------------------
-__global__ static void setValueK(CeedScalar * __restrict__ vec, CeedInt size,
+__global__ static void setValueK(CeedScalar * __restrict__ vec, CeedSize size,
                                  CeedScalar val) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size)
     return;
   vec[idx] = val;
@@ -22,10 +22,10 @@ __global__ static void setValueK(CeedScalar * __restrict__ vec, CeedInt size,
 //------------------------------------------------------------------------------
 // Set value on device memory
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceSetValue_Cuda(CeedScalar* d_array, CeedInt length,
+extern "C" int CeedDeviceSetValue_Cuda(CeedScalar* d_array, CeedSize length,
                                        CeedScalar val) {
   const int bsize = 512;
-  const int vecsize = length;
+  const CeedSize vecsize = length;
   int gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize)
@@ -37,8 +37,8 @@ extern "C" int CeedDeviceSetValue_Cuda(CeedScalar* d_array, CeedInt length,
 //------------------------------------------------------------------------------
 // Kernel for taking reciprocal
 //------------------------------------------------------------------------------
-__global__ static void rcpValueK(CeedScalar * __restrict__ vec, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void rcpValueK(CeedScalar * __restrict__ vec, CeedSize size) {
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size)
     return;
   if (fabs(vec[idx]) > 1E-16)
@@ -48,9 +48,9 @@ __global__ static void rcpValueK(CeedScalar * __restrict__ vec, CeedInt size) {
 //------------------------------------------------------------------------------
 // Take vector reciprocal in device memory
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceReciprocal_Cuda(CeedScalar* d_array, CeedInt length) {
+extern "C" int CeedDeviceReciprocal_Cuda(CeedScalar* d_array, CeedSize length) {
   const int bsize = 512;
-  const int vecsize = length;
+  const CeedSize vecsize = length;
   int gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize)
@@ -63,8 +63,8 @@ extern "C" int CeedDeviceReciprocal_Cuda(CeedScalar* d_array, CeedInt length) {
 // Kernel for scale
 //------------------------------------------------------------------------------
 __global__ static void scaleValueK(CeedScalar * __restrict__ x, CeedScalar alpha,
-    CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+    CeedSize size) {
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size)
     return;
   x[idx] *= alpha;
@@ -74,9 +74,9 @@ __global__ static void scaleValueK(CeedScalar * __restrict__ x, CeedScalar alpha
 // Compute x = alpha x on device
 //------------------------------------------------------------------------------
 extern "C" int CeedDeviceScale_Cuda(CeedScalar *x_array, CeedScalar alpha,
-    CeedInt length) {
+    CeedSize length) {
   const int bsize = 512;
-  const int vecsize = length;
+  const CeedSize vecsize = length;
   int gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize)
@@ -89,8 +89,8 @@ extern "C" int CeedDeviceScale_Cuda(CeedScalar *x_array, CeedScalar alpha,
 // Kernel for axpy
 //------------------------------------------------------------------------------
 __global__ static void axpyValueK(CeedScalar * __restrict__ y, CeedScalar alpha,
-    CeedScalar * __restrict__ x, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+    CeedScalar * __restrict__ x, CeedSize size) {
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size)
     return;
   y[idx] += alpha * x[idx];
@@ -100,9 +100,9 @@ __global__ static void axpyValueK(CeedScalar * __restrict__ y, CeedScalar alpha,
 // Compute y = alpha x + y on device
 //------------------------------------------------------------------------------
 extern "C" int CeedDeviceAXPY_Cuda(CeedScalar *y_array, CeedScalar alpha,
-    CeedScalar *x_array, CeedInt length) {
+    CeedScalar *x_array, CeedSize length) {
   const int bsize = 512;
-  const int vecsize = length;
+  const CeedSize vecsize = length;
   int gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize)
@@ -115,8 +115,8 @@ extern "C" int CeedDeviceAXPY_Cuda(CeedScalar *y_array, CeedScalar alpha,
 // Kernel for axpby
 //------------------------------------------------------------------------------
 __global__ static void axpbyValueK(CeedScalar * __restrict__ y, CeedScalar alpha, CeedScalar beta,
-    CeedScalar * __restrict__ x, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+    CeedScalar * __restrict__ x, CeedSize size) {
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size)
     return;
   y[idx] = beta * y[idx];
@@ -127,9 +127,9 @@ __global__ static void axpbyValueK(CeedScalar * __restrict__ y, CeedScalar alpha
 // Compute y = alpha x + beta y on device
 //------------------------------------------------------------------------------
 extern "C" int CeedDeviceAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta,
-    CeedScalar *x_array, CeedInt length) {
+    CeedScalar *x_array, CeedSize length) {
   const int bsize = 512;
-  const int vecsize = length;
+  const CeedSize vecsize = length;
   int gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize)
@@ -142,8 +142,8 @@ extern "C" int CeedDeviceAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedS
 // Kernel for pointwise mult
 //------------------------------------------------------------------------------
 __global__ static void pointwiseMultValueK(CeedScalar * __restrict__ w,
-    CeedScalar * x, CeedScalar * __restrict__ y, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+    CeedScalar * x, CeedScalar * __restrict__ y, CeedSize size) {
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size)
     return;
   w[idx] = x[idx] * y[idx];
@@ -153,9 +153,9 @@ __global__ static void pointwiseMultValueK(CeedScalar * __restrict__ w,
 // Compute the pointwise multiplication w = x .* y on device
 //------------------------------------------------------------------------------
 extern "C" int CeedDevicePointwiseMult_Cuda(CeedScalar *w_array, CeedScalar *x_array,
-    CeedScalar *y_array, CeedInt length) {
+    CeedScalar *y_array, CeedSize length) {
   const int bsize = 512;
-  const int vecsize = length;
+  const CeedSize vecsize = length;
   int gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize)

--- a/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
+++ b/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "../hip/ceed-hip-common.h"
 #include "../hip/ceed-hip-compile.h"
 #include "ceed-hip-ref.h"
 

--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -460,106 +460,80 @@ static int CeedVectorNorm_Hip(CeedVector vec, CeedNormType type, CeedScalar *nor
   switch (type) {
     case CEED_NORM_1: {
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-        if (num_calls <= 1) CeedCallHipblas(ceed, hipblasSasum(handle, (CeedInt)length, (float *)d_array, 1, (float *)norm));
-        else {
-          float  sub_norm = 0.0;
-          float *d_array_start;
-          for (CeedInt i = 0; i < num_calls; i++) {
-            d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
-            CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
-            CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
-            CeedCallHipblas(ceed, hipblasSasum(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &sub_norm));
-            *norm += sub_norm;
-          }
+        float  sub_norm = 0.0;
+        float *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallHipblas(ceed, hipblasSasum(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &sub_norm));
+          *norm += sub_norm;
         }
       } else {
-        if (num_calls <= 1) CeedCallHipblas(ceed, hipblasDasum(handle, (CeedInt)length, (double *)d_array, 1, (double *)norm));
-        else {
-          double  sub_norm = 0.0;
-          double *d_array_start;
-          for (CeedInt i = 0; i < num_calls; i++) {
-            d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
-            CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
-            CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
-            CeedCallHipblas(ceed, hipblasDasum(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &sub_norm));
-            *norm += sub_norm;
-          }
+        double  sub_norm = 0.0;
+        double *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallHipblas(ceed, hipblasDasum(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &sub_norm));
+          *norm += sub_norm;
         }
       }
       break;
     }
     case CEED_NORM_2: {
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-        if (num_calls <= 1) CeedCallHipblas(ceed, hipblasSnrm2(handle, (CeedInt)length, (float *)d_array, 1, (float *)norm));
-        else {
-          float  sub_norm = 0.0, norm_sum = 0.0;
-          float *d_array_start;
-          for (CeedInt i = 0; i < num_calls; i++) {
-            d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
-            CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
-            CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
-            CeedCallHipblas(ceed, hipblasSnrm2(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &sub_norm));
-            norm_sum += sub_norm * sub_norm;
-          }
-          *norm = sqrt(norm_sum);
+        float  sub_norm = 0.0, norm_sum = 0.0;
+        float *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallHipblas(ceed, hipblasSnrm2(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &sub_norm));
+          norm_sum += sub_norm * sub_norm;
         }
+        *norm = sqrt(norm_sum);
       } else {
-        if (num_calls <= 1) CeedCallHipblas(ceed, hipblasDnrm2(handle, (CeedInt)length, (double *)d_array, 1, (double *)norm));
-        else {
-          double  sub_norm = 0.0, norm_sum = 0.0;
-          double *d_array_start;
-          for (CeedInt i = 0; i < num_calls; i++) {
-            d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
-            CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
-            CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
-            CeedCallHipblas(ceed, hipblasDnrm2(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &sub_norm));
-            norm_sum += sub_norm * sub_norm;
-          }
-          *norm = sqrt(norm_sum);
+        double  sub_norm = 0.0, norm_sum = 0.0;
+        double *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallHipblas(ceed, hipblasDnrm2(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &sub_norm));
+          norm_sum += sub_norm * sub_norm;
         }
+        *norm = sqrt(norm_sum);
       }
       break;
     }
     case CEED_NORM_MAX: {
       CeedInt indx;
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
-        if (num_calls <= 1) {
-          CeedCallHipblas(ceed, hipblasIsamax(handle, (CeedInt)length, (float *)d_array, 1, &indx));
-          CeedScalar normNoAbs;
-          CeedCallHip(ceed, hipMemcpy(&normNoAbs, impl->d_array + indx - 1, sizeof(CeedScalar), hipMemcpyDeviceToHost));
-          *norm = fabs(normNoAbs);
-        } else {
-          float  sub_max = 0.0, current_max = 0.0;
-          float *d_array_start;
-          for (CeedInt i = 0; i < num_calls; i++) {
-            d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
-            CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
-            CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
-            CeedCallHipblas(ceed, hipblasIsamax(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &indx));
-            CeedCallHip(ceed, hipMemcpy(&sub_max, d_array_start + indx - 1, sizeof(CeedScalar), hipMemcpyDeviceToHost));
-            if (fabs(sub_max) > current_max) current_max = fabs(sub_max);
-          }
-          *norm = current_max;
+        float  sub_max = 0.0, current_max = 0.0;
+        float *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (float *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallHipblas(ceed, hipblasIsamax(handle, (CeedInt)sub_length, (float *)d_array_start, 1, &indx));
+          CeedCallHip(ceed, hipMemcpy(&sub_max, d_array_start + indx - 1, sizeof(CeedScalar), hipMemcpyDeviceToHost));
+          if (fabs(sub_max) > current_max) current_max = fabs(sub_max);
         }
+        *norm = current_max;
       } else {
-        if (num_calls <= 1) {
-          CeedCallHipblas(ceed, hipblasIdamax(handle, (CeedInt)length, (double *)d_array, 1, &indx));
-          CeedScalar normNoAbs;
-          CeedCallHip(ceed, hipMemcpy(&normNoAbs, impl->d_array + indx - 1, sizeof(CeedScalar), hipMemcpyDeviceToHost));
-          *norm = fabs(normNoAbs);
-        } else {
-          double  sub_max = 0.0, current_max = 0.0;
-          double *d_array_start;
-          for (CeedInt i = 0; i < num_calls; i++) {
-            d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
-            CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
-            CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
-            CeedCallHipblas(ceed, hipblasIdamax(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &indx));
-            CeedCallHip(ceed, hipMemcpy(&sub_max, d_array_start + indx - 1, sizeof(CeedScalar), hipMemcpyDeviceToHost));
-            if (fabs(sub_max) > current_max) current_max = fabs(sub_max);
-          }
-          *norm = current_max;
+        double  sub_max = 0.0, current_max = 0.0;
+        double *d_array_start;
+        for (CeedInt i = 0; i < num_calls; i++) {
+          d_array_start             = (double *)d_array + (CeedSize)(i)*INT_MAX;
+          CeedSize remaining_length = length - (CeedSize)(i)*INT_MAX;
+          CeedInt  sub_length       = (i == num_calls - 1) ? (CeedInt)(remaining_length) : INT_MAX;
+          CeedCallHipblas(ceed, hipblasIdamax(handle, (CeedInt)sub_length, (double *)d_array_start, 1, &indx));
+          CeedCallHip(ceed, hipMemcpy(&sub_max, d_array_start + indx - 1, sizeof(CeedScalar), hipMemcpyDeviceToHost));
+          if (fabs(sub_max) > current_max) current_max = fabs(sub_max);
         }
+        *norm = current_max;
       }
       break;
     }

--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -459,6 +459,7 @@ static int CeedVectorNorm_Hip(CeedVector vec, CeedNormType type, CeedScalar *nor
   CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &d_array));
   switch (type) {
     case CEED_NORM_1: {
+      *norm = 0.0;
       if (CEED_SCALAR_TYPE == CEED_SCALAR_FP32) {
         float  sub_norm = 0.0;
         float *d_array_start;

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -13,6 +13,12 @@
 #include <ceed/jit-source/hip/hip-types.h>
 #include <hip/hip_runtime.h>
 
+#if (HIP_VERSION >= 50200000)
+#include <hipblas/hipblas.h>  // IWYU pragma: export
+#else
+#include <hipblas.h>  // IWYU pragma: export
+#endif
+
 typedef struct {
   CeedScalar *h_array;
   CeedScalar *h_array_borrowed;

--- a/backends/hip-ref/kernels/hip-ref-vector.hip.cpp
+++ b/backends/hip-ref/kernels/hip-ref-vector.hip.cpp
@@ -12,7 +12,7 @@
 // Kernel for set value on device
 //------------------------------------------------------------------------------
 __global__ static void setValueK(CeedScalar *__restrict__ vec, CeedSize size, CeedScalar val) {
-  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size) return;
   vec[idx] = val;
 }
@@ -34,7 +34,7 @@ extern "C" int CeedDeviceSetValue_Hip(CeedScalar *d_array, CeedSize length, Ceed
 // Kernel for taking reciprocal
 //------------------------------------------------------------------------------
 __global__ static void rcpValueK(CeedScalar *__restrict__ vec, CeedSize size) {
-  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size) return;
   if (fabs(vec[idx]) > 1E-16) vec[idx] = 1. / vec[idx];
 }
@@ -56,7 +56,7 @@ extern "C" int CeedDeviceReciprocal_Hip(CeedScalar *d_array, CeedSize length) {
 // Kernel for scale
 //------------------------------------------------------------------------------
 __global__ static void scaleValueK(CeedScalar *__restrict__ x, CeedScalar alpha, CeedSize size) {
-  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size) return;
   x[idx] *= alpha;
 }
@@ -78,7 +78,7 @@ extern "C" int CeedDeviceScale_Hip(CeedScalar *x_array, CeedScalar alpha, CeedSi
 // Kernel for axpy
 //------------------------------------------------------------------------------
 __global__ static void axpyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar *__restrict__ x, CeedSize size) {
-  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size) return;
   y[idx] += alpha * x[idx];
 }
@@ -100,7 +100,7 @@ extern "C" int CeedDeviceAXPY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedSca
 // Kernel for axpby
 //------------------------------------------------------------------------------
 __global__ static void axpbyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar beta, CeedScalar *__restrict__ x, CeedSize size) {
-  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size) return;
   y[idx] = beta * y[idx];
   y[idx] += alpha * x[idx];
@@ -123,7 +123,7 @@ extern "C" int CeedDeviceAXPBY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedSc
 // Kernel for pointwise mult
 //------------------------------------------------------------------------------
 __global__ static void pointwiseMultValueK(CeedScalar *__restrict__ w, CeedScalar *x, CeedScalar *__restrict__ y, CeedSize size) {
-  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
+  CeedSize idx = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
   if (idx >= size) return;
   w[idx] = x[idx] * y[idx];
 }

--- a/backends/hip-ref/kernels/hip-ref-vector.hip.cpp
+++ b/backends/hip-ref/kernels/hip-ref-vector.hip.cpp
@@ -11,8 +11,8 @@
 //------------------------------------------------------------------------------
 // Kernel for set value on device
 //------------------------------------------------------------------------------
-__global__ static void setValueK(CeedScalar *__restrict__ vec, CeedInt size, CeedScalar val) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void setValueK(CeedScalar *__restrict__ vec, CeedSize size, CeedScalar val) {
+  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx >= size) return;
   vec[idx] = val;
 }
@@ -20,10 +20,10 @@ __global__ static void setValueK(CeedScalar *__restrict__ vec, CeedInt size, Cee
 //------------------------------------------------------------------------------
 // Set value on device memory
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceSetValue_Hip(CeedScalar *d_array, CeedInt length, CeedScalar val) {
-  const int bsize    = 512;
-  const int vecsize  = length;
-  int       gridsize = vecsize / bsize;
+extern "C" int CeedDeviceSetValue_Hip(CeedScalar *d_array, CeedSize length, CeedScalar val) {
+  const int      bsize    = 512;
+  const CeedSize vecsize  = length;
+  int            gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize) gridsize += 1;
   hipLaunchKernelGGL(setValueK, dim3(gridsize), dim3(bsize), 0, 0, d_array, length, val);
@@ -33,8 +33,8 @@ extern "C" int CeedDeviceSetValue_Hip(CeedScalar *d_array, CeedInt length, CeedS
 //------------------------------------------------------------------------------
 // Kernel for taking reciprocal
 //------------------------------------------------------------------------------
-__global__ static void rcpValueK(CeedScalar *__restrict__ vec, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void rcpValueK(CeedScalar *__restrict__ vec, CeedSize size) {
+  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx >= size) return;
   if (fabs(vec[idx]) > 1E-16) vec[idx] = 1. / vec[idx];
 }
@@ -42,10 +42,10 @@ __global__ static void rcpValueK(CeedScalar *__restrict__ vec, CeedInt size) {
 //------------------------------------------------------------------------------
 // Take vector reciprocal in device memory
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceReciprocal_Hip(CeedScalar *d_array, CeedInt length) {
-  const int bsize    = 512;
-  const int vecsize  = length;
-  int       gridsize = vecsize / bsize;
+extern "C" int CeedDeviceReciprocal_Hip(CeedScalar *d_array, CeedSize length) {
+  const int      bsize    = 512;
+  const CeedSize vecsize  = length;
+  int            gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize) gridsize += 1;
   hipLaunchKernelGGL(rcpValueK, dim3(gridsize), dim3(bsize), 0, 0, d_array, length);
@@ -55,8 +55,8 @@ extern "C" int CeedDeviceReciprocal_Hip(CeedScalar *d_array, CeedInt length) {
 //------------------------------------------------------------------------------
 // Kernel for scale
 //------------------------------------------------------------------------------
-__global__ static void scaleValueK(CeedScalar *__restrict__ x, CeedScalar alpha, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void scaleValueK(CeedScalar *__restrict__ x, CeedScalar alpha, CeedSize size) {
+  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx >= size) return;
   x[idx] *= alpha;
 }
@@ -64,10 +64,10 @@ __global__ static void scaleValueK(CeedScalar *__restrict__ x, CeedScalar alpha,
 //------------------------------------------------------------------------------
 // Compute x = alpha x on device
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceScale_Hip(CeedScalar *x_array, CeedScalar alpha, CeedInt length) {
-  const int bsize    = 512;
-  const int vecsize  = length;
-  int       gridsize = vecsize / bsize;
+extern "C" int CeedDeviceScale_Hip(CeedScalar *x_array, CeedScalar alpha, CeedSize length) {
+  const int      bsize    = 512;
+  const CeedSize vecsize  = length;
+  int            gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize) gridsize += 1;
   hipLaunchKernelGGL(scaleValueK, dim3(gridsize), dim3(bsize), 0, 0, x_array, alpha, length);
@@ -77,8 +77,8 @@ extern "C" int CeedDeviceScale_Hip(CeedScalar *x_array, CeedScalar alpha, CeedIn
 //------------------------------------------------------------------------------
 // Kernel for axpy
 //------------------------------------------------------------------------------
-__global__ static void axpyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar *__restrict__ x, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void axpyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar *__restrict__ x, CeedSize size) {
+  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx >= size) return;
   y[idx] += alpha * x[idx];
 }
@@ -86,10 +86,10 @@ __global__ static void axpyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, 
 //------------------------------------------------------------------------------
 // Compute y = alpha x + y on device
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceAXPY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedInt length) {
-  const int bsize    = 512;
-  const int vecsize  = length;
-  int       gridsize = vecsize / bsize;
+extern "C" int CeedDeviceAXPY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedSize length) {
+  const int      bsize    = 512;
+  const CeedSize vecsize  = length;
+  int            gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize) gridsize += 1;
   hipLaunchKernelGGL(axpyValueK, dim3(gridsize), dim3(bsize), 0, 0, y_array, alpha, x_array, length);
@@ -99,8 +99,8 @@ extern "C" int CeedDeviceAXPY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedSca
 //------------------------------------------------------------------------------
 // Kernel for axpby
 //------------------------------------------------------------------------------
-__global__ static void axpbyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar beta, CeedScalar *__restrict__ x, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void axpbyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar beta, CeedScalar *__restrict__ x, CeedSize size) {
+  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx >= size) return;
   y[idx] = beta * y[idx];
   y[idx] += alpha * x[idx];
@@ -109,10 +109,10 @@ __global__ static void axpbyValueK(CeedScalar *__restrict__ y, CeedScalar alpha,
 //------------------------------------------------------------------------------
 // Compute y = alpha x + beta y on device
 //------------------------------------------------------------------------------
-extern "C" int CeedDeviceAXPBY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedInt length) {
-  const int bsize    = 512;
-  const int vecsize  = length;
-  int       gridsize = vecsize / bsize;
+extern "C" int CeedDeviceAXPBY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedSize length) {
+  const int      bsize    = 512;
+  const CeedSize vecsize  = length;
+  int            gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize) gridsize += 1;
   hipLaunchKernelGGL(axpbyValueK, dim3(gridsize), dim3(bsize), 0, 0, y_array, alpha, beta, x_array, length);
@@ -122,8 +122,8 @@ extern "C" int CeedDeviceAXPBY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedSc
 //------------------------------------------------------------------------------
 // Kernel for pointwise mult
 //------------------------------------------------------------------------------
-__global__ static void pointwiseMultValueK(CeedScalar *__restrict__ w, CeedScalar *x, CeedScalar *__restrict__ y, CeedInt size) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+__global__ static void pointwiseMultValueK(CeedScalar *__restrict__ w, CeedScalar *x, CeedScalar *__restrict__ y, CeedSize size) {
+  CeedSize idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx >= size) return;
   w[idx] = x[idx] * y[idx];
 }
@@ -131,10 +131,10 @@ __global__ static void pointwiseMultValueK(CeedScalar *__restrict__ w, CeedScala
 //------------------------------------------------------------------------------
 // Compute the pointwise multiplication w = x .* y on device
 //------------------------------------------------------------------------------
-extern "C" int CeedDevicePointwiseMult_Hip(CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedInt length) {
-  const int bsize    = 512;
-  const int vecsize  = length;
-  int       gridsize = vecsize / bsize;
+extern "C" int CeedDevicePointwiseMult_Hip(CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedSize length) {
+  const int      bsize    = 512;
+  const CeedSize vecsize  = length;
+  int            gridsize = vecsize / bsize;
 
   if (bsize * gridsize < vecsize) gridsize += 1;
   hipLaunchKernelGGL(pointwiseMultValueK, dim3(gridsize), dim3(bsize), 0, 0, w_array, x_array, y_array, length);

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h
@@ -7,6 +7,12 @@
 
 #include <ceed.h>
 
+#if CEEDSIZE
+typedef CeedSize IndexType;
+#else
+typedef CeedInt IndexType;
+#endif
+
 //------------------------------------------------------------------------------
 // Get Basis Emode Pointer
 //------------------------------------------------------------------------------
@@ -40,26 +46,26 @@ __device__ void diagonalCore(const CeedInt nelem, const bool pointBlock, const C
 
   // Compute the diagonal of B^T D B
   // Each element
-  for (CeedInt e = blockIdx.x * blockDim.z + threadIdx.z; e < nelem; e += gridDim.x * blockDim.z) {
-    CeedInt dout = -1;
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < nelem; e += gridDim.x * blockDim.z) {
+    IndexType dout = -1;
     // Each basis eval mode pair
-    for (CeedInt eout = 0; eout < NUMEMODEOUT; eout++) {
+    for (IndexType eout = 0; eout < NUMEMODEOUT; eout++) {
       const CeedScalar *bt = NULL;
       if (emodeout[eout] == CEED_EVAL_GRAD) dout += 1;
       CeedOperatorGetBasisPointer_Cuda(&bt, emodeout[eout], identity, interpout, &gradout[dout * NQPTS * NNODES]);
-      CeedInt din = -1;
-      for (CeedInt ein = 0; ein < NUMEMODEIN; ein++) {
+      IndexType din = -1;
+      for (IndexType ein = 0; ein < NUMEMODEIN; ein++) {
         const CeedScalar *b = NULL;
         if (emodein[ein] == CEED_EVAL_GRAD) din += 1;
         CeedOperatorGetBasisPointer_Cuda(&b, emodein[ein], identity, interpin, &gradin[din * NQPTS * NNODES]);
         // Each component
-        for (CeedInt compOut = 0; compOut < NCOMP; compOut++) {
+        for (IndexType compOut = 0; compOut < NCOMP; compOut++) {
           // Each qpoint/node pair
           if (pointBlock) {
             // Point Block Diagonal
-            for (CeedInt compIn = 0; compIn < NCOMP; compIn++) {
+            for (IndexType compIn = 0; compIn < NCOMP; compIn++) {
               CeedScalar evalue = 0.;
-              for (CeedInt q = 0; q < NQPTS; q++) {
+              for (IndexType q = 0; q < NQPTS; q++) {
                 const CeedScalar qfvalue =
                     assembledqfarray[((((ein * NCOMP + compIn) * NUMEMODEOUT + eout) * NCOMP + compOut) * nelem + e) * NQPTS + q];
                 evalue += bt[q * NNODES + tid] * qfvalue * b[q * NNODES + tid];
@@ -69,7 +75,7 @@ __device__ void diagonalCore(const CeedInt nelem, const bool pointBlock, const C
           } else {
             // Diagonal Only
             CeedScalar evalue = 0.;
-            for (CeedInt q = 0; q < NQPTS; q++) {
+            for (IndexType q = 0; q < NQPTS; q++) {
               const CeedScalar qfvalue =
                   assembledqfarray[((((ein * NCOMP + compOut) * NUMEMODEOUT + eout) * NCOMP + compOut) * nelem + e) * NQPTS + q];
               evalue += bt[q * NNODES + tid] * qfvalue * b[q * NNODES + tid];

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
@@ -7,6 +7,12 @@
 
 #include <ceed.h>
 
+#if CEEDSIZE
+typedef CeedSize IndexType;
+#else
+typedef CeedInt IndexType;
+#endif
+
 //------------------------------------------------------------------------------
 // Matrix assembly kernel for low-order elements (2D thread block)
 //------------------------------------------------------------------------------
@@ -21,34 +27,34 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
 
   // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
   // comp_in, comp_out, node_row, node_col
-  const CeedInt comp_out_stride = NNODES * NNODES;
-  const CeedInt comp_in_stride  = comp_out_stride * NCOMP;
-  const CeedInt e_stride        = comp_in_stride * NCOMP;
+  const IndexType comp_out_stride = NNODES * NNODES;
+  const IndexType comp_in_stride  = comp_out_stride * NCOMP;
+  const IndexType e_stride        = comp_in_stride * NCOMP;
   // Strides for QF array, slowest --> fastest:  emode_in, comp_in, emode_out, comp_out, elem, qpt
-  const CeedInt qe_stride         = NQPTS;
-  const CeedInt qcomp_out_stride  = NELEM * qe_stride;
-  const CeedInt qemode_out_stride = qcomp_out_stride * NCOMP;
-  const CeedInt qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
-  const CeedInt qemode_in_stride  = qcomp_in_stride * NCOMP;
+  const IndexType qe_stride         = NQPTS;
+  const IndexType qcomp_out_stride  = NELEM * qe_stride;
+  const IndexType qemode_out_stride = qcomp_out_stride * NCOMP;
+  const IndexType qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
+  const IndexType qemode_in_stride  = qcomp_in_stride * NCOMP;
 
   // Loop over each element (if necessary)
-  for (CeedInt e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
-    for (CeedInt comp_in = 0; comp_in < NCOMP; comp_in++) {
-      for (CeedInt comp_out = 0; comp_out < NCOMP; comp_out++) {
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NCOMP; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NCOMP; comp_out++) {
         CeedScalar result        = 0.0;
-        CeedInt    qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
-        for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
-          CeedInt b_in_index = emode_in * NQPTS * NNODES;
-          for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-            CeedInt b_out_index = emode_out * NQPTS * NNODES;
-            CeedInt qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+        IndexType  qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
+        for (IndexType emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
+          IndexType b_in_index = emode_in * NQPTS * NNODES;
+          for (IndexType emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
+            IndexType b_out_index = emode_out * NQPTS * NNODES;
+            IndexType qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
             // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-            for (CeedInt j = 0; j < NQPTS; j++) {
+            for (IndexType j = 0; j < NQPTS; j++) {
               result += B_out[b_out_index + j * NNODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];
             }
           }  // end of emode_out
         }    // end of emode_in
-        CeedInt val_index       = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
+        IndexType val_index     = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
         values_array[val_index] = result;
       }  // end of out component
     }    // end of in component
@@ -68,35 +74,35 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
 
   // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
   // comp_in, comp_out, node_row, node_col
-  const CeedInt comp_out_stride = NNODES * NNODES;
-  const CeedInt comp_in_stride  = comp_out_stride * NCOMP;
-  const CeedInt e_stride        = comp_in_stride * NCOMP;
+  const IndexType comp_out_stride = NNODES * NNODES;
+  const IndexType comp_in_stride  = comp_out_stride * NCOMP;
+  const IndexType e_stride        = comp_in_stride * NCOMP;
   // Strides for QF array, slowest --> fastest:  emode_in, comp_in, emode_out, comp_out, elem, qpt
-  const CeedInt qe_stride         = NQPTS;
-  const CeedInt qcomp_out_stride  = NELEM * qe_stride;
-  const CeedInt qemode_out_stride = qcomp_out_stride * NCOMP;
-  const CeedInt qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
-  const CeedInt qemode_in_stride  = qcomp_in_stride * NCOMP;
+  const IndexType qe_stride         = NQPTS;
+  const IndexType qcomp_out_stride  = NELEM * qe_stride;
+  const IndexType qemode_out_stride = qcomp_out_stride * NCOMP;
+  const IndexType qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
+  const IndexType qemode_in_stride  = qcomp_in_stride * NCOMP;
 
   // Loop over each element (if necessary)
-  for (CeedInt e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
-    for (CeedInt comp_in = 0; comp_in < NCOMP; comp_in++) {
-      for (CeedInt comp_out = 0; comp_out < NCOMP; comp_out++) {
-        for (CeedInt i = 0; i < NNODES; i++) {
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NCOMP; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NCOMP; comp_out++) {
+        for (IndexType i = 0; i < NNODES; i++) {
           CeedScalar result        = 0.0;
-          CeedInt    qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
-          for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
-            CeedInt b_in_index = emode_in * NQPTS * NNODES;
-            for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-              CeedInt b_out_index = emode_out * NQPTS * NNODES;
-              CeedInt qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+          IndexType  qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
+          for (IndexType emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
+            IndexType b_in_index = emode_in * NQPTS * NNODES;
+            for (IndexType emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
+              IndexType b_out_index = emode_out * NQPTS * NNODES;
+              IndexType qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
               // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-              for (CeedInt j = 0; j < NQPTS; j++) {
+              for (IndexType j = 0; j < NQPTS; j++) {
                 result += B_out[b_out_index + j * NNODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];
               }
             }  // end of emode_out
           }    // end of emode_in
-          CeedInt val_index       = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
+          IndexType val_index     = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
           values_array[val_index] = result;
         }  // end of loop over element node index, i
       }    // end of out component

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
@@ -7,6 +7,12 @@
 
 #include <ceed.h>
 
+#if CEEDSIZE
+typedef CeedSize IndexType;
+#else
+typedef CeedInt IndexType;
+#endif
+
 //------------------------------------------------------------------------------
 // Matrix assembly kernel for low-order elements (2D thread block)
 //------------------------------------------------------------------------------
@@ -21,34 +27,34 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
 
   // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
   // comp_in, comp_out, node_row, node_col
-  const CeedInt comp_out_stride = NNODES * NNODES;
-  const CeedInt comp_in_stride  = comp_out_stride * NCOMP;
-  const CeedInt e_stride        = comp_in_stride * NCOMP;
+  const IndexType comp_out_stride = NNODES * NNODES;
+  const IndexType comp_in_stride  = comp_out_stride * NCOMP;
+  const IndexType e_stride        = comp_in_stride * NCOMP;
   // Strides for QF array, slowest --> fastest:  emode_in, comp_in, emode_out, comp_out, elem, qpt
-  const CeedInt qe_stride         = NQPTS;
-  const CeedInt qcomp_out_stride  = NELEM * qe_stride;
-  const CeedInt qemode_out_stride = qcomp_out_stride * NCOMP;
-  const CeedInt qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
-  const CeedInt qemode_in_stride  = qcomp_in_stride * NCOMP;
+  const IndexType qe_stride         = NQPTS;
+  const IndexType qcomp_out_stride  = NELEM * qe_stride;
+  const IndexType qemode_out_stride = qcomp_out_stride * NCOMP;
+  const IndexType qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
+  const IndexType qemode_in_stride  = qcomp_in_stride * NCOMP;
 
   // Loop over each element (if necessary)
-  for (CeedInt e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
-    for (CeedInt comp_in = 0; comp_in < NCOMP; comp_in++) {
-      for (CeedInt comp_out = 0; comp_out < NCOMP; comp_out++) {
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NCOMP; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NCOMP; comp_out++) {
         CeedScalar result        = 0.0;
-        CeedInt    qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
-        for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
-          CeedInt b_in_index = emode_in * NQPTS * NNODES;
-          for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-            CeedInt b_out_index = emode_out * NQPTS * NNODES;
-            CeedInt qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+        IndexType  qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
+        for (IndexType emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
+          IndexType b_in_index = emode_in * NQPTS * NNODES;
+          for (IndexType emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
+            IndexType b_out_index = emode_out * NQPTS * NNODES;
+            IndexType qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
             // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-            for (CeedInt j = 0; j < NQPTS; j++) {
+            for (IndexType j = 0; j < NQPTS; j++) {
               result += B_out[b_out_index + j * NNODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];
             }
           }  // end of emode_out
         }    // end of emode_in
-        CeedInt val_index       = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
+        IndexType val_index     = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
         values_array[val_index] = result;
       }  // end of out component
     }    // end of in component
@@ -68,35 +74,35 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
 
   // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
   // comp_in, comp_out, node_row, node_col
-  const CeedInt comp_out_stride = NNODES * NNODES;
-  const CeedInt comp_in_stride  = comp_out_stride * NCOMP;
-  const CeedInt e_stride        = comp_in_stride * NCOMP;
+  const IndexType comp_out_stride = NNODES * NNODES;
+  const IndexType comp_in_stride  = comp_out_stride * NCOMP;
+  const IndexType e_stride        = comp_in_stride * NCOMP;
   // Strides for QF array, slowest --> fastest:  emode_in, comp_in, emode_out, comp_out, elem, qpt
-  const CeedInt qe_stride         = NQPTS;
-  const CeedInt qcomp_out_stride  = NELEM * qe_stride;
-  const CeedInt qemode_out_stride = qcomp_out_stride * NCOMP;
-  const CeedInt qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
-  const CeedInt qemode_in_stride  = qcomp_in_stride * NCOMP;
+  const IndexType qe_stride         = NQPTS;
+  const IndexType qcomp_out_stride  = NELEM * qe_stride;
+  const IndexType qemode_out_stride = qcomp_out_stride * NCOMP;
+  const IndexType qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
+  const IndexType qemode_in_stride  = qcomp_in_stride * NCOMP;
 
   // Loop over each element (if necessary)
-  for (CeedInt e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
-    for (CeedInt comp_in = 0; comp_in < NCOMP; comp_in++) {
-      for (CeedInt comp_out = 0; comp_out < NCOMP; comp_out++) {
-        for (CeedInt i = 0; i < NNODES; i++) {
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NCOMP; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NCOMP; comp_out++) {
+        for (IndexType i = 0; i < NNODES; i++) {
           CeedScalar result        = 0.0;
-          CeedInt    qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
-          for (CeedInt emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
-            CeedInt b_in_index = emode_in * NQPTS * NNODES;
-            for (CeedInt emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-              CeedInt b_out_index = emode_out * NQPTS * NNODES;
-              CeedInt qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
+          IndexType  qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
+          for (IndexType emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
+            IndexType b_in_index = emode_in * NQPTS * NNODES;
+            for (IndexType emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
+              IndexType b_out_index = emode_out * NQPTS * NNODES;
+              IndexType qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
               // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-              for (CeedInt j = 0; j < NQPTS; j++) {
+              for (IndexType j = 0; j < NQPTS; j++) {
                 result += B_out[b_out_index + j * NNODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];
               }
             }  // end of emode_out
           }    // end of emode_in
-          CeedInt val_index       = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
+          IndexType val_index     = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
           values_array[val_index] = result;
         }  // end of loop over element node index, i
       }    // end of out component

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -274,7 +274,7 @@ int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
   } else {
     CeedScalar *array;
     CeedCall(CeedVectorGetArrayWrite(vec, CEED_MEM_HOST, &array));
-    for (CeedInt i = 0; i < vec->length; i++) array[i] = value;
+    for (CeedSize i = 0; i < vec->length; i++) array[i] = value;
     CeedCall(CeedVectorRestoreArray(vec, &array));
   }
   vec->state += 2;
@@ -503,17 +503,17 @@ int CeedVectorNorm(CeedVector vec, CeedNormType norm_type, CeedScalar *norm) {
   *norm = 0.;
   switch (norm_type) {
     case CEED_NORM_1:
-      for (CeedInt i = 0; i < vec->length; i++) {
+      for (CeedSize i = 0; i < vec->length; i++) {
         *norm += fabs(array[i]);
       }
       break;
     case CEED_NORM_2:
-      for (CeedInt i = 0; i < vec->length; i++) {
+      for (CeedSize i = 0; i < vec->length; i++) {
         *norm += fabs(array[i]) * fabs(array[i]);
       }
       break;
     case CEED_NORM_MAX:
-      for (CeedInt i = 0; i < vec->length; i++) {
+      for (CeedSize i = 0; i < vec->length; i++) {
         const CeedScalar abs_v_i = fabs(array[i]);
         *norm                    = *norm > abs_v_i ? *norm : abs_v_i;
       }
@@ -550,7 +550,7 @@ int CeedVectorScale(CeedVector x, CeedScalar alpha) {
 
   // Default implementation
   CeedCall(CeedVectorGetArrayWrite(x, CEED_MEM_HOST, &x_array));
-  for (CeedInt i = 0; i < n_x; i++) x_array[i] *= alpha;
+  for (CeedSize i = 0; i < n_x; i++) x_array[i] *= alpha;
   CeedCall(CeedVectorRestoreArray(x, &x_array));
 
   return CEED_ERROR_SUCCESS;
@@ -603,7 +603,7 @@ int CeedVectorAXPY(CeedVector y, CeedScalar alpha, CeedVector x) {
   assert(x_array);
   assert(y_array);
 
-  for (CeedInt i = 0; i < n_y; i++) y_array[i] += alpha * x_array[i];
+  for (CeedSize i = 0; i < n_y; i++) y_array[i] += alpha * x_array[i];
 
   CeedCall(CeedVectorRestoreArray(y, &y_array));
   CeedCall(CeedVectorRestoreArrayRead(x, &x_array));
@@ -659,7 +659,7 @@ int CeedVectorAXPBY(CeedVector y, CeedScalar alpha, CeedScalar beta, CeedVector 
   assert(x_array);
   assert(y_array);
 
-  for (CeedInt i = 0; i < n_y; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
+  for (CeedSize i = 0; i < n_y; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
 
   CeedCall(CeedVectorRestoreArray(y, &y_array));
   CeedCall(CeedVectorRestoreArrayRead(x, &x_array));
@@ -732,7 +732,7 @@ int CeedVectorPointwiseMult(CeedVector w, CeedVector x, CeedVector y) {
   assert(x_array);
   assert(y_array);
 
-  for (CeedInt i = 0; i < n_w; i++) w_array[i] = x_array[i] * y_array[i];
+  for (CeedSize i = 0; i < n_w; i++) w_array[i] = x_array[i] * y_array[i];
 
   if (y != w && y != x) CeedCall(CeedVectorRestoreArrayRead(y, &y_array));
   if (x != w) CeedCall(CeedVectorRestoreArrayRead(x, &x_array));
@@ -769,7 +769,7 @@ int CeedVectorReciprocal(CeedVector vec) {
   CeedCall(CeedVectorGetLength(vec, &len));
   CeedScalar *array;
   CeedCall(CeedVectorGetArrayWrite(vec, CEED_MEM_HOST, &array));
-  for (CeedInt i = 0; i < len; i++) {
+  for (CeedSize i = 0; i < len; i++) {
     if (fabs(array[i]) > CEED_EPSILON) array[i] = 1. / array[i];
   }
 
@@ -809,7 +809,7 @@ int CeedVectorViewRange(CeedVector vec, CeedSize start, CeedSize stop, CeedInt s
 
   snprintf(fmt, sizeof fmt, "  %s\n", fp_fmt ? fp_fmt : "%g");
   CeedCall(CeedVectorGetArrayRead(vec, CEED_MEM_HOST, &x));
-  for (CeedInt i = start; step > 0 ? (i < stop) : (i > stop); i += step) fprintf(stream, fmt, x[i]);
+  for (CeedSize i = start; step > 0 ? (i < stop) : (i > stop); i += step) fprintf(stream, fmt, x[i]);
   CeedCall(CeedVectorRestoreArrayRead(vec, &x));
   if (stop != vec->length) fprintf(stream, "  ...\n");
 


### PR DESCRIPTION
While 32-bit is sufficient for CeedElemRestriction, a Vector is used to store matrix entries and the number of entries can overflow 32-bit even for a small number of dofs. For example, 85k Q3 fluid elements is enough to overflow.

Reported-by: Ken Jansen