### PR TITLE
ci: Fix ifort configuration

### DIFF
--- a/.github/workflows/c-fortran-test-icc.yml
+++ b/.github/workflows/c-fortran-test-icc.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   LINUX_CPP_COMPONENTS: intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-  LINUX_FORTRAN_COMPONENTS: intel-oneapi-ifort
+  LINUX_FORTRAN_COMPONENTS: intel-oneapi-compiler-fortran
 
 jobs:
   test:


### PR DESCRIPTION
- Looks like intel changed names for their fortran compiler Debian package https://github.com/oneapi-src/oneapi-ci/blob/5432cb245e75152ac0c87a7cf6b8109973a36647/.github/workflows/build_all.yml#L19

Hopefully this will fix the CI errors with the fortran compiler and allow other PRs to be merged.