### PR TITLE
refactor junit.py for parity with Ratel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ noether-cpu:
     - rm -f .SUCCESS
 # libCEED
     - make configure OPT='-O -march=native -ffp-contract=fast'
-    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*')
+    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*' | tr '\n' ' ')
     - echo "-------------- libCEED -------------" && make info
     - echo "-------------- BACKENDS_CPU --------" && echo $BACKENDS_CPU
     - OCCA_DIR= PEDANTIC=1 make -j$NPROC_CPU
@@ -98,7 +98,7 @@ noether-rocm:
     - rm -f .SUCCESS
 # libCEED
     - make configure ROCM_DIR=/opt/rocm-5.5.0 OPT='-O -march=native -ffp-contract=fast'
-    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
+    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*' | tr '\n' ' ') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*' | tr '\n' ' ')
     - echo "-------------- libCEED -------------" && make info
     - echo "-------------- BACKENDS_GPU --------" && echo $BACKENDS_GPU
     - make -j$NPROC_CPU
@@ -172,7 +172,7 @@ noether-float:
     - sed -i 's/ceed-f64/ceed-f32/1' include/ceed/types.h
 # Build libCEED
     - make configure ROCM_DIR=/opt/rocm-5.5.0 OPT='-O -march=native -ffp-contract=fast'
-    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
+    - BACKENDS_CPU=$(make info-backends-all | grep -o '/cpu[^ ]*' | tr '\n' ' ') && BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*' | tr '\n' ' ')
     - echo "-------------- libCEED -------------" && make info
     - echo "-------------- BACKENDS_CPU --------" && echo $BACKENDS_CPU
     - echo "-------------- BACKENDS_GPU --------" && echo $BACKENDS_GPU
@@ -223,7 +223,7 @@ noether-cuda:
 # libCEED
     - make configure OPT='-O -march=native -ffp-contract=fast' CUDA_DIR=/usr
     - echo "-------------- libCEED -------------" && make info
-    - BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*')
+    - BACKENDS_GPU=$(make info-backends | grep -o '/gpu[^ ]*' | tr '\n' ' ')
     - echo "-------------- BACKENDS_GPU --------" && echo $BACKENDS_GPU
     - PEDANTIC=1 make -k -j$NPROC_CPU -l$NPROC_CPU
 # -- libCEED only tests

--- a/Makefile
+++ b/Makefile
@@ -642,6 +642,7 @@ allexamples = $(examples) $(external_examples)
 search ?= t ex
 realsearch = $(search:%=%%)
 matched = $(foreach pattern,$(realsearch),$(filter $(OBJDIR)/$(pattern),$(tests) $(allexamples)))
+JUNIT_BATCH ?= ''
 
 # Test core libCEED
 test : $(matched:$(OBJDIR)/%=run-%)
@@ -661,7 +662,7 @@ prove-all :
 	+$(MAKE) prove realsearch=%
 
 junit-% : $(OBJDIR)/%
-	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) $(<:$(OBJDIR)/%=%)
+	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --junit-batch $(JUNIT_BATCH) $(<:$(OBJDIR)/%=%)
 
 junit : $(matched:$(OBJDIR)/%=junit-%)
 

--- a/Makefile
+++ b/Makefile
@@ -616,8 +616,12 @@ $(examples) : $(libceed)
 $(tests) : $(libceed)
 $(tests) $(examples) : override LDFLAGS += $(if $(STATIC),,-Wl,-rpath,$(abspath $(LIBDIR))) -L$(LIBDIR)
 
+# Set number processes for testing
+NPROC_TEST ?= 1
+export NPROC_TEST
+
 run-% : $(OBJDIR)/%
-	@$(PYTHON) tests/junit.py --mode tap $(<:$(OBJDIR)/%=%)
+	@$(PYTHON) tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) $(<:$(OBJDIR)/%=%)
 
 external_examples := \
 	$(if $(MFEM_DIR),$(mfemexamples)) \
@@ -649,7 +653,7 @@ ctc-% : $(ctests);@$(foreach tst,$(ctests),$(tst) /cpu/$*;)
 
 prove : $(matched)
 	$(info Testing backends: $(BACKENDS))
-	$(PROVE) $(PROVE_OPTS) --exec 'tests/junit.py --mode tap' $(matched:$(OBJDIR)/%=%)
+	$(PROVE) $(PROVE_OPTS) --exec 'tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST)' $(matched:$(OBJDIR)/%=%)
 # Run prove target in parallel
 prv : ;@$(MAKE) $(MFLAGS) V=$(V) prove
 
@@ -657,7 +661,7 @@ prove-all :
 	+$(MAKE) prove realsearch=%
 
 junit-% : $(OBJDIR)/%
-	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py $(<:$(OBJDIR)/%=%)
+	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) $(<:$(OBJDIR)/%=%)
 
 junit : $(matched:$(OBJDIR)/%=junit-%)
 

