### PR TITLE
fluids: Remove ComputeL2Projection function

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -406,8 +406,6 @@ extern const PetscInt32 FLUIDS_FILE_TOKEN_64;
 // Create appropriate mass qfunction based on number of components N
 PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, CeedQFunction *qf);
 
-PetscErrorCode ComputeL2Projection(Vec source_vec, Vec target_vec, OperatorApplyContext rhs_matop_ctx, KSP ksp);
-
 PetscErrorCode NodalProjectionDataDestroy(NodalProjectionData context);
 
 PetscErrorCode PHASTADatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], const PetscInt char_array_len, PetscInt dims[2],

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -286,24 +286,6 @@ PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, Ce
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/* @brief L^2 Projection of a source FEM function to a target FEM space
- *
- * To solve system using a lumped mass matrix, pass a KSP object with ksp_type=preonly, pc_type=jacobi, pc_jacobi_type=rowsum.
- *
- * @param[in]  source_vec    Global Vec of the source FEM function. NULL indicates using rhs_matop_ctx->X_loc
- * @param[out] target_vec    Global Vec of the target (result) FEM function. NULL indicates using rhs_matop_ctx->Y_loc
- * @param[in]  rhs_matop_ctx MatopApplyContext for performing the RHS evaluation
- * @param[in]  ksp           KSP for solving the consistent projection problem
- */
-PetscErrorCode ComputeL2Projection(Vec source_vec, Vec target_vec, OperatorApplyContext rhs_matop_ctx, KSP ksp) {
-  PetscFunctionBeginUser;
-
-  PetscCall(ApplyCeedOperatorGlobalToGlobal(source_vec, target_vec, rhs_matop_ctx));
-  PetscCall(KSPSolve(ksp, target_vec, target_vec));
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 PetscErrorCode NodalProjectionDataDestroy(NodalProjectionData context) {
   PetscFunctionBeginUser;
   if (context == NULL) PetscFunctionReturn(PETSC_SUCCESS);


### PR DESCRIPTION
- It's superseded by using the `NodalProjectionData` struct + `ApplyCeedOperator*`   + `KSPSolve`
- Primary reason is to allow using  `ApplyCeedOperatorGlobalToGlobal`,  `ApplyCeedOperatorLocalToGlobal`,  or `ApplyCeedOperatorGlobalToLocal` depending on what's the most efficient for a specific application.