### PR TITLE
Memcheck - warn or error on NaN after write-only access

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -76,7 +76,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
   if ((prop.major < 6) && (CEED_SCALAR_TYPE != CEED_SCALAR_FP32)) {
     char *atomic_add_path, *atomic_add_source;
     CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-atomic-add-fallback.h", &atomic_add_path));
-    CeedDebug256(ceed, 2, "----- Loading Atomic Add Source -----\n");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Atomic Add Source -----\n");
     CeedCallBackend(CeedLoadSourceToBuffer(ceed, atomic_add_path, &atomic_add_source));
     code << atomic_add_source;
     CeedCallBackend(CeedFree(&atomic_add_path));
@@ -88,7 +88,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
   {
     char *tensor_basis_kernel_path, *tensor_basis_kernel_source;
     CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-shared-basis-tensor-templates.h", &tensor_basis_kernel_path));
-    CeedDebug256(ceed, 2, "----- Loading Tensor Basis Kernel Source -----\n");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Tensor Basis Kernel Source -----\n");
     CeedCallBackend(CeedLoadSourceToBuffer(ceed, tensor_basis_kernel_path, &tensor_basis_kernel_source));
     code << tensor_basis_kernel_source;
     CeedCallBackend(CeedFree(&tensor_basis_kernel_path));
@@ -97,7 +97,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
   {
     char *cuda_gen_template_path, *cuda_gen_template_source;
     CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-gen-templates.h", &cuda_gen_template_path));
-    CeedDebug256(ceed, 2, "----- Loading Cuda-Gen Template Source -----\n");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Cuda-Gen Template Source -----\n");
     CeedCallBackend(CeedLoadSourceToBuffer(ceed, cuda_gen_template_path, &cuda_gen_template_source));
     code << cuda_gen_template_source;
     CeedCallBackend(CeedFree(&cuda_gen_template_path));
@@ -679,7 +679,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
   code << "// -----------------------------------------------------------------------------\n\n";
 
   // View kernel for debugging
-  CeedDebug256(ceed, 2, "Generated Operator Kernels:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Generated Operator Kernels:\n");
   CeedDebug(ceed, code.str().c_str());
 
   CeedCallBackend(CeedCompile_Cuda(ceed, code.str().c_str(), &data->module, 1, "T_1D", CeedIntMax(Q_1d, data->max_P_1d)));

--- a/backends/cuda-gen/ceed-cuda-gen-qfunction.c
+++ b/backends/cuda-gen/ceed-cuda-gen-qfunction.c
@@ -47,9 +47,9 @@ int CeedQFunctionCreate_Cuda_gen(CeedQFunction qf) {
 
   // Read QFunction source
   CeedCallBackend(CeedQFunctionGetKernelName(qf, &data->q_function_name));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &data->q_function_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source Complete! -----\n");
   CeedCheck(data->q_function_source, ceed, CEED_ERROR_UNSUPPORTED, "/gpu/cuda/gen backend requires QFunction source code file");
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Apply", CeedQFunctionApply_Cuda_gen));

--- a/backends/cuda-ref/ceed-cuda-ref-basis.c
+++ b/backends/cuda-ref/ceed-cuda-ref-basis.c
@@ -228,9 +228,9 @@ int CeedBasisCreateTensorH1_Cuda(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const 
   CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-basis-tensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Cuda(ceed, basis_kernel_source, &data->module, 7, "BASIS_Q_1D", Q_1d, "BASIS_P_1D", P_1d, "BASIS_BUF_LEN",
                                    num_comp * CeedIntPow(Q_1d > P_1d ? Q_1d : P_1d, dim), "BASIS_DIM", dim, "BASIS_NUM_COMP", num_comp,
                                    "BASIS_NUM_NODES", CeedIntPow(P_1d, dim), "BASIS_NUM_QPTS", CeedIntPow(Q_1d, dim)));
@@ -275,9 +275,9 @@ int CeedBasisCreateH1_Cuda(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes
   CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-basis-nontensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete! -----\n");
   CeedCallCuda(ceed, CeedCompile_Cuda(ceed, basis_kernel_source, &data->module, 4, "BASIS_Q", num_qpts, "BASIS_P", num_nodes, "BASIS_DIM", dim,
                                       "BASIS_NUM_COMP", num_comp));
   CeedCallCuda(ceed, CeedGetKernel_Cuda(ceed, data->module, "Interp", &data->Interp));

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -722,9 +722,9 @@ static inline int CeedOperatorAssembleDiagonalSetup_Cuda(CeedOperator op, const 
   // Assemble kernel
   char *diagonal_kernel_path, *diagonal_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h", &diagonal_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Diagonal Assembly Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Diagonal Assembly Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, diagonal_kernel_path, &diagonal_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Diagonal Assembly Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Diagonal Assembly Source Complete! -----\n");
   CeedInt nnodes, nqpts;
   CeedCallBackend(CeedBasisGetNumNodes(basisin, &nnodes));
   CeedCallBackend(CeedBasisGetNumQuadraturePoints(basisin, &nqpts));
@@ -978,9 +978,9 @@ static int CeedSingleOperatorAssembleSetup_Cuda(CeedOperator op, CeedInt use_cee
   CeedCallBackend(CeedGetData(ceed, &cuda_data));
   char *assembly_kernel_path, *assembly_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-operator-assemble.h", &assembly_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Assembly Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Assembly Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, assembly_kernel_path, &assembly_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Assembly Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Assembly Source Complete! -----\n");
   bool fallback = block_size > cuda_data->device_prop.maxThreadsPerBlock;
   if (fallback) {
     // Use fallback kernel with 1D threadblock

--- a/backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp
@@ -40,9 +40,9 @@ extern "C" int CeedQFunctionBuildKernel_Cuda_ref(CeedQFunction qf) {
   // Build strings for final kernel
   char *read_write_kernel_path, *read_write_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-qfunction.h", &read_write_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading QFunction Read/Write Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction Read/Write Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, read_write_kernel_path, &read_write_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction Read/Write Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction Read/Write Kernel Source Complete! -----\n");
   string        qfunction_source(data->qfunction_source);
   string        qfunction_name(data->qfunction_name);
   string        read_write(read_write_kernel_source);
@@ -105,7 +105,7 @@ extern "C" int CeedQFunctionBuildKernel_Cuda_ref(CeedQFunction qf) {
   code << "}\n";
 
   // View kernel for debugging
-  CeedDebug256(ceed, 2, "Generated QFunction Kernels:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Generated QFunction Kernels:\n");
   CeedDebug(ceed, code.str().c_str());
 
   // Compile kernel

--- a/backends/cuda-ref/ceed-cuda-ref-qfunction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunction.c
@@ -97,9 +97,9 @@ int CeedQFunctionCreate_Cuda(CeedQFunction qf) {
 
   // Read QFunction source
   CeedCallBackend(CeedQFunctionGetKernelName(qf, &data->qfunction_name));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &data->qfunction_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source Complete! -----\n");
 
   // Register backend functions
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Apply", CeedQFunctionApply_Cuda));

--- a/backends/cuda-ref/ceed-cuda-ref-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-restriction.c
@@ -307,9 +307,9 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode,
   CeedInt num_nodes = impl->num_nodes;
   char   *restriction_kernel_path, *restriction_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-restriction.h", &restriction_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Restriction Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Restriction Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Cuda(ceed, restriction_kernel_source, &impl->module, 8, "RESTR_ELEM_SIZE", elem_size, "RESTR_NUM_ELEM", num_elem,
                                    "RESTR_NUM_COMP", num_comp, "RESTR_NUM_NODES", num_nodes, "RESTR_COMP_STRIDE", comp_stride, "RESTR_STRIDE_NODES",
                                    strides[0], "RESTR_STRIDE_COMP", strides[1], "RESTR_STRIDE_ELEM", strides[2]));

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -234,9 +234,9 @@ int CeedBasisCreateTensorH1_Cuda_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d,
   CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-shared-basis-tensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete -----\n");
   CeedCallBackend(CeedCompile_Cuda(ceed, basis_kernel_source, &data->module, 8, "BASIS_Q_1D", Q_1d, "BASIS_P_1D", P_1d, "T_1D",
                                    CeedIntMax(Q_1d, P_1d), "BASIS_DIM", dim, "BASIS_NUM_COMP", num_comp, "BASIS_NUM_NODES", CeedIntPow(P_1d, dim),
                                    "BASIS_NUM_QPTS", CeedIntPow(Q_1d, dim), "BASIS_HAS_COLLOCATED_GRAD", has_collocated_grad));

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -92,7 +92,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
   {
     char *tensor_basis_kernel_path, *tensor_basis_kernel_source;
     CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-shared-basis-tensor-templates.h", &tensor_basis_kernel_path));
-    CeedDebug256(ceed, 2, "----- Loading Tensor Basis Kernel Source -----\n");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Tensor Basis Kernel Source -----\n");
     CeedCallBackend(CeedLoadSourceToBuffer(ceed, tensor_basis_kernel_path, &tensor_basis_kernel_source));
     code << tensor_basis_kernel_source;
     CeedCallBackend(CeedFree(&tensor_basis_kernel_path));
@@ -101,7 +101,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
   {
     char *hip_gen_template_path, *hip_gen_template_source;
     CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-gen-templates.h", &hip_gen_template_path));
-    CeedDebug256(ceed, 2, "----- Loading Hip-Gen Template Source -----\n");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Hip-Gen Template Source -----\n");
     CeedCallBackend(CeedLoadSourceToBuffer(ceed, hip_gen_template_path, &hip_gen_template_source));
     code << hip_gen_template_source;
     CeedCallBackend(CeedFree(&hip_gen_template_path));
@@ -676,7 +676,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
   code << "// -----------------------------------------------------------------------------\n\n";
 
   // View kernel for debugging
-  CeedDebug256(ceed, 2, "Generated Operator Kernels:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Generated Operator Kernels:\n");
   CeedDebug(ceed, code.str().c_str());
 
   CeedInt block_sizes[3] = {0, 0, 0};

--- a/backends/hip-gen/ceed-hip-gen-qfunction.c
+++ b/backends/hip-gen/ceed-hip-gen-qfunction.c
@@ -47,9 +47,9 @@ int CeedQFunctionCreate_Hip_gen(CeedQFunction qf) {
 
   // Read QFunction source
   CeedCallBackend(CeedQFunctionGetKernelName(qf, &data->q_function_name));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &data->q_function_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source Complete! -----\n");
   CeedCheck(data->q_function_source, ceed, CEED_ERROR_UNSUPPORTED, "/gpu/hip/gen backend requires QFunction source code file");
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Apply", CeedQFunctionApply_Hip_gen));

--- a/backends/hip-ref/ceed-hip-ref-basis.c
+++ b/backends/hip-ref/ceed-hip-ref-basis.c
@@ -224,9 +224,9 @@ int CeedBasisCreateTensorH1_Hip(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const C
   CeedCallBackend(CeedBasisGetNumComponents(basis, &ncomp));
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-basis-tensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Hip(ceed, basis_kernel_source, &data->module, 7, "BASIS_Q_1D", Q_1d, "BASIS_P_1D", P_1d, "BASIS_BUF_LEN",
                                   ncomp * CeedIntPow(Q_1d > P_1d ? Q_1d : P_1d, dim), "BASIS_DIM", dim, "BASIS_NUM_COMP", ncomp, "BASIS_NUM_NODES",
                                   CeedIntPow(P_1d, dim), "BASIS_NUM_QPTS", CeedIntPow(Q_1d, dim)));
@@ -271,9 +271,9 @@ int CeedBasisCreateH1_Hip(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes,
   CeedCallBackend(CeedBasisGetNumComponents(basis, &ncomp));
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-basis-nontensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Hip(ceed, basis_kernel_source, &data->module, 4, "BASIS_Q", num_qpts, "BASIS_P", num_nodes, "BASIS_DIM", dim,
                                   "BASIS_NUM_COMP", ncomp));
   CeedCallBackend(CeedGetKernel_Hip(ceed, data->module, "Interp", &data->Interp));

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -722,9 +722,9 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, const b
 
   char *diagonal_kernel_path, *diagonal_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h", &diagonal_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Diagonal Assembly Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Diagonal Assembly Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, diagonal_kernel_path, &diagonal_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Diagonal Assembly Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Diagonal Assembly Source Complete! -----\n");
   CeedInt nnodes, nqpts;
   CeedCallBackend(CeedBasisGetNumNodes(basisin, &nnodes));
   CeedCallBackend(CeedBasisGetNumQuadraturePoints(basisin, &nqpts));
@@ -976,9 +976,9 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceed
   CeedInt block_size  = esize * esize * elemsPerBlock;
   char   *assembly_kernel_path, *assembly_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-operator-assemble.h", &assembly_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Assembly Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Assembly Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, assembly_kernel_path, &assembly_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Assembly Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Assembly Source Complete! -----\n");
   bool fallback = block_size > 1024;
   if (fallback) {  // Use fallback kernel with 1D threadblock
     block_size         = esize * elemsPerBlock;

--- a/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
+++ b/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
@@ -43,9 +43,9 @@ extern "C" int CeedQFunctionBuildKernel_Hip_ref(CeedQFunction qf) {
   // Build strings for final kernel
   char *read_write_kernel_path, *read_write_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-qfunction.h", &read_write_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading QFunction Read/Write Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction Read/Write Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, read_write_kernel_path, &read_write_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction Read/Write Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction Read/Write Kernel Source Complete! -----\n");
   string        qfunction_source(data->qfunction_source);
   string        qfunction_name(data->qfunction_name);
   string        read_write(read_write_kernel_source);
@@ -109,7 +109,7 @@ extern "C" int CeedQFunctionBuildKernel_Hip_ref(CeedQFunction qf) {
   code << "}\n";
 
   // View kernel for debugging
-  CeedDebug256(ceed, 2, "Generated QFunction Kernels:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Generated QFunction Kernels:\n");
   CeedDebug(ceed, code.str().c_str());
 
   // Compile kernel

--- a/backends/hip-ref/ceed-hip-ref-qfunction.c
+++ b/backends/hip-ref/ceed-hip-ref-qfunction.c
@@ -90,9 +90,9 @@ int CeedQFunctionCreate_Hip(CeedQFunction qf) {
 
   // Read QFunction source
   CeedCallBackend(CeedQFunctionGetKernelName(qf, &data->qfunction_name));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &data->qfunction_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source Complete! -----\n");
 
   // Register backend functions
   CeedCallBackend(CeedSetBackendFunction(ceed, "QFunction", qf, "Apply", CeedQFunctionApply_Hip));

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -305,9 +305,9 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
   CeedInt num_nodes = impl->num_nodes;
   char   *restriction_kernel_path, *restriction_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-restriction.h", &restriction_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Restriction Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Restriction Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Hip(ceed, restriction_kernel_source, &impl->module, 8, "RESTR_ELEM_SIZE", elem_size, "RESTR_NUM_ELEM", num_elem,
                                   "RESTR_NUM_COMP", num_comp, "RESTR_NUM_NODES", num_nodes, "RESTR_COMP_STRIDE", comp_stride, "RESTR_STRIDE_NODES",
                                   strides[0], "RESTR_STRIDE_COMP", strides[1], "RESTR_STRIDE_ELEM", strides[2]));

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -294,9 +294,9 @@ int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, 
   // Compile basis kernels
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-shared-basis-tensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Hip(ceed, basis_kernel_source, &data->module, 11, "BASIS_Q_1D", Q_1d, "BASIS_P_1D", P_1d, "T_1D",
                                   CeedIntMax(Q_1d, P_1d), "BASIS_DIM", dim, "BASIS_NUM_COMP", num_comp, "BASIS_NUM_NODES", CeedIntPow(P_1d, dim),
                                   "BASIS_NUM_QPTS", CeedIntPow(Q_1d, dim), "BASIS_INTERP_BLOCK_SIZE", data->block_sizes[0], "BASIS_GRAD_BLOCK_SIZE",

--- a/backends/magma/ceed-magma-basis.c
+++ b/backends/magma/ceed-magma-basis.c
@@ -487,7 +487,7 @@ CEED_INTERN "C"
   char *interp_path, *grad_path, *weight_path;
   char *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/magma_common_defs.h", &magma_common_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, magma_common_path, &basis_kernel_source));
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/magma_common_tensor.h", &magma_common_path));
   CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, magma_common_path, &basis_kernel_source));
@@ -509,7 +509,7 @@ CEED_INTERN "C"
   snprintf(weight_name, weight_name_len, "%s-%" CeedInt_FMT "d.h", weight_name_base, dim);
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, weight_name, &weight_path));
   CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, weight_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete! -----\n");
   // The RTC compilation code expects a Ceed with the common Ceed_Cuda or Ceed_Hip
   // data
   Ceed delegate;
@@ -589,7 +589,7 @@ CEED_INTERN "C"
   char *interp_path, *grad_path;
   char *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/magma_common_defs.h", &magma_common_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, magma_common_path, &basis_kernel_source));
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/magma_common_nontensor.h", &magma_common_path));
   CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, magma_common_path, &basis_kernel_source));

--- a/backends/magma/ceed-magma-restriction.c
+++ b/backends/magma/ceed-magma-restriction.c
@@ -237,13 +237,13 @@ int CeedElemRestrictionCreate_Magma(CeedMemType mtype, CeedCopyMode cmode, const
   char *magma_common_path;
   char *restriction_kernel_path, *restriction_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/magma_common_defs.h", &magma_common_path));
-  CeedDebug256(ceed, 2, "----- Loading Restriction Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, magma_common_path, &restriction_kernel_source));
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/magma_common_tensor.h", &magma_common_path));
   CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, magma_common_path, &restriction_kernel_source));
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/magma/elem_restriction.h", &restriction_kernel_path));
   CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Restriction Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
   // The RTC compilation code expects a Ceed with the common Ceed_Cuda or Ceed_Hip
   // data
   Ceed delegate;

--- a/backends/memcheck/ceed-memcheck-vector.c
+++ b/backends/memcheck/ceed-memcheck-vector.c
@@ -166,7 +166,7 @@ static int CeedVectorGetArrayWrite_Memcheck(CeedVector vec, CeedMemType mem_type
   // Invalidate data to make sure no read occurs
   if (!impl->array) CeedCallBackend(CeedVectorSetArray_Memcheck(vec, mem_type, CEED_COPY_VALUES, NULL));
   CeedCallBackend(CeedVectorGetArray_Memcheck(vec, mem_type, array));
-  for (CeedInt i = 0; i < length; i++) (*array)[i] = NAN;
+  for (CeedSize i = 0; i < length; i++) (*array)[i] = NAN;
   impl->is_write_only_access = true;
 
   return CEED_ERROR_SUCCESS;
@@ -184,8 +184,8 @@ static int CeedVectorRestoreArray_Memcheck(CeedVector vec) {
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
   if (impl->is_write_only_access) {
-    for (CeedInt i = 0; i < length; i++) {
-      if (isnan(impl->array[i])) CeedDebug256(ceed, 196, "WARNING: Vec entry %d is NaN after restoring write-only access", i);
+    for (CeedSize i = 0; i < length; i++) {
+      if (isnan(impl->array[i])) CeedDebug256(ceed, 196, "WARNING: Vec entry %ld is NaN after restoring write-only access", i);
     }
     impl->is_write_only_access = false;
   }

--- a/backends/memcheck/ceed-memcheck-vector.c
+++ b/backends/memcheck/ceed-memcheck-vector.c
@@ -167,6 +167,7 @@ static int CeedVectorGetArrayWrite_Memcheck(CeedVector vec, CeedMemType mem_type
   if (!impl->array) CeedCallBackend(CeedVectorSetArray_Memcheck(vec, mem_type, CEED_COPY_VALUES, NULL));
   CeedCallBackend(CeedVectorGetArray_Memcheck(vec, mem_type, array));
   for (CeedInt i = 0; i < length; i++) (*array)[i] = NAN;
+  impl->is_write_only_access = true;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -182,6 +183,12 @@ static int CeedVectorRestoreArray_Memcheck(CeedVector vec) {
   Ceed ceed;
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
 
+  if (impl->is_write_only_access) {
+    for (CeedInt i = 0; i < length; i++) {
+      if (isnan(impl->array[i])) CeedDebug256(ceed, 196, "WARNING: Vec entry %d is NaN after restoring write-only access", i);
+    }
+    impl->is_write_only_access = false;
+  }
   if (impl->array_borrowed) {
     memcpy(impl->array_borrowed, impl->array, length * sizeof(impl->array[0]));
   }

--- a/backends/memcheck/ceed-memcheck-vector.c
+++ b/backends/memcheck/ceed-memcheck-vector.c
@@ -185,7 +185,7 @@ static int CeedVectorRestoreArray_Memcheck(CeedVector vec) {
 
   if (impl->is_write_only_access) {
     for (CeedSize i = 0; i < length; i++) {
-      if (isnan(impl->array[i])) CeedDebug256(ceed, 196, "WARNING: Vec entry %ld is NaN after restoring write-only access", i);
+      if (isnan(impl->array[i])) CeedDebug256(ceed, CEED_DEBUG_COLOR_WARNING, "WARNING: Vec entry %ld is NaN after restoring write-only access", i);
     }
     impl->is_write_only_access = false;
   }

--- a/backends/memcheck/ceed-memcheck.h
+++ b/backends/memcheck/ceed-memcheck.h
@@ -13,6 +13,7 @@
 
 typedef struct {
   int         mem_block_id;
+  bool        is_write_only_access;
   CeedScalar *array;
   CeedScalar *array_allocated;
   CeedScalar *array_owned;

--- a/backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp
@@ -60,17 +60,17 @@ extern "C" int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf) {
   CeedCallBackend(CeedQFunctionGetKernelName(qf, &qfunction_name));
 
   char* qfunction_source;
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source -----\n");
   CeedCallBackend(CeedQFunctionLoadSourceToBuffer(qf, &qfunction_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction User Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction User Source Complete! -----\n");
 
   char* read_write_kernel_path;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/sycl/sycl-ref-qfunction.h", &read_write_kernel_path));
 
   char* read_write_kernel_source;
-  CeedDebug256(ceed, 2, "----- Loading QFunction Read/Write Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction Read/Write Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, read_write_kernel_path, &read_write_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading QFunction Read/Write Kernel Source Complete! -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading QFunction Read/Write Kernel Source Complete! -----\n");
 
   std::string_view  qf_name_view(qfunction_name);
   std::string_view  qf_source_view(qfunction_source);
@@ -158,7 +158,7 @@ extern "C" int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf) {
   code << "}\n";
 
   // View kernel for debugging
-  CeedDebug256(ceed, 2, "Generated QFunction Kernels:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Generated QFunction Kernels:\n");
   CeedDebug(ceed, code.str().c_str());
 
   // Compile kernel

--- a/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
@@ -234,9 +234,9 @@ int CeedBasisCreateTensorH1_Sycl_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d,
   // Load kernel source
   char *basis_kernel_path, *basis_kernel_source;
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/sycl/sycl-shared-basis-tensor.h", &basis_kernel_path));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, basis_kernel_path, &basis_kernel_source));
-  CeedDebug256(ceed, 2, "----- Loading Basis Kernel Source Complete -----\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Basis Kernel Source Complete -----\n");
 
   // Compile kernels into a kernel bundle
   CeedCallBackend(CeedBuildModule_Sycl(ceed, basis_kernel_source, &impl->sycl_module, jit_constants));

--- a/backends/sycl/online_compiler.hpp
+++ b/backends/sycl/online_compiler.hpp
@@ -195,8 +195,8 @@ template <>
 template <>
 std::vector<byte> online_compiler<source_language::opencl_c>::compile(const std::string &src, const std::vector<std::string> &options);
 
-/// Compiles the given OpenCL source. May throw \c online_compile_error.
-/// @param src - contents of the source.
+// /// Compiles the given OpenCL source. May throw \c online_compile_error.
+// /// @param src - contents of the source.
 // template <>
 // template <>
 // std::vector<byte>

--- a/doc/sphinx/source/api/backend/Ceed.rst
+++ b/doc/sphinx/source/api/backend/Ceed.rst
@@ -6,3 +6,24 @@ Ceed
    :path: ../../../../xml
    :content-only:
    :members:
+
+Macros
+--------------------------------------
+
+.. doxygendefine:: CeedDebug256
+   :project: libCEED
+
+.. doxygendefine:: CeedDebug
+   :project: libCEED
+
+.. doxygendefine:: CeedDebugEnv256
+   :project: libCEED
+
+.. doxygendefine:: CeedDebugEnv
+   :project: libCEED
+
+Typedefs and Enumerations
+--------------------------------------
+
+.. doxygenenum:: CeedDebugColor
+   :project: libCEED

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -62,8 +62,19 @@
 #endif
 #endif
 
-/// CEED_DEBUG_COLOR default value, forward CeedDebug* declarations & macros
-#define CEED_DEBUG_COLOR_NONE 255
+/// Common colors for CeedDebug256 debugging output.
+/// Set CEED_DEBUG=1 to activate debugging output.
+/// @ingroup CeedBackend
+typedef enum {
+  /// Success color
+  CEED_DEBUG_COLOR_SUCCESS = 108,
+  /// Warning color
+  CEED_DEBUG_COLOR_WARNING = 208,
+  /// Error color
+  CEED_DEBUG_COLOR_ERROR = 196,
+  /// Use native terminal coloring
+  CEED_DEBUG_COLOR_NONE = 255,
+} CeedDebugColor;
 
 CEED_EXTERN void CeedDebugImpl256(const unsigned char, const char *, ...);
 CEED_EXTERN bool CeedDebugFlag(const Ceed ceed);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -30,12 +30,10 @@
 #define CEED_COMPOSITE_MAX 16
 #define CEED_FIELD_MAX 16
 
-/**
-  @ingroup Ceed
-  This macro provides the ability to disable optimization flags for functions that are sensitive to floating point optimizations.
-**/
 #ifndef CeedPragmaOptimizeOff
 #if defined(__clang__)
+/// This macro provides the ability to disable optimization flags for functions that are sensitive to floating point optimizations.
+/// @ingroup Ceed
 #define CeedPragmaOptimizeOff _Pragma("clang optimize off")
 #elif defined(__GNUC__)
 #define CeedPragmaOptimizeOff _Pragma("GCC push_options") _Pragma("GCC optimize 0")
@@ -46,12 +44,10 @@
 #endif
 #endif
 
-/**
-  @ingroup Ceed
-  This macro restores previously set optimization flags after CeedPragmaOptimizeOff.
-**/
 #ifndef CeedPragmaOptimizeOn
 #if defined(__clang__)
+/// This macro restores previously set optimization flags after CeedPragmaOptimizeOff.
+/// @ingroup Ceed
 #define CeedPragmaOptimizeOn _Pragma("clang optimize on")
 #elif defined(__GNUC__)
 #define CeedPragmaOptimizeOn _Pragma("GCC pop_options")
@@ -62,9 +58,13 @@
 #endif
 #endif
 
-/// Common colors for CeedDebug256 debugging output.
-/// Set CEED_DEBUG=1 to activate debugging output.
-/// @ingroup CeedBackend
+/**
+  This enum supples common colors for CeedDebug256 debugging output.
+  Set the environment variable `CEED_DEBUG = 1` to activate debugging output.
+
+  @ingroup Ceed
+  @ref     Backend
+**/
 typedef enum {
   /// Success color
   CEED_DEBUG_COLOR_SUCCESS = 108,
@@ -79,15 +79,46 @@ typedef enum {
 CEED_EXTERN void CeedDebugImpl256(const unsigned char, const char *, ...);
 CEED_EXTERN bool CeedDebugFlag(const Ceed ceed);
 CEED_EXTERN bool CeedDebugFlagEnv(void);
+/**
+  Print debugging information in color
+
+  @param[in] ceed  Ceed
+  @param[in] color Color to print with
+
+  @ingroup Ceed
+  @ref     Backend
+**/
 #define CeedDebug256(ceed, color, ...)                               \
   {                                                                  \
     if (CeedDebugFlag(ceed)) CeedDebugImpl256(color, ##__VA_ARGS__); \
   }
+/**
+  Print debugging information to terminal
+
+  @param[in] ceed  Ceed
+
+  @ingroup Ceed
+  @ref     Backend
+**/
 #define CeedDebug(ceed, ...) CeedDebug256(ceed, (unsigned char)CEED_DEBUG_COLOR_NONE, ##__VA_ARGS__)
+/**
+  Print debugging information in color without Ceed to reference
+
+  @param[in] color Color to print with
+
+  @ingroup Ceed
+  @ref     Backend
+**/
 #define CeedDebugEnv256(color, ...)                                 \
   {                                                                 \
     if (CeedDebugFlagEnv()) CeedDebugImpl256(color, ##__VA_ARGS__); \
   }
+/**
+  Print debugging information to terminal without Ceed to reference
+
+  @ingroup Ceed
+  @ref     Backend
+**/
 #define CeedDebugEnv(...) CeedDebugEnv256((unsigned char)CEED_DEBUG_COLOR_NONE, ##__VA_ARGS__)
 
 /// Handle for object handling TensorContraction

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -39,7 +39,7 @@ int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid) {
   }
 
   // Debug
-  CeedDebug256(ceed, 1, "Checking for source file: ");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Checking for source file: ");
   CeedDebug(ceed, "%s\n", source_file_path_only);
 
   // Check for valid file path
@@ -49,7 +49,7 @@ int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid) {
 
   if (*is_valid) {
     // Debug
-    CeedDebug256(ceed, 1, "Found JiT source file: ");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Found JiT source file: ");
     CeedDebug(ceed, "%s\n", source_file_path_only);
 
     fclose(source_file);
@@ -78,10 +78,10 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, c
   char *temp_buffer;
 
   // Debug
-  CeedDebug256(ceed, 1, "---------- Ceed JiT ----------\n");
-  CeedDebug256(ceed, 1, "Current source file: ");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "---------- Ceed JiT ----------\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Current source file: ");
   CeedDebug(ceed, "%s\n", source_file_path);
-  CeedDebug256(ceed, 1, "Current buffer:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Current buffer:\n");
   CeedDebug(ceed, "%s\n", *buffer);
 
   // Read file to temporary buffer
@@ -153,7 +153,7 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, c
           CeedCall(CeedFree(&ceed_relative_path));
         }
         // ---- Recursive call to load source to buffer
-        CeedDebug256(ceed, 2, "JiT Including: %s\n", include_source_path);
+        CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "JiT Including: %s\n", include_source_path);
         CeedCall(CeedLoadSourceToInitializedBuffer(ceed, include_source_path, buffer));
         CeedCall(CeedFree(&include_source_path));
       }
@@ -174,10 +174,10 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, c
   CeedCall(CeedFree(&temp_buffer));
 
   // Debug
-  CeedDebug256(ceed, 1, "---------- Ceed JiT ----------\n");
-  CeedDebug256(ceed, 1, "Current source file: ");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "---------- Ceed JiT ----------\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Current source file: ");
   CeedDebug(ceed, "%s\n", source_file_path);
-  CeedDebug256(ceed, 1, "Final buffer:\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Final buffer:\n");
   CeedDebug(ceed, "%s\n", *buffer);
 
   return CEED_ERROR_SUCCESS;
@@ -265,8 +265,8 @@ int CeedGetJitAbsolutePath(Ceed ceed, const char *relative_file_path, char **abs
   Ceed ceed_parent;
 
   // Debug
-  CeedDebug256(ceed, 1, "---------- Ceed JiT ----------\n");
-  CeedDebug256(ceed, 1, "Relative JiT source file: ");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "---------- Ceed JiT ----------\n");
+  CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Relative JiT source file: ");
   CeedDebug(ceed, "%s\n", relative_file_path);
 
   CeedCall(CeedGetParent(ceed, &ceed_parent));
@@ -274,7 +274,7 @@ int CeedGetJitAbsolutePath(Ceed ceed, const char *relative_file_path, char **abs
     bool is_valid;
 
     // Debug
-    CeedDebug256(ceed, 1, "Checking JiT root: ");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Checking JiT root: ");
     CeedDebug(ceed, "%s\n", ceed_parent->jit_source_roots[i]);
 
     // Build and check absolute path with current root

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -167,7 +167,7 @@ int CeedOperatorGetFallback(CeedOperator op, CeedOperator *op_fallback) {
       CeedCall(CeedGetResource(ceed, &resource));
       CeedCall(CeedGetResource(ceed_fallback, &resource_fallback));
 
-      CeedDebug256(ceed, 1, "---------- CeedOperator Fallback ----------\n");
+      CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "---------- CeedOperator Fallback ----------\n");
       CeedDebug(ceed, "Falling back from %s operator at address %ld to %s operator at address %ld\n", resource, op, resource_fallback,
                 op->op_fallback);
     }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -482,7 +482,7 @@ int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource) {
 **/
 int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed) {
   if (ceed->has_valid_op_fallback_resource) {
-    CeedDebug256(ceed, 1, "---------- CeedOperator Fallback ----------\n");
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "---------- CeedOperator Fallback ----------\n");
     CeedDebug(ceed, "Getting fallback from %s to %s\n", ceed->resource, ceed->op_fallback_resource);
   }
 


### PR DESCRIPTION
I added a `CeedDebug` warning if a vector has a NaN after restoring write-only access and an error if a QFunction output has a NaN after applying the user QFunction function.