--- a/tests/junit.py
+++ b/tests/junit.py
@@ -10,7 +10,7 @@ def create_argparser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser('Test runner with JUnit and TAP output')
     parser.add_argument('-c', '--ceed-backends', type=str, nargs='*', default=['/cpu/self'], help='libCEED backend to use with convergence tests')
-    parser.add_argument('-m', '--mode', type=RunMode, action=CaseInsensitiveEnumAction, help='Output mode, JUnit or TAP', default='JUnit')
+    parser.add_argument('-m', '--mode', type=RunMode, action=CaseInsensitiveEnumAction, help='Output mode, junit or tap', default=RunMode.JUNIT)
     parser.add_argument('-n', '--nproc', type=int, default=1, help='number of MPI processes')
     parser.add_argument('-o', '--output', type=Optional[Path], default=None, help='Output file to write test')
     parser.add_argument('-b', '--junit-batch', type=str, default='', help='Name of JUnit batch for output file')

--- a/tests/junit.py
+++ b/tests/junit.py
@@ -1,264 +1,128 @@
 #!/usr/bin/env python3
 
-from dataclasses import dataclass, field
-import difflib
-from itertools import combinations
-import os
-from pathlib import Path
-import re
-import subprocess
-import sys
-import time
-sys.path.insert(0, str(Path(__file__).parent / "junit-xml"))
-from junit_xml import TestCase, TestSuite
-
-
-@dataclass
-class TestSpec:
-    name: str
-    only: list = field(default_factory=list)
-    args: list = field(default_factory=list)
-    
-
-def parse_test_line(line: str) -> TestSpec:
-    args = line.strip().split()
-    if args[0] == 'TESTARGS':
-        return TestSpec(name='', args=args[1:])
-    test_args = args[0][args[0].index('TESTARGS(')+9:args[0].rindex(')')]
-    # transform 'name="myname",only="serial,int32"' into {'name': 'myname', 'only': 'serial,int32'}
-    test_args = dict([''.join(t).split('=') for t in re.findall(r"""([^,=]+)(=)"([^"]*)\"""", test_args)])
-    constraints = test_args['only'].split(',') if 'only' in test_args else []
-    if len(args) > 1:
-        return TestSpec(name=test_args['name'], only=constraints, args=args[1:])
-    else:
-        return TestSpec(name=test_args['name'], only=constraints)
-
-
-def get_testargs(file : Path) -> list[TestSpec]:
-    if file.suffix in ['.c', '.cpp']: comment_str = '//'
-    elif file.suffix in ['.py']:      comment_str = '#'
-    elif file.suffix in ['.usr']:     comment_str = 'C_'
-    elif file.suffix in ['.f90']:     comment_str = '! '
-    else:                             raise RuntimeError(f'Unrecognized extension for file: {file}')
-
-    return [parse_test_line(line.strip(comment_str)) 
-            for line in file.read_text().splitlines() 
-            if line.startswith(f'{comment_str}TESTARGS')] or [TestSpec('', args=['{ceed_resource}'])]
-
-
-def get_source(test: str) -> Path:
-    prefix, rest = test.split('-', 1)
-    if prefix == 'petsc':
-        return (Path('examples') / 'petsc' / rest).with_suffix('.c')
-    elif prefix == 'mfem':
-        return (Path('examples') / 'mfem' / rest).with_suffix('.cpp')
-    elif prefix == 'nek':
-        return (Path('examples') / 'nek' / 'bps' / rest).with_suffix('.usr')
-    elif prefix == 'fluids':
-        return (Path('examples') / 'fluids' / rest).with_suffix('.c')
-    elif prefix == 'solids':
-        return (Path('examples') / 'solids' / rest).with_suffix('.c')
-    elif test.startswith('ex'):
-        return (Path('examples') / 'ceed' / test).with_suffix('.c')
-    elif test.endswith('-f'):
-        return (Path('tests') / test).with_suffix('.f90')
-    else:
-        return (Path('tests') / test).with_suffix('.c')
-
-
-def check_required_failure(test_case: TestCase, stderr: str, required: str) -> None:
-    if required in stderr:
-        test_case.status = 'fails with required: {}'.format(required)
-    else:
-        test_case.add_failure_info('required: {}'.format(required))
+import argparse
+from junit_common import *
 
 
 def contains_any(resource: str, substrings: list[str]) -> bool:
     return any((sub in resource for sub in substrings))
 
 
