### PR TITLE
fluids: Misc cleanup

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
   //    communication. If we disable this, we should still get the same results due to the problem->bc function, but with potentially much slower
   //    execution.
   if (problem->bc_from_ics) {
-    PetscCall(SetBCsFromICs_NS(dm, Q, user->Q_loc));
+    PetscCall(SetBCsFromICs(dm, Q, user->Q_loc));
   }
 
   // ---------------------------------------------------------------------------
@@ -247,7 +247,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   // Post-processing
   // ---------------------------------------------------------------------------
-  PetscCall(PostProcess_NS(ts, ceed_data, dm, problem, user, Q, final_time));
+  PetscCall(PostProcess(ts, ceed_data, dm, problem, user, Q, final_time));
 
   // ---------------------------------------------------------------------------
   // Destroy libCEED objects

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -255,7 +255,7 @@ int main(int argc, char **argv) {
 
   PetscCall(TurbulenceStatisticsDestroy(user, ceed_data));
   PetscCall(NodalProjectionDataDestroy(user->grad_velo_proj));
-  PetscCall(SGS_DD_DataDestroy(user->sgs_dd_data));
+  PetscCall(SgsDDDataDestroy(user->sgs_dd_data));
   PetscCall(DifferentialFilterDataDestroy(user->diff_filter));
 
   // -- Vectors

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -405,23 +405,23 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
 // -----------------------------------------------------------------------------
 PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_loc, Vec Q, CeedScalar time);
 
-PetscErrorCode DMPlexInsertBoundaryValues_NS(DM dm, PetscBool insert_essential, Vec Q_loc, PetscReal time, Vec face_geom_FVM, Vec cell_geom_FVM,
-                                             Vec grad_FVM);
+PetscErrorCode DMPlexInsertBoundaryValues_FromICs(DM dm, PetscBool insert_essential, Vec Q_loc, PetscReal time, Vec face_geom_FVM, Vec cell_geom_FVM,
+                                                  Vec grad_FVM);
 
 // Compare reference solution values with current test run for CI
-PetscErrorCode RegressionTests_NS(AppCtx app_ctx, Vec Q);
+PetscErrorCode RegressionTest(AppCtx app_ctx, Vec Q);
 
 // Get error for problems with exact solutions
-PetscErrorCode GetError_NS(CeedData ceed_data, DM dm, User user, Vec Q, PetscScalar final_time);
+PetscErrorCode PrintError(CeedData ceed_data, DM dm, User user, Vec Q, PetscScalar final_time);
 
 // Post-processing
-PetscErrorCode PostProcess_NS(TS ts, CeedData ceed_data, DM dm, ProblemData *problem, User user, Vec Q, PetscScalar final_time);
+PetscErrorCode PostProcess(TS ts, CeedData ceed_data, DM dm, ProblemData *problem, User user, Vec Q, PetscScalar final_time);
 
 // -- Gather initial Q values in case of continuation of simulation
 PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q);
 
 // Record boundary values from initial condition
-PetscErrorCode SetBCsFromICs_NS(DM dm, Vec Q, Vec Q_loc);
+PetscErrorCode SetBCsFromICs(DM dm, Vec Q, Vec Q_loc);
 
 // Versioning token for binary checkpoints
 extern const PetscInt32 FLUIDS_FILE_TOKEN;  // for backwards compatibility

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -193,7 +193,7 @@ typedef struct {
   PetscBool             do_mms_test;
   OperatorApplyContext  mms_error_ctx;
   CeedContextFieldLabel solution_time_label, previous_time_label;
-} Span_Stats;
+} SpanStatsData;
 
 typedef struct {
   DM                   dm;
@@ -207,7 +207,7 @@ typedef struct {
   PetscInt             num_comp_sgs;
   OperatorApplyContext op_nodal_evaluation_ctx, op_sgs_apply_ctx;
   CeedVector           sgs_nodal_ceed;
-} *SGS_DD_Data;
+} *SgsDDData;
 
 typedef struct {
   DM                   dm_filter;
@@ -234,9 +234,9 @@ struct User_private {
   OperatorApplyContext op_rhs_ctx, op_strong_bc_ctx;
   bool                 matrices_set_up;
   CeedScalar           time_bc_set;
-  Span_Stats           spanstats;
+  SpanStatsData        spanstats;
   NodalProjectionData  grad_velo_proj;
-  SGS_DD_Data          sgs_dd_data;
+  SgsDDData            sgs_dd_data;
   DiffFilterData       diff_filter;
 };
 
@@ -433,12 +433,12 @@ PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, Ce
 
 PetscErrorCode NodalProjectionDataDestroy(NodalProjectionData context);
 
-PetscErrorCode PHASTADatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], const PetscInt char_array_len, PetscInt dims[2],
+PetscErrorCode PhastaDatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], const PetscInt char_array_len, PetscInt dims[2],
                                  FILE **fp);
 
-PetscErrorCode PHASTADatFileGetNRows(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscInt *nrows);
+PetscErrorCode PhastaDatFileGetNRows(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscInt *nrows);
 
-PetscErrorCode PHASTADatFileReadToArrayReal(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscReal array[]);
+PetscErrorCode PhastaDatFileReadToArrayReal(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscReal array[]);
 
 PetscErrorCode IntArrayC2P(PetscInt num_entries, CeedInt **array_ceed, PetscInt **array_petsc);
 PetscErrorCode IntArrayP2C(PetscInt num_entries, PetscInt **array_petsc, CeedInt **array_ceed);
@@ -455,9 +455,9 @@ PetscErrorCode TurbulenceStatisticsDestroy(User user, CeedData ceed_data);
 // Data-Driven Subgrid Stress (DD-SGS) Modeling Functions
 // -----------------------------------------------------------------------------
 
