### PR TITLE
Fix -fsanitize=address bugs

### DIFF
--- a/.github/workflows/c-fortran-test-linux-osx.yml
+++ b/.github/workflows/c-fortran-test-linux-osx.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-12]
         compiler: [gcc-11, clang]
+        include:
+        - os: ubuntu-22.04
+          asan: 1
 
     runs-on: ${{ matrix.os }}
 
@@ -22,6 +25,8 @@ jobs:
       env:
         CC: ${{ matrix.compiler }}
         FC: gfortran-11
+        AFLAGS: -fsanitize=address -fsanitize=leak
+        ASAN: ${{ matrix.asan }}
       run: |
         make -v
         make info

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ endif
 
 # Warning: SANTIZ options still don't run with /gpu/occa
 # export LSAN_OPTIONS=suppressions=.asanignore
-AFLAGS = -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
+AFLAGS ?= -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
 # Note: Intel oneAPI C/C++ compiler is now icx/icpx
 CC_VENDOR := $(subst icc_orig,icc,$(firstword $(filter gcc clang icc icc_orig oneAPI XL emcc,$(subst -, ,$(shell $(CC) --version)))))

--- a/backends/memcheck/ceed-memcheck-qfunction.c
+++ b/backends/memcheck/ceed-memcheck-qfunction.c
@@ -34,14 +34,14 @@ static int CeedQFunctionApply_Memcheck(CeedQFunction qf, CeedInt Q, CeedVector *
   int mem_block_ids[num_out];
   for (CeedInt i = 0; i < num_out; i++) {
     CeedSize len;
-    char     name[30] = "";
+    char     name[32] = "";
 
     CeedCallBackend(CeedVectorGetArrayWrite(V[i], CEED_MEM_HOST, &impl->outputs[i]));
 
     CeedCallBackend(CeedVectorGetLength(V[i], &len));
     VALGRIND_MAKE_MEM_UNDEFINED(impl->outputs[i], len);
 
-    snprintf(name, 30, "'QFunction output %" CeedInt_FMT "'", i);
+    snprintf(name, 32, "'QFunction output %" CeedInt_FMT "'", i);
     mem_block_ids[i] = VALGRIND_CREATE_BLOCK(impl->outputs[i], len, name);
   }
 

--- a/tests/t568-operator.c
+++ b/tests/t568-operator.c
@@ -72,8 +72,8 @@ int main(int argc, char **argv) {
   CeedQFunctionAddOutput(qf_setup, "qdata", dim * (dim + 1) / 2, CEED_EVAL_NONE);
 
   CeedQFunctionCreateInterior(ceed, 1, diff, diff_loc, &qf_diff);
-  CeedQFunctionAddInput(qf_diff, "qdata", dim * (dim + 1) / 2, CEED_EVAL_NONE);
   CeedQFunctionAddInput(qf_diff, "du", num_comp * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_diff, "qdata", dim * (dim + 1) / 2, CEED_EVAL_NONE);
   CeedQFunctionAddInput(qf_diff, "dummy u", num_comp, CEED_EVAL_INTERP);
   CeedQFunctionAddOutput(qf_diff, "dv", num_comp * dim, CEED_EVAL_GRAD);
 


### PR DESCRIPTION
note: ‘snprintf’ output between 21 and 31 bytes into a destination of size 30

The assembly test had inconsistent ordering of arguments between the qfunction itself and the call to CeedQFunctionAddInput.