-def skip_rule(test: str, resource: str) -> bool:
-    return any((
-        test.startswith('t4') and contains_any(resource, ['occa']),
-        test.startswith('t5') and contains_any(resource, ['occa']),
-        test.startswith('ex') and contains_any(resource, ['occa']),
-        test.startswith('mfem') and contains_any(resource, ['occa']),
-        test.startswith('nek') and contains_any(resource, ['occa']),
-        test.startswith('petsc-') and contains_any(resource, ['occa']),
-        test.startswith('fluids-') and contains_any(resource, ['occa']),
-        test.startswith('solids-') and contains_any(resource, ['occa']),
-        test.startswith('t318') and contains_any(resource, ['/gpu/cuda/ref']),
-        test.startswith('t506') and contains_any(resource, ['/gpu/cuda/shared']),
-    ))
+# create parser for command line arguments
+def create_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser('Test runner with JUnit and TAP output')
+    parser.add_argument('-c', '--ceed-backends', type=str, nargs='*', default=['/cpu/self'], help='libCEED backend to use with convergence tests')
+    parser.add_argument('-m', '--mode', help='Output mode, JUnit or TAP', default='JUnit')
+    parser.add_argument('-n', '--nproc', type=int, default=1, help='number of MPI processes')
+    parser.add_argument('-o', '--output', help='Output file to write test', default=None)
+    parser.add_argument('test', help='Test executable', nargs='?')
+
+    return parser
 
 
-def run(test: str, backends: list[str], mode: str) -> TestSuite:
-    source = get_source(test)
-    test_specs = get_testargs(source)
+# Necessary functions for running tests
+class CeedSuiteSpec(SuiteSpec):
+    def get_source_path(self, test: str) -> Path:
+        prefix, rest = test.split('-', 1)
+        if prefix == 'petsc':
+            return (Path('examples') / 'petsc' / rest).with_suffix('.c')
+        elif prefix == 'mfem':
+            return (Path('examples') / 'mfem' / rest).with_suffix('.cpp')
+        elif prefix == 'nek':
+            return (Path('examples') / 'nek' / 'bps' / rest).with_suffix('.usr')
+        elif prefix == 'fluids':
+            return (Path('examples') / 'fluids' / rest).with_suffix('.c')
+        elif prefix == 'solids':
+            return (Path('examples') / 'solids' / rest).with_suffix('.c')
+        elif test.startswith('ex'):
+            return (Path('examples') / 'ceed' / test).with_suffix('.c')
+        elif test.endswith('-f'):
+            return (Path('tests') / test).with_suffix('.f90')
+        else:
+            return (Path('tests') / test).with_suffix('.c')
 
-    if mode.lower() == "tap":
-        print('1..' + str(len(test_specs) * len(backends)))
+    # get path to executable
+    def get_run_path(self, test: str) -> Path:
+        return Path('build') / test
 
-    test_cases = []
-    my_env = os.environ.copy()
-    my_env["CEED_ERROR_HANDLER"] = 'exit'
-    index = 1
-    for spec in test_specs:
-        for ceed_resource in backends:
-            rargs = [str(Path('build') / test), *spec.args]
-            rargs[rargs.index('{ceed_resource}')] = ceed_resource
+    def get_output_path(self, test: str, output_file: str) -> Path:
+        return Path('tests') / 'output' / output_file
 
-            # run test
-            if skip_rule(test, ceed_resource):
-                test_case = TestCase(f'{test} {ceed_resource}',
-                                     elapsed_sec=0,
-                                     timestamp=time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime()),
-                                     stdout='',
-                                     stderr='')
-                test_case.add_skipped_info('Pre-run skip rule')
-            else:
-                start = time.time()
-                proc = subprocess.run(rargs,
-                                      stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE,
-                                      env=my_env)
-                proc.stdout = proc.stdout.decode('utf-8')
-                proc.stderr = proc.stderr.decode('utf-8')
+    def check_pre_skip(self, test: str, spec: TestSpec, resource: str, nproc: int) -> Optional[str]:
+        return 'Pre-Check Skipped' if any((
+            test.startswith('t4') and contains_any(resource, ['occa']),
+            test.startswith('t5') and contains_any(resource, ['occa']),
+            test.startswith('ex') and contains_any(resource, ['occa']),
+            test.startswith('mfem') and contains_any(resource, ['occa']),
+            test.startswith('nek') and contains_any(resource, ['occa']),
+            test.startswith('petsc-') and contains_any(resource, ['occa']),
+            test.startswith('fluids-') and contains_any(resource, ['occa']),
+            test.startswith('solids-') and contains_any(resource, ['occa']),
+            test.startswith('t318') and contains_any(resource, ['/gpu/cuda/ref']),
+            test.startswith('t506') and contains_any(resource, ['/gpu/cuda/shared']),
+        )) else None
 