-PetscErrorCode SGS_DD_ModelSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
-PetscErrorCode SGS_DD_DataDestroy(SGS_DD_Data sgs_dd_data);
-PetscErrorCode SGS_DD_ModelApplyIFunction(User user, const Vec Q_loc, Vec G_loc);
+PetscErrorCode SgsDDModelSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
+PetscErrorCode SgsDDDataDestroy(SgsDDData sgs_dd_data);
+PetscErrorCode SgsDDModelApplyIFunction(User user, const Vec Q_loc, Vec G_loc);
 PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
 PetscErrorCode VelocityGradientProjectionApply(User user, Vec Q_loc, Vec VelocityGradient);
 PetscErrorCode GridAnisotropyTensorProjectionSetupApply(Ceed ceed, User user, CeedData ceed_data, CeedElemRestriction *elem_restr_grid_aniso,
@@ -483,6 +483,6 @@ PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data,
 PetscErrorCode DifferentialFilterDataDestroy(DiffFilterData diff_filter);
 PetscErrorCode TSMonitor_DifferentialFilter(TS ts, PetscInt steps, PetscReal solution_time, Vec Q, void *ctx);
 PetscErrorCode DifferentialFilterApply(User user, const PetscReal solution_time, const Vec Q, Vec Filtered_Solution);
-PetscErrorCode DifferentialFilter_MMS_ICSetup(ProblemData *problem);
+PetscErrorCode DifferentialFilterMmsICSetup(ProblemData *problem);
 
 #endif  // libceed_fluids_examples_navier_stokes_h

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -338,9 +338,9 @@ PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
   PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->ics.qfunction_context));
   problem->ics.qfunction_context = blasius_context;
   if (use_stg) {
-    PetscCall(SetupSTG(comm, dm, problem, user, weakT, T_inf, P0));
+    PetscCall(SetupStg(comm, dm, problem, user, weakT, T_inf, P0));
   } else if (diff_filter_mms) {
-    PetscCall(DifferentialFilter_MMS_ICSetup(problem));
+    PetscCall(DifferentialFilterMmsICSetup(problem));
   } else {
     problem->apply_inflow.qfunction              = Blasius_Inflow;
     problem->apply_inflow.qfunction_loc          = Blasius_Inflow_loc;

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -21,10 +21,12 @@ PetscErrorCode CompressibleBlasiusResidual(SNES snes, Vec X, Vec R, void *ctx) {
   const BlasiusContext blasius = (BlasiusContext)ctx;
   const PetscScalar   *Tf, *Th;  // Chebyshev coefficients
   PetscScalar         *r, f[4], h[4];
-  PetscInt             N  = blasius->n_cheb;
-  PetscScalar          Ma = Mach(&blasius->newtonian_ctx, blasius->T_inf, blasius->U_inf), Pr = Prandtl(&blasius->newtonian_ctx),
+  PetscInt             N = blasius->n_cheb;
+
+  PetscFunctionBeginUser;
+  PetscScalar Ma = Mach(&blasius->newtonian_ctx, blasius->T_inf, blasius->U_inf), Pr = Prandtl(&blasius->newtonian_ctx),
               gamma = HeatCapacityRatio(&blasius->newtonian_ctx);
-  PetscFunctionBegin;
+
   PetscCall(VecGetArrayRead(X, &Tf));
   Th = Tf + N;
   PetscCall(VecGetArray(R, &r));
@@ -76,8 +78,8 @@ PetscErrorCode ComputeChebyshevCoefficients(BlasiusContext blasius) {
   PetscInt            N = blasius->n_cheb;
   SNESConvergedReason reason;
   const PetscScalar  *cheb_coefs;
-  PetscFunctionBegin;
 
+  PetscFunctionBeginUser;
   // Allocate memory
   PetscCall(PetscMalloc2(N - 3, &blasius->X, N - 3, &w));
   PetscCall(PetscDTGaussQuadrature(N - 3, -1., 1., blasius->X, w));
@@ -117,8 +119,8 @@ static PetscErrorCode GetYNodeLocs(const MPI_Comm comm, const char path[PETSC_MA
   char           line[char_array_len];
   char         **array;
   PetscReal     *node_locs;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(PetscFOpen(comm, path, "r", &fp));
   PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));
   PetscCall(PetscStrToArray(line, ' ', &ndims, &array));
@@ -158,10 +160,9 @@ static PetscErrorCode ModifyMesh(MPI_Comm comm, DM dm, PetscInt dim, PetscReal g
   PetscReal    domain_min[3], domain_max[3], domain_size[3];
   PetscScalar *arr_coords;
   Vec          vec_coords;
+
   PetscFunctionBeginUser;
-
   PetscReal angle_coeff = tan(top_angle * (M_PI / 180));
-
   // Get domain boundary information
   PetscCall(DMGetBoundingBox(dm, domain_min, domain_max));
   for (PetscInt i = 0; i < 3; i++) domain_size[i] = domain_max[i] - domain_min[i];
@@ -225,7 +226,6 @@ static PetscErrorCode ModifyMesh(MPI_Comm comm, DM dm, PetscInt dim, PetscReal g
 
   PetscCall(VecRestoreArray(vec_coords, &arr_coords));
   PetscCall(DMSetCoordinatesLocal(dm, vec_coords));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/problems/densitycurrent.c
+++ b/examples/fluids/problems/densitycurrent.c
@@ -102,6 +102,5 @@ PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *ctx, Simple
   PetscCallCeed(ceed, CeedQFunctionContextSetData(density_current_context, CEED_MEM_HOST, CEED_USE_POINTER, sizeof(*dc_ctx), dc_ctx));
   PetscCallCeed(ceed, CeedQFunctionContextSetDataDestroy(density_current_context, CEED_MEM_HOST, FreeContextPetsc));
   problem->ics.qfunction_context = density_current_context;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/problems/freestream_bc.c
+++ b/examples/fluids/problems/freestream_bc.c
@@ -25,14 +25,12 @@ PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, Newtoni
   FreestreamContext    freestream_ctx;
   CeedQFunctionContext freestream_context;
   RiemannFluxType      riemann = RIEMANN_HLLC;
+  PetscScalar          meter   = user->units->meter;
+  PetscScalar          second  = user->units->second;
+  PetscScalar          Kelvin  = user->units->Kelvin;
+  PetscScalar          Pascal  = user->units->Pascal;
+
   PetscFunctionBeginUser;
-  PetscScalar meter  = user->units->meter;
-  PetscScalar second = user->units->second;
-  PetscScalar Kelvin = user->units->Kelvin;
-  PetscScalar Pascal = user->units->Pascal;
-
-  // -- Option Defaults
-
   // Freestream inherits reference state. We re-dimensionalize so the defaults
   // in -help will be visible in SI units.
   StatePrimitive Y_inf = {.pressure = reference->pressure / Pascal, .velocity = {0}, .temperature = reference->temperature / Kelvin};

--- a/examples/fluids/problems/gaussianwave.c
+++ b/examples/fluids/problems/gaussianwave.c
@@ -74,6 +74,5 @@ PetscErrorCode NS_GAUSSIAN_WAVE(ProblemData *problem, DM dm, void *ctx, SimpleBC
   PetscCallCeed(ceed, CeedQFunctionContextSetDataDestroy(gausswave_context, CEED_MEM_HOST, FreeContextPetsc));
   PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->ics.qfunction_context));
   problem->ics.qfunction_context = gausswave_context;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -22,8 +22,9 @@ static const char *const StateVariables[] = {"CONSERVATIVE", "PRIMITIVE", "State
 // Compute relative error |a - b|/|s|
 static PetscErrorCode CheckPrimitiveWithTolerance(StatePrimitive sY, StatePrimitive aY, StatePrimitive bY, const char *name, PetscReal rtol_pressure,
                                                   PetscReal rtol_velocity, PetscReal rtol_temperature) {
-  PetscFunctionBeginUser;
   StatePrimitive eY;  // relative error
+
+  PetscFunctionBeginUser;
   eY.pressure   = (aY.pressure - bY.pressure) / sY.pressure;
   PetscScalar u = sqrt(Square(sY.velocity[0]) + Square(sY.velocity[1]) + Square(sY.velocity[2]));
   for (int j = 0; j < 3; j++) eY.velocity[j] = (aY.velocity[j] - bY.velocity[j]) / u;
@@ -39,11 +40,12 @@ static PetscErrorCode CheckPrimitiveWithTolerance(StatePrimitive sY, StatePrimit
 static PetscErrorCode UnitTests_Newtonian(User user, NewtonianIdealGasContext gas) {
   Units            units = user->units;
   const CeedScalar eps   = 1e-6;
+  const CeedScalar x[3]  = {.1, .2, .3};
   const CeedScalar kg = units->kilogram, m = units->meter, sec = units->second, Pascal = units->Pascal;
+
   PetscFunctionBeginUser;
   const CeedScalar rho = 1.2 * kg / (m * m * m), u = 40 * m / sec;
   CeedScalar       U[5] = {rho, rho * u, rho * u * 1.1, rho * u * 1.2, 250e3 * Pascal + .5 * rho * u * u};
-  const CeedScalar x[3] = {.1, .2, .3};
   State            s    = StateFromU(gas, U, x);
   for (int i = 0; i < 8; i++) {
     CeedScalar dU[5] = {0}, dx[3] = {0};

--- a/examples/fluids/problems/sgs_dd_model.c
+++ b/examples/fluids/problems/sgs_dd_model.c
@@ -50,7 +50,6 @@ PetscErrorCode SgsDDModelCreateDM(DM dm_source, DM *dm_sgs, PetscInt degree, Pet
   PetscCall(PetscSectionSetComponentName(section, 0, 3, "KMSubgridStressYZ"));
   PetscCall(PetscSectionSetComponentName(section, 0, 4, "KMSubgridStressXZ"));
   PetscCall(PetscSectionSetComponentName(section, 0, 5, "KMSubgridStressXY"));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 
@@ -229,7 +228,6 @@ PetscErrorCode SgsDDModelApplyIFunction(User user, const Vec Q_loc, Vec G_loc) {
   PetscCall(VecC2P(sgs_dd_data->sgs_nodal_ceed, sgs_nodal_mem_type, SGSNodal_loc));
   PetscCall(DMRestoreLocalVector(sgs_dd_data->dm_sgs, &SGSNodal_loc));
   PetscCall(DMRestoreGlobalVector(user->grad_velo_proj->dm, &VelocityGradient));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -302,8 +300,8 @@ PetscErrorCode SgsDDModelSetup(Ceed ceed, User user, CeedData ceed_data, Problem
   char                     sgs_dd_dir[PETSC_MAX_PATH_LEN] = "./dd_sgs_parameters";
   SgsDDModelSetupData      sgs_dd_setup_data;
   NewtonianIdealGasContext gas;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(VelocityGradientProjectionSetup(ceed, user, ceed_data, problem));
 
   PetscCall(PetscNew(&sgsdd_ctx));
@@ -360,6 +358,5 @@ PetscErrorCode SgsDDDataDestroy(SgsDDData sgs_dd_data) {
   PetscCall(OperatorApplyContextDestroy(sgs_dd_data->op_nodal_evaluation_ctx));
   PetscCall(DMDestroy(&sgs_dd_data->dm_sgs));
   PetscCall(PetscFree(sgs_dd_data));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/problems/sgs_dd_model.c
+++ b/examples/fluids/problems/sgs_dd_model.c
@@ -15,11 +15,10 @@ typedef struct {
   CeedElemRestriction  elem_restr_grid_aniso, elem_restr_sgs;
   CeedVector           grid_aniso_ceed;
   CeedQFunctionContext sgsdd_qfctx;
-} *SGS_DD_ModelSetupData;
+} *SgsDDModelSetupData;
 
-PetscErrorCode SGS_DD_ModelSetupDataDestroy(SGS_DD_ModelSetupData sgs_dd_setup_data) {
+PetscErrorCode SgsDDModelSetupDataDestroy(SgsDDModelSetupData sgs_dd_setup_data) {
   Ceed ceed;
-
   PetscFunctionBeginUser;
   PetscCall(CeedElemRestrictionGetCeed(sgs_dd_setup_data->elem_restr_sgs, &ceed));
   PetscCallCeed(ceed, CeedElemRestrictionDestroy(&sgs_dd_setup_data->elem_restr_grid_aniso));
@@ -32,7 +31,7 @@ PetscErrorCode SGS_DD_ModelSetupDataDestroy(SGS_DD_ModelSetupData sgs_dd_setup_d
 }
 
 // @brief Create DM for storing subgrid stress at nodes
-PetscErrorCode SGS_DD_ModelCreateDM(DM dm_source, DM *dm_sgs, PetscInt degree, PetscInt q_extra, PetscInt *num_components) {
+PetscErrorCode SgsDDModelCreateDM(DM dm_source, DM *dm_sgs, PetscInt degree, PetscInt q_extra, PetscInt *num_components) {
   PetscSection section;
 
   PetscFunctionBeginUser;
@@ -56,8 +55,8 @@ PetscErrorCode SGS_DD_ModelCreateDM(DM dm_source, DM *dm_sgs, PetscInt degree, P
 };
 
 // @brief Create CeedOperator to calculate data-drive SGS at nodes
-PetscErrorCode SGS_DD_ModelSetupNodalEvaluation(Ceed ceed, User user, CeedData ceed_data, SGS_DD_ModelSetupData sgs_dd_setup_data) {
-  SGS_DD_Data         sgs_dd_data = user->sgs_dd_data;
+PetscErrorCode SgsDDModelSetupNodalEvaluation(Ceed ceed, User user, CeedData ceed_data, SgsDDModelSetupData sgs_dd_setup_data) {
+  SgsDDData           sgs_dd_data = user->sgs_dd_data;
   CeedQFunction       qf_multiplicity, qf_sgs_dd_nodal;
   CeedOperator        op_multiplicity, op_sgs_dd_nodal;
   CeedInt             num_elem, elem_size, num_comp_q, num_comp_grad_velo, num_comp_x, num_comp_grid_aniso;
@@ -104,11 +103,11 @@ PetscErrorCode SGS_DD_ModelSetupNodalEvaluation(Ceed ceed, User user, CeedData c
   // -- Create operator for SGS DD model nodal evaluation
   switch (user->phys->state_var) {
     case STATEVAR_PRIMITIVE:
-      PetscCallCeed(
-          ceed, CeedQFunctionCreateInterior(ceed, 1, ComputeSGS_DDAnisotropicNodal_Prim, ComputeSGS_DDAnisotropicNodal_Prim_loc, &qf_sgs_dd_nodal));
+      PetscCallCeed(ceed,
+                    CeedQFunctionCreateInterior(ceed, 1, ComputeSgsDDAnisotropicNodal_Prim, ComputeSgsDDAnisotropicNodal_Prim_loc, &qf_sgs_dd_nodal));
       break;
     case STATEVAR_CONSERVATIVE:
-      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, ComputeSGS_DDAnisotropicNodal_Conserv, ComputeSGS_DDAnisotropicNodal_Conserv_loc,
+      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, ComputeSgsDDAnisotropicNodal_Conserv, ComputeSgsDDAnisotropicNodal_Conserv_loc,
                                                       &qf_sgs_dd_nodal));
       break;
     default:
@@ -155,8 +154,8 @@ PetscErrorCode SGS_DD_ModelSetupNodalEvaluation(Ceed ceed, User user, CeedData c
 }
 
 // @brief Create CeedOperator to compute SGS contribution to the residual
-PetscErrorCode SGS_ModelSetupNodalIFunction(Ceed ceed, User user, CeedData ceed_data, SGS_DD_ModelSetupData sgs_dd_setup_data) {
-  SGS_DD_Data   sgs_dd_data = user->sgs_dd_data;
+PetscErrorCode SgsModelSetupNodalIFunction(Ceed ceed, User user, CeedData ceed_data, SgsDDModelSetupData sgs_dd_setup_data) {
+  SgsDDData     sgs_dd_data = user->sgs_dd_data;
   CeedInt       num_comp_q, num_comp_qd, num_comp_x;
   PetscInt      dim;
   CeedQFunction qf_sgs_apply;
@@ -173,12 +172,10 @@ PetscErrorCode SGS_ModelSetupNodalIFunction(Ceed ceed, User user, CeedData ceed_
 
   switch (user->phys->state_var) {
     case STATEVAR_PRIMITIVE:
-      PetscCallCeed(ceed,
-                    CeedQFunctionCreateInterior(ceed, 1, IFunction_NodalSubgridStress_Prim, IFunction_NodalSubgridStress_Prim_loc, &qf_sgs_apply));
+      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, IFunction_NodalSgs_Prim, IFunction_NodalSgs_Prim_loc, &qf_sgs_apply));
       break;
     case STATEVAR_CONSERVATIVE:
-      PetscCallCeed(
-          ceed, CeedQFunctionCreateInterior(ceed, 1, IFunction_NodalSubgridStress_Conserv, IFunction_NodalSubgridStress_Conserv_loc, &qf_sgs_apply));
+      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, IFunction_NodalSgs_Conserv, IFunction_NodalSgs_Conserv_loc, &qf_sgs_apply));
       break;
     default:
       SETERRQ(PetscObjectComm((PetscObject)user->dm), PETSC_ERR_SUP, "Nodal SGS evaluation not available for chosen state variable");
@@ -207,8 +204,8 @@ PetscErrorCode SGS_ModelSetupNodalIFunction(Ceed ceed, User user, CeedData ceed_
 }
 
 // @brief Calculate and add data-driven SGS residual to the global residual
-PetscErrorCode SGS_DD_ModelApplyIFunction(User user, const Vec Q_loc, Vec G_loc) {
-  SGS_DD_Data  sgs_dd_data = user->sgs_dd_data;
+PetscErrorCode SgsDDModelApplyIFunction(User user, const Vec Q_loc, Vec G_loc) {
+  SgsDDData    sgs_dd_data = user->sgs_dd_data;
   Vec          VelocityGradient, SGSNodal_loc;
   PetscMemType sgs_nodal_mem_type, q_mem_type;
 
@@ -248,15 +245,15 @@ PetscErrorCode TransposeMatrix(const PetscScalar *A, PetscScalar *B, const Petsc
 }
 
 // @brief Read neural network coefficients from file and put into context struct
-PetscErrorCode SGS_DD_ModelContextFill(MPI_Comm comm, char data_dir[PETSC_MAX_PATH_LEN], SGS_DDModelContext *psgsdd_ctx) {
-  SGS_DDModelContext sgsdd_ctx;
-  PetscInt           num_inputs = (*psgsdd_ctx)->num_inputs, num_outputs = (*psgsdd_ctx)->num_outputs, num_neurons = (*psgsdd_ctx)->num_neurons;
-  char               file_path[PETSC_MAX_PATH_LEN];
-  PetscScalar       *temp;
+PetscErrorCode SgsDDModelContextFill(MPI_Comm comm, char data_dir[PETSC_MAX_PATH_LEN], SgsDDModelContext *psgsdd_ctx) {
+  SgsDDModelContext sgsdd_ctx;
+  PetscInt          num_inputs = (*psgsdd_ctx)->num_inputs, num_outputs = (*psgsdd_ctx)->num_outputs, num_neurons = (*psgsdd_ctx)->num_neurons;
+  char              file_path[PETSC_MAX_PATH_LEN];
+  PetscScalar      *temp;
 
   PetscFunctionBeginUser;
   {
-    SGS_DDModelContext sgsdd_temp;
+    SgsDDModelContext sgsdd_temp;
     PetscCall(PetscNew(&sgsdd_temp));
     *sgsdd_temp                     = **psgsdd_ctx;
     sgsdd_temp->offsets.bias1       = 0;
@@ -272,23 +269,23 @@ PetscErrorCode SGS_DD_ModelContextFill(MPI_Comm comm, char data_dir[PETSC_MAX_PA
   }
 
   PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/%s", data_dir, "b1.dat"));
-  PetscCall(PHASTADatFileReadToArrayReal(comm, file_path, &sgsdd_ctx->data[sgsdd_ctx->offsets.bias1]));
+  PetscCall(PhastaDatFileReadToArrayReal(comm, file_path, &sgsdd_ctx->data[sgsdd_ctx->offsets.bias1]));
   PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/%s", data_dir, "b2.dat"));
-  PetscCall(PHASTADatFileReadToArrayReal(comm, file_path, &sgsdd_ctx->data[sgsdd_ctx->offsets.bias2]));
+  PetscCall(PhastaDatFileReadToArrayReal(comm, file_path, &sgsdd_ctx->data[sgsdd_ctx->offsets.bias2]));
   PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/%s", data_dir, "OutScaling.dat"));
-  PetscCall(PHASTADatFileReadToArrayReal(comm, file_path, &sgsdd_ctx->data[sgsdd_ctx->offsets.out_scaling]));
+  PetscCall(PhastaDatFileReadToArrayReal(comm, file_path, &sgsdd_ctx->data[sgsdd_ctx->offsets.out_scaling]));
 
   {
     PetscCall(PetscMalloc1(num_inputs * num_neurons, &temp));
     PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/%s", data_dir, "w1.dat"));
-    PetscCall(PHASTADatFileReadToArrayReal(comm, file_path, temp));
+    PetscCall(PhastaDatFileReadToArrayReal(comm, file_path, temp));
     PetscCall(TransposeMatrix(temp, &sgsdd_ctx->data[sgsdd_ctx->offsets.weight1], num_inputs, num_neurons));
     PetscCall(PetscFree(temp));
   }
   {
     PetscCall(PetscMalloc1(num_outputs * num_neurons, &temp));
     PetscCall(PetscSNPrintf(file_path, sizeof file_path, "%s/%s", data_dir, "w2.dat"));
-    PetscCall(PHASTADatFileReadToArrayReal(comm, file_path, temp));
+    PetscCall(PhastaDatFileReadToArrayReal(comm, file_path, temp));
     PetscCall(TransposeMatrix(temp, &sgsdd_ctx->data[sgsdd_ctx->offsets.weight2], num_neurons, num_outputs));
     PetscCall(PetscFree(temp));
   }
@@ -298,12 +295,12 @@ PetscErrorCode SGS_DD_ModelContextFill(MPI_Comm comm, char data_dir[PETSC_MAX_PA
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SGS_DD_ModelSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
+PetscErrorCode SgsDDModelSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
   PetscReal                alpha = 0;
-  SGS_DDModelContext       sgsdd_ctx;
+  SgsDDModelContext        sgsdd_ctx;
   MPI_Comm                 comm                           = user->comm;
   char                     sgs_dd_dir[PETSC_MAX_PATH_LEN] = "./dd_sgs_parameters";
-  SGS_DD_ModelSetupData    sgs_dd_setup_data;
+  SgsDDModelSetupData      sgs_dd_setup_data;
   NewtonianIdealGasContext gas;
   PetscFunctionBeginUser;
 
@@ -323,12 +320,12 @@ PetscErrorCode SGS_DD_ModelSetup(Ceed ceed, User user, CeedData ceed_data, Probl
   sgsdd_ctx->num_neurons = 20;
   sgsdd_ctx->alpha       = alpha;
 
-  PetscCall(SGS_DD_ModelContextFill(comm, sgs_dd_dir, &sgsdd_ctx));
+  PetscCall(SgsDDModelContextFill(comm, sgs_dd_dir, &sgsdd_ctx));
 
   // -- Create DM for storing SGS tensor at nodes
   PetscCall(PetscNew(&user->sgs_dd_data));
   PetscCall(
-      SGS_DD_ModelCreateDM(user->dm, &user->sgs_dd_data->dm_sgs, user->app_ctx->degree, user->app_ctx->q_extra, &user->sgs_dd_data->num_comp_sgs));
+      SgsDDModelCreateDM(user->dm, &user->sgs_dd_data->dm_sgs, user->app_ctx->degree, user->app_ctx->q_extra, &user->sgs_dd_data->num_comp_sgs));
 
   PetscCall(PetscNew(&sgs_dd_setup_data));
 
@@ -345,16 +342,16 @@ PetscErrorCode SGS_DD_ModelSetup(Ceed ceed, User user, CeedData ceed_data, Probl
                                                      &sgs_dd_setup_data->grid_aniso_ceed));
 
   // -- Create Nodal Evaluation Operator
-  PetscCall(SGS_DD_ModelSetupNodalEvaluation(ceed, user, ceed_data, sgs_dd_setup_data));
+  PetscCall(SgsDDModelSetupNodalEvaluation(ceed, user, ceed_data, sgs_dd_setup_data));
 
   // -- Create Operator to evalutate residual of SGS stress
-  PetscCall(SGS_ModelSetupNodalIFunction(ceed, user, ceed_data, sgs_dd_setup_data));
+  PetscCall(SgsModelSetupNodalIFunction(ceed, user, ceed_data, sgs_dd_setup_data));
 
-  PetscCall(SGS_DD_ModelSetupDataDestroy(sgs_dd_setup_data));
+  PetscCall(SgsDDModelSetupDataDestroy(sgs_dd_setup_data));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SGS_DD_DataDestroy(SGS_DD_Data sgs_dd_data) {
+PetscErrorCode SgsDDDataDestroy(SgsDDData sgs_dd_data) {
   PetscFunctionBeginUser;
   if (!sgs_dd_data) PetscFunctionReturn(PETSC_SUCCESS);
   Ceed ceed = sgs_dd_data->op_sgs_apply_ctx->ceed;

--- a/examples/fluids/problems/shocktube.c
+++ b/examples/fluids/problems/shocktube.c
@@ -152,12 +152,11 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc)
 
 PetscErrorCode PRINT_SHOCKTUBE(User user, ProblemData *problem, AppCtx app_ctx) {
   MPI_Comm comm = user->comm;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(PetscPrintf(comm,
                         "  Problem:\n"
                         "    Problem Name                       : %s\n",
                         app_ctx->problem_name));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -169,7 +169,6 @@ PetscErrorCode GetStgContextData(const MPI_Comm comm, const DM dm, char stg_infl
   PetscInt nmodes, nprofs;
   PetscFunctionBeginUser;
 
-  // Get options
   PetscCall(PhastaDatFileGetNRows(comm, stg_rand_path, &nmodes));
   PetscCall(PhastaDatFileGetNRows(comm, stg_inflow_path, &nprofs));
   PetscCheck(nmodes < STG_NMODES_MAX, comm, PETSC_ERR_SUP,

--- a/examples/fluids/problems/stg_shur14.h
+++ b/examples/fluids/problems/stg_shur14.h
@@ -11,13 +11,13 @@
 #include "../navierstokes.h"
 #include "../qfunctions/stg_shur14_type.h"
 
-extern PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *problem, User user, const bool prescribe_T, const CeedScalar theta0,
+extern PetscErrorCode SetupStg(const MPI_Comm comm, const DM dm, ProblemData *problem, User user, const bool prescribe_T, const CeedScalar theta0,
                                const CeedScalar P0);
 
-extern PetscErrorCode SetupStrongSTG(DM dm, SimpleBC bc, ProblemData *problem, Physics phys);
+extern PetscErrorCode SetupStrongStg(DM dm, SimpleBC bc, ProblemData *problem, Physics phys);
 
-extern PetscErrorCode SetupStrongSTG_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size,
+extern PetscErrorCode SetupStrongStg_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size,
                                         CeedInt dXdx_size, CeedQFunction *qf_strongbc);
 
-extern PetscErrorCode SetupStrongSTG_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
+extern PetscErrorCode SetupStrongStg_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
                                                    CeedQFunction *pqf_strongbc);

--- a/examples/fluids/problems/taylorgreen.c
+++ b/examples/fluids/problems/taylorgreen.c
@@ -18,6 +18,5 @@ PetscErrorCode NS_TAYLOR_GREEN(ProblemData *problem, DM dm, void *ctx, SimpleBC 
 
   problem->ics.qfunction     = ICsTaylorGreen;
   problem->ics.qfunction_loc = ICsTaylorGreen_loc;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/qfunctions/stg_shur14_type.h
+++ b/examples/fluids/qfunctions/stg_shur14_type.h
@@ -15,7 +15,7 @@
 /* Access data arrays via:
  *  CeedScalar (*sigma)[ctx->nmodes] = (CeedScalar (*)[ctx->nmodes])&ctx->data[ctx->offsets.sigma];
  *  CeedScalar *eps = &ctx->data[ctx->offsets.eps]; */
-typedef struct STGShur14Context_ *STGShur14Context;
+typedef struct STGShur14Context_ *StgShur14Context;
 struct STGShur14Context_ {
   CeedInt                          nmodes;              // !< Number of wavemodes
   CeedInt                          nprofs;              // !< Number of profile points in STGInflow.dat

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -16,8 +16,8 @@
 // Register problems to be available on the command line
 PetscErrorCode RegisterProblems_NS(AppCtx app_ctx) {
   app_ctx->problems = NULL;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(PetscFunctionListAdd(&app_ctx->problems, "density_current", NS_DENSITY_CURRENT));
   PetscCall(PetscFunctionListAdd(&app_ctx->problems, "euler_vortex", NS_EULER_VORTEX));
   PetscCall(PetscFunctionListAdd(&app_ctx->problems, "shocktube", NS_SHOCKTUBE));
@@ -28,7 +28,6 @@ PetscErrorCode RegisterProblems_NS(AppCtx app_ctx) {
   PetscCall(PetscFunctionListAdd(&app_ctx->problems, "gaussian_wave", NS_GAUSSIAN_WAVE));
   PetscCall(PetscFunctionListAdd(&app_ctx->problems, "newtonian", NS_NEWTONIAN_IG));
   PetscCall(PetscFunctionListAdd(&app_ctx->problems, "taylor_green", NS_TAYLOR_GREEN));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -39,7 +38,6 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
   PetscBool option_set   = PETSC_FALSE;
 
   PetscFunctionBeginUser;
-
   PetscOptionsBegin(comm, NULL, "Navier-Stokes in PETSc with libCEED", NULL);
 
   PetscCall(PetscOptionsString("-ceed", "CEED resource specifier", NULL, app_ctx->ceed_resource, app_ctx->ceed_resource,
@@ -193,6 +191,5 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
                              (PetscEnum *)&app_ctx->mesh_transform_type, NULL));
 
   PetscOptionsEnd();
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -276,7 +276,6 @@ PetscErrorCode DifferentialFilterApply(User user, const PetscReal solution_time,
   PetscCall(VecViewFromOptions(Filtered_Solution, NULL, "-diff_filter_rhs_view"));
 
   PetscCall(KSPSolve(diff_filter->ksp, Filtered_Solution, Filtered_Solution));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -295,7 +294,6 @@ PetscErrorCode TSMonitor_DifferentialFilter(TS ts, PetscInt steps, PetscReal sol
   if (user->app_ctx->test_type == TESTTYPE_DIFF_FILTER) PetscCall(RegressionTests_NS(user->app_ctx, Filtered_Field));
 
   PetscCall(DMRestoreGlobalVector(diff_filter->dm_filter, &Filtered_Field));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -309,7 +307,6 @@ PetscErrorCode DifferentialFilterDataDestroy(DiffFilterData diff_filter) {
 
   PetscCall(PetscFree(diff_filter->num_field_components));
   PetscCall(PetscFree(diff_filter));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -317,6 +314,5 @@ PetscErrorCode DifferentialFilterMmsICSetup(ProblemData *problem) {
   PetscFunctionBeginUser;
   problem->ics.qfunction     = DifferentialFilter_MMS_IC;
   problem->ics.qfunction_loc = DifferentialFilter_MMS_IC_loc;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -291,7 +291,7 @@ PetscErrorCode TSMonitor_DifferentialFilter(TS ts, PetscInt steps, PetscReal sol
 
   PetscCall(DifferentialFilterApply(user, solution_time, Q, Filtered_Field));
   PetscCall(VecViewFromOptions(Filtered_Field, NULL, "-diff_filter_view"));
-  if (user->app_ctx->test_type == TESTTYPE_DIFF_FILTER) PetscCall(RegressionTests_NS(user->app_ctx, Filtered_Field));
+  if (user->app_ctx->test_type == TESTTYPE_DIFF_FILTER) PetscCall(RegressionTest(user->app_ctx, Filtered_Field));
 
   PetscCall(DMRestoreGlobalVector(diff_filter->dm_filter, &Filtered_Field));
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -313,7 +313,7 @@ PetscErrorCode DifferentialFilterDataDestroy(DiffFilterData diff_filter) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode DifferentialFilter_MMS_ICSetup(ProblemData *problem) {
+PetscErrorCode DifferentialFilterMmsICSetup(ProblemData *problem) {
   PetscFunctionBeginUser;
   problem->ics.qfunction     = DifferentialFilter_MMS_IC;
   problem->ics.qfunction_loc = DifferentialFilter_MMS_IC_loc;

--- a/examples/fluids/src/dm_utils.c
+++ b/examples/fluids/src/dm_utils.c
@@ -28,7 +28,6 @@ PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height, DMLab
   PetscCallCeed(ceed, CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp, 1, num_dof, CEED_MEM_HOST, CEED_COPY_VALUES,
                                                 elem_restr_offsets_ceed, elem_restr));
   PetscCall(PetscFree(elem_restr_offsets_ceed));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -40,8 +39,8 @@ PetscErrorCode GetRestrictionForDomain(Ceed ceed, DM dm, CeedInt height, DMLabel
   CeedInt             loc_num_elem;
   PetscInt            dim;
   CeedElemRestriction elem_restr_tmp;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(DMGetDimension(dm, &dim));
   dim -= height;
   PetscCall(CreateRestrictionFromPlex(ceed, dm, height, domain_label, label_value, dm_field, &elem_restr_tmp));
@@ -92,7 +91,6 @@ PetscErrorCode DMFieldToDSField(DM dm, DMLabel domain_label, PetscInt dm_field, 
   PetscCall(ISRestoreIndices(field_is, &fields));
 
   if (*ds_field == -1) SETERRQ(PetscObjectComm((PetscObject)dm), PETSC_ERR_SUP, "Could not find dm_field %" PetscInt_FMT " in DS", dm_field);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -204,7 +202,6 @@ PetscErrorCode BasisCreateFromTabulation(Ceed ceed, DM dm, DMLabel domain_label,
   PetscCall(PetscFree(q_points));
   PetscCall(PetscFree(interp));
   PetscCall(PetscFree(grad));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -219,7 +216,6 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
   PetscInt        ds_field   = -1;
 
   PetscFunctionBeginUser;
-
   // Get element information
   PetscCall(DMGetRegionDS(dm, domain_label, NULL, &ds, NULL));
   PetscCall(DMFieldToDSField(dm, domain_label, dm_field, &ds_field));
@@ -254,7 +250,6 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
 
     PetscCallCeed(ceed, CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp, P_1d, Q_1d, CEED_GAUSS, basis));
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -320,7 +315,6 @@ PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_co
     PetscCall(DMProjectCoordinates(dm, fe_coord_new));
     PetscCall(PetscFEDestroy(&fe_coord_new));
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -336,8 +330,8 @@ PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_co
 **/
 PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm) {
   PetscBool is_simplex;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(DMPlexIsSimplex(dm, &is_simplex));
   // Set tensor permutation if needed
   if (!is_simplex) {
@@ -349,7 +343,6 @@ PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm) {
       PetscCall(DMPlexSetClosurePermutationTensor(dm_coord, PETSC_DETERMINE, NULL));
     }
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -315,7 +315,7 @@ PetscErrorCode NodalProjectionDataDestroy(NodalProjectionData context) {
  * @param[out] dims           Dimensions of the file, taken from the first line of the file
  * @param[out] fp File        pointer to the opened file
  */
-PetscErrorCode PHASTADatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], const PetscInt char_array_len, PetscInt dims[2],
+PetscErrorCode PhastaDatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], const PetscInt char_array_len, PetscInt dims[2],
                                  FILE **fp) {
   int    ndims;
   char   line[char_array_len];
@@ -342,20 +342,20 @@ PetscErrorCode PHASTADatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_
  * @param[in]  path  Path to the file
  * @param[out] nrows Number of rows
  */
-PetscErrorCode PHASTADatFileGetNRows(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscInt *nrows) {
+PetscErrorCode PhastaDatFileGetNRows(const MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscInt *nrows) {
   const PetscInt char_array_len = 512;
   PetscInt       dims[2];
   FILE          *fp;
 
   PetscFunctionBeginUser;
-  PetscCall(PHASTADatFileOpen(comm, path, char_array_len, dims, &fp));
+  PetscCall(PhastaDatFileOpen(comm, path, char_array_len, dims, &fp));
   *nrows = dims[0];
   PetscCall(PetscFClose(comm, fp));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode PHASTADatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscReal array[]) {
+PetscErrorCode PhastaDatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC_MAX_PATH_LEN], PetscReal array[]) {
   PetscInt       dims[2];
   int            ndims;
   FILE          *fp;
@@ -364,7 +364,7 @@ PetscErrorCode PHASTADatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC
   char         **row_array;
   PetscFunctionBeginUser;
 
-  PetscCall(PHASTADatFileOpen(comm, path, char_array_len, dims, &fp));
+  PetscCall(PhastaDatFileOpen(comm, path, char_array_len, dims, &fp));
 
   for (PetscInt i = 0; i < dims[0]; i++) {
     PetscCall(PetscSynchronizedFGets(comm, fp, char_array_len, line));

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -19,7 +19,6 @@
 PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_loc, Vec Q, CeedScalar time) {
   Ceed ceed = user->ceed;
   PetscFunctionBeginUser;
-
   // ---------------------------------------------------------------------------
   // Update time for evaluation
   // ---------------------------------------------------------------------------
@@ -71,15 +70,14 @@ PetscErrorCode ICs_FixMultiplicity(DM dm, CeedData ceed_data, User user, Vec Q_l
   // Cleanup
   PetscCallCeed(ceed, CeedVectorDestroy(&mult_vec));
   PetscCallCeed(ceed, CeedVectorDestroy(&q0_ceed));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode DMPlexInsertBoundaryValues_NS(DM dm, PetscBool insert_essential, Vec Q_loc, PetscReal time, Vec face_geom_FVM, Vec cell_geom_FVM,
                                              Vec grad_FVM) {
   Vec Qbc, boundary_mask;
-  PetscFunctionBegin;
 
+  PetscFunctionBeginUser;
   // Mask (zero) Strong BC entries
   PetscCall(DMGetNamedLocalVector(dm, "boundary mask", &boundary_mask));
   PetscCall(VecPointwiseMult(Q_loc, Q_loc, boundary_mask));
@@ -88,7 +86,6 @@ PetscErrorCode DMPlexInsertBoundaryValues_NS(DM dm, PetscBool insert_essential, 
   PetscCall(DMGetNamedLocalVector(dm, "Qbc", &Qbc));
   PetscCall(VecAXPY(Q_loc, 1., Qbc));
   PetscCall(DMRestoreNamedLocalVector(dm, "Qbc", &Qbc));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -97,8 +94,8 @@ PetscErrorCode LoadFluidsBinaryVec(MPI_Comm comm, PetscViewer viewer, Vec Q, Pet
   PetscInt   file_step_number;
   PetscInt32 token;
   PetscReal  file_time;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // Attempt
   PetscCall(PetscViewerBinaryRead(viewer, &token, 1, NULL, PETSC_INT32));
   if (token == FLUIDS_FILE_TOKEN_32 || token == FLUIDS_FILE_TOKEN_64 ||
@@ -117,7 +114,6 @@ PetscErrorCode LoadFluidsBinaryVec(MPI_Comm comm, PetscViewer viewer, Vec Q, Pet
 
   // Load Q from existent solution
   PetscCall(VecLoad(Q, viewer));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -127,8 +123,8 @@ PetscErrorCode RegressionTests_NS(AppCtx app_ctx, Vec Q) {
   PetscViewer viewer;
   PetscReal   error, Qrefnorm;
   MPI_Comm    comm = PetscObjectComm((PetscObject)Q);
-  PetscFunctionBegin;
 
+  PetscFunctionBeginUser;
   // Read reference file
   PetscCall(VecDuplicate(Q, &Qref));
   PetscCall(PetscViewerBinaryOpen(comm, app_ctx->test_file_path, FILE_MODE_READ, &viewer));
@@ -148,7 +144,6 @@ PetscErrorCode RegressionTests_NS(AppCtx app_ctx, Vec Q) {
   // Cleanup
   PetscCall(PetscViewerDestroy(&viewer));
   PetscCall(VecDestroy(&Qref));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -157,8 +152,8 @@ PetscErrorCode GetError_NS(CeedData ceed_data, DM dm, User user, Vec Q, PetscSca
   PetscInt  loc_nodes;
   Vec       Q_exact, Q_exact_loc;
   PetscReal rel_error, norm_error, norm_exact;
-  PetscFunctionBegin;
 
+  PetscFunctionBeginUser;
   // Get exact solution at final time
   PetscCall(DMCreateGlobalVector(dm, &Q_exact));
   PetscCall(DMGetLocalVector(dm, &Q_exact_loc));
@@ -178,7 +173,6 @@ PetscErrorCode GetError_NS(CeedData ceed_data, DM dm, User user, Vec Q, PetscSca
   // Cleanup
   PetscCall(DMRestoreLocalVector(dm, &Q_exact_loc));
   PetscCall(VecDestroy(&Q_exact));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -186,8 +180,8 @@ PetscErrorCode GetError_NS(CeedData ceed_data, DM dm, User user, Vec Q, PetscSca
 PetscErrorCode PostProcess_NS(TS ts, CeedData ceed_data, DM dm, ProblemData *problem, User user, Vec Q, PetscScalar final_time) {
   PetscInt          steps;
   TSConvergedReason reason;
-  PetscFunctionBegin;
 
+  PetscFunctionBeginUser;
   // Print relative error
   if (problem->non_zero_time && user->app_ctx->test_type == TESTTYPE_NONE) {
     PetscCall(GetError_NS(ceed_data, dm, user, Q, final_time));
@@ -219,20 +213,18 @@ const PetscInt32 FLUIDS_FILE_TOKEN_64 = 0xceedf64;
 PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q) {
   PetscViewer viewer;
 
-  PetscFunctionBegin;
-
+  PetscFunctionBeginUser;
   PetscCall(PetscViewerBinaryOpen(comm, app_ctx->cont_file, FILE_MODE_READ, &viewer));
   PetscCall(LoadFluidsBinaryVec(comm, viewer, Q, &app_ctx->cont_time, &app_ctx->cont_steps));
   PetscCall(PetscViewerDestroy(&viewer));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 // Record boundary values from initial condition
 PetscErrorCode SetBCsFromICs_NS(DM dm, Vec Q, Vec Q_loc) {
   Vec Qbc, boundary_mask;
-  PetscFunctionBegin;
 
+  PetscFunctionBeginUser;
   PetscCall(DMGetNamedLocalVector(dm, "Qbc", &Qbc));
   PetscCall(VecCopy(Q_loc, Qbc));
   PetscCall(VecZeroEntries(Q_loc));
@@ -247,7 +239,6 @@ PetscErrorCode SetBCsFromICs_NS(DM dm, Vec Q, Vec Q_loc) {
   PetscCall(VecSet(Q, 1.0));
   PetscCall(DMGlobalToLocal(dm, Q, INSERT_VALUES, boundary_mask));
   PetscCall(DMRestoreNamedLocalVector(dm, "boundary mask", &boundary_mask));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -260,7 +251,6 @@ int FreeContextPetsc(void *data) {
 // Return mass qfunction specification for number of components N
 PetscErrorCode CreateMassQFunction(Ceed ceed, CeedInt N, CeedInt q_data_size, CeedQFunction *qf) {
   PetscFunctionBeginUser;
-
   switch (N) {
     case 1:
       PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, Mass_1, Mass_1_loc, qf));
@@ -297,7 +287,6 @@ PetscErrorCode NodalProjectionDataDestroy(NodalProjectionData context) {
   PetscCall(OperatorApplyContextDestroy(context->l2_rhs_ctx));
 
   PetscCall(PetscFree(context));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -329,7 +318,6 @@ PetscErrorCode PhastaDatFileOpen(const MPI_Comm comm, const char path[PETSC_MAX_
 
   for (PetscInt i = 0; i < ndims; i++) dims[i] = atoi(array[i]);
   PetscCall(PetscStrToArrayDestroy(ndims, array));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -351,7 +339,6 @@ PetscErrorCode PhastaDatFileGetNRows(const MPI_Comm comm, const char path[PETSC_
   PetscCall(PhastaDatFileOpen(comm, path, char_array_len, dims, &fp));
   *nrows = dims[0];
   PetscCall(PetscFClose(comm, fp));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -362,8 +349,8 @@ PetscErrorCode PhastaDatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC
   const PetscInt char_array_len = 512;
   char           line[char_array_len];
   char         **row_array;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(PhastaDatFileOpen(comm, path, char_array_len, dims, &fp));
 
   for (PetscInt i = 0; i < dims[0]; i++) {
@@ -378,7 +365,6 @@ PetscErrorCode PhastaDatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC
   }
 
   PetscCall(PetscFClose(comm, fp));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -420,7 +406,6 @@ PetscErrorCode IntArrayC2P(PetscInt num_entries, CeedInt **array_ceed, PetscInt 
     free(*array_ceed);
   }
   *array_ceed = NULL;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -446,7 +431,6 @@ PetscErrorCode IntArrayP2C(PetscInt num_entries, PetscInt **array_petsc, CeedInt
     PetscCall(PetscFree(*array_petsc));
   }
   *array_petsc = NULL;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -623,6 +607,5 @@ PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData *problem, M
 
     if (!rank) PetscCall(PetscFree(gather_buffer));
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -123,7 +123,6 @@ PetscErrorCode OperatorApplyContextCreate(DM dm_x, DM dm_y, Ceed ceed, CeedOpera
 
   PetscCallCeed(ceed, CeedOperatorReferenceCopy(op_apply, &(*ctx)->op));
   PetscCallCeed(ceed, CeedReferenceCopy(ceed, &(*ctx)->ceed));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -150,7 +149,6 @@ PetscErrorCode OperatorApplyContextDestroy(OperatorApplyContext ctx) {
   PetscCallCeed(ceed, CeedDestroy(&ctx->ceed));
 
   PetscCall(PetscFree(ctx));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -178,7 +176,6 @@ PetscErrorCode VecP2C(Vec X_petsc, PetscMemType *mem_type, CeedVector x_ceed) {
 
   PetscCall(VecGetArrayAndMemType(X_petsc, &x, mem_type));
   PetscCallCeed(ceed, CeedVectorSetArray(x_ceed, MemTypeP2C(*mem_type), CEED_USE_POINTER, x));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -206,7 +203,6 @@ PetscErrorCode VecC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc) {
 
   PetscCallCeed(ceed, CeedVectorTakeArray(x_ceed, MemTypeP2C(mem_type), &x));
   PetscCall(VecRestoreArrayAndMemType(X_petsc, &x));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -234,7 +230,6 @@ PetscErrorCode VecReadP2C(Vec X_petsc, PetscMemType *mem_type, CeedVector x_ceed
 
   PetscCall(VecGetArrayReadAndMemType(X_petsc, (const PetscScalar **)&x, mem_type));
   PetscCallCeed(ceed, CeedVectorSetArray(x_ceed, MemTypeP2C(*mem_type), CEED_USE_POINTER, x));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -262,7 +257,6 @@ PetscErrorCode VecReadC2P(CeedVector x_ceed, PetscMemType mem_type, Vec X_petsc)
 
   PetscCallCeed(ceed, CeedVectorTakeArray(x_ceed, MemTypeP2C(mem_type), &x));
   PetscCall(VecRestoreArrayReadAndMemType(X_petsc, (const PetscScalar **)&x));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -291,7 +285,6 @@ PetscErrorCode VecCopyP2C(Vec X_petsc, CeedVector x_ceed) {
   PetscCall(VecGetArrayReadAndMemType(X_petsc, (const PetscScalar **)&x, &mem_type));
   PetscCallCeed(ceed, CeedVectorSetArray(x_ceed, MemTypeP2C(mem_type), CEED_COPY_VALUES, x));
   PetscCall(VecRestoreArrayReadAndMemType(X_petsc, (const PetscScalar **)&x));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -332,7 +325,6 @@ PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, MP
     PetscCall(VecSetType(*output, vec_type));
     PetscCall(VecSetSizes(*output, output_size, output_size));
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -370,7 +362,6 @@ PetscErrorCode ApplyCeedOperator_Core(Vec X, Vec X_loc, CeedVector x_ceed, CeedV
 
   if (Y_loc) PetscCall(VecC2P(ctx->y_ceed, y_mem_type, Y_loc));
   if (Y) PetscCall(DMLocalToGlobal(ctx->dm_y, Y_loc, ADD_VALUES, Y));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 
@@ -389,7 +380,6 @@ PetscErrorCode ApplyCeedOperatorGlobalToGlobal(Vec X, Vec Y, OperatorApplyContex
   // Restore local vector (if needed)
   if (!ctx->X_loc) PetscCall(DMRestoreLocalVector(ctx->dm_x, &X_loc));
   if (!ctx->Y_loc) PetscCall(DMRestoreLocalVector(ctx->dm_y, &Y_loc));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -406,7 +396,6 @@ PetscErrorCode ApplyCeedOperatorLocalToGlobal(Vec X_loc, Vec Y, OperatorApplyCon
 
   // Restore local vectors (if needed)
   if (!ctx->Y_loc) PetscCall(DMRestoreLocalVector(ctx->dm_y, &Y_loc));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -421,7 +410,6 @@ PetscErrorCode ApplyCeedOperatorGlobalToLocal(Vec X, Vec Y_loc, OperatorApplyCon
 
   // Restore local vector (if needed)
   if (!ctx->X_loc) PetscCall(DMRestoreLocalVector(ctx->dm_x, &X_loc));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -442,11 +430,10 @@ PetscErrorCode ApplyAddCeedOperatorLocalToLocal(Vec X_loc, Vec Y_loc, OperatorAp
 // -----------------------------------------------------------------------------
 PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y) {
   OperatorApplyContext ctx;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(MatShellGetContext(A, &ctx));
   PetscCall(ApplyCeedOperatorGlobalToGlobal(X, Y, ctx));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 
@@ -457,8 +444,8 @@ PetscErrorCode MatGetDiag_Ceed(Mat A, Vec D) {
   OperatorApplyContext ctx;
   Vec                  Y_loc;
   PetscMemType         mem_type;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(MatShellGetContext(A, &ctx));
   Ceed ceed = ctx->ceed;
   if (ctx->Y_loc) Y_loc = ctx->Y_loc;
@@ -509,7 +496,6 @@ PetscErrorCode CreateMatShell_Ceed(OperatorApplyContext ctx, Mat *mat) {
   PetscCheck(X_vec_type == Y_vec_type, PETSC_COMM_WORLD, PETSC_ERR_ARG_NOTSAMETYPE, "Vec_type of ctx->dm_x (%s) and ctx->dm_y (%s) must be the same",
              X_vec_type, Y_vec_type);
   PetscCall(MatShellSetVecType(*mat, X_vec_type));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -71,7 +71,7 @@ PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_
     {
       PetscBool use_strongstg = PETSC_FALSE;
       PetscCall(PetscOptionsGetBool(NULL, NULL, "-stg_strong", &use_strongstg, NULL));
-      if (use_strongstg) PetscCall(SetupStrongSTG(dm, bc, problem, phys));
+      if (use_strongstg) PetscCall(SetupStrongStg(dm, bc, problem, phys));
     }
   }
 

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -105,8 +105,8 @@ PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_
 PetscErrorCode VizRefineDM(DM dm, User user, ProblemData *problem, SimpleBC bc, Physics phys) {
   DM      dm_hierarchy[user->app_ctx->viz_refine + 1];
   VecType vec_type;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(DMPlexSetRefinementUniform(dm, PETSC_TRUE));
 
   dm_hierarchy[0] = dm;
@@ -136,6 +136,5 @@ PetscErrorCode VizRefineDM(DM dm, User user, ProblemData *problem, SimpleBC bc, 
     PetscCall(DMDestroy(&dm_hierarchy[i]));
   }
   user->dm_viz = dm_hierarchy[user->app_ctx->viz_refine];
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -20,8 +20,8 @@ PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DMLabel do
   CeedOperator        op_setup_sur, op_apply_bc, op_apply_bc_jacobian = NULL;
   CeedElemRestriction elem_restr_x_sur, elem_restr_q_sur, elem_restr_qd_i_sur, elem_restr_jd_i_sur;
   CeedInt             num_qpts_sur;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // --- Get number of quadrature points for the boundaries
   PetscCallCeed(ceed, CeedBasisGetNumQuadraturePoints(ceed_data->basis_q_sur, &num_qpts_sur));
 
@@ -88,7 +88,6 @@ PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DMLabel do
   PetscCallCeed(ceed, CeedOperatorDestroy(&op_setup_sur));
   PetscCallCeed(ceed, CeedOperatorDestroy(&op_apply_bc));
   PetscCallCeed(ceed, CeedOperatorDestroy(&op_apply_bc_jacobian));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -97,8 +96,8 @@ PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc, CeedData c
                                        CeedOperator op_apply_ijacobian_vol, CeedInt height, CeedInt P_sur, CeedInt Q_sur, CeedInt q_data_size_sur,
                                        CeedInt jac_data_size_sur, CeedOperator *op_apply, CeedOperator *op_apply_ijacobian) {
   DMLabel domain_label;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // Create Composite Operaters
   PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, op_apply));
   if (op_apply_ijacobian) PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, op_apply_ijacobian));
@@ -132,7 +131,6 @@ PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc, CeedData c
   // ----- Get Context Labels for Operator
   PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(*op_apply, "solution time", &phys->solution_time_label));
   PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(*op_apply, "timestep size", &phys->timestep_size_label));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -140,7 +138,6 @@ PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_
                                  PetscInt jac_data_size_sur, ProblemQFunctionSpec apply_bc, ProblemQFunctionSpec apply_bc_jacobian,
                                  CeedQFunction *qf_apply_bc, CeedQFunction *qf_apply_bc_jacobian) {
   PetscFunctionBeginUser;
-
   if (apply_bc.qfunction) {
     PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, apply_bc.qfunction, apply_bc.qfunction_loc, qf_apply_bc));
     PetscCallCeed(ceed, CeedQFunctionSetContext(*qf_apply_bc, apply_bc.qfunction_context));
@@ -166,7 +163,6 @@ PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_
 
 PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData *problem, SimpleBC bc) {
   PetscFunctionBeginUser;
-
   // *****************************************************************************
   // Set up CEED objects for the interior domain (volume)
   // *****************************************************************************

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -407,7 +407,7 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
       PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(user->op_ijacobian, "ijacobian time shift", &user->phys->ijacobian_time_shift_label));
     }
     if (problem->use_strong_bc_ceed) PetscCall(SetupStrongBC_Ceed(ceed, ceed_data, dm, user, problem, bc));
-    if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SGS_DD_ModelSetup(ceed, user, ceed_data, problem));
+    if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SgsDDModelSetup(ceed, user, ceed_data, problem));
   }
 
   if (app_ctx->turb_spanstats_enable) PetscCall(TurbulenceStatisticsSetup(ceed, user, ceed_data, problem));

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -107,7 +107,7 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
 
   PetscCall(ApplyCeedOperatorGlobalToGlobal(Q, G, user->op_rhs_ctx));
 
-  // Inverse of the lumped mass matrix (M is Minv)
+  // Inverse of the lumped mass matrix
   PetscCall(VecPointwiseMult(G, G, user->M_inv));
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -202,7 +202,7 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
   PetscCall(VecC2P(user->g_ceed, g_mem_type, G_loc));
 
   if (user->app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) {
-    PetscCall(SGS_DD_ModelApplyIFunction(user, Q_loc, G_loc));
+    PetscCall(SgsDDModelApplyIFunction(user, Q_loc, G_loc));
   }
 
   // Local-to-Global

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -22,8 +22,8 @@ PetscErrorCode ComputeLumpedMassMatrix(Ceed ceed, DM dm, CeedData ceed_data, Vec
   OperatorApplyContext op_mass_ctx;
   Vec                  Ones_loc;
   CeedInt              num_comp_q, q_data_size;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // CEED Restriction
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(ceed_data->elem_restr_q, &num_comp_q));
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(ceed_data->elem_restr_qd_i, &q_data_size));
@@ -51,7 +51,6 @@ PetscErrorCode ComputeLumpedMassMatrix(Ceed ceed, DM dm, CeedData ceed_data, Vec
   PetscCall(DMRestoreLocalVector(dm, &Ones_loc));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_mass));
   PetscCallCeed(ceed, CeedOperatorDestroy(&op_mass));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -97,8 +96,8 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
   MPI_Comm    comm = PetscObjectComm((PetscObject)ts);
   PetscScalar dt;
   Vec         Q_loc = user->Q_loc;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // Update time dependent data
   PetscCall(UpdateBoundaryValues(user, Q_loc, t));
   if (user->phys->solution_time_label) PetscCall(UpdateContextLabel(user->ceed, comm, t, user->op_rhs_ctx->op, user->phys->solution_time_label));
@@ -109,7 +108,6 @@ PetscErrorCode RHS_NS(TS ts, PetscReal t, Vec Q, Vec G, void *user_data) {
 
   // Inverse of the lumped mass matrix
   PetscCall(VecPointwiseMult(G, G, user->M_inv));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -156,7 +154,6 @@ static PetscErrorCode Surface_Forces_NS(DM dm, Vec G_loc, PetscInt num_walls, co
   PetscCallMPI(MPI_Allreduce(MPI_IN_PLACE, reaction_force, dim * num_walls, MPIU_SCALAR, MPI_SUM, comm));
   //  Restore Vectors
   PetscCall(VecRestoreArrayRead(G_loc, &g));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -167,8 +164,8 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
   PetscScalar  dt;
   Vec          Q_loc = user->Q_loc, Q_dot_loc = user->Q_dot_loc, G_loc;
   PetscMemType q_mem_type, q_dot_mem_type, g_mem_type;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // Get local vectors
   PetscCall(DMGetNamedLocalVector(user->dm, "ResidualLocal", &G_loc));
 
@@ -211,7 +208,6 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
 
   // Restore vectors
   PetscCall(DMRestoreNamedLocalVector(user->dm, "ResidualLocal", &G_loc));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -278,6 +274,7 @@ PetscErrorCode FormIJacobian_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, PetscReal 
   User      user = *(User *)user_data;
   Ceed      ceed = user->ceed;
   PetscBool J_is_shell, J_is_mffd, J_pre_is_shell;
+
   PetscFunctionBeginUser;
   if (user->phys->ijacobian_time_shift_label)
     PetscCallCeed(ceed, CeedOperatorSetContextDouble(user->op_ijacobian, user->phys->ijacobian_time_shift_label, &shift));
@@ -319,8 +316,8 @@ PetscErrorCode WriteOutput(User user, Vec Q, PetscInt step_no, PetscScalar time)
   Vec         Q_loc;
   char        file_path[PETSC_MAX_PATH_LEN];
   PetscViewer viewer;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   if (user->app_ctx->checkpoint_vtk) {
     // Set up output
     PetscCall(DMGetLocalVector(user->dm, &Q_loc));
@@ -421,8 +418,8 @@ PetscErrorCode TSMonitor_WallForce(TS ts, PetscInt step_no, PetscReal time, Vec 
 // User provided TS Monitor
 PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time, Vec Q, void *ctx) {
   User user = ctx;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   // Print every 'checkpoint_interval' steps
   if (user->app_ctx->checkpoint_interval <= 0 || step_no % user->app_ctx->checkpoint_interval != 0 ||
       (user->app_ctx->cont_steps == step_no && step_no != 0)) {
@@ -430,7 +427,6 @@ PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time, Vec Q, void
   }
 
   PetscCall(WriteOutput(user, Q, step_no, time));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -439,8 +435,8 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
   MPI_Comm    comm = user->comm;
   TSAdapt     adapt;
   PetscScalar final_time;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(TSCreate(comm, ts));
   PetscCall(TSSetDM(*ts, dm));
   if (phys->implicit) {

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -24,14 +24,10 @@ PetscErrorCode ComputeLumpedMassMatrix(Ceed ceed, DM dm, CeedData ceed_data, Vec
   CeedInt              num_comp_q, q_data_size;
 
   PetscFunctionBeginUser;
-  // CEED Restriction
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(ceed_data->elem_restr_q, &num_comp_q));
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(ceed_data->elem_restr_qd_i, &q_data_size));
 
-  // CEED QFunction
   PetscCall(CreateMassQFunction(ceed, num_comp_q, q_data_size, &qf_mass));
-
-  // CEED Operator
   PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_mass, NULL, NULL, &op_mass));
   PetscCallCeed(ceed, CeedOperatorSetField(op_mass, "u", ceed_data->elem_restr_q, ceed_data->basis_q, CEED_VECTOR_ACTIVE));
   PetscCallCeed(ceed, CeedOperatorSetField(op_mass, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, ceed_data->q_data));

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -125,7 +125,6 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
 
   PetscCallCeed(ceed, CeedBasisDestroy(&basis_x_to_q_sur));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_setup));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -147,7 +146,6 @@ PetscErrorCode DMPlexInsertBoundaryValues_StrongBCCeed(DM dm, PetscBool insert_e
   PetscCall(DMRestoreNamedLocalVector(dm, "boundary mask", &boundary_mask));
 
   PetscCall(ApplyAddCeedOperatorLocalToLocal(NULL, Q_loc, user->op_strong_bc_ctx));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -42,7 +42,7 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
   PetscCallCeed(ceed, CeedQFunctionAddOutput(qf_setup, "dXdx", dXdx_size, CEED_EVAL_NONE));
 
   // Setup STG Setup QFunction
-  PetscCall(SetupStrongSTG_PreProcessing(ceed, problem, num_comp_x, stg_data_size, dXdx_size, &qf_stgdata));
+  PetscCall(SetupStrongStg_PreProcessing(ceed, problem, num_comp_x, stg_data_size, dXdx_size, &qf_stgdata));
 
   // Compute contribution on each boundary face
   for (CeedInt i = 0; i < bc->num_inflow; i++) {
@@ -90,7 +90,7 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
     PetscCallCeed(ceed, CeedOperatorApply(op_stgdata, CEED_VECTOR_NONE, stg_data, CEED_REQUEST_IMMEDIATE));
 
     // -- Setup BC QFunctions
-    SetupStrongSTG_QF(ceed, problem, num_comp_x, num_comp_q, stg_data_size, dXdx_size, &qf_strongbc);
+    SetupStrongStg_QF(ceed, problem, num_comp_x, num_comp_q, stg_data_size, dXdx_size, &qf_strongbc);
     PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_strongbc, NULL, NULL, &op_strong_bc_sub));
     PetscCallCeed(ceed, CeedOperatorSetName(op_strong_bc_sub, "Strong STG"));
 

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -626,24 +626,15 @@ PetscErrorCode TSMonitor_TurbulenceStatistics(TS ts, PetscInt steps, PetscReal s
 
 PetscErrorCode TurbulenceStatisticsDestroy(User user, CeedData ceed_data) {
   PetscFunctionBeginUser;
-
-  // -- CeedVectors
   PetscCall(VecDestroy(&user->spanstats.Child_Stats_loc));
   PetscCall(VecDestroy(&user->spanstats.Parent_Stats_loc));
 
-  // -- CeedOperators
   PetscCall(OperatorApplyContextDestroy(user->spanstats.op_stats_collect_ctx));
   PetscCall(OperatorApplyContextDestroy(user->spanstats.op_proj_rhs_ctx));
   PetscCall(OperatorApplyContextDestroy(user->spanstats.mms_error_ctx));
 
-  // -- KSP
   PetscCall(KSPDestroy(&user->spanstats.ksp));
-
-  // -- SF
   PetscCall(PetscSFDestroy(&user->spanstats.sf));
-
-  // -- DM
   PetscCall(DMDestroy(&user->spanstats.dm));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -607,7 +607,7 @@ PetscErrorCode TSMonitor_TurbulenceStatistics(TS ts, PetscInt steps, PetscReal s
         PetscCall(PetscViewerPopFormat(user->app_ctx->turb_spanstats_viewer));
       }
       if (user->app_ctx->test_type == TESTTYPE_TURB_SPANSTATS && reason != TS_CONVERGED_ITERATING) {
-        PetscCall(RegressionTests_NS(user->app_ctx, stats));
+        PetscCall(RegressionTest(user->app_ctx, stats));
       }
       if (user->spanstats.do_mms_test && reason != TS_CONVERGED_ITERATING) {
         Vec error;

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -514,7 +514,7 @@ PetscErrorCode TurbulenceStatisticsSetup(Ceed ceed, User user, CeedData ceed_dat
 
 // Collect statistics based on the solution Q
 PetscErrorCode CollectStatistics(User user, PetscScalar solution_time, Vec Q) {
-  Span_Stats user_stats = user->spanstats;
+  SpanStatsData user_stats = user->spanstats;
 
   PetscFunctionBeginUser;
   PetscLogStage stage_stats_collect;
@@ -535,7 +535,7 @@ PetscErrorCode CollectStatistics(User user, PetscScalar solution_time, Vec Q) {
 
 // Process the child statistics into parent statistics and project them onto stats
 PetscErrorCode ProcessStatistics(User user, Vec stats) {
-  Span_Stats         user_stats = user->spanstats;
+  SpanStatsData      user_stats = user->spanstats;
   const PetscScalar *child_stats;
   PetscScalar       *parent_stats;
   MPI_Datatype       unit;

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -28,8 +28,8 @@ PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree) {
   PetscSection  section;
   PetscLogStage stage_stats_setup;
   MPI_Comm      comm = PetscObjectComm((PetscObject)user->dm);
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(PetscLogStageGetId("Stats Setup", &stage_stats_setup));
   if (stage_stats_setup == -1) PetscCall(PetscLogStageRegister("Stats Setup", &stage_stats_setup));
   PetscCall(PetscLogStagePush(stage_stats_setup));
@@ -125,8 +125,8 @@ PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree) {
 PetscErrorCode CreateElemRestrColloc(Ceed ceed, CeedInt num_comp, CeedBasis basis, CeedElemRestriction elem_restr_base,
                                      CeedElemRestriction *elem_restr_collocated) {
   CeedInt num_elem_qpts, loc_num_elem;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCallCeed(ceed, CeedBasisGetNumQuadraturePoints(basis, &num_elem_qpts));
   PetscCallCeed(ceed, CeedElemRestrictionGetNumElements(elem_restr_base, &loc_num_elem));
 
@@ -178,8 +178,8 @@ PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data
   PetscInt dim;
   CeedInt  num_qpts_child1d, num_comp_x, num_comp_stats = user->spanstats.num_comp_stats;
   Vec      X_loc;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCall(PetscNew(stats_data));
 
   PetscCall(DMGetDimension(dm, &dim));
@@ -213,7 +213,6 @@ PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data
   }
   PetscCall(VecScale(X_loc, problem->dm_scale));
   PetscCall(VecCopyP2C(X_loc, (*stats_data)->x_coord));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -439,8 +438,8 @@ PetscErrorCode SetupMMSErrorChecking(Ceed ceed, User user, CeedData ceed_data, S
   CeedQFunction qf_error;
   CeedOperator  op_error;
   CeedVector    x_ceed, y_ceed;
-  PetscFunctionBeginUser;
 
+  PetscFunctionBeginUser;
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(stats_data->elem_restr_parent_qd, &q_data_size));
   PetscCallCeed(ceed, CeedBasisGetNumComponents(stats_data->basis_x, &num_comp_x));
 
@@ -587,6 +586,7 @@ PetscErrorCode TSMonitor_TurbulenceStatistics(TS ts, PetscInt steps, PetscReal s
   Vec               stats;
   TSConvergedReason reason;
   PetscInt collect_interval = user->app_ctx->turb_spanstats_collect_interval, viewer_interval = user->app_ctx->turb_spanstats_viewer_interval;
+
   PetscFunctionBeginUser;
   PetscCall(TSGetConvergedReason(ts, &reason));
   // Do not collect or process on the first step of the run (ie. on the initial condition)

--- a/examples/fluids/src/velocity_gradient_projection.c
+++ b/examples/fluids/src/velocity_gradient_projection.c
@@ -36,7 +36,6 @@ PetscErrorCode VelocityGradientProjectionCreateDM(NodalProjectionData grad_velo_
   PetscCall(PetscSectionSetComponentName(section, 0, 6, "VelocityGradientZX"));
   PetscCall(PetscSectionSetComponentName(section, 0, 7, "VelocityGradientZY"));
   PetscCall(PetscSectionSetComponentName(section, 0, 8, "VelocityGradientZZ"));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 
@@ -140,6 +139,5 @@ PetscErrorCode VelocityGradientProjectionApply(User user, Vec Q_loc, Vec Velocit
   PetscCall(ApplyCeedOperatorLocalToGlobal(Q_loc, VelocityGradient, l2_rhs_ctx));
 
   PetscCall(KSPSolve(grad_velo_proj->ksp, VelocityGradient, VelocityGradient));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
- Change function names to consistent format
   - Acronyms respect CamelCase if they're more than 2 letters long (ie `StgFunction` instead of `STGFunction`)
   - Remove unnecessary `*_NS` suffix (this is the navierstokes code, so no need to specify that).
- Consistent placement of `PetscFunction{Return,BeginUser}`
  - To match up with [PETSc style guidelines](https://petsc.org/release/developers/style/#coding-conventions-and-style)
- Misc cleanup of some functions