### PR TITLE
Check for compatible num_qpts with CEED_BASIS_COLLOCATED

### DIFF
--- a/examples/fluids/problems/sgs_dd_model.c
+++ b/examples/fluids/problems/sgs_dd_model.c
@@ -104,7 +104,6 @@ PetscErrorCode SGS_DD_ModelSetupNodalEvaluation(Ceed ceed, User user, CeedData c
   CeedOperatorSetName(op_multiplicity, "SGS DD Model - Create Multiplicity Scaling");
   CeedOperatorSetField(op_multiplicity, "multiplicity", ceed_data->elem_restr_q, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_multiplicity, "inverse multiplicity", elem_restr_inv_multiplicity, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetNumQuadraturePoints(op_multiplicity, elem_size);
 
   CeedOperatorApply(op_multiplicity, multiplicity, inv_multiplicity, CEED_REQUEST_IMMEDIATE);
 

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -280,8 +280,8 @@ CEED_QFUNCTION(Preprocess_STGShur14)(void *ctx, CeedInt Q, const CeedScalar *con
 // Extrude the STGInflow profile through out the domain for an initial condition
 CEED_QFUNCTION(ICsSTG)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
-  const CeedScalar(*x)[CEED_Q_VLA]      = (const CeedScalar(*)[CEED_Q_VLA])in[0];
-  const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*x)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[0];
+  const CeedScalar(*J)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[1];
 
   // Outputs
   CeedScalar(*q0)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
@@ -297,12 +297,39 @@ CEED_QFUNCTION(ICsSTG)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSc
   const CeedScalar       nu     = stg_ctx->newtonian_ctx.mu / rho;
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-    const CeedScalar x_i[3]     = {x[0][i], x[1][i], x[2][i]};
-    const CeedScalar dXdx[3][3] = {
-        {q_data[1][i], q_data[2][i], q_data[3][i]},
-        {q_data[4][i], q_data[5][i], q_data[6][i]},
-        {q_data[7][i], q_data[8][i], q_data[9][i]}
-    };
+    const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
+    CeedScalar       dXdx[3][3];
+    {
+      const CeedScalar J11  = J[0][0][i];
+      const CeedScalar J21  = J[0][1][i];
+      const CeedScalar J31  = J[0][2][i];
+      const CeedScalar J12  = J[1][0][i];
+      const CeedScalar J22  = J[1][1][i];
+      const CeedScalar J32  = J[1][2][i];
+      const CeedScalar J13  = J[2][0][i];
+      const CeedScalar J23  = J[2][1][i];
+      const CeedScalar J33  = J[2][2][i];
+      const CeedScalar A11  = J22 * J33 - J23 * J32;
+      const CeedScalar A12  = J13 * J32 - J12 * J33;
+      const CeedScalar A13  = J12 * J23 - J13 * J22;
+      const CeedScalar A21  = J23 * J31 - J21 * J33;
+      const CeedScalar A22  = J11 * J33 - J13 * J31;
+      const CeedScalar A23  = J13 * J21 - J11 * J23;
+      const CeedScalar A31  = J21 * J32 - J22 * J31;
+      const CeedScalar A32  = J12 * J31 - J11 * J32;
+      const CeedScalar A33  = J11 * J22 - J12 * J21;
+      const CeedScalar detJ = J11 * A11 + J21 * A12 + J31 * A13;
+
+      dXdx[0][0] = A11 / detJ;
+      dXdx[0][1] = A12 / detJ;
+      dXdx[0][2] = A13 / detJ;
+      dXdx[1][0] = A21 / detJ;
+      dXdx[1][1] = A22 / detJ;
+      dXdx[1][2] = A23 / detJ;
+      dXdx[2][0] = A31 / detJ;
+      dXdx[2][1] = A32 / detJ;
+      dXdx[2][2] = A33 / detJ;
+    }
 
     CeedScalar h[3];
     h[0] = dx;

--- a/examples/fluids/src/grid_anisotropy_tensor.c
+++ b/examples/fluids/src/grid_anisotropy_tensor.c
@@ -157,7 +157,6 @@ PetscErrorCode GridAnisotropyTensorCalculateCollocatedVector(Ceed ceed, User use
   CeedOperatorSetField(op_colloc, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, ceed_data->q_data);
   CeedOperatorSetField(op_colloc, "v", *elem_restr_grid_aniso, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
   CeedBasisGetNumQuadraturePoints(ceed_data->basis_q, &num_qpts);
-  CeedOperatorSetNumQuadraturePoints(op_colloc, num_qpts);
 
   CeedElemRestrictionCreateVector(*elem_restr_grid_aniso, aniso_colloc_ceed, NULL);
 

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -261,7 +261,7 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   CeedQFunctionCreateInterior(ceed, 1, problem->ics.qfunction, problem->ics.qfunction_loc, &ceed_data->qf_ics);
   CeedQFunctionSetContext(ceed_data->qf_ics, problem->ics.qfunction_context);
   CeedQFunctionAddInput(ceed_data->qf_ics, "x", num_comp_x, CEED_EVAL_INTERP);
-  CeedQFunctionAddInput(ceed_data->qf_ics, "qdata", q_data_size_vol, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(ceed_data->qf_ics, "dx", num_comp_x * dim, CEED_EVAL_GRAD);
   CeedQFunctionAddOutput(ceed_data->qf_ics, "q0", num_comp_q, CEED_EVAL_NONE);
 
   // -- Create QFunction for RHS
@@ -344,7 +344,7 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   CeedOperator op_ics;
   CeedOperatorCreate(ceed, ceed_data->qf_ics, NULL, NULL, &op_ics);
   CeedOperatorSetField(op_ics, "x", ceed_data->elem_restr_x, ceed_data->basis_xc, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetField(op_ics, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, ceed_data->q_data);
+  CeedOperatorSetField(op_ics, "dx", ceed_data->elem_restr_x, ceed_data->basis_xc, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_ics, "q0", ceed_data->elem_restr_q, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
   CeedOperatorGetContextFieldLabel(op_ics, "evaluation time", &user->phys->ics_time_label);
   PetscCall(OperatorApplyContextCreate(NULL, dm, user->ceed, op_ics, ceed_data->x_coord, NULL, NULL, user->Q_loc, &ceed_data->op_ics_ctx));

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -85,7 +85,6 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
     CeedOperatorSetField(op_stgdata, "surface qdata", elem_restr_qd_sur, CEED_BASIS_COLLOCATED, q_data_sur);
     CeedOperatorSetField(op_stgdata, "x", elem_restr_x_stored, CEED_BASIS_COLLOCATED, x_stored);
     CeedOperatorSetField(op_stgdata, "stg data", elem_restr_stgdata, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetNumQuadraturePoints(op_stgdata, elem_size);
 
     CeedOperatorApply(op_stgdata, CEED_VECTOR_NONE, stg_data, CEED_REQUEST_IMMEDIATE);
 
@@ -99,7 +98,6 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
     CeedOperatorSetField(op_strong_bc_sub, "scale", elem_restr_scale, CEED_BASIS_COLLOCATED, scale_stored);
     CeedOperatorSetField(op_strong_bc_sub, "stg data", elem_restr_stgdata, CEED_BASIS_COLLOCATED, stg_data);
     CeedOperatorSetField(op_strong_bc_sub, "q", elem_restr_q_sur, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-    CeedOperatorSetNumQuadraturePoints(op_strong_bc_sub, elem_size);
 
     // -- Add to composite operator
     CeedCompositeOperatorAddSub(op_strong_bc, op_strong_bc_sub);

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -640,8 +640,9 @@ int CeedOperatorSetField(CeedOperator op, const char *field_name, CeedElemRestri
             "ElemRestriction with %" CeedInt_FMT " elements incompatible with prior %" CeedInt_FMT " elements", num_elem, op->num_elem);
 
   CeedInt num_qpts = 0;
-  CeedCall(CeedBasisGetNumQuadraturePoints(b, &num_qpts));
-  CeedCheck(b == CEED_BASIS_COLLOCATED || !op->num_qpts || op->num_qpts == num_qpts, op->ceed, CEED_ERROR_DIMENSION,
+  if (b == CEED_BASIS_COLLOCATED) CeedCall(CeedElemRestrictionGetElementSize(r, &num_qpts));
+  else CeedCall(CeedBasisGetNumQuadraturePoints(b, &num_qpts));
+  CeedCheck(!op->num_qpts || op->num_qpts == num_qpts, op->ceed, CEED_ERROR_DIMENSION,
             "Basis with %" CeedInt_FMT " quadrature points incompatible with prior %" CeedInt_FMT " points", num_qpts, op->num_qpts);
   CeedQFunctionField qf_field;
   CeedOperatorField *op_field;

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -690,7 +690,7 @@ found:
     op->has_restriction = true;  // Restriction set, but num_elem may be 0
   }
   CeedCall(CeedBasisReferenceCopy(b, &(*op_field)->basis));
-  if (!op->num_qpts && b != CEED_BASIS_COLLOCATED) CeedCall(CeedOperatorSetNumQuadraturePoints(op, num_qpts));
+  if (op->num_qpts == 0) CeedCall(CeedOperatorSetNumQuadraturePoints(op, num_qpts));
 
   op->num_fields += 1;
   CeedCall(CeedStringAllocCopy(field_name, (char **)&(*op_field)->field_name));

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -124,9 +124,7 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
                                     op->output_fields[i]->vec));
     }
     CeedCall(CeedQFunctionAssemblyDataReferenceCopy(op->qf_assembled, &op_fallback->qf_assembled));
-    if (op_fallback->num_qpts == 0) {
-      CeedCall(CeedOperatorSetNumQuadraturePoints(op_fallback, op->num_qpts));
-    }
+    if (op_fallback->num_qpts == 0) CeedCall(CeedOperatorSetNumQuadraturePoints(op_fallback, op->num_qpts));
     // Cleanup
     CeedCall(CeedQFunctionDestroy(&qf_fallback));
     CeedCall(CeedQFunctionDestroy(&dqf_fallback));

--- a/rust/libceed/src/operator.rs
+++ b/rust/libceed/src/operator.rs
@@ -42,7 +42,7 @@ impl<'a> OperatorField<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -86,7 +86,7 @@ impl<'a> OperatorField<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -154,7 +154,7 @@ impl<'a> OperatorField<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -226,7 +226,7 @@ impl<'a> OperatorField<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -330,7 +330,7 @@ impl<'a> fmt::Display for OperatorCore<'a> {
 /// }
 /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
 /// let strides: [i32; 3] = [1, q as i32, q as i32];
-/// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+/// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
 ///
 /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
 ///
@@ -369,7 +369,7 @@ impl<'a> fmt::Display for Operator<'a> {
 /// }
 /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
 /// let strides: [i32; 3] = [1, q as i32, q as i32];
-/// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+/// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
 ///
 /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
 ///
@@ -568,7 +568,7 @@ impl<'a> Operator<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -814,7 +814,7 @@ impl<'a> Operator<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -873,7 +873,7 @@ impl<'a> Operator<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///
@@ -2104,7 +2104,7 @@ impl<'a> CompositeOperator<'a> {
     /// }
     /// let r = ceed.elem_restriction(ne, 2, 1, 1, ne + 1, MemType::Host, &ind)?;
     /// let strides: [i32; 3] = [1, q as i32, q as i32];
-    /// let rq = ceed.strided_elem_restriction(ne, 2, 1, q * ne, strides)?;
+    /// let rq = ceed.strided_elem_restriction(ne, q, 1, q * ne, strides)?;
     ///
     /// let b = ceed.basis_tensor_H1_Lagrange(1, 1, 2, q, QuadMode::Gauss)?;
     ///

--- a/rust/libceed/src/vector.rs
+++ b/rust/libceed/src/vector.rs
@@ -274,11 +274,25 @@ impl<'a> Vector<'a> {
     /// # arguments
     ///
     /// * `vec_source` - vector to copy array values from
-    #[allow(unused_mut)]
-    fn copy_from(mut self, vec_source: &crate::Vector) -> crate::Result<Self> {
+    ///
+    /// ```
+    /// # use libceed::prelude::*;
+    /// # fn main() -> libceed::Result<()> {
+    /// # let ceed = libceed::Ceed::default_init();
+    /// let a = ceed.vector_from_slice(&[1., 2., 3.])?;
+    /// let mut b = ceed.vector(3)?;
+    ///
+    /// b.copy_from(&a)?;
+    /// for (i, v) in b.view()?.iter().enumerate() {
+    ///     assert_eq!(*v, (i + 1) as Scalar, "Copy contents not set correctly");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// ```
+    pub fn copy_from(&mut self, vec_source: &crate::Vector) -> crate::Result<i32> {
         let ierr = unsafe { bind_ceed::CeedVectorCopy(vec_source.ptr, self.ptr) };
-        self.check_error(ierr)?;
-        Ok(self)
+        self.check_error(ierr)
     }
 
     /// Create a Vector from a slice

--- a/tests/t509-operator.c
+++ b/tests/t509-operator.c
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
 
   // Operators
   CeedOperatorCreate(ceed, qf_identity, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_identity);
+  // -- Note: number of quadrature points for field set by elem_size of restriction when CEED_BASIS_COLLOCATED used
   CeedOperatorSetField(op_identity, "input", elem_restriction_u, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_identity, "output", elem_restriction_u_i, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-  CeedOperatorSetNumQuadraturePoints(op_identity, elem_size);
 
   CeedVectorSetValue(u, 3.0);
   CeedOperatorApply(op_identity, u, v, CEED_REQUEST_IMMEDIATE);


### PR DESCRIPTION
We haven't been checking the `num_qpts` for `CEED_BASIS_COLLOCATED` (for legacy reasons), but in this case, the `elem_size` of the `CeedElemRestriction` is the `num_qpts` and we should make this check.

See Zulip discussions with @jrwrigh for context.

@jrwrigh I'm not sure how you'd prefer to fix the issue in the fluids example that this exposed. Since `num_qpts >= elem_size` for the fluids example this hadn't been caught yet, but I'd still like to fix the correctness.

Note to me: Ratel is passing `make prove` with this libCEED branch.

```console
$ make prove -j PROVE_OPTS=-v search=flu BACKENDS=/cpu/self/ref/serial
make: 'lib' with optional backends: 
Testing backends: /cpu/self/ref/serial
prove -v --exec 'tests/junit.py --mode tap' fluids-navierstokes
fluids-navierstokes .. 
1..20
# Test: blasius_aniso_diff_filter
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type diff_filter -options_file examples/fluids/tests-output/blasius_test.yaml -compare_final_state_atol 5e-10 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius_diff_filter_aniso_vandriest.bin -diff_filter_monitor -ts_max_steps 0 -state_var primitive -diff_filter_friction_length 1e-5 -diff_filter_wall_damping_function van_driest -diff_filter_ksp_rtol 1e-8 -diff_filter_grid_based_width -diff_filter_width_scaling 1,0.7,1
ok 1 - PASS
# Test: blasius_iso_diff_filter
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type diff_filter -options_file examples/fluids/tests-output/blasius_test.yaml -compare_final_state_atol 2e-12 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius_diff_filter_iso.bin -diff_filter_monitor -ts_max_steps 0 -diff_filter_width_scaling 4.2e-5,4.2e-5,4.2e-5 -diff_filter_ksp_atol 1e-14 -diff_filter_ksp_rtol 1e-16
ok 2 - PASS
# Test: blasius_SGS_DataDriven
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/tests-output/blasius_stgtest.yaml -sgs_model_type data_driven -sgs_model_dd_leakyrelu_alpha 0.3 -sgs_model_dd_parameter_dir examples/fluids/dd_sgs_data -ts_dt 1e-9 -compare_final_state_atol 2e-12 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius-sgs-data-driven.bin -state_var primitive
ok 3 - PASS
# Test: gaussianwave_idl
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/gaussianwave.yaml -compare_final_state_atol 2e-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-gaussianwave-IDL.bin -dm_plex_box_faces 5,5,1 -ts_max_steps 5 -idl_decay_time 2e-3 -idl_length 0.25 -idl_start 0
ok 4 - PASS
# Test: turb_spanstats
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type turb_spanstats -options_file examples/fluids/tests-output/stats_test.yaml -compare_final_state_atol 1E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-turb-spanstats-stats.bin
ok 5 - PASS
# Test: blasius
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/tests-output/blasius_test.yaml -compare_final_state_atol 2E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius.bin
ok 6 - PASS
# Test: blasius_STG
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/tests-output/blasius_stgtest.yaml -compare_final_state_atol 2E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius_STG.bin
ok 7 - PASS
# Test: blasius_STG_weakT
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/tests-output/blasius_stgtest.yaml -compare_final_state_atol 1E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius_STG_weakT.bin -weakT
ok 8 - PASS
# Test: blasius_STG_strongBC
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/tests-output/blasius_stgtest.yaml -compare_final_state_atol 1E-10 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-blasius_STG_strongBC.bin -stg_strong true
ok 9 - PASS
# Test: channel
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/channel.yaml -compare_final_state_atol 2e-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-channel.bin -dm_plex_box_faces 5,5,1 -ts_max_steps 5
not ok 10 - FAIL: stderr
Output: 
/home/jeremy/Dev/libCEED/interface/ceed-operator.c:645 in CeedOperatorSetField(): Basis with 64 quadrature points incompatible with prior 8 points
# Test: channel-primitive
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -options_file examples/fluids/channel.yaml -compare_final_state_atol 2e-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-channel-prim.bin -dm_plex_box_faces 5,5,1 -ts_max_steps 5 -state_var primitive
not ok 11 - FAIL: stderr
Output: 
/home/jeremy/Dev/libCEED/interface/ceed-operator.c:645 in CeedOperatorSetField(): Basis with 64 quadrature points incompatible with prior 8 points
# Test: dc_explicit
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -degree 3 -q_extra 2 -dm_plex_box_faces 1,1,2 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 125,125,250 -dm_plex_dim 3 -bc_slip_x 5,6 -bc_slip_y 3,4 -bc_Slip_z 1,2 -units_kilogram 1e-9 -center 62.5,62.5,187.5 -rc 100. -thetaC -35. -mu 75 -ts_dt 1e-3 -units_meter 1e-2 -units_second 1e-2 -compare_final_state_atol 1E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-dc-explicit.bin
not ok 12 - FAIL: stderr
Output: 
/home/jeremy/Dev/libCEED/interface/ceed-operator.c:645 in CeedOperatorSetField(): Basis with 216 quadrature points incompatible with prior 64 points
# Test: dc_implicit_stab_none
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -degree 3 -dm_plex_box_faces 1,1,2 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 125,125,250 -dm_plex_dim 3 -bc_slip_x 5,6 -bc_slip_y 3,4 -bc_Slip_z 1,2 -units_kilogram 1e-9 -center 62.5,62.5,187.5 -rc 100. -thetaC -35. -mu 75 -units_meter 1e-2 -units_second 1e-2 -ksp_atol 1e-4 -ksp_rtol 1e-3 -ksp_type bcgs -snes_atol 1e-3 -snes_lag_jacobian 100 -snes_lag_jacobian_persists -snes_mf_operator -ts_dt 1e-3 -implicit -ts_type alpha -compare_final_state_atol 5E-4 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-dc-implicit-stab-none.bin
ok 13 - PASS
# Test: adv_rotation_implicit_stab_supg
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem advection -CtauS .3 -stab supg -degree 3 -dm_plex_box_faces 1,1,2 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 125,125,250 -dm_plex_dim 3 -bc_wall 1,2,3,4,5,6 -wall_comps 4 -units_kilogram 1e-9 -rc 100. -ksp_atol 1e-4 -ksp_rtol 1e-3 -ksp_type bcgs -snes_atol 1e-3 -snes_lag_jacobian 100 -snes_lag_jacobian_persists -snes_mf_operator -ts_dt 1e-3 -implicit -dm_mat_preallocate_skip 0 -ts_type alpha -compare_final_state_atol 5E-4 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-adv-rotation-implicit-stab-supg.bin
ok 14 - PASS
# Test: adv_translation_implicit_stab_su
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem advection -CtauS .3 -stab su -degree 3 -dm_plex_box_faces 1,1,2 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 125,125,250 -dm_plex_dim 3 -units_kilogram 1e-9 -rc 100. -ksp_atol 1e-4 -ksp_rtol 1e-3 -ksp_type bcgs -snes_atol 1e-3 -snes_lag_jacobian 100 -snes_lag_jacobian_persists -snes_mf_operator -ts_dt 1e-3 -implicit -dm_mat_preallocate_skip 0 -ts_type alpha -wind_type translation -wind_translation .53,-1.33,-2.65 -bc_inflow 1,2,3,4,5,6 -compare_final_state_atol 5E-4 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-adv-translation-implicit-stab-su.bin
ok 15 - PASS
# Test: adv2d_rotation_explicit_strong
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem advection2d -strong_form 1 -degree 3 -dm_plex_box_faces 2,2 -dm_plex_box_lower 0,0 -dm_plex_box_upper 125,125 -bc_wall 1,2,3,4 -wall_comps 4 -units_kilogram 1e-9 -rc 100. -ts_dt 1e-3 -compare_final_state_atol 1E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-adv2d-rotation-explicit-strong.bin
ok 16 - PASS
# Test: adv2d_rotation_implicit_stab_supg
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem advection2d -CtauS .3 -stab supg -degree 3 -dm_plex_box_faces 1,1,2 -dm_plex_box_lower 0,0 -dm_plex_box_upper 125,125 -bc_wall 1,2,3,4 -wall_comps 4 -units_kilogram 1e-9 -rc 100. -ksp_atol 1e-4 -ksp_rtol 1e-3 -ksp_type bcgs -snes_atol 1e-3 -snes_lag_jacobian 100 -snes_lag_jacobian_persists -snes_mf_operator -ts_dt 1e-3 -implicit -dm_mat_preallocate_skip 0 -ts_type alpha -compare_final_state_atol 5E-4 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-adv2d-rotation-implicit-stab-supg.bin
ok 17 - PASS
# Test: euler_implicit
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem euler_vortex -degree 3 -dm_plex_box_faces 1,1,2 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 125,125,250 -dm_plex_dim 3 -units_meter 1e-4 -units_second 1e-4 -mean_velocity 1.4,-2.,0 -bc_inflow 4,6 -bc_outflow 3,5 -bc_slip_z 1,2 -vortex_strength 2 -ksp_atol 1e-4 -ksp_rtol 1e-3 -ksp_type bcgs -snes_atol 1e-3 -snes_lag_jacobian 100 -snes_lag_jacobian_persists -snes_mf_operator -ts_dt 1e-3 -implicit -dm_mat_preallocate_skip 0 -ts_type alpha -compare_final_state_atol 5E-4 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-euler-implicit.bin
ok 18 - PASS
# Test: euler_explicit
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem euler_vortex -degree 3 -q_extra 2 -dm_plex_box_faces 2,2,1 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 125,125,250 -dm_plex_dim 3 -units_meter 1e-4 -units_second 1e-4 -mean_velocity 1.4,-2.,0 -bc_inflow 4,6 -bc_outflow 3,5 -bc_slip_z 1,2 -vortex_strength 2 -ts_dt 1e-7 -ts_rk_type 5bs -ts_rtol 1e-10 -ts_atol 1e-10 -compare_final_state_atol 1E-7 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-euler-explicit.bin
not ok 19 - FAIL: stderr
Output: 
/home/jeremy/Dev/libCEED/interface/ceed-operator.c:645 in CeedOperatorSetField(): Basis with 216 quadrature points incompatible with prior 64 points
# Test: shocktube_explicit_su_yzb
# $ build/fluids-navierstokes -ceed /cpu/self/ref/serial -test_type solver -problem shocktube -degree 1 -q_extra 2 -dm_plex_box_faces 50,1,1 -units_meter 1e-2 units_second 1e-2 -dm_plex_box_lower 0,0,0 -dm_plex_box_upper 1000,20,20 -dm_plex_dim 3 -bc_slip_x 5,6 -bc_slip_y 3,4 -bc_Slip_z 1,2 -yzb -stab su -compare_final_state_atol 1E-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-shocktube-explicit-su-yzb.bin
not ok 20 - FAIL: stderr
Output: 
/home/jeremy/Dev/libCEED/interface/ceed-operator.c:645 in CeedOperatorSetField(): Basis with 64 quadrature points incompatible with prior 8 points
Failed 5/20 subtests
```