-                test_case = TestCase(f'{test} {spec.name} {ceed_resource}',
-                                     classname=source.parent,
-                                     elapsed_sec=time.time() - start,
-                                     timestamp=time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime(start)),
-                                     stdout=proc.stdout,
-                                     stderr=proc.stderr)
-                ref_stdout = (Path('tests') / 'output' / test).with_suffix('.out')
+    def check_post_skip(self, test: str, spec: TestSpec, resource: str, stderr: str) -> Optional[str]:
+        if 'OCCA backend failed to use' in stderr:
+            return f'occa mode not supported {test} {resource}'
+        elif 'Backend does not implement' in stderr:
+            return f'not implemented {test} {resource}'
+        elif 'Can only provide HOST memory for this backend' in stderr:
+            return f'device memory not supported {test} {resource}'
+        elif 'Test not implemented in single precision' in stderr:
+            return f'not implemented {test} {resource}'
+        elif 'No SYCL devices of the requested type are available' in stderr:
+            return f'sycl device type not available {test} {resource}'
+        return None
 
-            # check for allowed errors
-            if not test_case.is_skipped() and proc.stderr:
-                if 'OCCA backend failed to use' in proc.stderr:
-                    test_case.add_skipped_info('occa mode not supported {} {}'.format(test, ceed_resource))
-                elif 'Backend does not implement' in proc.stderr:
-                    test_case.add_skipped_info('not implemented {} {}'.format(test, ceed_resource))
-                elif 'Can only provide HOST memory for this backend' in proc.stderr:
-                    test_case.add_skipped_info('device memory not supported {} {}'.format(test, ceed_resource))
-                elif 'Test not implemented in single precision' in proc.stderr:
-                    test_case.add_skipped_info('not implemented {} {}'.format(test, ceed_resource))
-                elif 'No SYCL devices of the requested type are available' in proc.stderr:
-                    test_case.add_skipped_info('sycl device type not available {} {}'.format(test, ceed_resource))
+    def check_required_failure(self, test: str, spec: TestSpec, resource: str, stderr: str) -> tuple[str, bool]:
+        test_id: str = test[:4]
+        fail_str: str = ''
+        if test_id in ['t006', 't007']:
+            fail_str = 'No suitable backend:'
+        elif test_id in ['t008']:
+            fail_str = 'Available backend resources:'
+        elif test_id in ['t110', 't111', 't112', 't113', 't114']:
+            fail_str = 'Cannot grant CeedVector array access'
+        elif test_id in ['t115']:
+            fail_str = 'Cannot grant CeedVector read-only array access, the access lock is already in use'
+        elif test_id in ['t116']:
+            fail_str = 'Cannot destroy CeedVector, the writable access lock is in use'
+        elif test_id in ['t117']:
+            fail_str = 'Cannot restore CeedVector array access, access was not granted'
+        elif test_id in ['t118']:
+            fail_str = 'Cannot sync CeedVector, the access lock is already in use'
+        elif test_id in ['t215']:
+            fail_str = 'Cannot destroy CeedElemRestriction, a process has read access to the offset data'
+        elif test_id in ['t303']:
+            fail_str = 'Length of input/output vectors incompatible with basis dimensions'
+        elif test_id in ['t408']:
+            fail_str = 'CeedQFunctionContextGetData(): Cannot grant CeedQFunctionContext data access, a process has read access'
+        elif test_id in ['t409'] and contains_any(resource, ['memcheck']):
+            fail_str = 'Context data changed while accessed in read-only mode'
 
-            # check required failures
-            if not test_case.is_skipped():
-                if test[:4] in ['t006', 't007']:
-                    check_required_failure(test_case, proc.stderr, 'No suitable backend:')
-                if test[:4] in ['t008']:
-                    check_required_failure(test_case, proc.stderr, 'Available backend resources:')
-                if test[:4] in ['t110', 't111', 't112', 't113', 't114']:
-                    check_required_failure(test_case, proc.stderr, 'Cannot grant CeedVector array access')
-                if test[:4] in ['t115']:
-                    check_required_failure(test_case, proc.stderr, 'Cannot grant CeedVector read-only array access, the access lock is already in use')
-                if test[:4] in ['t116']:
-                    check_required_failure(test_case, proc.stderr, 'Cannot destroy CeedVector, the writable access lock is in use')
-                if test[:4] in ['t117']:
-                    check_required_failure(test_case, proc.stderr, 'Cannot restore CeedVector array access, access was not granted')
-                if test[:4] in ['t118']:
-                    check_required_failure(test_case, proc.stderr, 'Cannot sync CeedVector, the access lock is already in use')
-                if test[:4] in ['t215']:
-                    check_required_failure(test_case, proc.stderr, 'Cannot destroy CeedElemRestriction, a process has read access to the offset data')
-                if test[:4] in ['t303']:
-                    check_required_failure(test_case, proc.stderr, 'Length of input/output vectors incompatible with basis dimensions')
-                if test[:4] in ['t408']:
-                    check_required_failure(test_case, proc.stderr, 'CeedQFunctionContextGetData(): Cannot grant CeedQFunctionContext data access, a process has read access')
-                if test[:4] in ['t409'] and contains_any(ceed_resource, ['memcheck']):
-                    check_required_failure(test_case, proc.stderr, 'Context data changed while accessed in read-only mode')
+        return fail_str, fail_str in stderr
 
