### PR TITLE
Silence compiler warnings for PETSc examples

### DIFF
--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -346,7 +346,7 @@ int main(int argc, char **argv) {
   char      hostname[PETSC_MAX_PATH_LEN];
 
   PetscInt    dim = 3, mesh_elem[3] = {3, 3, 3};
-  PetscInt    num_degrees = 30, degree[30] = {}, num_local_nodes = 2, local_nodes[2] = {};
+  PetscInt    num_degrees = 30, degree[30] = {0}, num_local_nodes = 2, local_nodes[2] = {0};
   PetscMPIInt ranks_per_node;
   PetscBool   degree_set;
   BPType      bp_choices[10];

--- a/examples/petsc/src/matops.c
+++ b/examples/petsc/src/matops.c
@@ -67,7 +67,7 @@ PetscErrorCode MatGetDiag(Mat A, Vec D) {
   PetscCall(DMLocalToGlobal(op_apply_ctx->dm, op_apply_ctx->Y_loc, ADD_VALUES, D));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // This function uses libCEED to compute the action of the Laplacian with Dirichlet boundary conditions
@@ -101,7 +101,7 @@ PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, OperatorApplyContext op_apply_ctx) 
   PetscCall(DMLocalToGlobal(op_apply_ctx->dm, op_apply_ctx->Y_loc, ADD_VALUES, Y));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // This function wraps the libCEED operator for a MatShell
@@ -117,7 +117,7 @@ PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y) {
   PetscCall(ApplyLocal_Ceed(X, Y, op_apply_ctx));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // This function uses libCEED to compute the action of the prolongation operator
@@ -158,7 +158,7 @@ PetscErrorCode MatMult_Prolong(Mat A, Vec X, Vec Y) {
   PetscCall(DMLocalToGlobal(pr_restr_ctx->dmf, pr_restr_ctx->loc_vec_f, ADD_VALUES, Y));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // This function uses libCEED to compute the action of the restriction operator
@@ -199,7 +199,7 @@ PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y) {
   PetscCall(DMLocalToGlobal(pr_restr_ctx->dmc, pr_restr_ctx->loc_vec_c, ADD_VALUES, Y));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // This function calculates the error in the final solution
@@ -214,6 +214,6 @@ PetscErrorCode ComputeL2Error(Vec X, PetscScalar *l2_error, OperatorApplyContext
   *l2_error = sqrt(error_sq);
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------

--- a/examples/petsc/src/petscutils.c
+++ b/examples/petsc/src/petscutils.c
@@ -83,7 +83,7 @@ static PetscErrorCode CreateBCLabel(DM dm, const char name[]) {
   PetscCall(DMPlexLabelComplete(dm, label));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // This function sets up a DM for a given degree
@@ -141,7 +141,7 @@ PetscErrorCode SetupDMByDegree(DM dm, PetscInt p_degree, PetscInt q_extra, Petsc
   PetscCall(PetscFEDestroy(&fe));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // Get CEED restriction data from DMPlex
@@ -157,7 +157,7 @@ PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height, DMLab
   PetscCall(PetscFree(elem_restr_offsets));
 
   PetscFunctionReturn(PETSC_SUCCESS);
-};
+}
 
 // -----------------------------------------------------------------------------
 // Utility function - convert from DMPolytopeType to CeedElemTopology


### PR DESCRIPTION
Remove some trailing semicolons from PETSc examples function definitions to silence compiler warnings.