-            # classify other results
-            if not test_case.is_skipped() and not test_case.status:
-                if proc.stderr:
-                    test_case.add_failure_info('stderr', proc.stderr)
-                elif proc.returncode != 0:
-                    test_case.add_error_info(f'returncode = {proc.returncode}')
-                elif ref_stdout.is_file():
-                    diff = list(difflib.unified_diff(ref_stdout.read_text().splitlines(keepends=True),
-                                                     proc.stdout.splitlines(keepends=True),
-                                                     fromfile=str(ref_stdout),
-                                                     tofile='New'))
-                    if diff:
-                        test_case.add_failure_info('stdout', output=''.join(diff))
-                elif proc.stdout and test[:4] not in 't003':
-                    test_case.add_failure_info('stdout', output=proc.stdout)
+    def check_allowed_stdout(self, test: str) -> bool:
+        return test[:4] in ['t003']
 
-            # store result
-            test_case.args = ' '.join(rargs)
-            test_cases.append(test_case)
-
-            if mode.lower() == "tap":
-                # print incremental output if TAP mode
-                print('# Test: {}'.format(test_case.name.split(' ')[1]))
-                print('# $ {}'.format(test_case.args))
-                if test_case.is_error():
-                    print('not ok {} - ERROR: {}'.format(index, (test_case.errors[0]['message'] or "NO MESSAGE").strip()))
-                    print('Output: \n{}'.format((test_case.errors[0]['output'] or "NO OUTPUT").strip()))
-                    if test_case.is_failure():
-                        print('            FAIL: {}'.format(index, (test_case.failures[0]['message'] or "NO MESSAGE").strip()))
-                        print('Output: \n{}'.format((test_case.failures[0]['output'] or "NO OUTPUT").strip()))
-                elif test_case.is_failure():
-                    print('not ok {} - FAIL: {}'.format(index, (test_case.failures[0]['message'] or "NO MESSAGE").strip()))
-                    print('Output: \n{}'.format((test_case.failures[0]['output'] or "NO OUTPUT").strip()))
-                elif test_case.is_skipped():
-                    print('ok {} - SKIP: {}'.format(index, (test_case.skipped[0]['message'] or "NO MESSAGE").strip()))
-                else:
-                    print('ok {} - PASS'.format(index))
-                sys.stdout.flush()
-            else:
-                # print error or failure information if JUNIT mode
-                if test_case.is_error() or test_case.is_failure():
-                    print('Test: {} {}'.format(test_case.name.split(' ')[0], test_case.name.split(' ')[1]))
-                    print('  $ {}'.format(test_case.args))
-                    if test_case.is_error():
-                        print('ERROR: {}'.format((test_case.errors[0]['message'] or "NO MESSAGE").strip()))
-                        print('Output: \n{}'.format((test_case.errors[0]['output'] or "NO OUTPUT").strip()))
-                    if test_case.is_failure():
-                        print('FAIL: {}'.format((test_case.failures[0]['message'] or "NO MESSAGE").strip()))
-                        print('Output: \n{}'.format((test_case.failures[0]['output'] or "NO OUTPUT").strip()))
-                sys.stdout.flush()
-            index += 1
-
-    return TestSuite(test, test_cases)
 
 if __name__ == '__main__':
-    import argparse
-    parser = argparse.ArgumentParser('Test runner with JUnit and TAP output')
-    parser.add_argument('--mode', help='Output mode, JUnit or TAP', default="JUnit")
-    parser.add_argument('--output', help='Output file to write test', default=None)
-    parser.add_argument('--gather', help='Gather all *.junit files into XML', action='store_true')
-    parser.add_argument('test', help='Test executable', nargs='?')
-    args = parser.parse_args()
+    args = create_argparser().parse_args()
 
-    if args.gather:
-        gather()
-    else:
-        backends = os.environ['BACKENDS'].split()
+    # run tests
+    mode: RunMode = RunMode(args.mode.lower())
+    result: TestSuite = run_tests(args.test, args.ceed_backends, mode, args.nproc, CeedSuiteSpec())
 
-        # run tests
-        result = run(args.test, backends, args.mode)
+    # build output
+    if mode is RunMode.JUNIT:
+        junit_batch: str = f'-{os.environ["JUNIT_BATCH"]}' if 'JUNIT_BATCH' in os.environ else ''
+        output: Path = Path('build') / (args.test + junit_batch + '.junit') if args.output is None else Path(args.output)
+        with output.open('w') as fd:
+            TestSuite.to_file(fd, [result])
 
-        # build output
-        if args.mode.lower() == "junit":
-            junit_batch = ''
-            try:
-                junit_batch = '-' + os.environ['JUNIT_BATCH']
-            except:
-                pass
-            output = Path('build') / (args.test + junit_batch + '.junit') if args.output is None else Path(args.output)
-
-            with output.open('w') as fd:
-                TestSuite.to_file(fd, [result])
-        elif args.mode.lower() != "tap":
-            raise Exception("output mode not recognized")
-
-        # check return code
-        for t in result.test_cases:
-            failures = len([c for c in result.test_cases if c.is_failure()])
-            errors = len([c for c in result.test_cases if c.is_error()])
-            if failures + errors > 0 and args.mode.lower() != "tap":
-                sys.exit(1)
+    # check return code
+    for t in result.test_cases:
+        any_failures: bool = any(c.is_failure() or c.is_error() for c in result.test_cases)
+        if any_failures and mode is not RunMode.TAP:
+            sys.exit(1)

--- a/tests/junit_common.py
+++ b/tests/junit_common.py
@@ -13,19 +13,23 @@ import time
 from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent / "junit-xml"))
-from junit_xml import TestCase, TestSuite  # nopep8
+from junit_xml import TestCase, TestSuite, to_xml_report_string  # nopep8
 
 
 class CaseInsensitiveEnumAction(argparse.Action):
     """Action to convert input values to lower case prior to converting to an Enum type"""
 
-    def __init__(self, option_strings, dest, type, **kwargs):
+    def __init__(self, option_strings, dest, type, default, **kwargs):
         if not (issubclass(type, Enum) and issubclass(type, str)):
             raise ValueError(f"{type} must be a StrEnum or str and Enum")
         # store provided enum type
         self.enum_type = type
+        if isinstance(default, str):
+            default = self.enum_type(default.lower())
+        else:
+            default = [self.enum_type(v.lower()) for v in default]
         # prevent automatic type conversion
-        super().__init__(option_strings, dest, type=str, **kwargs)
+        super().__init__(option_strings, dest, default=default, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         if isinstance(values, str):

--- a/tests/junit_common.py
+++ b/tests/junit_common.py
@@ -1,0 +1,289 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+import difflib
+from enum import Enum
+from math import isclose
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent / "junit-xml"))
+from junit_xml import TestCase, TestSuite  # nopep8
+
+
+@dataclass
+class TestSpec:
+    name: str
+    only: list = field(default_factory=list)
+    args: list = field(default_factory=list)
+
+
+class RunMode(Enum):
+    TAP: str = 'tap'
+    JUNIT: str = 'junit'
+
+
+class SuiteSpec(ABC):
+    @abstractmethod
+    def get_source_path(self, test: str) -> Path:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_run_path(self, test: str) -> Path:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_output_path(self, test: str, output_file: str) -> Path:
+        raise NotImplementedError
+
+    def post_test_hook(self, test: str, spec: TestSpec) -> None:
+        pass
+
+    def check_pre_skip(self, test: str, spec: TestSpec, resource: str, nproc: int) -> Optional[str]:
+        return None
+
+    def check_post_skip(self, test: str, spec: TestSpec, resource: str, stderr: str) -> Optional[str]:
+        return None
+
+    def check_required_failure(self, test: str, spec: TestSpec, resource: str, stderr: str) -> tuple[str, bool]:
+        return '', True
+
+    def check_allowed_stdout(self, test: str) -> bool:
+        return False
+
+
+# parse source file test case line
+def parse_test_line(line: str) -> TestSpec:
+    args: list[str] = re.findall("(?:\".*?\"|\\S)+", line.strip())
+    if args[0] == 'TESTARGS':
+        return TestSpec(name='', args=args[1:])
+    raw_test_args: str = args[0][args[0].index('TESTARGS(') + 9:args[0].rindex(')')]
+    # transform 'name="myname",only="serial,int32"' into {'name': 'myname', 'only': 'serial,int32'}
+    test_args: dict = dict([''.join(t).split('=') for t in re.findall(r"""([^,=]+)(=)"([^"]*)\"""", raw_test_args)])
+    constraints: list[str] = test_args['only'].split(',') if 'only' in test_args else []
+    if len(args) > 1:
+        return TestSpec(name=test_args['name'], only=constraints, args=args[1:])
+    else:
+        return TestSpec(name=test_args['name'], only=constraints)
+
+
+def has_cgnsdiff() -> bool:
+    my_env: dict = os.environ.copy()
+    proc = subprocess.run('cgnsdiff',
+                          shell=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          env=my_env)
+    return 'not found' not in proc.stderr.decode('utf-8')
+
+
+# get all test cases from source file
+def get_test_args(source_file: Path) -> list[TestSpec]:
+    comment_str: str = ''
+    if source_file.suffix in ['.c', '.cpp']:
+        comment_str = '//'
+    elif source_file.suffix in ['.py']:
+        comment_str = '#'
+    elif source_file.suffix in ['.usr']:
+        comment_str = 'C_'
+    elif source_file.suffix in ['.f90']:
+        comment_str = '! '
+    else:
+        raise RuntimeError(f'Unrecognized extension for file: {source_file}')
+
+    return [parse_test_line(line.strip(comment_str))
+            for line in source_file.read_text().splitlines()
+            if line.startswith(f'{comment_str}TESTARGS')] or [TestSpec('', args=['{ceed_resource}'])]
+
+
+# diff output CSV and test file
+def diff_csv(test_csv: Path, true_csv: Path, zero_tol: float = 3e-10, rel_tol: float = 1e-2) -> str:
+    test_lines: list[str] = test_csv.read_text().splitlines()
+    true_lines: list[str] = true_csv.read_text().splitlines()
+
+    if test_lines[0] != true_lines[0]:
+        return ''.join(difflib.unified_diff([f'{test_lines[0]}\n'], [f'{true_lines[0]}\n'],
+                       tofile='found CSV columns', fromfile='expected CSV columns'))
+
+    diff_lines: list[str] = list()
+    column_names: list[str] = true_lines[0].strip().split(',')
+    for test_line, true_line in zip(test_lines[1:], true_lines[1:]):
+        test_vals: list[float] = [float(val.strip()) for val in test_line.strip().split(',')]
+        true_vals: list[float] = [float(val.strip()) for val in true_line.strip().split(',')]
+        for test_val, true_val, column_name in zip(test_vals, true_vals, column_names):
+            true_zero: bool = abs(true_val) < zero_tol
+            test_zero: bool = abs(test_val) < zero_tol
+            fail: bool = False
+            if true_zero:
+                fail = not test_zero
+            else:
+                fail = not isclose(test_val, true_val, rel_tol=rel_tol)
+            if fail:
+                diff_lines.append(f'step: {true_line[0]}, column: {column_name}, expected: {true_val}, got: {test_val}')
+    return '\n'.join(diff_lines)
+
+
+# diff output CGNS and test file
+def diff_cgns(test_cgns: Path, true_cgns: Path) -> str:
+    my_env: dict = os.environ.copy()
+
+    run_args: list[str] = ['cgnsdiff', '-d', '-t', '1e-12', str(test_cgns), str(true_cgns)]
+    proc = subprocess.run(' '.join(run_args),
+                          shell=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          env=my_env)
+
+    return proc.stderr.decode('utf-8') + proc.stdout.decode('utf-8')
+
+
+# driver to run full test suite
+def run_tests(test: str, ceed_backends: list[str], mode: RunMode, nproc: int, suite_spec: SuiteSpec) -> TestSuite:
+    source_path: Path = suite_spec.get_source_path(test)
+    test_specs: list[TestSpec] = get_test_args(source_path)
+
+    if mode is RunMode.TAP:
+        print('1..' + str(len(test_specs) * len(ceed_backends)))
+
+    test_cases: list[TestCase] = []
+    my_env: dict = os.environ.copy()
+    my_env['CEED_ERROR_HANDLER'] = 'exit'
+
+    index: int = 1
+    for spec in test_specs:
+        for ceed_resource in ceed_backends:
+            run_args: list = [suite_spec.get_run_path(test), *spec.args]
+
+            if '{ceed_resource}' in run_args:
+                run_args[run_args.index('{ceed_resource}')] = ceed_resource
+            if '{nproc}' in run_args:
+                run_args[run_args.index('{nproc}')] = f'{nproc}'
+            elif nproc > 1 and source_path.suffix != '.py':
+                run_args = ['mpiexec', '-n', f'{nproc}', *run_args]
+
+            # run test
+            skip_reason: str = suite_spec.check_pre_skip(test, spec, ceed_resource, nproc)
+            if skip_reason:
+                test_case: TestCase = TestCase(f'{test}, "{spec.name}", n{nproc}, {ceed_resource}',
+                                               elapsed_sec=0,
+                                               timestamp=time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime()),
+                                               stdout='',
+                                               stderr='')
+                test_case.add_skipped_info(skip_reason)
+            else:
+                start: float = time.time()
+                proc = subprocess.run(' '.join(str(arg) for arg in run_args),
+                                      shell=True,
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE,
+                                      env=my_env)
+
+                test_case = TestCase(f'{test}, "{spec.name}", n{nproc}, {ceed_resource}',
+                                     classname=source_path.parent,
+                                     elapsed_sec=time.time() - start,
+                                     timestamp=time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime(start)),
+                                     stdout=proc.stdout.decode('utf-8'),
+                                     stderr=proc.stderr.decode('utf-8'),
+                                     allow_multiple_subelements=True)
+                ref_csvs: list[Path] = []
+                if output_files := [arg for arg in spec.args if 'ascii:' in arg]:
+                    ref_csvs = [suite_spec.get_output_path(test, file.split('ascii:')[-1]) for file in output_files]
+                ref_cgns: list[Path] = []
+                if output_files := [arg for arg in spec.args if 'cgns:' in arg]:
+                    ref_cgns = [suite_spec.get_output_path(test, file.split('cgns:')[-1]) for file in output_files]
+                ref_stdout: Path = suite_spec.get_output_path(test, test + '.out')
+                suite_spec.post_test_hook(test, spec)
+
+            # check allowed failures
+            if not test_case.is_skipped() and test_case.stderr:
+                skip_reason: str = suite_spec.check_post_skip(test, spec, ceed_resource, test_case.stderr)
+                if skip_reason:
+                    test_case.add_skipped_info(skip_reason)
+
+            # check required failures
+            if not test_case.is_skipped():
+                required_message, did_fail = suite_spec.check_required_failure(test, spec, ceed_resource, test_case.stderr)
+                if required_message and did_fail:
+                    test_case.status = f'fails with required: {required_message}'
+                elif required_message:
+                    test_case.add_failure_info(f'required failure missing: {required_message}')
+
+            # classify other results
+            if not test_case.is_skipped() and not test_case.status:
+                if test_case.stderr:
+                    test_case.add_failure_info('stderr', test_case.stderr)
+                if proc.returncode != 0:
+                    test_case.add_error_info(f'returncode = {proc.returncode}')
+                if ref_stdout.is_file():
+                    diff = list(difflib.unified_diff(ref_stdout.read_text().splitlines(keepends=True),
+                                                     test_case.stdout.splitlines(keepends=True),
+                                                     fromfile=str(ref_stdout),
+                                                     tofile='New'))
+                    if diff:
+                        test_case.add_failure_info('stdout', output=''.join(diff))
+                elif test_case.stdout and not suite_spec.check_allowed_stdout(test):
+                    test_case.add_failure_info('stdout', output=test_case.stdout)
+                # expected CSV output
+                for ref_csv in ref_csvs:
+                    if not ref_csv.is_file():
+                        test_case.add_failure_info('csv', output=f'{ref_csv} not found')
+                    else:
+                        diff: str = diff_csv(Path.cwd() / ref_csv.name, ref_csv)
+                        if diff:
+                            test_case.add_failure_info('csv', output=diff)
+                        else:
+                            (Path.cwd() / ref_csv.name).unlink()
+                # expected CGNS output
+                for ref_cgn in ref_cgns:
+                    if not ref_cgn.is_file():
+                        test_case.add_failure_info('cgns', output=f'{ref_cgn} not found')
+                    else:
+                        diff = diff_cgns(Path.cwd() / ref_cgn.name, ref_cgn)
+                        if diff:
+                            test_case.add_failure_info('cgns', output=diff)
+                        else:
+                            (Path.cwd() / ref_cgn.name).unlink()
+
+            # store result
+            test_case.args = ' '.join(str(arg) for arg in run_args)
+            test_cases.append(test_case)
+
+            if mode is RunMode.TAP:
+                # print incremental output if TAP mode
+                print(f'# Test: {spec.name}')
+                if spec.only:
+                    print('# Only: {}'.format(','.join(spec.only)))
+                print(f'# $ {test_case.args}')
+                if test_case.is_skipped():
+                    print('ok {} - SKIP: {}'.format(index, (test_case.skipped[0]['message'] or 'NO MESSAGE').strip()))
+                elif test_case.is_failure() or test_case.is_error():
+                    print(f'not ok {index}')
+                    if test_case.is_error():
+                        print(f'  ERROR: {test_case.errors[0]["message"]}')
+                    if test_case.is_failure():
+                        for i, failure in enumerate(test_case.failures):
+                            print(f'  FAILURE {i}: {failure["message"]}')
+                            print(f'    Output: \n{failure["output"]}')
+                else:
+                    print(f'ok {index} - PASS')
+                sys.stdout.flush()
+            else:
+                # print error or failure information if JUNIT mode
+                if test_case.is_error() or test_case.is_failure():
+                    print(f'Test: {test} {spec.name}')
+                    print(f'  $ {test_case.args}')
+                    if test_case.is_error():
+                        print('ERROR: {}'.format((test_case.errors[0]['message'] or 'NO MESSAGE').strip()))
+                        print('Output: \n{}'.format((test_case.errors[0]['output'] or 'NO MESSAGE').strip()))
+                    if test_case.is_failure():
+                        for failure in test_case.failures:
+                            print('FAIL: {}'.format((failure['message'] or 'NO MESSAGE').strip()))
+                            print('Output: \n{}'.format((failure['output'] or 'NO MESSAGE').strip()))
+                sys.stdout.flush()
+            index += 1
+
+    return TestSuite(test, test_cases)


### PR DESCRIPTION
This PR refactors `junit.py` into a CEED-specific `junit.py` and a common driver `junit_common.py`, the latter of which will have an exact copy in the Ratel repository. This should prevent future parity issues between the libCEED and Ratel test suites.

Addresses part of #1283.