### PR TITLE
GPU element restriction for `CEED_RESTRICTION_ORIENTED` and `CEED_RESTRICTION_CURL_ORIENTED`

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-restriction.c
@@ -19,22 +19,23 @@
 #include "ceed-cuda-ref.h"
 
 //------------------------------------------------------------------------------
-// Apply restriction
+// Core apply restriction code
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r, CeedTransposeMode t_mode, CeedVector u, CeedVector v, CeedRequest *request) {
+static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, CeedTransposeMode t_mode, bool use_signs, bool use_orients,
+                                                     CeedVector u, CeedVector v, CeedRequest *request) {
   Ceed                      ceed;
-  Ceed_Cuda                *data;
-  CUfunction                kernel;
   CeedInt                   num_elem, elem_size;
+  CeedRestrictionType       rstr_type;
   const CeedScalar         *d_u;
   CeedScalar               *d_v;
   CeedElemRestriction_Cuda *impl;
+  CUfunction                kernel;
 
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedGetData(ceed, &data));
-  CeedElemRestrictionGetNumElements(r, &num_elem);
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
   const CeedInt num_nodes = impl->num_nodes;
 
   // Get vectors
@@ -50,45 +51,124 @@ static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r, CeedTransposeMod
   // Restrict
   if (t_mode == CEED_NOTRANSPOSE) {
     // L-vector -> E-vector
-    if (impl->d_ind) {
-      // -- Offsets provided
-      kernel             = impl->OffsetNoTranspose;
-      void   *args[]     = {&num_elem, &impl->d_ind, &d_u, &d_v};
-      CeedInt block_size = elem_size < 1024 ? (elem_size > 32 ? elem_size : 32) : 1024;
+    const CeedInt block_size = elem_size < 1024 ? (elem_size > 32 ? elem_size : 32) : 1024;
+    const CeedInt grid       = CeedDivUpInt(num_nodes, block_size);
 
-      CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
-    } else {
-      // -- Strided restriction
-      kernel             = impl->StridedNoTranspose;
-      void   *args[]     = {&num_elem, &d_u, &d_v};
-      CeedInt block_size = elem_size < 1024 ? (elem_size > 32 ? elem_size : 32) : 1024;
+    switch (rstr_type) {
+      case CEED_RESTRICTION_STRIDED: {
+        kernel       = impl->StridedNoTranspose;
+        void *args[] = {&num_elem, &d_u, &d_v};
 
-      CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
+        CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+      } break;
+      case CEED_RESTRICTION_STANDARD: {
+        kernel       = impl->OffsetNoTranspose;
+        void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+        CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+      } break;
+      case CEED_RESTRICTION_ORIENTED: {
+        if (use_signs) {
+          kernel       = impl->OrientedNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else {
+          kernel       = impl->OffsetNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        }
+      } break;
+      case CEED_RESTRICTION_CURL_ORIENTED: {
+        if (use_signs && use_orients) {
+          kernel       = impl->CurlOrientedNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else if (use_orients) {
+          kernel       = impl->CurlOrientedUnsignedNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else {
+          kernel       = impl->OffsetNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        }
+      } break;
     }
   } else {
     // E-vector -> L-vector
-    if (impl->d_ind) {
-      // -- Offsets provided
-      CeedInt block_size = 32;
+    const CeedInt block_size = 32;
+    const CeedInt grid       = CeedDivUpInt(num_nodes, block_size);
 
-      if (impl->OffsetTranspose) {
-        kernel       = impl->OffsetTranspose;
-        void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+    switch (rstr_type) {
+      case CEED_RESTRICTION_STRIDED: {
+        kernel       = impl->StridedTranspose;
+        void *args[] = {&num_elem, &d_u, &d_v};
 
-        CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
-      } else {
-        kernel       = impl->OffsetTransposeDet;
-        void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
+        CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+      } break;
+      case CEED_RESTRICTION_STANDARD: {
+        if (impl->OffsetTranspose) {
+          kernel       = impl->OffsetTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
 
-        CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
-      }
-    } else {
-      // -- Strided restriction
-      kernel             = impl->StridedTranspose;
-      void   *args[]     = {&num_elem, &d_u, &d_v};
-      CeedInt block_size = 32;
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else {
+          kernel       = impl->OffsetTransposeDet;
+          void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
 
-      CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        }
+      } break;
+      case CEED_RESTRICTION_ORIENTED: {
+        if (use_signs) {
+          kernel       = impl->OrientedTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else {
+          if (impl->OffsetTranspose) {
+            kernel       = impl->OffsetTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->OffsetTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+          }
+        }
+      } break;
+      case CEED_RESTRICTION_CURL_ORIENTED: {
+        if (use_signs && use_orients) {
+          kernel       = impl->CurlOrientedTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else if (use_orients) {
+          kernel       = impl->CurlOrientedUnsignedTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+        } else {
+          if (impl->OffsetTranspose) {
+            kernel       = impl->OffsetTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->OffsetTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
+          }
+        }
+      } break;
     }
   }
 
@@ -98,6 +178,29 @@ static int CeedElemRestrictionApply_Cuda(CeedElemRestriction r, CeedTransposeMod
   CeedCallBackend(CeedVectorRestoreArrayRead(u, &d_u));
   CeedCallBackend(CeedVectorRestoreArray(v, &d_v));
   return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Apply restriction
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionApply_Cuda(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v, CeedRequest *request) {
+  return CeedElemRestrictionApply_Cuda_Core(rstr, t_mode, true, true, u, v, request);
+}
+
+//------------------------------------------------------------------------------
+// Apply unsigned restriction
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionApplyUnsigned_Cuda(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v,
+                                                 CeedRequest *request) {
+  return CeedElemRestrictionApply_Cuda_Core(rstr, t_mode, false, true, u, v, request);
+}
+
+//------------------------------------------------------------------------------
+// Apply unoriented restriction
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionApplyUnoriented_Cuda(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v,
+                                                   CeedRequest *request) {
+  return CeedElemRestrictionApply_Cuda_Core(rstr, t_mode, false, false, u, v, request);
 }
 
 //------------------------------------------------------------------------------
@@ -119,20 +222,60 @@ static int CeedElemRestrictionGetOffsets_Cuda(CeedElemRestriction rstr, CeedMemT
 }
 
 //------------------------------------------------------------------------------
+// Get orientations
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionGetOrientations_Cuda(CeedElemRestriction rstr, CeedMemType mem_type, const bool **orients) {
+  CeedElemRestriction_Cuda *impl;
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+
+  switch (mem_type) {
+    case CEED_MEM_HOST:
+      *orients = impl->h_orients;
+      break;
+    case CEED_MEM_DEVICE:
+      *orients = impl->d_orients;
+      break;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Get curl-conforming orientations
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionGetCurlOrientations_Cuda(CeedElemRestriction rstr, CeedMemType mem_type, const CeedInt8 **curl_orients) {
+  CeedElemRestriction_Cuda *impl;
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+
+  switch (mem_type) {
+    case CEED_MEM_HOST:
+      *curl_orients = impl->h_curl_orients;
+      break;
+    case CEED_MEM_DEVICE:
+      *curl_orients = impl->d_curl_orients;
+      break;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
 // Destroy restriction
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionDestroy_Cuda(CeedElemRestriction r) {
+static int CeedElemRestrictionDestroy_Cuda(CeedElemRestriction rstr) {
   Ceed                      ceed;
   CeedElemRestriction_Cuda *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
   CeedCallCuda(ceed, cuModuleUnload(impl->module));
   CeedCallBackend(CeedFree(&impl->h_ind_allocated));
   CeedCallCuda(ceed, cudaFree(impl->d_ind_allocated));
   CeedCallCuda(ceed, cudaFree(impl->d_t_offsets));
   CeedCallCuda(ceed, cudaFree(impl->d_t_indices));
   CeedCallCuda(ceed, cudaFree(impl->d_l_vec_indices));
+  CeedCallBackend(CeedFree(&impl->h_orients_allocated));
+  CeedCallCuda(ceed, cudaFree(impl->d_orients_allocated));
+  CeedCallBackend(CeedFree(&impl->h_curl_orients_allocated));
+  CeedCallCuda(ceed, cudaFree(impl->d_curl_orients_allocated));
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
 }
@@ -140,7 +283,7 @@ static int CeedElemRestrictionDestroy_Cuda(CeedElemRestriction r) {
 //------------------------------------------------------------------------------
 // Create transpose offsets and indices
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionOffset_Cuda(const CeedElemRestriction r, const CeedInt *indices) {
+static int CeedElemRestrictionOffset_Cuda(const CeedElemRestriction rstr, const CeedInt *indices) {
   Ceed                      ceed;
   bool                     *is_node;
   CeedSize                  l_size;
@@ -148,12 +291,12 @@ static int CeedElemRestrictionOffset_Cuda(const CeedElemRestriction r, const Cee
   CeedInt                  *ind_to_offset, *l_vec_indices, *t_offsets, *t_indices;
   CeedElemRestriction_Cuda *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(r, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
-  CeedCallBackend(CeedElemRestrictionGetLVectorSize(r, &l_size));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(r, &num_comp));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetLVectorSize(rstr, &l_size));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr, &num_comp));
   const CeedInt size_indices = num_elem * elem_size;
 
   // Count num_nodes
@@ -221,135 +364,194 @@ static int CeedElemRestrictionOffset_Cuda(const CeedElemRestriction r, const Cee
 // Create restriction
 //------------------------------------------------------------------------------
 int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
-                                   const CeedInt8 *curl_orients, CeedElemRestriction r) {
+                                   const CeedInt8 *curl_orients, CeedElemRestriction rstr) {
   Ceed                      ceed, ceed_parent;
-  bool                      is_deterministic, is_strided;
+  bool                      is_deterministic;
   CeedInt                   num_elem, num_comp, elem_size, comp_stride = 1;
   CeedRestrictionType       rstr_type;
+  char                     *restriction_kernel_path, *restriction_kernel_source;
   CeedElemRestriction_Cuda *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedCalloc(1, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
   CeedCallBackend(CeedGetParent(ceed, &ceed_parent));
   CeedCallBackend(CeedIsDeterministic(ceed_parent, &is_deterministic));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(r, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(r, &num_comp));
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr, &num_comp));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
   const CeedInt size       = num_elem * elem_size;
   CeedInt       strides[3] = {1, size, elem_size};
   CeedInt       layout[3]  = {1, elem_size * num_elem, elem_size};
 
-  CeedCallBackend(CeedElemRestrictionGetType(r, &rstr_type));
-  CeedCheck(rstr_type != CEED_RESTRICTION_ORIENTED && rstr_type != CEED_RESTRICTION_CURL_ORIENTED, ceed, CEED_ERROR_BACKEND,
-            "Backend does not implement CeedElemRestrictionCreateOriented or CeedElemRestrictionCreateCurlOriented");
-
   // Stride data
-  CeedCallBackend(CeedElemRestrictionIsStrided(r, &is_strided));
-  if (is_strided) {
+  CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
+  if (rstr_type == CEED_RESTRICTION_STRIDED) {
     bool has_backend_strides;
 
-    CeedCallBackend(CeedElemRestrictionHasBackendStrides(r, &has_backend_strides));
+    CeedCallBackend(CeedElemRestrictionHasBackendStrides(rstr, &has_backend_strides));
     if (!has_backend_strides) {
-      CeedCallBackend(CeedElemRestrictionGetStrides(r, &strides));
+      CeedCallBackend(CeedElemRestrictionGetStrides(rstr, &strides));
     }
   } else {
-    CeedCallBackend(CeedElemRestrictionGetCompStride(r, &comp_stride));
+    CeedCallBackend(CeedElemRestrictionGetCompStride(rstr, &comp_stride));
   }
 
-  impl->h_ind           = NULL;
-  impl->h_ind_allocated = NULL;
-  impl->d_ind           = NULL;
-  impl->d_ind_allocated = NULL;
-  impl->d_t_indices     = NULL;
-  impl->d_t_offsets     = NULL;
-  impl->num_nodes       = size;
-  CeedCallBackend(CeedElemRestrictionSetData(r, impl));
-  CeedCallBackend(CeedElemRestrictionSetELayout(r, layout));
+  CeedCallBackend(CeedCalloc(1, &impl));
+  impl->num_nodes                = size;
+  impl->h_ind                    = NULL;
+  impl->h_ind_allocated          = NULL;
+  impl->d_ind                    = NULL;
+  impl->d_ind_allocated          = NULL;
+  impl->d_t_indices              = NULL;
+  impl->d_t_offsets              = NULL;
+  impl->h_orients                = NULL;
+  impl->h_orients_allocated      = NULL;
+  impl->d_orients                = NULL;
+  impl->d_orients_allocated      = NULL;
+  impl->h_curl_orients           = NULL;
+  impl->h_curl_orients_allocated = NULL;
+  impl->d_curl_orients           = NULL;
+  impl->d_curl_orients_allocated = NULL;
+  CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
+  CeedCallBackend(CeedElemRestrictionSetELayout(rstr, layout));
 
-  // Set up device indices/offset arrays
-  switch (mem_type) {
-    case CEED_MEM_HOST: {
-      switch (copy_mode) {
-        case CEED_OWN_POINTER:
-          impl->h_ind_allocated = (CeedInt *)indices;
-          impl->h_ind           = (CeedInt *)indices;
-          break;
-        case CEED_USE_POINTER:
-          impl->h_ind = (CeedInt *)indices;
-          break;
-        case CEED_COPY_VALUES:
-          if (indices != NULL) {
-            CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-            memcpy(impl->h_ind_allocated, indices, elem_size * num_elem * sizeof(CeedInt));
+  // Set up device offset/orientation arrays
+  if (rstr_type != CEED_RESTRICTION_STRIDED) {
+    switch (mem_type) {
+      case CEED_MEM_HOST: {
+        switch (copy_mode) {
+          case CEED_OWN_POINTER:
+            impl->h_ind_allocated = (CeedInt *)indices;
+            impl->h_ind           = (CeedInt *)indices;
+            break;
+          case CEED_USE_POINTER:
+            impl->h_ind = (CeedInt *)indices;
+            break;
+          case CEED_COPY_VALUES:
+            CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
+            memcpy(impl->h_ind_allocated, indices, size * sizeof(CeedInt));
             impl->h_ind = impl->h_ind_allocated;
-          }
-          break;
-      }
-      if (indices != NULL) {
+            break;
+        }
         CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
         impl->d_ind_allocated = impl->d_ind;  // We own the device memory
         CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyHostToDevice));
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(r, indices));
-      }
-      break;
-    }
-    case CEED_MEM_DEVICE: {
-      switch (copy_mode) {
-        case CEED_COPY_VALUES:
-          if (indices != NULL) {
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(rstr, indices));
+      } break;
+      case CEED_MEM_DEVICE: {
+        switch (copy_mode) {
+          case CEED_COPY_VALUES:
             CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
             impl->d_ind_allocated = impl->d_ind;  // We own the device memory
             CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyDeviceToDevice));
-          }
-          break;
-        case CEED_OWN_POINTER:
-          impl->d_ind           = (CeedInt *)indices;
-          impl->d_ind_allocated = impl->d_ind;
-          break;
-        case CEED_USE_POINTER:
-          impl->d_ind = (CeedInt *)indices;
-      }
-      if (indices != NULL) {
-        CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-        CeedCallCuda(ceed, cudaMemcpy(impl->h_ind_allocated, impl->d_ind, elem_size * num_elem * sizeof(CeedInt), cudaMemcpyDeviceToHost));
+            break;
+          case CEED_OWN_POINTER:
+            impl->d_ind           = (CeedInt *)indices;
+            impl->d_ind_allocated = impl->d_ind;
+            break;
+          case CEED_USE_POINTER:
+            impl->d_ind = (CeedInt *)indices;
+            break;
+        }
+        CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
+        CeedCallCuda(ceed, cudaMemcpy(impl->h_ind_allocated, impl->d_ind, size * sizeof(CeedInt), cudaMemcpyDeviceToHost));
         impl->h_ind = impl->h_ind_allocated;
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(r, indices));
-      }
-      break;
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(rstr, indices));
+      } break;
     }
-    // LCOV_EXCL_START
-    default:
-      return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
-      // LCOV_EXCL_STOP
+
+    // Orientation data
+    if (rstr_type == CEED_RESTRICTION_ORIENTED) {
+      switch (mem_type) {
+        case CEED_MEM_HOST: {
+          switch (copy_mode) {
+            case CEED_OWN_POINTER:
+              impl->h_orients_allocated = (bool *)orients;
+              impl->h_orients           = (bool *)orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->h_orients = (bool *)orients;
+              break;
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
+              memcpy(impl->h_orients_allocated, orients, size * sizeof(bool));
+              impl->h_orients = impl->h_orients_allocated;
+              break;
+          }
+          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_orients, size * sizeof(bool)));
+          impl->d_orients_allocated = impl->d_orients;  // We own the device memory
+          CeedCallCuda(ceed, cudaMemcpy(impl->d_orients, orients, size * sizeof(bool), cudaMemcpyHostToDevice));
+        } break;
+        case CEED_MEM_DEVICE: {
+          switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_orients, size * sizeof(bool)));
+              impl->d_orients_allocated = impl->d_orients;  // We own the device memory
+              CeedCallCuda(ceed, cudaMemcpy(impl->d_orients, orients, size * sizeof(bool), cudaMemcpyDeviceToDevice));
+              break;
+            case CEED_OWN_POINTER:
+              impl->d_orients           = (bool *)orients;
+              impl->d_orients_allocated = impl->d_orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->d_orients = (bool *)orients;
+              break;
+          }
+          CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
+          CeedCallCuda(ceed, cudaMemcpy(impl->h_orients_allocated, impl->d_orients, size * sizeof(bool), cudaMemcpyDeviceToHost));
+          impl->h_orients = impl->h_orients_allocated;
+        } break;
+      }
+    } else if (rstr_type == CEED_RESTRICTION_CURL_ORIENTED) {
+      switch (mem_type) {
+        case CEED_MEM_HOST: {
+          switch (copy_mode) {
+            case CEED_OWN_POINTER:
+              impl->h_curl_orients_allocated = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients           = (CeedInt8 *)curl_orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->h_curl_orients = (CeedInt8 *)curl_orients;
+              break;
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
+              memcpy(impl->h_curl_orients_allocated, curl_orients, 3 * size * sizeof(CeedInt8));
+              impl->h_curl_orients = impl->h_curl_orients_allocated;
+              break;
+          }
+          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
+          impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
+          CeedCallCuda(ceed, cudaMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyHostToDevice));
+        } break;
+        case CEED_MEM_DEVICE: {
+          switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
+              impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
+              CeedCallCuda(ceed, cudaMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyDeviceToDevice));
+              break;
+            case CEED_OWN_POINTER:
+              impl->d_curl_orients           = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients_allocated = impl->d_curl_orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->d_curl_orients = (CeedInt8 *)curl_orients;
+              break;
+          }
+          CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
+          CeedCallCuda(ceed, cudaMemcpy(impl->h_curl_orients_allocated, impl->d_curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyDeviceToHost));
+          impl->h_curl_orients = impl->h_curl_orients_allocated;
+        } break;
+      }
+    }
   }
 
-  // Compile CUDA kernels (add atomicAdd function for old NVidia architectures)
-  CeedInt num_nodes = impl->num_nodes;
-  char   *restriction_kernel_path, *restriction_kernel_source = NULL;
-
+  // Compile CUDA kernels
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-ref-restriction.h", &restriction_kernel_path));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
-  if (!is_deterministic) {
-    struct cudaDeviceProp prop;
-    Ceed_Cuda            *ceed_data;
-
-    CeedCallBackend(CeedGetData(ceed, &ceed_data));
-    CeedCallBackend(cudaGetDeviceProperties(&prop, ceed_data->device_id));
-    if ((prop.major < 6) && (CEED_SCALAR_TYPE != CEED_SCALAR_FP32)) {
-      char *atomic_add_path;
-
-      CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/cuda/cuda-atomic-add-fallback.h", &atomic_add_path));
-      CeedCallBackend(CeedLoadSourceToBuffer(ceed, atomic_add_path, &restriction_kernel_source));
-      CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
-      CeedCallBackend(CeedFree(&atomic_add_path));
-    }
-  }
-  if (!restriction_kernel_source) {
-    CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
-  }
+  CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
   CeedCallBackend(CeedCompile_Cuda(ceed, restriction_kernel_source, &impl->module, 8, "RSTR_ELEM_SIZE", elem_size, "RSTR_NUM_ELEM", num_elem,
-                                   "RSTR_NUM_COMP", num_comp, "RSTR_NUM_NODES", num_nodes, "RSTR_COMP_STRIDE", comp_stride, "RSTR_STRIDE_NODES",
+                                   "RSTR_NUM_COMP", num_comp, "RSTR_NUM_NODES", impl->num_nodes, "RSTR_COMP_STRIDE", comp_stride, "RSTR_STRIDE_NODES",
                                    strides[0], "RSTR_STRIDE_COMP", strides[1], "RSTR_STRIDE_ELEM", strides[2]));
   CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "StridedNoTranspose", &impl->StridedNoTranspose));
   CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "StridedTranspose", &impl->StridedTranspose));
@@ -359,15 +561,23 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode,
   } else {
     CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "OffsetTransposeDet", &impl->OffsetTransposeDet));
   }
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "OrientedNoTranspose", &impl->OrientedNoTranspose));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "OrientedTranspose", &impl->OrientedTranspose));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "CurlOrientedNoTranspose", &impl->CurlOrientedNoTranspose));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "CurlOrientedUnsignedNoTranspose", &impl->CurlOrientedUnsignedNoTranspose));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "CurlOrientedTranspose", &impl->CurlOrientedTranspose));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, impl->module, "CurlOrientedUnsignedTranspose", &impl->CurlOrientedUnsignedTranspose));
   CeedCallBackend(CeedFree(&restriction_kernel_path));
   CeedCallBackend(CeedFree(&restriction_kernel_source));
 
   // Register backend functions
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "Apply", CeedElemRestrictionApply_Cuda));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "ApplyUnsigned", CeedElemRestrictionApply_Cuda));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "ApplyUnoriented", CeedElemRestrictionApply_Cuda));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "GetOffsets", CeedElemRestrictionGetOffsets_Cuda));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "Destroy", CeedElemRestrictionDestroy_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Apply", CeedElemRestrictionApply_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnsigned", CeedElemRestrictionApplyUnsigned_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnoriented", CeedElemRestrictionApplyUnoriented_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOffsets", CeedElemRestrictionGetOffsets_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOrientations", CeedElemRestrictionGetOrientations_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetCurlOrientations", CeedElemRestrictionGetCurlOrientations_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Destroy", CeedElemRestrictionDestroy_Cuda));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/cuda-ref/ceed-cuda-ref-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-restriction.c
@@ -98,6 +98,11 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
           CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
         }
       } break;
+      case CEED_RESTRICTION_POINTS: {
+        // LCOV_EXCL_START
+        return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement restriction CeedElemRestrictionAtPoints");
+        // LCOV_EXCL_STOP
+      } break;
     }
   } else {
     // E-vector -> L-vector
@@ -168,6 +173,11 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
             CeedCallBackend(CeedRunKernel_Cuda(ceed, kernel, grid, block_size, args));
           }
         }
+      } break;
+      case CEED_RESTRICTION_POINTS: {
+        // LCOV_EXCL_START
+        return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement restriction CeedElemRestrictionAtPoints");
+        // LCOV_EXCL_STOP
       } break;
     }
   }

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -30,6 +30,12 @@ typedef struct {
   CUfunction OffsetNoTranspose;
   CUfunction OffsetTranspose;
   CUfunction OffsetTransposeDet;
+  CUfunction OrientedNoTranspose;
+  CUfunction OrientedTranspose;
+  CUfunction CurlOrientedNoTranspose;
+  CUfunction CurlOrientedTranspose;
+  CUfunction CurlOrientedUnsignedNoTranspose;
+  CUfunction CurlOrientedUnsignedTranspose;
   CeedInt    num_nodes;
   CeedInt   *h_ind;
   CeedInt   *h_ind_allocated;
@@ -38,6 +44,14 @@ typedef struct {
   CeedInt   *d_t_offsets;
   CeedInt   *d_t_indices;
   CeedInt   *d_l_vec_indices;
+  bool      *h_orients;
+  bool      *h_orients_allocated;
+  bool      *d_orients;
+  bool      *d_orients_allocated;
+  CeedInt8  *h_curl_orients;
+  CeedInt8  *h_curl_orients_allocated;
+  CeedInt8  *d_curl_orients;
+  CeedInt8  *d_curl_orients_allocated;
 } CeedElemRestriction_Cuda;
 
 typedef struct {

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -32,10 +32,13 @@ typedef struct {
   CUfunction OffsetTransposeDet;
   CUfunction OrientedNoTranspose;
   CUfunction OrientedTranspose;
+  CUfunction OrientedTransposeDet;
   CUfunction CurlOrientedNoTranspose;
   CUfunction CurlOrientedTranspose;
+  CUfunction CurlOrientedTransposeDet;
   CUfunction CurlOrientedUnsignedNoTranspose;
   CUfunction CurlOrientedUnsignedTranspose;
+  CUfunction CurlOrientedUnsignedTransposeDet;
   CeedInt    num_nodes;
   CeedInt   *h_ind;
   CeedInt   *h_ind_allocated;

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -98,21 +98,19 @@ typedef struct {
 
 typedef struct {
   CUmodule            module;
-  CUfunction          linearDiagonal;
-  CUfunction          linearPointBlock;
-  CeedBasis           basis_in, basis_out;
+  CUfunction          LinearDiagonal;
+  CUfunction          LinearPointBlock;
   CeedElemRestriction diag_rstr, point_block_diag_rstr;
   CeedVector          elem_diag, point_block_elem_diag;
-  CeedInt             num_e_mode_in, num_e_mode_out, num_nodes;
-  CeedEvalMode       *h_e_mode_in, *h_e_mode_out;
-  CeedEvalMode       *d_e_mode_in, *d_e_mode_out;
-  CeedScalar         *d_identity, *d_interp_in, *d_interp_out, *d_grad_in, *d_grad_out;
+  CeedEvalMode       *d_eval_modes_in, *d_eval_modes_out;
+  CeedScalar         *d_identity, *d_interp_in, *d_grad_in, *d_div_in, *d_curl_in;
+  CeedScalar         *d_interp_out, *d_grad_out, *d_div_out, *d_curl_out;
 } CeedOperatorDiag_Cuda;
 
 typedef struct {
   CUmodule    module;
-  CUfunction  linearAssemble;
-  CeedInt     num_elem, block_size_x, block_size_y, elem_per_block;
+  CUfunction  LinearAssemble;
+  CeedInt     block_size_x, block_size_y, elems_per_block;
   CeedScalar *d_B_in, *d_B_out;
 } CeedOperatorAssemble_Cuda;
 

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -53,15 +53,18 @@ static int CeedOperatorDestroy_Hip(CeedOperator op) {
 
     CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
     CeedCallHip(ceed, hipModuleUnload(impl->diag->module));
-    CeedCallBackend(CeedFree(&impl->diag->h_e_mode_in));
-    CeedCallBackend(CeedFree(&impl->diag->h_e_mode_out));
-    CeedCallHip(ceed, hipFree(impl->diag->d_e_mode_in));
-    CeedCallHip(ceed, hipFree(impl->diag->d_e_mode_out));
+    CeedCallHip(ceed, hipFree(impl->diag->d_eval_modes_in));
+    CeedCallHip(ceed, hipFree(impl->diag->d_eval_modes_out));
     CeedCallHip(ceed, hipFree(impl->diag->d_identity));
     CeedCallHip(ceed, hipFree(impl->diag->d_interp_in));
     CeedCallHip(ceed, hipFree(impl->diag->d_interp_out));
     CeedCallHip(ceed, hipFree(impl->diag->d_grad_in));
     CeedCallHip(ceed, hipFree(impl->diag->d_grad_out));
+    CeedCallHip(ceed, hipFree(impl->diag->d_div_in));
+    CeedCallHip(ceed, hipFree(impl->diag->d_div_out));
+    CeedCallHip(ceed, hipFree(impl->diag->d_curl_in));
+    CeedCallHip(ceed, hipFree(impl->diag->d_curl_out));
+    CeedCallBackend(CeedElemRestrictionDestroy(&impl->diag->diag_rstr));
     CeedCallBackend(CeedElemRestrictionDestroy(&impl->diag->point_block_diag_rstr));
     CeedCallBackend(CeedVectorDestroy(&impl->diag->elem_diag));
     CeedCallBackend(CeedVectorDestroy(&impl->diag->point_block_elem_diag));
@@ -102,30 +105,29 @@ static int CeedOperatorSetupFields_Hip(CeedQFunction qf, CeedOperator op, bool i
 
   // Loop over fields
   for (CeedInt i = 0; i < num_fields; i++) {
-    bool                is_strided, skip_restriction;
-    CeedSize            q_size;
-    CeedInt             dim, size;
-    CeedEvalMode        e_mode;
-    CeedVector          vec;
-    CeedElemRestriction elem_rstr;
-    CeedBasis           basis;
+    bool         is_strided = false, skip_restriction = false;
+    CeedSize     q_size;
+    CeedInt      size;
+    CeedEvalMode eval_mode;
+    CeedBasis    basis;
 
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &e_mode));
-    is_strided       = false;
-    skip_restriction = false;
-    if (e_mode != CEED_EVAL_WEIGHT) {
-      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_fields[i], &elem_rstr));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
+    if (eval_mode != CEED_EVAL_WEIGHT) {
+      CeedElemRestriction elem_rstr;
 
       // Check whether this field can skip the element restriction:
-      // must be passive input, with e_mode NONE, and have a strided restriction with CEED_STRIDES_BACKEND.
+      // Must be passive input, with eval_mode NONE, and have a strided restriction with CEED_STRIDES_BACKEND.
+      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_fields[i], &elem_rstr));
 
       // First, check whether the field is input or output:
       if (is_input) {
-        // Check for passive input:
+        CeedVector vec;
+
+        // Check for passive input
         CeedCallBackend(CeedOperatorFieldGetVector(op_fields[i], &vec));
         if (vec != CEED_VECTOR_ACTIVE) {
-          // Check e_mode
-          if (e_mode == CEED_EVAL_NONE) {
+          // Check eval_mode
+          if (eval_mode == CEED_EVAL_NONE) {
             // Check for strided restriction
             CeedCallBackend(CeedElemRestrictionIsStrided(elem_rstr, &is_strided));
             if (is_strided) {
@@ -143,21 +145,17 @@ static int CeedOperatorSetupFields_Hip(CeedQFunction qf, CeedOperator op, bool i
       }
     }
 
-    switch (e_mode) {
+    switch (eval_mode) {
       case CEED_EVAL_NONE:
         CeedCallBackend(CeedQFunctionFieldGetSize(qf_fields[i], &size));
         q_size = (CeedSize)num_elem * Q * size;
         CeedCallBackend(CeedVectorCreate(ceed, q_size, &q_vecs[i]));
         break;
       case CEED_EVAL_INTERP:
-        CeedCallBackend(CeedQFunctionFieldGetSize(qf_fields[i], &size));
-        q_size = (CeedSize)num_elem * Q * size;
-        CeedCallBackend(CeedVectorCreate(ceed, q_size, &q_vecs[i]));
-        break;
       case CEED_EVAL_GRAD:
-        CeedCallBackend(CeedOperatorFieldGetBasis(op_fields[i], &basis));
+      case CEED_EVAL_DIV:
+      case CEED_EVAL_CURL:
         CeedCallBackend(CeedQFunctionFieldGetSize(qf_fields[i], &size));
-        CeedCallBackend(CeedBasisGetDimension(basis, &dim));
         q_size = (CeedSize)num_elem * Q * size;
         CeedCallBackend(CeedVectorCreate(ceed, q_size, &q_vecs[i]));
         break;
@@ -167,10 +165,6 @@ static int CeedOperatorSetupFields_Hip(CeedQFunction qf, CeedOperator op, bool i
         CeedCallBackend(CeedVectorCreate(ceed, q_size, &q_vecs[i]));
         CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, CEED_VECTOR_NONE, q_vecs[i]));
         break;
-      case CEED_EVAL_DIV:
-        break;  // TODO: Not implemented
-      case CEED_EVAL_CURL:
-        break;  // TODO: Not implemented
     }
   }
   return CEED_ERROR_SUCCESS;
@@ -201,17 +195,14 @@ static int CeedOperatorSetup_Hip(CeedOperator op) {
 
   // Allocate
   CeedCallBackend(CeedCalloc(num_input_fields + num_output_fields, &impl->e_vecs));
-
   CeedCallBackend(CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_in));
   CeedCallBackend(CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_out));
-
   impl->num_inputs  = num_input_fields;
   impl->num_outputs = num_output_fields;
 
   // Set up infield and outfield e_vecs and q_vecs
   // Infields
   CeedCallBackend(CeedOperatorSetupFields_Hip(qf, op, true, impl->e_vecs, impl->q_vecs_in, 0, num_input_fields, Q, num_elem));
-
   // Outfields
   CeedCallBackend(CeedOperatorSetupFields_Hip(qf, op, false, impl->e_vecs, impl->q_vecs_out, num_input_fields, num_output_fields, Q, num_elem));
 
@@ -226,7 +217,7 @@ static inline int CeedOperatorSetupInputs_Hip(CeedInt num_input_fields, CeedQFun
                                               CeedVector in_vec, const bool skip_active, CeedScalar *e_data[2 * CEED_FIELD_MAX],
                                               CeedOperator_Hip *impl, CeedRequest *request) {
   for (CeedInt i = 0; i < num_input_fields; i++) {
-    CeedEvalMode        e_mode;
+    CeedEvalMode        eval_mode;
     CeedVector          vec;
     CeedElemRestriction elem_rstr;
 
@@ -237,8 +228,8 @@ static inline int CeedOperatorSetupInputs_Hip(CeedInt num_input_fields, CeedQFun
       else vec = in_vec;
     }
 
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &e_mode));
-    if (e_mode == CEED_EVAL_WEIGHT) {  // Skip
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
+    if (eval_mode == CEED_EVAL_WEIGHT) {  // Skip
     } else {
       // Get input vector
       CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
@@ -267,7 +258,7 @@ static inline int CeedOperatorInputBasis_Hip(CeedInt num_elem, CeedQFunctionFiel
                                              CeedOperator_Hip *impl) {
   for (CeedInt i = 0; i < num_input_fields; i++) {
     CeedInt             elem_size, size;
-    CeedEvalMode        e_mode;
+    CeedEvalMode        eval_mode;
     CeedElemRestriction elem_rstr;
     CeedBasis           basis;
 
@@ -278,30 +269,25 @@ static inline int CeedOperatorInputBasis_Hip(CeedInt num_elem, CeedQFunctionFiel
       CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
       if (vec == CEED_VECTOR_ACTIVE) continue;
     }
-    // Get elem_size, e_mode, size
+    // Get elem_size, eval_mode, size
     CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &elem_rstr));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &e_mode));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
     CeedCallBackend(CeedQFunctionFieldGetSize(qf_input_fields[i], &size));
     // Basis action
-    switch (e_mode) {
+    switch (eval_mode) {
       case CEED_EVAL_NONE:
         CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_DEVICE, CEED_USE_POINTER, e_data[i]));
         break;
       case CEED_EVAL_INTERP:
-        CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
-        CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_NOTRANSPOSE, CEED_EVAL_INTERP, impl->e_vecs[i], impl->q_vecs_in[i]));
-        break;
       case CEED_EVAL_GRAD:
+      case CEED_EVAL_DIV:
+      case CEED_EVAL_CURL:
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
-        CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_NOTRANSPOSE, CEED_EVAL_GRAD, impl->e_vecs[i], impl->q_vecs_in[i]));
+        CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_NOTRANSPOSE, eval_mode, impl->e_vecs[i], impl->q_vecs_in[i]));
         break;
       case CEED_EVAL_WEIGHT:
         break;  // No action
-      case CEED_EVAL_DIV:
-        break;  // TODO: Not implemented
-      case CEED_EVAL_CURL:
-        break;  // TODO: Not implemented
     }
   }
   return CEED_ERROR_SUCCESS;
@@ -313,15 +299,16 @@ static inline int CeedOperatorInputBasis_Hip(CeedInt num_elem, CeedQFunctionFiel
 static inline int CeedOperatorRestoreInputs_Hip(CeedInt num_input_fields, CeedQFunctionField *qf_input_fields, CeedOperatorField *op_input_fields,
                                                 const bool skip_active, CeedScalar *e_data[2 * CEED_FIELD_MAX], CeedOperator_Hip *impl) {
   for (CeedInt i = 0; i < num_input_fields; i++) {
-    CeedEvalMode e_mode;
+    CeedEvalMode eval_mode;
     CeedVector   vec;
+
     // Skip active input
     if (skip_active) {
       CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
       if (vec == CEED_VECTOR_ACTIVE) continue;
     }
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &e_mode));
-    if (e_mode == CEED_EVAL_WEIGHT) {  // Skip
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
+    if (eval_mode == CEED_EVAL_WEIGHT) {  // Skip
     } else {
       if (!impl->e_vecs[i]) {  // This was a skip_restriction case
         CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
@@ -363,10 +350,10 @@ static int CeedOperatorApplyAdd_Hip(CeedOperator op, CeedVector in_vec, CeedVect
 
   // Output pointers, as necessary
   for (CeedInt i = 0; i < num_output_fields; i++) {
-    CeedEvalMode e_mode;
+    CeedEvalMode eval_mode;
 
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &e_mode));
-    if (e_mode == CEED_EVAL_NONE) {
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
+    if (eval_mode == CEED_EVAL_NONE) {
       // Set the output Q-Vector to use the E-Vector data directly.
       CeedCallBackend(CeedVectorGetArrayWrite(impl->e_vecs[i + impl->num_inputs], CEED_MEM_DEVICE, &e_data[i + num_input_fields]));
       CeedCallBackend(CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_DEVICE, CEED_USE_POINTER, e_data[i + num_input_fields]));
@@ -378,26 +365,25 @@ static int CeedOperatorApplyAdd_Hip(CeedOperator op, CeedVector in_vec, CeedVect
 
   // Output basis apply if needed
   for (CeedInt i = 0; i < num_output_fields; i++) {
-    CeedEvalMode        e_mode;
+    CeedEvalMode        eval_mode;
     CeedElemRestriction elem_rstr;
     CeedBasis           basis;
 
-    // Get elem_size, e_mode, size
+    // Get elem_size, eval_mode, size
     CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &e_mode));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     CeedCallBackend(CeedQFunctionFieldGetSize(qf_output_fields[i], &size));
     // Basis action
-    switch (e_mode) {
+    switch (eval_mode) {
       case CEED_EVAL_NONE:
-        break;
+        break;  // No action
       case CEED_EVAL_INTERP:
-        CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
-        CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_TRANSPOSE, CEED_EVAL_INTERP, impl->q_vecs_out[i], impl->e_vecs[i + impl->num_inputs]));
-        break;
       case CEED_EVAL_GRAD:
+      case CEED_EVAL_DIV:
+      case CEED_EVAL_CURL:
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
-        CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_TRANSPOSE, CEED_EVAL_GRAD, impl->q_vecs_out[i], impl->e_vecs[i + impl->num_inputs]));
+        CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_TRANSPOSE, eval_mode, impl->q_vecs_out[i], impl->e_vecs[i + impl->num_inputs]));
         break;
       // LCOV_EXCL_START
       case CEED_EVAL_WEIGHT: {
@@ -405,25 +391,20 @@ static int CeedOperatorApplyAdd_Hip(CeedOperator op, CeedVector in_vec, CeedVect
 
         CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
         return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
-        break;  // Should not occur
+        // LCOV_EXCL_STOP
       }
-      case CEED_EVAL_DIV:
-        break;  // TODO: Not implemented
-      case CEED_EVAL_CURL:
-        break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
 
   // Output restriction
   for (CeedInt i = 0; i < num_output_fields; i++) {
-    CeedEvalMode        e_mode;
+    CeedEvalMode        eval_mode;
     CeedVector          vec;
     CeedElemRestriction elem_rstr;
 
     // Restore evec
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &e_mode));
-    if (e_mode == CEED_EVAL_NONE) {
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
+    if (eval_mode == CEED_EVAL_NONE) {
       CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
     }
     // Get output vector
@@ -442,15 +423,14 @@ static int CeedOperatorApplyAdd_Hip(CeedOperator op, CeedVector in_vec, CeedVect
 }
 
 //------------------------------------------------------------------------------
-// Core code for assembling linear QFunction
+// Linear QFunction Assembly Core
 //------------------------------------------------------------------------------
 static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, bool build_objects, CeedVector *assembled, CeedElemRestriction *rstr,
                                                               CeedRequest *request) {
   Ceed                ceed, ceed_parent;
-  CeedSize            q_size;
   CeedInt             num_active_in, num_active_out, Q, num_elem, num_input_fields, num_output_fields, size;
   CeedScalar         *assembled_array, *e_data[2 * CEED_FIELD_MAX] = {NULL};
-  CeedVector         *active_in;
+  CeedVector         *active_inputs;
   CeedQFunctionField *qf_input_fields, *qf_output_fields;
   CeedQFunction       qf;
   CeedOperatorField  *op_input_fields, *op_output_fields;
@@ -459,14 +439,13 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
   CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
   CeedCallBackend(CeedOperatorGetFallbackParentCeed(op, &ceed_parent));
   CeedCallBackend(CeedOperatorGetData(op, &impl));
-  CeedCallBackend(CeedOperatorGetQFunction(op, &qf));
   CeedCallBackend(CeedOperatorGetNumQuadraturePoints(op, &Q));
   CeedCallBackend(CeedOperatorGetNumElements(op, &num_elem));
+  CeedCallBackend(CeedOperatorGetQFunction(op, &qf));
   CeedCallBackend(CeedQFunctionGetFields(qf, NULL, &qf_input_fields, NULL, &qf_output_fields));
   CeedCallBackend(CeedOperatorGetFields(op, &num_input_fields, &op_input_fields, &num_output_fields, &op_output_fields));
-  active_in      = impl->qf_active_in;
-  num_active_in  = impl->num_active_in;
-  num_active_out = impl->num_active_out;
+  active_inputs = impl->qf_active_in;
+  num_active_in = impl->num_active_in, num_active_out = impl->num_active_out;
 
   // Setup
   CeedCallBackend(CeedOperatorSetup_Hip(op));
@@ -487,19 +466,20 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
         CeedCallBackend(CeedQFunctionFieldGetSize(qf_input_fields[i], &size));
         CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
         CeedCallBackend(CeedVectorGetArray(impl->q_vecs_in[i], CEED_MEM_DEVICE, &q_vec_array));
-        CeedCallBackend(CeedRealloc(num_active_in + size, &active_in));
+        CeedCallBackend(CeedRealloc(num_active_in + size, &active_inputs));
         for (CeedInt field = 0; field < size; field++) {
-          q_size = (CeedSize)Q * num_elem;
-          CeedCallBackend(CeedVectorCreate(ceed, q_size, &active_in[num_active_in + field]));
+          CeedSize q_size = (CeedSize)Q * num_elem;
+
+          CeedCallBackend(CeedVectorCreate(ceed, q_size, &active_inputs[num_active_in + field]));
           CeedCallBackend(
-              CeedVectorSetArray(active_in[num_active_in + field], CEED_MEM_DEVICE, CEED_USE_POINTER, &q_vec_array[field * Q * num_elem]));
+              CeedVectorSetArray(active_inputs[num_active_in + field], CEED_MEM_DEVICE, CEED_USE_POINTER, &q_vec_array[field * Q * num_elem]));
         }
         num_active_in += size;
         CeedCallBackend(CeedVectorRestoreArray(impl->q_vecs_in[i], &q_vec_array));
       }
     }
     impl->num_active_in = num_active_in;
-    impl->qf_active_in  = active_in;
+    impl->qf_active_in  = active_inputs;
   }
 
   // Count number of active output fields
@@ -523,10 +503,10 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
 
   // Build objects if needed
   if (build_objects) {
-    // Create output restriction
     CeedSize l_size     = (CeedSize)num_elem * Q * num_active_in * num_active_out;
     CeedInt  strides[3] = {1, num_elem * Q, Q}; /* *NOPAD* */
 
+    // Create output restriction
     CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out,
                                                      num_active_in * num_active_out * num_elem * Q, strides, rstr));
     // Create assembled vector
@@ -541,9 +521,9 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
   // Assemble QFunction
   for (CeedInt in = 0; in < num_active_in; in++) {
     // Set Inputs
-    CeedCallBackend(CeedVectorSetValue(active_in[in], 1.0));
+    CeedCallBackend(CeedVectorSetValue(active_inputs[in], 1.0));
     if (num_active_in > 1) {
-      CeedCallBackend(CeedVectorSetValue(active_in[(in + num_active_in - 1) % num_active_in], 0.0));
+      CeedCallBackend(CeedVectorSetValue(active_inputs[(in + num_active_in - 1) % num_active_in], 0.0));
     }
     // Set Outputs
     for (CeedInt out = 0; out < num_output_fields; out++) {
@@ -562,7 +542,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
     CeedCallBackend(CeedQFunctionApply(qf, Q * num_elem, impl->q_vecs_in, impl->q_vecs_out));
   }
 
-  // Un-set output Qvecs to prevent accidental overwrite of Assembled
+  // Un-set output q_vecs to prevent accidental overwrite of Assembled
   for (CeedInt out = 0; out < num_output_fields; out++) {
     CeedVector vec;
 
@@ -597,14 +577,14 @@ static int CeedOperatorLinearAssembleQFunctionUpdate_Hip(CeedOperator op, CeedVe
 }
 
 //------------------------------------------------------------------------------
-// Assemble diagonal setup
+// Assemble Diagonal Setup
 //------------------------------------------------------------------------------
 static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, CeedInt use_ceedsize_idx) {
   Ceed                ceed;
   char               *diagonal_kernel_path, *diagonal_kernel_source;
-  CeedInt             num_input_fields, num_output_fields, num_e_mode_in = 0, num_comp = 0, dim = 1, num_e_mode_out = 0;
-  CeedEvalMode       *e_mode_in = NULL, *e_mode_out = NULL;
-  CeedElemRestriction rstr_in = NULL, rstr_out = NULL;
+  CeedInt             num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
+  CeedInt             num_comp, q_comp, num_nodes, num_qpts;
+  CeedEvalMode       *eval_modes_in = NULL, *eval_modes_out = NULL;
   CeedBasis           basis_in = NULL, basis_out = NULL;
   CeedQFunctionField *qf_fields;
   CeedQFunction       qf;
@@ -623,33 +603,20 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, CeedInt
 
     CeedCallBackend(CeedOperatorFieldGetVector(op_fields[i], &vec));
     if (vec == CEED_VECTOR_ACTIVE) {
-      CeedEvalMode        e_mode;
-      CeedElemRestriction rstr;
+      CeedBasis    basis;
+      CeedEvalMode eval_mode;
 
-      CeedCallBackend(CeedOperatorFieldGetBasis(op_fields[i], &basis_in));
-      CeedCallBackend(CeedBasisGetNumComponents(basis_in, &num_comp));
-      CeedCallBackend(CeedBasisGetDimension(basis_in, &dim));
-      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_fields[i], &rstr));
-      CeedCheck(!rstr_in || rstr_in == rstr, ceed, CEED_ERROR_BACKEND,
-                "Backend does not implement multi-field non-composite operator diagonal assembly");
-      rstr_in = rstr;
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &e_mode));
-      switch (e_mode) {
-        case CEED_EVAL_NONE:
-        case CEED_EVAL_INTERP:
-          CeedCallBackend(CeedRealloc(num_e_mode_in + 1, &e_mode_in));
-          e_mode_in[num_e_mode_in] = e_mode;
-          num_e_mode_in += 1;
-          break;
-        case CEED_EVAL_GRAD:
-          CeedCallBackend(CeedRealloc(num_e_mode_in + dim, &e_mode_in));
-          for (CeedInt d = 0; d < dim; d++) e_mode_in[num_e_mode_in + d] = e_mode;
-          num_e_mode_in += dim;
-          break;
-        case CEED_EVAL_WEIGHT:
-        case CEED_EVAL_DIV:
-        case CEED_EVAL_CURL:
-          break;  // Caught by QF Assembly
+      CeedCallBackend(CeedOperatorFieldGetBasis(op_fields[i], &basis));
+      CeedCheck(!basis_in || basis_in == basis, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement operator diagonal assembly with multiple active bases");
+      basis_in = basis;
+      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
+      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis_in, eval_mode, &q_comp));
+      if (eval_mode != CEED_EVAL_WEIGHT) {
+        // q_comp = 1 if CEED_EVAL_NONE, CEED_EVAL_WEIGHT caught by QF assembly
+        CeedCallBackend(CeedRealloc(num_eval_modes_in + q_comp, &eval_modes_in));
+        for (CeedInt d = 0; d < q_comp; d++) eval_modes_in[num_eval_modes_in + d] = eval_mode;
+        num_eval_modes_in += q_comp;
       }
     }
   }
@@ -662,31 +629,20 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, CeedInt
 
     CeedCallBackend(CeedOperatorFieldGetVector(op_fields[i], &vec));
     if (vec == CEED_VECTOR_ACTIVE) {
-      CeedEvalMode        e_mode;
-      CeedElemRestriction rstr;
+      CeedBasis    basis;
+      CeedEvalMode eval_mode;
 
-      CeedCallBackend(CeedOperatorFieldGetBasis(op_fields[i], &basis_out));
-      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_fields[i], &rstr));
-      CeedCheck(!rstr_out || rstr_out == rstr, ceed, CEED_ERROR_BACKEND,
-                "Backend does not implement multi-field non-composite operator diagonal assembly");
-      rstr_out = rstr;
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &e_mode));
-      switch (e_mode) {
-        case CEED_EVAL_NONE:
-        case CEED_EVAL_INTERP:
-          CeedCallBackend(CeedRealloc(num_e_mode_out + 1, &e_mode_out));
-          e_mode_out[num_e_mode_out] = e_mode;
-          num_e_mode_out += 1;
-          break;
-        case CEED_EVAL_GRAD:
-          CeedCallBackend(CeedRealloc(num_e_mode_out + dim, &e_mode_out));
-          for (CeedInt d = 0; d < dim; d++) e_mode_out[num_e_mode_out + d] = e_mode;
-          num_e_mode_out += dim;
-          break;
-        case CEED_EVAL_WEIGHT:
-        case CEED_EVAL_DIV:
-        case CEED_EVAL_CURL:
-          break;  // Caught by QF Assembly
+      CeedCallBackend(CeedOperatorFieldGetBasis(op_fields[i], &basis));
+      CeedCheck(!basis_out || basis_out == basis, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement operator diagonal assembly with multiple active bases");
+      basis_out = basis;
+      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
+      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis_out, eval_mode, &q_comp));
+      if (eval_mode != CEED_EVAL_WEIGHT) {
+        // q_comp = 1 if CEED_EVAL_NONE, CEED_EVAL_WEIGHT caught by QF assembly
+        CeedCallBackend(CeedRealloc(num_eval_modes_out + q_comp, &eval_modes_out));
+        for (CeedInt d = 0; d < q_comp; d++) eval_modes_out[num_eval_modes_out + d] = eval_mode;
+        num_eval_modes_out += q_comp;
       }
     }
   }
@@ -696,95 +652,147 @@ static inline int CeedOperatorAssembleDiagonalSetup_Hip(CeedOperator op, CeedInt
   CeedCallBackend(CeedCalloc(1, &impl->diag));
   CeedOperatorDiag_Hip *diag = impl->diag;
 
-  diag->basis_in       = basis_in;
-  diag->basis_out      = basis_out;
-  diag->h_e_mode_in    = e_mode_in;
-  diag->h_e_mode_out   = e_mode_out;
-  diag->num_e_mode_in  = num_e_mode_in;
-  diag->num_e_mode_out = num_e_mode_out;
-
   // Assemble kernel
+  CeedCallBackend(CeedBasisGetNumNodes(basis_in, &num_nodes));
+  CeedCallBackend(CeedBasisGetNumComponents(basis_in, &num_comp));
+  if (basis_in == CEED_BASIS_NONE) num_qpts = num_nodes;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts));
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h", &diagonal_kernel_path));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Diagonal Assembly Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, diagonal_kernel_path, &diagonal_kernel_source));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Diagonal Assembly Source Complete! -----\n");
-  CeedInt num_modes, num_qpts;
-  CeedCallBackend(CeedBasisGetNumNodes(basis_in, &num_modes));
-  CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts));
-  diag->num_modes = num_modes;
-  CeedCallBackend(CeedCompile_Hip(ceed, diagonal_kernel_source, &diag->module, 6, "NUMEMODEIN", num_e_mode_in, "NUMEMODEOUT", num_e_mode_out,
-                                  "NNODES", num_modes, "NQPTS", num_qpts, "NCOMP", num_comp, "CEEDSIZE", use_ceedsize_idx));
-  CeedCallBackend(CeedGetKernel_Hip(ceed, diag->module, "linearDiagonal", &diag->linearDiagonal));
-  CeedCallBackend(CeedGetKernel_Hip(ceed, diag->module, "linearPointBlockDiagonal", &diag->linearPointBlock));
+  CeedCallHip(ceed,
+              CeedCompile_Hip(ceed, diagonal_kernel_source, &diag->module, 6, "NUM_EVAL_MODES_IN", num_eval_modes_in, "NUM_EVAL_MODES_OUT",
+                              num_eval_modes_out, "NUM_COMP", num_comp, "NUM_NODES", num_nodes, "NUM_QPTS", num_qpts, "CEED_SIZE", use_ceedsize_idx));
+  CeedCallHip(ceed, CeedGetKernel_Hip(ceed, diag->module, "LinearDiagonal", &diag->LinearDiagonal));
+  CeedCallHip(ceed, CeedGetKernel_Hip(ceed, diag->module, "LinearPointBlockDiagonal", &diag->LinearPointBlock));
   CeedCallBackend(CeedFree(&diagonal_kernel_path));
   CeedCallBackend(CeedFree(&diagonal_kernel_source));
 
   // Basis matrices
-  const CeedInt     q_bytes      = num_qpts * sizeof(CeedScalar);
-  const CeedInt     interp_bytes = q_bytes * num_modes;
-  const CeedInt     grad_bytes   = q_bytes * num_modes * dim;
-  const CeedInt     e_mode_bytes = sizeof(CeedEvalMode);
-  const CeedScalar *interp_in, *interp_out, *grad_in, *grad_out;
+  const CeedInt interp_bytes     = num_nodes * num_qpts * sizeof(CeedScalar);
+  const CeedInt eval_modes_bytes = sizeof(CeedEvalMode);
+  bool          has_eval_none    = false;
 
   // CEED_EVAL_NONE
-  CeedScalar *identity     = NULL;
-  bool        is_eval_none = false;
+  for (CeedInt i = 0; i < num_eval_modes_in; i++) has_eval_none = has_eval_none || (eval_modes_in[i] == CEED_EVAL_NONE);
+  for (CeedInt i = 0; i < num_eval_modes_out; i++) has_eval_none = has_eval_none || (eval_modes_out[i] == CEED_EVAL_NONE);
+  if (has_eval_none) {
+    CeedScalar *identity = NULL;
 
-  for (CeedInt i = 0; i < num_e_mode_in; i++) is_eval_none = is_eval_none || (e_mode_in[i] == CEED_EVAL_NONE);
-  for (CeedInt i = 0; i < num_e_mode_out; i++) is_eval_none = is_eval_none || (e_mode_out[i] == CEED_EVAL_NONE);
-  if (is_eval_none) {
-    CeedCallBackend(CeedCalloc(num_qpts * num_modes, &identity));
-    for (CeedInt i = 0; i < (num_modes < num_qpts ? num_modes : num_qpts); i++) identity[i * num_modes + i] = 1.0;
+    CeedCallBackend(CeedCalloc(num_nodes * num_qpts, &identity));
+    for (CeedInt i = 0; i < (num_nodes < num_qpts ? num_nodes : num_qpts); i++) identity[i * num_nodes + i] = 1.0;
     CeedCallHip(ceed, hipMalloc((void **)&diag->d_identity, interp_bytes));
     CeedCallHip(ceed, hipMemcpy(diag->d_identity, identity, interp_bytes, hipMemcpyHostToDevice));
+    CeedCallBackend(CeedFree(&identity));
   }
 
-  // CEED_EVAL_INTERP
-  CeedCallBackend(CeedBasisGetInterp(basis_in, &interp_in));
-  CeedCallHip(ceed, hipMalloc((void **)&diag->d_interp_in, interp_bytes));
-  CeedCallHip(ceed, hipMemcpy(diag->d_interp_in, interp_in, interp_bytes, hipMemcpyHostToDevice));
-  CeedCallBackend(CeedBasisGetInterp(basis_out, &interp_out));
-  CeedCallHip(ceed, hipMalloc((void **)&diag->d_interp_out, interp_bytes));
-  CeedCallHip(ceed, hipMemcpy(diag->d_interp_out, interp_out, interp_bytes, hipMemcpyHostToDevice));
+  // CEED_EVAL_INTERP, CEED_EVAL_GRAD, CEED_EVAL_DIV, and CEED_EVAL_CURL
+  for (CeedInt in = 0; in < 2; in++) {
+    CeedFESpace fespace;
+    CeedBasis   basis = in ? basis_in : basis_out;
 
-  // CEED_EVAL_GRAD
-  CeedCallBackend(CeedBasisGetGrad(basis_in, &grad_in));
-  CeedCallHip(ceed, hipMalloc((void **)&diag->d_grad_in, grad_bytes));
-  CeedCallHip(ceed, hipMemcpy(diag->d_grad_in, grad_in, grad_bytes, hipMemcpyHostToDevice));
-  CeedCallBackend(CeedBasisGetGrad(basis_out, &grad_out));
-  CeedCallHip(ceed, hipMalloc((void **)&diag->d_grad_out, grad_bytes));
-  CeedCallHip(ceed, hipMemcpy(diag->d_grad_out, grad_out, grad_bytes, hipMemcpyHostToDevice));
+    CeedCallBackend(CeedBasisGetFESpace(basis, &fespace));
+    switch (fespace) {
+      case CEED_FE_SPACE_H1: {
+        CeedInt           q_comp_interp, q_comp_grad;
+        const CeedScalar *interp, *grad;
+        CeedScalar       *d_interp, *d_grad;
 
-  // Arrays of e_modes
-  CeedCallHip(ceed, hipMalloc((void **)&diag->d_e_mode_in, num_e_mode_in * e_mode_bytes));
-  CeedCallHip(ceed, hipMemcpy(diag->d_e_mode_in, e_mode_in, num_e_mode_in * e_mode_bytes, hipMemcpyHostToDevice));
-  CeedCallHip(ceed, hipMalloc((void **)&diag->d_e_mode_out, num_e_mode_out * e_mode_bytes));
-  CeedCallHip(ceed, hipMemcpy(diag->d_e_mode_out, e_mode_out, num_e_mode_out * e_mode_bytes, hipMemcpyHostToDevice));
+        CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
+        CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_GRAD, &q_comp_grad));
 
-  // Restriction
-  diag->diag_rstr = rstr_out;
+        CeedCallBackend(CeedBasisGetInterp(basis, &interp));
+        CeedCallHip(ceed, hipMalloc((void **)&d_interp, interp_bytes * q_comp_interp));
+        CeedCallHip(ceed, hipMemcpy(d_interp, interp, interp_bytes * q_comp_interp, hipMemcpyHostToDevice));
+        CeedCallBackend(CeedBasisGetGrad(basis, &grad));
+        CeedCallHip(ceed, hipMalloc((void **)&d_grad, interp_bytes * q_comp_grad));
+        CeedCallHip(ceed, hipMemcpy(d_grad, grad, interp_bytes * q_comp_grad, hipMemcpyHostToDevice));
+        if (in) {
+          diag->d_interp_in = d_interp;
+          diag->d_grad_in   = d_grad;
+        } else {
+          diag->d_interp_out = d_interp;
+          diag->d_grad_out   = d_grad;
+        }
+      } break;
+      case CEED_FE_SPACE_HDIV: {
+        CeedInt           q_comp_interp, q_comp_div;
+        const CeedScalar *interp, *div;
+        CeedScalar       *d_interp, *d_div;
+
+        CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
+        CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_DIV, &q_comp_div));
+
+        CeedCallBackend(CeedBasisGetInterp(basis, &interp));
+        CeedCallHip(ceed, hipMalloc((void **)&d_interp, interp_bytes * q_comp_interp));
+        CeedCallHip(ceed, hipMemcpy(d_interp, interp, interp_bytes * q_comp_interp, hipMemcpyHostToDevice));
+        CeedCallBackend(CeedBasisGetDiv(basis, &div));
+        CeedCallHip(ceed, hipMalloc((void **)&d_div, interp_bytes * q_comp_div));
+        CeedCallHip(ceed, hipMemcpy(d_div, div, interp_bytes * q_comp_div, hipMemcpyHostToDevice));
+        if (in) {
+          diag->d_interp_in = d_interp;
+          diag->d_div_in    = d_div;
+        } else {
+          diag->d_interp_out = d_interp;
+          diag->d_div_out    = d_div;
+        }
+      } break;
+      case CEED_FE_SPACE_HCURL: {
+        CeedInt           q_comp_interp, q_comp_curl;
+        const CeedScalar *interp, *curl;
+        CeedScalar       *d_interp, *d_curl;
+
+        CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_INTERP, &q_comp_interp));
+        CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis, CEED_EVAL_CURL, &q_comp_curl));
+
+        CeedCallBackend(CeedBasisGetInterp(basis, &interp));
+        CeedCallHip(ceed, hipMalloc((void **)&d_interp, interp_bytes * q_comp_interp));
+        CeedCallHip(ceed, hipMemcpy(d_interp, interp, interp_bytes * q_comp_interp, hipMemcpyHostToDevice));
+        CeedCallBackend(CeedBasisGetCurl(basis, &curl));
+        CeedCallHip(ceed, hipMalloc((void **)&d_curl, interp_bytes * q_comp_curl));
+        CeedCallHip(ceed, hipMemcpy(d_curl, curl, interp_bytes * q_comp_curl, hipMemcpyHostToDevice));
+        if (in) {
+          diag->d_interp_in = d_interp;
+          diag->d_curl_in   = d_curl;
+        } else {
+          diag->d_interp_out = d_interp;
+          diag->d_curl_out   = d_curl;
+        }
+      } break;
+    }
+  }
+
+  // Arrays of eval_modes
+  CeedCallHip(ceed, hipMalloc((void **)&diag->d_eval_modes_in, num_eval_modes_in * eval_modes_bytes));
+  CeedCallHip(ceed, hipMemcpy(diag->d_eval_modes_in, eval_modes_in, num_eval_modes_in * eval_modes_bytes, hipMemcpyHostToDevice));
+  CeedCallHip(ceed, hipMalloc((void **)&diag->d_eval_modes_out, num_eval_modes_out * eval_modes_bytes));
+  CeedCallHip(ceed, hipMemcpy(diag->d_eval_modes_out, eval_modes_out, num_eval_modes_out * eval_modes_bytes, hipMemcpyHostToDevice));
+  CeedCallBackend(CeedFree(&eval_modes_in));
+  CeedCallBackend(CeedFree(&eval_modes_out));
   return CEED_ERROR_SUCCESS;
 }
 
 //------------------------------------------------------------------------------
-// Assemble diagonal common code
+// Assemble Diagonal Core
 //------------------------------------------------------------------------------
 static inline int CeedOperatorAssembleDiagonalCore_Hip(CeedOperator op, CeedVector assembled, CeedRequest *request, const bool is_point_block) {
   Ceed                ceed;
-  CeedSize            assembled_length = 0, assembled_qf_length = 0;
-  CeedInt             use_ceedsize_idx = 0, num_elem;
+  CeedSize            assembled_length, assembled_qf_length;
+  CeedInt             use_ceedsize_idx = 0, num_elem, num_nodes;
   CeedScalar         *elem_diag_array;
   const CeedScalar   *assembled_qf_array;
-  CeedVector          assembled_qf = NULL;
-  CeedElemRestriction rstr         = NULL;
+  CeedVector          assembled_qf   = NULL, elem_diag;
+  CeedElemRestriction assembled_rstr = NULL, rstr_in, rstr_out, diag_rstr;
   CeedOperator_Hip   *impl;
 
   CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
   CeedCallBackend(CeedOperatorGetData(op, &impl));
 
   // Assemble QFunction
-  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &rstr, request));
-  CeedCallBackend(CeedElemRestrictionDestroy(&rstr));
+  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &assembled_rstr, request));
+  CeedCallBackend(CeedElemRestrictionDestroy(&assembled_rstr));
+  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
 
   CeedCallBackend(CeedVectorGetLength(assembled, &assembled_length));
   CeedCallBackend(CeedVectorGetLength(assembled_qf, &assembled_qf_length));
@@ -796,39 +804,39 @@ static inline int CeedOperatorAssembleDiagonalCore_Hip(CeedOperator op, CeedVect
 
   assert(diag != NULL);
 
-  // Restriction
-  if (is_point_block && !diag->point_block_diag_rstr) {
-    CeedCallBackend(CeedOperatorCreateActivePointBlockRestriction(diag->diag_rstr, &diag->point_block_diag_rstr));
+  // Restriction and diagonal vector
+  CeedCallBackend(CeedOperatorGetActiveElemRestrictions(op, &rstr_in, &rstr_out));
+  CeedCheck(rstr_in == rstr_out, ceed, CEED_ERROR_BACKEND,
+            "Cannot assemble operator diagonal with different input and output active element restrictions");
+  if (!is_point_block && !diag->diag_rstr) {
+    CeedCallBackend(CeedElemRestrictionCreateUnsignedCopy(rstr_out, &diag->diag_rstr));
+    CeedCallBackend(CeedElemRestrictionCreateVector(diag->diag_rstr, NULL, &diag->elem_diag));
+  } else if (is_point_block && !diag->point_block_diag_rstr) {
+    CeedCallBackend(CeedOperatorCreateActivePointBlockRestriction(rstr_out, &diag->point_block_diag_rstr));
+    CeedCallBackend(CeedElemRestrictionCreateVector(diag->point_block_diag_rstr, NULL, &diag->point_block_elem_diag));
   }
-  CeedElemRestriction diag_rstr = is_point_block ? diag->point_block_diag_rstr : diag->diag_rstr;
-
-  // Create diagonal vector
-  CeedVector elem_diag = is_point_block ? diag->point_block_elem_diag : diag->elem_diag;
-
-  if (!elem_diag) {
-    CeedCallBackend(CeedElemRestrictionCreateVector(diag_rstr, NULL, &elem_diag));
-    if (is_point_block) diag->point_block_elem_diag = elem_diag;
-    else diag->elem_diag = elem_diag;
-  }
+  diag_rstr = is_point_block ? diag->point_block_diag_rstr : diag->diag_rstr;
+  elem_diag = is_point_block ? diag->point_block_elem_diag : diag->elem_diag;
   CeedCallBackend(CeedVectorSetValue(elem_diag, 0.0));
 
   // Only assemble diagonal if the basis has nodes, otherwise inputs are null pointers
-  if (diag->num_modes > 0) {
+  CeedCallBackend(CeedElemRestrictionGetElementSize(diag_rstr, &num_nodes));
+  if (num_nodes > 0) {
     // Assemble element operator diagonals
     CeedCallBackend(CeedVectorGetArray(elem_diag, CEED_MEM_DEVICE, &elem_diag_array));
-    CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
     CeedCallBackend(CeedElemRestrictionGetNumElements(diag_rstr, &num_elem));
 
     // Compute the diagonal of B^T D B
-    int   elem_per_block = 1;
-    int   grid           = num_elem / elem_per_block + ((num_elem / elem_per_block * elem_per_block < num_elem) ? 1 : 0);
-    void *args[]         = {(void *)&num_elem, &diag->d_identity,  &diag->d_interp_in,  &diag->d_grad_in,    &diag->d_interp_out,
-                            &diag->d_grad_out, &diag->d_e_mode_in, &diag->d_e_mode_out, &assembled_qf_array, &elem_diag_array};
+    CeedInt elems_per_block = 1;
+    CeedInt grid            = CeedDivUpInt(num_elem, elems_per_block);
+    void   *args[]          = {(void *)&num_elem,      &diag->d_identity,       &diag->d_interp_in,  &diag->d_grad_in, &diag->d_div_in,
+                               &diag->d_curl_in,       &diag->d_interp_out,     &diag->d_grad_out,   &diag->d_div_out, &diag->d_curl_out,
+                               &diag->d_eval_modes_in, &diag->d_eval_modes_out, &assembled_qf_array, &elem_diag_array};
 
     if (is_point_block) {
-      CeedCallBackend(CeedRunKernelDim_Hip(ceed, diag->linearPointBlock, grid, diag->num_modes, 1, elem_per_block, args));
+      CeedCallBackend(CeedRunKernelDim_Hip(ceed, diag->LinearPointBlock, grid, num_nodes, 1, elems_per_block, args));
     } else {
-      CeedCallBackend(CeedRunKernelDim_Hip(ceed, diag->linearDiagonal, grid, diag->num_modes, 1, elem_per_block, args));
+      CeedCallBackend(CeedRunKernelDim_Hip(ceed, diag->LinearDiagonal, grid, num_nodes, 1, elems_per_block, args));
     }
 
     // Restore arrays
@@ -861,13 +869,14 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Hip(CeedOperator op, 
 }
 
 //------------------------------------------------------------------------------
-// Single operator assembly setup
+// Single Operator Assembly Setup
 //------------------------------------------------------------------------------
 static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceedsize_idx) {
-  Ceed    ceed;
-  CeedInt num_input_fields, num_output_fields, num_e_mode_in = 0, dim = 1, num_B_in_mats_to_load = 0, size_B_in = 0, num_qpts = 0, elem_size = 0,
-                                               num_e_mode_out = 0, num_B_out_mats_to_load = 0, size_B_out = 0, num_elem, num_comp;
-  CeedEvalMode       *eval_mode_in = NULL, *eval_mode_out = NULL;
+  Ceed                ceed;
+  char               *assembly_kernel_path, *assembly_kernel_source;
+  CeedInt             num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
+  CeedInt             elem_size_in, num_qpts_in, num_comp_in, elem_size_out, num_qpts_out, num_comp_out, q_comp;
+  CeedEvalMode       *eval_modes_in = NULL, *eval_modes_out = NULL;
   CeedElemRestriction rstr_in = NULL, rstr_out = NULL;
   CeedBasis           basis_in = NULL, basis_out = NULL;
   CeedQFunctionField *qf_fields;
@@ -884,34 +893,30 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceed
   // Determine active input basis eval mode
   CeedCallBackend(CeedOperatorGetQFunction(op, &qf));
   CeedCallBackend(CeedQFunctionGetFields(qf, NULL, &qf_fields, NULL, NULL));
-  // Note that the kernel will treat each dimension of a gradient action separately;
-  // i.e., when an active input has a CEED_EVAL_GRAD mode, num_e_mode_in will increment by dim.
-  // However, for the purposes of loading the B matrices, it will be treated as one mode, and we will load/copy the entire gradient matrix at once, so
-  // num_B_in_mats_to_load will be incremented by 1.
   for (CeedInt i = 0; i < num_input_fields; i++) {
     CeedVector vec;
 
     CeedCallBackend(CeedOperatorFieldGetVector(input_fields[i], &vec));
     if (vec == CEED_VECTOR_ACTIVE) {
+      CeedBasis    basis;
       CeedEvalMode eval_mode;
 
-      CeedCallBackend(CeedOperatorFieldGetBasis(input_fields[i], &basis_in));
-      CeedCallBackend(CeedBasisGetDimension(basis_in, &dim));
-      CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts));
+      CeedCallBackend(CeedOperatorFieldGetBasis(input_fields[i], &basis));
+      CeedCheck(!basis_in || basis_in == basis, ceed, CEED_ERROR_BACKEND, "Backend does not implement operator assembly with multiple active bases");
+      basis_in = basis;
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr_in));
-      CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size));
+      CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+      if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
+      else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
-      if (eval_mode != CEED_EVAL_NONE) {
-        CeedCallBackend(CeedRealloc(num_B_in_mats_to_load + 1, &eval_mode_in));
-        eval_mode_in[num_B_in_mats_to_load] = eval_mode;
-        num_B_in_mats_to_load += 1;
-        if (eval_mode == CEED_EVAL_GRAD) {
-          num_e_mode_in += dim;
-          size_B_in += dim * elem_size * num_qpts;
-        } else {
-          num_e_mode_in += 1;
-          size_B_in += elem_size * num_qpts;
+      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis_in, eval_mode, &q_comp));
+      if (eval_mode != CEED_EVAL_WEIGHT) {
+        // q_comp = 1 if CEED_EVAL_NONE, CEED_EVAL_WEIGHT caught by QF Assembly
+        CeedCallBackend(CeedRealloc(num_eval_modes_in + q_comp, &eval_modes_in));
+        for (CeedInt d = 0; d < q_comp; d++) {
+          eval_modes_in[num_eval_modes_in + d] = eval_mode;
         }
+        num_eval_modes_in += q_comp;
       }
     }
   }
@@ -923,106 +928,133 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceed
 
     CeedCallBackend(CeedOperatorFieldGetVector(output_fields[i], &vec));
     if (vec == CEED_VECTOR_ACTIVE) {
+      CeedBasis    basis;
       CeedEvalMode eval_mode;
 
-      CeedCallBackend(CeedOperatorFieldGetBasis(output_fields[i], &basis_out));
+      CeedCallBackend(CeedOperatorFieldGetBasis(output_fields[i], &basis));
+      CeedCheck(!basis_out || basis_out == basis, ceed, CEED_ERROR_BACKEND,
+                "Backend does not implement operator assembly with multiple active bases");
+      basis_out = basis;
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr_out));
-      CeedCheck(!rstr_out || rstr_out == rstr_in, ceed, CEED_ERROR_BACKEND, "Backend does not implement multi-field non-composite operator assembly");
+      CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+      if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
+      else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
+      CeedCheck(num_qpts_in == num_qpts_out, ceed, CEED_ERROR_UNSUPPORTED,
+                "Active input and output bases must have the same number of quadrature points");
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
-      if (eval_mode != CEED_EVAL_NONE) {
-        CeedCallBackend(CeedRealloc(num_B_out_mats_to_load + 1, &eval_mode_out));
-        eval_mode_out[num_B_out_mats_to_load] = eval_mode;
-        num_B_out_mats_to_load += 1;
-        if (eval_mode == CEED_EVAL_GRAD) {
-          num_e_mode_out += dim;
-          size_B_out += dim * elem_size * num_qpts;
-        } else {
-          num_e_mode_out += 1;
-          size_B_out += elem_size * num_qpts;
+      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis_out, eval_mode, &q_comp));
+      if (eval_mode != CEED_EVAL_WEIGHT) {
+        // q_comp = 1 if CEED_EVAL_NONE, CEED_EVAL_WEIGHT caught by QF Assembly
+        CeedCallBackend(CeedRealloc(num_eval_modes_out + q_comp, &eval_modes_out));
+        for (CeedInt d = 0; d < q_comp; d++) {
+          eval_modes_out[num_eval_modes_out + d] = eval_mode;
         }
+        num_eval_modes_out += q_comp;
       }
     }
   }
-
-  CeedCheck(num_e_mode_in > 0 && num_e_mode_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
-
-  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp));
+  CeedCheck(num_eval_modes_in > 0 && num_eval_modes_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
 
   CeedCallBackend(CeedCalloc(1, &impl->asmb));
   CeedOperatorAssemble_Hip *asmb = impl->asmb;
-  asmb->num_elem                 = num_elem;
+  asmb->elems_per_block          = 1;
+  asmb->block_size_x             = elem_size_in;
+  asmb->block_size_y             = elem_size_out;
+
+  bool fallback = asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block > 1024;
+
+  if (fallback) {
+    // Use fallback kernel with 1D threadblock
+    asmb->block_size_y = 1;
+  }
 
   // Compile kernels
-  int elem_per_block   = 1;
-  asmb->elem_per_block = elem_per_block;
-  CeedInt block_size   = elem_size * elem_size * elem_per_block;
-  char   *assembly_kernel_path, *assembly_kernel_source;
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-operator-assemble.h", &assembly_kernel_path));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Assembly Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, assembly_kernel_path, &assembly_kernel_source));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Assembly Source Complete! -----\n");
-  bool fallback = block_size > 1024;
-  if (fallback) {  // Use fallback kernel with 1D threadblock
-    block_size         = elem_size * elem_per_block;
-    asmb->block_size_x = elem_size;
-    asmb->block_size_y = 1;
-  } else {  // Use kernel with 2D threadblock
-    asmb->block_size_x = elem_size;
-    asmb->block_size_y = elem_size;
-  }
-  CeedCallBackend(CeedCompile_Hip(ceed, assembly_kernel_source, &asmb->module, 8, "NELEM", num_elem, "NUMEMODEIN", num_e_mode_in, "NUMEMODEOUT",
-                                  num_e_mode_out, "NQPTS", num_qpts, "NNODES", elem_size, "BLOCK_SIZE", block_size, "NCOMP", num_comp, "CEEDSIZE",
+  CeedCallBackend(CeedCompile_Hip(ceed, assembly_kernel_source, &asmb->module, 10, "NUM_EVAL_MODES_IN", num_eval_modes_in, "NUM_EVAL_MODES_OUT",
+                                  num_eval_modes_out, "NUM_COMP_IN", num_comp_in, "NUM_COMP_OUT", num_comp_out, "NUM_NODES_IN", elem_size_in,
+                                  "NUM_NODES_OUT", elem_size_out, "NUM_QPTS", num_qpts_in, "BLOCK_SIZE",
+                                  asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block, "BLOCK_SIZE_Y", asmb->block_size_y, "CEED_SIZE",
                                   use_ceedsize_idx));
-  CeedCallBackend(CeedGetKernel_Hip(ceed, asmb->module, fallback ? "linearAssembleFallback" : "linearAssemble", &asmb->linearAssemble));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, asmb->module, "LinearAssemble", &asmb->LinearAssemble));
   CeedCallBackend(CeedFree(&assembly_kernel_path));
   CeedCallBackend(CeedFree(&assembly_kernel_source));
 
-  // Build 'full' B matrices (not 1D arrays used for tensor-product matrices)
-  const CeedScalar *interp_in, *grad_in;
-  CeedCallBackend(CeedBasisGetInterp(basis_in, &interp_in));
-  CeedCallBackend(CeedBasisGetGrad(basis_in, &grad_in));
+  // Load into B_in, in order that they will be used in eval_modes_in
+  {
+    const CeedInt in_bytes           = elem_size_in * num_qpts_in * num_eval_modes_in * sizeof(CeedScalar);
+    CeedInt       d_in               = 0;
+    CeedEvalMode  eval_modes_in_prev = CEED_EVAL_NONE;
+    bool          has_eval_none      = false;
+    CeedScalar   *identity           = NULL;
 
-  // Load into B_in, in order that they will be used in eval_mode
-  const CeedInt in_bytes  = size_B_in * sizeof(CeedScalar);
-  CeedInt       mat_start = 0;
+    for (CeedInt i = 0; i < num_eval_modes_in; i++) {
+      has_eval_none = has_eval_none || (eval_modes_in[i] == CEED_EVAL_NONE);
+    }
+    if (has_eval_none) {
+      CeedCallBackend(CeedCalloc(elem_size_in * num_qpts_in, &identity));
+      for (CeedInt i = 0; i < (elem_size_in < num_qpts_in ? elem_size_in : num_qpts_in); i++) identity[i * elem_size_in + i] = 1.0;
+    }
 
-  CeedCallHip(ceed, hipMalloc((void **)&asmb->d_B_in, in_bytes));
-  for (int i = 0; i < num_B_in_mats_to_load; i++) {
-    CeedEvalMode eval_mode = eval_mode_in[i];
-    if (eval_mode == CEED_EVAL_INTERP) {
-      CeedCallHip(ceed, hipMemcpy(&asmb->d_B_in[mat_start], interp_in, elem_size * num_qpts * sizeof(CeedScalar), hipMemcpyHostToDevice));
-      mat_start += elem_size * num_qpts;
-    } else if (eval_mode == CEED_EVAL_GRAD) {
-      CeedCallHip(ceed, hipMemcpy(&asmb->d_B_in[mat_start], grad_in, dim * elem_size * num_qpts * sizeof(CeedScalar), hipMemcpyHostToDevice));
-      mat_start += dim * elem_size * num_qpts;
+    CeedCallHip(ceed, hipMalloc((void **)&asmb->d_B_in, in_bytes));
+    for (CeedInt i = 0; i < num_eval_modes_in; i++) {
+      const CeedScalar *h_B_in;
+
+      CeedCallBackend(CeedOperatorGetBasisPointer(basis_in, eval_modes_in[i], identity, &h_B_in));
+      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis_in, eval_modes_in[i], &q_comp));
+      if (q_comp > 1) {
+        if (i == 0 || eval_modes_in[i] != eval_modes_in_prev) d_in = 0;
+        else h_B_in = &h_B_in[(++d_in) * elem_size_in * num_qpts_in];
+      }
+      eval_modes_in_prev = eval_modes_in[i];
+
+      CeedCallHip(ceed, hipMemcpy(&asmb->d_B_in[i * elem_size_in * num_qpts_in], h_B_in, elem_size_in * num_qpts_in * sizeof(CeedScalar),
+                                  hipMemcpyHostToDevice));
+    }
+
+    if (identity) {
+      CeedCallBackend(CeedFree(&identity));
     }
   }
 
-  const CeedScalar *interp_out, *grad_out;
+  // Load into B_out, in order that they will be used in eval_modes_out
+  {
+    const CeedInt out_bytes           = elem_size_out * num_qpts_out * num_eval_modes_out * sizeof(CeedScalar);
+    CeedInt       d_out               = 0;
+    CeedEvalMode  eval_modes_out_prev = CEED_EVAL_NONE;
+    bool          has_eval_none       = false;
+    CeedScalar   *identity            = NULL;
 
-  // Note that this function currently assumes 1 basis, so this should always be true for now
-  if (basis_out == basis_in) {
-    interp_out = interp_in;
-    grad_out   = grad_in;
-  } else {
-    CeedCallBackend(CeedBasisGetInterp(basis_out, &interp_out));
-    CeedCallBackend(CeedBasisGetGrad(basis_out, &grad_out));
-  }
+    for (CeedInt i = 0; i < num_eval_modes_out; i++) {
+      has_eval_none = has_eval_none || (eval_modes_out[i] == CEED_EVAL_NONE);
+    }
+    if (has_eval_none) {
+      CeedCallBackend(CeedCalloc(elem_size_out * num_qpts_out, &identity));
+      for (CeedInt i = 0; i < (elem_size_out < num_qpts_out ? elem_size_out : num_qpts_out); i++) identity[i * elem_size_out + i] = 1.0;
+    }
 
-  // Load into B_out, in order that they will be used in eval_mode
-  const CeedInt out_bytes = size_B_out * sizeof(CeedScalar);
+    CeedCallHip(ceed, hipMalloc((void **)&asmb->d_B_out, out_bytes));
+    for (CeedInt i = 0; i < num_eval_modes_out; i++) {
+      const CeedScalar *h_B_out;
 
-  mat_start = 0;
-  CeedCallHip(ceed, hipMalloc((void **)&asmb->d_B_out, out_bytes));
-  for (int i = 0; i < num_B_out_mats_to_load; i++) {
-    CeedEvalMode eval_mode = eval_mode_out[i];
-    if (eval_mode == CEED_EVAL_INTERP) {
-      CeedCallHip(ceed, hipMemcpy(&asmb->d_B_out[mat_start], interp_out, elem_size * num_qpts * sizeof(CeedScalar), hipMemcpyHostToDevice));
-      mat_start += elem_size * num_qpts;
-    } else if (eval_mode == CEED_EVAL_GRAD) {
-      CeedCallHip(ceed, hipMemcpy(&asmb->d_B_out[mat_start], grad_out, dim * elem_size * num_qpts * sizeof(CeedScalar), hipMemcpyHostToDevice));
-      mat_start += dim * elem_size * num_qpts;
+      CeedCallBackend(CeedOperatorGetBasisPointer(basis_out, eval_modes_out[i], identity, &h_B_out));
+      CeedCallBackend(CeedBasisGetNumQuadratureComponents(basis_out, eval_modes_out[i], &q_comp));
+      if (q_comp > 1) {
+        if (i == 0 || eval_modes_out[i] != eval_modes_out_prev) d_out = 0;
+        else h_B_out = &h_B_out[(++d_out) * elem_size_out * num_qpts_out];
+      }
+      eval_modes_out_prev = eval_modes_out[i];
+
+      CeedCallHip(ceed, hipMemcpy(&asmb->d_B_out[i * elem_size_out * num_qpts_out], h_B_out, elem_size_out * num_qpts_out * sizeof(CeedScalar),
+                                  hipMemcpyHostToDevice));
+    }
+
+    if (identity) {
+      CeedCallBackend(CeedFree(&identity));
     }
   }
   return CEED_ERROR_SUCCESS;
@@ -1039,47 +1071,96 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceed
 static int CeedSingleOperatorAssemble_Hip(CeedOperator op, CeedInt offset, CeedVector values) {
   Ceed                ceed;
   CeedSize            values_length = 0, assembled_qf_length = 0;
-  CeedInt             use_ceedsize_idx = 0;
+  CeedInt             use_ceedsize_idx = 0, num_elem_in, num_elem_out, elem_size_in, elem_size_out;
   CeedScalar         *values_array;
-  const CeedScalar   *qf_array;
-  CeedVector          assembled_qf = NULL;
-  CeedElemRestriction rstr_q       = NULL;
+  const CeedScalar   *assembled_qf_array;
+  CeedVector          assembled_qf   = NULL;
+  CeedElemRestriction assembled_rstr = NULL, rstr_in, rstr_out;
+  CeedRestrictionType rstr_type_in, rstr_type_out;
+  const bool         *orients_in = NULL, *orients_out = NULL;
+  const CeedInt8     *curl_orients_in = NULL, *curl_orients_out = NULL;
   CeedOperator_Hip   *impl;
 
   CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
   CeedCallBackend(CeedOperatorGetData(op, &impl));
 
   // Assemble QFunction
-  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &rstr_q, CEED_REQUEST_IMMEDIATE));
-  CeedCallBackend(CeedElemRestrictionDestroy(&rstr_q));
-  CeedCallBackend(CeedVectorGetArray(values, CEED_MEM_DEVICE, &values_array));
-  values_array += offset;
-  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &qf_array));
+  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &assembled_rstr, CEED_REQUEST_IMMEDIATE));
+  CeedCallBackend(CeedElemRestrictionDestroy(&assembled_rstr));
+  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
 
   CeedCallBackend(CeedVectorGetLength(values, &values_length));
   CeedCallBackend(CeedVectorGetLength(assembled_qf, &assembled_qf_length));
   if ((values_length > INT_MAX) || (assembled_qf_length > INT_MAX)) use_ceedsize_idx = 1;
+
   // Setup
-  if (!impl->asmb) {
-    CeedCallBackend(CeedSingleOperatorAssembleSetup_Hip(op, use_ceedsize_idx));
-    assert(impl->asmb != NULL);
+  if (!impl->asmb) CeedCallBackend(CeedSingleOperatorAssembleSetup_Hip(op, use_ceedsize_idx));
+  CeedOperatorAssemble_Hip *asmb = impl->asmb;
+
+  assert(asmb != NULL);
+
+  // Assemble element operator
+  CeedCallBackend(CeedVectorGetArray(values, CEED_MEM_DEVICE, &values_array));
+  values_array += offset;
+
+  CeedCallBackend(CeedOperatorGetActiveElemRestrictions(op, &rstr_in, &rstr_out));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+
+  CeedCallBackend(CeedElemRestrictionGetType(rstr_in, &rstr_type_in));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_in, CEED_MEM_DEVICE, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_in, CEED_MEM_DEVICE, &curl_orients_in));
+  }
+
+  if (rstr_in != rstr_out) {
+    CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
+    CeedCheck(num_elem_in == num_elem_out, ceed, CEED_ERROR_UNSUPPORTED,
+              "Active input and output operator restrictions must have the same number of elements");
+    CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+
+    CeedCallBackend(CeedElemRestrictionGetType(rstr_out, &rstr_type_out));
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_out, CEED_MEM_DEVICE, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_out, CEED_MEM_DEVICE, &curl_orients_out));
+    }
+  } else {
+    elem_size_out    = elem_size_in;
+    orients_out      = orients_in;
+    curl_orients_out = curl_orients_in;
   }
 
   // Compute B^T D B
-  const CeedInt num_elem       = impl->asmb->num_elem;
-  const CeedInt elem_per_block = impl->asmb->elem_per_block;
-  const CeedInt grid           = num_elem / elem_per_block + ((num_elem / elem_per_block * elem_per_block < num_elem) ? 1 : 0);
-  void         *args[]         = {&impl->asmb->d_B_in, &impl->asmb->d_B_out, &qf_array, &values_array};
+  CeedInt shared_mem =
+      ((curl_orients_in || curl_orients_out ? elem_size_in * elem_size_out : 0) + (curl_orients_in ? elem_size_in * asmb->block_size_y : 0)) *
+      sizeof(CeedScalar);
+  CeedInt grid   = CeedDivUpInt(num_elem_in, asmb->elems_per_block);
+  void   *args[] = {(void *)&num_elem_in, &asmb->d_B_in,     &asmb->d_B_out,      &orients_in,  &curl_orients_in,
+                    &orients_out,         &curl_orients_out, &assembled_qf_array, &values_array};
 
   CeedCallBackend(
-      CeedRunKernelDim_Hip(ceed, impl->asmb->linearAssemble, grid, impl->asmb->block_size_x, impl->asmb->block_size_y, elem_per_block, args));
+      CeedRunKernelDimShared_Hip(ceed, asmb->LinearAssemble, grid, asmb->block_size_x, asmb->block_size_y, asmb->elems_per_block, shared_mem, args));
 
   // Restore arrays
   CeedCallBackend(CeedVectorRestoreArray(values, &values_array));
-  CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &qf_array));
+  CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
 
   // Cleanup
   CeedCallBackend(CeedVectorDestroy(&assembled_qf));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_in, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_in, &curl_orients_in));
+  }
+  if (rstr_in != rstr_out) {
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_out, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_out, &curl_orients_out));
+    }
+  }
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -18,22 +18,23 @@
 #include "ceed-hip-ref.h"
 
 //------------------------------------------------------------------------------
-// Apply restriction
+// Core apply restriction code
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionApply_Hip(CeedElemRestriction r, CeedTransposeMode t_mode, CeedVector u, CeedVector v, CeedRequest *request) {
+static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, CeedTransposeMode t_mode, bool use_signs, bool use_orients,
+                                                    CeedVector u, CeedVector v, CeedRequest *request) {
   Ceed                     ceed;
-  Ceed_Hip                *data;
   CeedInt                  num_elem, elem_size;
+  CeedRestrictionType      rstr_type;
   const CeedScalar        *d_u;
   CeedScalar              *d_v;
   CeedElemRestriction_Hip *impl;
   hipFunction_t            kernel;
 
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedGetData(ceed, &data));
-  CeedElemRestrictionGetNumElements(r, &num_elem);
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
   const CeedInt num_nodes = impl->num_nodes;
 
   // Get vectors
@@ -49,45 +50,124 @@ static int CeedElemRestrictionApply_Hip(CeedElemRestriction r, CeedTransposeMode
   // Restrict
   if (t_mode == CEED_NOTRANSPOSE) {
     // L-vector -> E-vector
-    if (impl->d_ind) {
-      // -- Offsets provided
-      kernel             = impl->OffsetNoTranspose;
-      void   *args[]     = {&num_elem, &impl->d_ind, &d_u, &d_v};
-      CeedInt block_size = elem_size < 256 ? (elem_size > 64 ? elem_size : 64) : 256;
+    const CeedInt block_size = elem_size < 256 ? (elem_size > 64 ? elem_size : 64) : 256;
+    const CeedInt grid       = CeedDivUpInt(num_nodes, block_size);
 
-      CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
-    } else {
-      // -- Strided restriction
-      kernel             = impl->StridedNoTranspose;
-      void   *args[]     = {&num_elem, &d_u, &d_v};
-      CeedInt block_size = elem_size < 256 ? (elem_size > 64 ? elem_size : 64) : 256;
+    switch (rstr_type) {
+      case CEED_RESTRICTION_STRIDED: {
+        kernel       = impl->StridedNoTranspose;
+        void *args[] = {&num_elem, &d_u, &d_v};
 
-      CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
+        CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+      } break;
+      case CEED_RESTRICTION_STANDARD: {
+        kernel       = impl->OffsetNoTranspose;
+        void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+        CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+      } break;
+      case CEED_RESTRICTION_ORIENTED: {
+        if (use_signs) {
+          kernel       = impl->OrientedNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else {
+          kernel       = impl->OffsetNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        }
+      } break;
+      case CEED_RESTRICTION_CURL_ORIENTED: {
+        if (use_signs && use_orients) {
+          kernel       = impl->CurlOrientedNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else if (use_orients) {
+          kernel       = impl->CurlOrientedUnsignedNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else {
+          kernel       = impl->OffsetNoTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        }
+      } break;
     }
   } else {
     // E-vector -> L-vector
-    if (impl->d_ind) {
-      // -- Offsets provided
-      CeedInt block_size = 64;
+    const CeedInt block_size = 64;
+    const CeedInt grid       = CeedDivUpInt(num_nodes, block_size);
 
-      if (impl->OffsetTranspose) {
-        kernel       = impl->OffsetTranspose;
-        void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+    switch (rstr_type) {
+      case CEED_RESTRICTION_STRIDED: {
+        kernel       = impl->StridedTranspose;
+        void *args[] = {&num_elem, &d_u, &d_v};
 
-        CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
-      } else {
-        kernel       = impl->OffsetTransposeDet;
-        void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
+        CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+      } break;
+      case CEED_RESTRICTION_STANDARD: {
+        if (impl->OffsetTranspose) {
+          kernel       = impl->OffsetTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
 
-        CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
-      }
-    } else {
-      // -- Strided restriction
-      kernel             = impl->StridedTranspose;
-      void   *args[]     = {&num_elem, &d_u, &d_v};
-      CeedInt block_size = 64;
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else {
+          kernel       = impl->OffsetTransposeDet;
+          void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
 
-      CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, CeedDivUpInt(num_nodes, block_size), block_size, args));
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        }
+      } break;
+      case CEED_RESTRICTION_ORIENTED: {
+        if (use_signs) {
+          kernel       = impl->OrientedTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else {
+          if (impl->OffsetTranspose) {
+            kernel       = impl->OffsetTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->OffsetTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          }
+        }
+      } break;
+      case CEED_RESTRICTION_CURL_ORIENTED: {
+        if (use_signs && use_orients) {
+          kernel       = impl->CurlOrientedTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else if (use_orients) {
+          kernel       = impl->CurlOrientedUnsignedTranspose;
+          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+
+          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+        } else {
+          if (impl->OffsetTranspose) {
+            kernel       = impl->OffsetTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->OffsetTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          }
+        }
+      } break;
     }
   }
 
@@ -97,6 +177,29 @@ static int CeedElemRestrictionApply_Hip(CeedElemRestriction r, CeedTransposeMode
   CeedCallBackend(CeedVectorRestoreArrayRead(u, &d_u));
   CeedCallBackend(CeedVectorRestoreArray(v, &d_v));
   return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Apply restriction
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionApply_Hip(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v, CeedRequest *request) {
+  return CeedElemRestrictionApply_Hip_Core(rstr, t_mode, true, true, u, v, request);
+}
+
+//------------------------------------------------------------------------------
+// Apply unsigned restriction
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionApplyUnsigned_Hip(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v,
+                                                CeedRequest *request) {
+  return CeedElemRestrictionApply_Hip_Core(rstr, t_mode, false, true, u, v, request);
+}
+
+//------------------------------------------------------------------------------
+// Apply unoriented restriction
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionApplyUnoriented_Hip(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v,
+                                                  CeedRequest *request) {
+  return CeedElemRestrictionApply_Hip_Core(rstr, t_mode, false, false, u, v, request);
 }
 
 //------------------------------------------------------------------------------
@@ -118,20 +221,60 @@ static int CeedElemRestrictionGetOffsets_Hip(CeedElemRestriction rstr, CeedMemTy
 }
 
 //------------------------------------------------------------------------------
+// Get orientations
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionGetOrientations_Hip(CeedElemRestriction rstr, CeedMemType mem_type, const bool **orients) {
+  CeedElemRestriction_Hip *impl;
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+
+  switch (mem_type) {
+    case CEED_MEM_HOST:
+      *orients = impl->h_orients;
+      break;
+    case CEED_MEM_DEVICE:
+      *orients = impl->d_orients;
+      break;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Get curl-conforming orientations
+//------------------------------------------------------------------------------
+static int CeedElemRestrictionGetCurlOrientations_Hip(CeedElemRestriction rstr, CeedMemType mem_type, const CeedInt8 **curl_orients) {
+  CeedElemRestriction_Hip *impl;
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+
+  switch (mem_type) {
+    case CEED_MEM_HOST:
+      *curl_orients = impl->h_curl_orients;
+      break;
+    case CEED_MEM_DEVICE:
+      *curl_orients = impl->d_curl_orients;
+      break;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
 // Destroy restriction
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionDestroy_Hip(CeedElemRestriction r) {
+static int CeedElemRestrictionDestroy_Hip(CeedElemRestriction rstr) {
   Ceed                     ceed;
   CeedElemRestriction_Hip *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
   CeedCallHip(ceed, hipModuleUnload(impl->module));
   CeedCallBackend(CeedFree(&impl->h_ind_allocated));
   CeedCallHip(ceed, hipFree(impl->d_ind_allocated));
   CeedCallHip(ceed, hipFree(impl->d_t_offsets));
   CeedCallHip(ceed, hipFree(impl->d_t_indices));
   CeedCallHip(ceed, hipFree(impl->d_l_vec_indices));
+  CeedCallBackend(CeedFree(&impl->h_orients_allocated));
+  CeedCallHip(ceed, hipFree(impl->d_orients_allocated));
+  CeedCallBackend(CeedFree(&impl->h_curl_orients_allocated));
+  CeedCallHip(ceed, hipFree(impl->d_curl_orients_allocated));
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
 }
@@ -139,23 +282,25 @@ static int CeedElemRestrictionDestroy_Hip(CeedElemRestriction r) {
 //------------------------------------------------------------------------------
 // Create transpose offsets and indices
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionOffset_Hip(const CeedElemRestriction r, const CeedInt *indices) {
+static int CeedElemRestrictionOffset_Hip(const CeedElemRestriction rstr, const CeedInt *indices) {
   Ceed                     ceed;
   bool                    *is_node;
   CeedSize                 l_size;
-  CeedInt                  num_elem, elem_size, num_comp, num_nodes = 0, *ind_to_offset, *l_vec_indices, *t_offsets, *t_indices;
+  CeedInt                  num_elem, elem_size, num_comp, num_nodes = 0;
+  CeedInt                 *ind_to_offset, *l_vec_indices, *t_offsets, *t_indices;
   CeedElemRestriction_Hip *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(r, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
-  CeedCallBackend(CeedElemRestrictionGetLVectorSize(r, &l_size));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(r, &num_comp));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetLVectorSize(rstr, &l_size));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr, &num_comp));
   const CeedInt size_indices = num_elem * elem_size;
 
   // Count num_nodes
   CeedCallBackend(CeedCalloc(l_size, &is_node));
+
   for (CeedInt i = 0; i < size_indices; i++) is_node[indices[i]] = 1;
   for (CeedInt i = 0; i < l_size; i++) num_nodes += is_node[i];
   impl->num_nodes = num_nodes;
@@ -218,119 +363,195 @@ static int CeedElemRestrictionOffset_Hip(const CeedElemRestriction r, const Ceed
 // Create restriction
 //------------------------------------------------------------------------------
 int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
-                                  const CeedInt8 *curl_orients, CeedElemRestriction r) {
+                                  const CeedInt8 *curl_orients, CeedElemRestriction rstr) {
   Ceed                     ceed, ceed_parent;
-  bool                     is_deterministic, is_strided;
-  char                    *restriction_kernel_path, *restriction_kernel_source;
+  bool                     is_deterministic;
   CeedInt                  num_elem, num_comp, elem_size, comp_stride = 1;
   CeedRestrictionType      rstr_type;
+  char                    *restriction_kernel_path, *restriction_kernel_source;
   CeedElemRestriction_Hip *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedCalloc(1, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
   CeedCallBackend(CeedGetParent(ceed, &ceed_parent));
   CeedCallBackend(CeedIsDeterministic(ceed_parent, &is_deterministic));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(r, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(r, &num_comp));
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
-  CeedInt size       = num_elem * elem_size;
-  CeedInt strides[3] = {1, size, elem_size};
-  CeedInt layout[3]  = {1, elem_size * num_elem, elem_size};
-
-  CeedCallBackend(CeedElemRestrictionGetType(r, &rstr_type));
-  CeedCheck(rstr_type != CEED_RESTRICTION_ORIENTED && rstr_type != CEED_RESTRICTION_CURL_ORIENTED, ceed, CEED_ERROR_BACKEND,
-            "Backend does not implement CeedElemRestrictionCreateOriented or CeedElemRestrictionCreateCurlOriented");
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr, &num_comp));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  const CeedInt size       = num_elem * elem_size;
+  CeedInt       strides[3] = {1, size, elem_size};
+  CeedInt       layout[3]  = {1, elem_size * num_elem, elem_size};
 
   // Stride data
-  CeedCallBackend(CeedElemRestrictionIsStrided(r, &is_strided));
-  if (is_strided) {
+  CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
+  if (rstr_type == CEED_RESTRICTION_STRIDED) {
     bool has_backend_strides;
 
-    CeedCallBackend(CeedElemRestrictionHasBackendStrides(r, &has_backend_strides));
+    CeedCallBackend(CeedElemRestrictionHasBackendStrides(rstr, &has_backend_strides));
     if (!has_backend_strides) {
-      CeedCallBackend(CeedElemRestrictionGetStrides(r, &strides));
+      CeedCallBackend(CeedElemRestrictionGetStrides(rstr, &strides));
     }
   } else {
-    CeedCallBackend(CeedElemRestrictionGetCompStride(r, &comp_stride));
+    CeedCallBackend(CeedElemRestrictionGetCompStride(rstr, &comp_stride));
   }
 
-  impl->h_ind           = NULL;
-  impl->h_ind_allocated = NULL;
-  impl->d_ind           = NULL;
-  impl->d_ind_allocated = NULL;
-  impl->d_t_indices     = NULL;
-  impl->d_t_offsets     = NULL;
-  impl->num_nodes       = size;
-  CeedCallBackend(CeedElemRestrictionSetData(r, impl));
-  CeedCallBackend(CeedElemRestrictionSetELayout(r, layout));
+  CeedCallBackend(CeedCalloc(1, &impl));
+  impl->num_nodes                = size;
+  impl->h_ind                    = NULL;
+  impl->h_ind_allocated          = NULL;
+  impl->d_ind                    = NULL;
+  impl->d_ind_allocated          = NULL;
+  impl->d_t_indices              = NULL;
+  impl->d_t_offsets              = NULL;
+  impl->h_orients                = NULL;
+  impl->h_orients_allocated      = NULL;
+  impl->d_orients                = NULL;
+  impl->d_orients_allocated      = NULL;
+  impl->h_curl_orients           = NULL;
+  impl->h_curl_orients_allocated = NULL;
+  impl->d_curl_orients           = NULL;
+  impl->d_curl_orients_allocated = NULL;
+  CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
+  CeedCallBackend(CeedElemRestrictionSetELayout(rstr, layout));
 
-  // Set up device indices/offset arrays
-  switch (mem_type) {
-    case CEED_MEM_HOST: {
-      switch (copy_mode) {
-        case CEED_OWN_POINTER:
-          impl->h_ind_allocated = (CeedInt *)indices;
-          impl->h_ind           = (CeedInt *)indices;
-          break;
-        case CEED_USE_POINTER:
-          impl->h_ind = (CeedInt *)indices;
-          break;
-        case CEED_COPY_VALUES:
-          if (indices != NULL) {
-            CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-            memcpy(impl->h_ind_allocated, indices, elem_size * num_elem * sizeof(CeedInt));
+  // Set up device offset/orientation arrays
+  if (rstr_type != CEED_RESTRICTION_STRIDED) {
+    switch (mem_type) {
+      case CEED_MEM_HOST: {
+        switch (copy_mode) {
+          case CEED_OWN_POINTER:
+            impl->h_ind_allocated = (CeedInt *)indices;
+            impl->h_ind           = (CeedInt *)indices;
+            break;
+          case CEED_USE_POINTER:
+            impl->h_ind = (CeedInt *)indices;
+            break;
+          case CEED_COPY_VALUES:
+            CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
+            memcpy(impl->h_ind_allocated, indices, size * sizeof(CeedInt));
             impl->h_ind = impl->h_ind_allocated;
-          }
-          break;
-      }
-      if (indices != NULL) {
+            break;
+        }
         CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
         impl->d_ind_allocated = impl->d_ind;  // We own the device memory
         CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyHostToDevice));
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(r, indices));
-      }
-      break;
-    }
-    case CEED_MEM_DEVICE: {
-      switch (copy_mode) {
-        case CEED_COPY_VALUES:
-          if (indices != NULL) {
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(rstr, indices));
+      } break;
+      case CEED_MEM_DEVICE: {
+        switch (copy_mode) {
+          case CEED_COPY_VALUES:
             CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
             impl->d_ind_allocated = impl->d_ind;  // We own the device memory
             CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyDeviceToDevice));
-          }
-          break;
-        case CEED_OWN_POINTER:
-          impl->d_ind           = (CeedInt *)indices;
-          impl->d_ind_allocated = impl->d_ind;
-          break;
-        case CEED_USE_POINTER:
-          impl->d_ind = (CeedInt *)indices;
-      }
-      if (indices != NULL) {
-        CeedCallBackend(CeedMalloc(elem_size * num_elem, &impl->h_ind_allocated));
-        CeedCallHip(ceed, hipMemcpy(impl->h_ind_allocated, impl->d_ind, elem_size * num_elem * sizeof(CeedInt), hipMemcpyDeviceToHost));
+            break;
+          case CEED_OWN_POINTER:
+            impl->d_ind           = (CeedInt *)indices;
+            impl->d_ind_allocated = impl->d_ind;
+            break;
+          case CEED_USE_POINTER:
+            impl->d_ind = (CeedInt *)indices;
+            break;
+        }
+        CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
+        CeedCallHip(ceed, hipMemcpy(impl->h_ind_allocated, impl->d_ind, size * sizeof(CeedInt), hipMemcpyDeviceToHost));
         impl->h_ind = impl->h_ind_allocated;
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(r, indices));
-      }
-      break;
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(rstr, indices));
+      } break;
     }
-    // LCOV_EXCL_START
-    default:
-      return CeedError(ceed, CEED_ERROR_BACKEND, "Only MemType = HOST or DEVICE supported");
-      // LCOV_EXCL_STOP
+
+    // Orientation data
+    if (rstr_type == CEED_RESTRICTION_ORIENTED) {
+      switch (mem_type) {
+        case CEED_MEM_HOST: {
+          switch (copy_mode) {
+            case CEED_OWN_POINTER:
+              impl->h_orients_allocated = (bool *)orients;
+              impl->h_orients           = (bool *)orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->h_orients = (bool *)orients;
+              break;
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
+              memcpy(impl->h_orients_allocated, orients, size * sizeof(bool));
+              impl->h_orients = impl->h_orients_allocated;
+              break;
+          }
+          CeedCallHip(ceed, hipMalloc((void **)&impl->d_orients, size * sizeof(bool)));
+          impl->d_orients_allocated = impl->d_orients;  // We own the device memory
+          CeedCallHip(ceed, hipMemcpy(impl->d_orients, orients, size * sizeof(bool), hipMemcpyHostToDevice));
+        } break;
+        case CEED_MEM_DEVICE: {
+          switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallHip(ceed, hipMalloc((void **)&impl->d_orients, size * sizeof(bool)));
+              impl->d_orients_allocated = impl->d_orients;  // We own the device memory
+              CeedCallHip(ceed, hipMemcpy(impl->d_orients, orients, size * sizeof(bool), hipMemcpyDeviceToDevice));
+              break;
+            case CEED_OWN_POINTER:
+              impl->d_orients           = (bool *)orients;
+              impl->d_orients_allocated = impl->d_orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->d_orients = (bool *)orients;
+              break;
+          }
+          CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
+          CeedCallHip(ceed, hipMemcpy(impl->h_orients_allocated, impl->d_orients, size * sizeof(bool), hipMemcpyDeviceToHost));
+          impl->h_orients = impl->h_orients_allocated;
+        } break;
+      }
+    } else if (rstr_type == CEED_RESTRICTION_CURL_ORIENTED) {
+      switch (mem_type) {
+        case CEED_MEM_HOST: {
+          switch (copy_mode) {
+            case CEED_OWN_POINTER:
+              impl->h_curl_orients_allocated = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients           = (CeedInt8 *)curl_orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->h_curl_orients = (CeedInt8 *)curl_orients;
+              break;
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
+              memcpy(impl->h_curl_orients_allocated, curl_orients, 3 * size * sizeof(CeedInt8));
+              impl->h_curl_orients = impl->h_curl_orients_allocated;
+              break;
+          }
+          CeedCallHip(ceed, hipMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
+          impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
+          CeedCallHip(ceed, hipMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyHostToDevice));
+        } break;
+        case CEED_MEM_DEVICE: {
+          switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallHip(ceed, hipMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
+              impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
+              CeedCallHip(ceed, hipMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyDeviceToDevice));
+              break;
+            case CEED_OWN_POINTER:
+              impl->d_curl_orients           = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients_allocated = impl->d_curl_orients;
+              break;
+            case CEED_USE_POINTER:
+              impl->d_curl_orients = (CeedInt8 *)curl_orients;
+              break;
+          }
+          CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
+          CeedCallHip(ceed, hipMemcpy(impl->h_curl_orients_allocated, impl->d_curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyDeviceToHost));
+          impl->h_curl_orients = impl->h_curl_orients_allocated;
+        } break;
+      }
+    }
   }
 
   // Compile HIP kernels
-  CeedInt num_nodes = impl->num_nodes;
-
   CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-restriction.h", &restriction_kernel_path));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
-  CeedCallBackend(CeedCompile_Hip(ceed, restriction_kernel_source, &impl->module, 8, "RESTR_ELEM_SIZE", elem_size, "RESTR_NUM_ELEM", num_elem,
-                                  "RESTR_NUM_COMP", num_comp, "RESTR_NUM_NODES", num_nodes, "RESTR_COMP_STRIDE", comp_stride, "RESTR_STRIDE_NODES",
-                                  strides[0], "RESTR_STRIDE_COMP", strides[1], "RESTR_STRIDE_ELEM", strides[2]));
+  CeedCallBackend(CeedCompile_Hip(ceed, restriction_kernel_source, &impl->module, 8, "RSTR_ELEM_SIZE", elem_size, "RSTR_NUM_ELEM", num_elem,
+                                  "RSTR_NUM_COMP", num_comp, "RSTR_NUM_NODES", impl->num_nodes, "RSTR_COMP_STRIDE", comp_stride, "RSTR_STRIDE_NODES",
+                                  strides[0], "RSTR_STRIDE_COMP", strides[1], "RSTR_STRIDE_ELEM", strides[2]));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "StridedNoTranspose", &impl->StridedNoTranspose));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "StridedTranspose", &impl->StridedTranspose));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetNoTranspose", &impl->OffsetNoTranspose));
@@ -339,15 +560,23 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
   } else {
     CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTransposeDet", &impl->OffsetTransposeDet));
   }
+  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedNoTranspose", &impl->OrientedNoTranspose));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedTranspose", &impl->OrientedTranspose));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedNoTranspose", &impl->CurlOrientedNoTranspose));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedNoTranspose", &impl->CurlOrientedUnsignedNoTranspose));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedTranspose", &impl->CurlOrientedTranspose));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedTranspose", &impl->CurlOrientedUnsignedTranspose));
   CeedCallBackend(CeedFree(&restriction_kernel_path));
   CeedCallBackend(CeedFree(&restriction_kernel_source));
 
   // Register backend functions
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "Apply", CeedElemRestrictionApply_Hip));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "ApplyUnsigned", CeedElemRestrictionApply_Hip));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "ApplyUnoriented", CeedElemRestrictionApply_Hip));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "GetOffsets", CeedElemRestrictionGetOffsets_Hip));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", r, "Destroy", CeedElemRestrictionDestroy_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Apply", CeedElemRestrictionApply_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnsigned", CeedElemRestrictionApplyUnsigned_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnoriented", CeedElemRestrictionApplyUnoriented_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOffsets", CeedElemRestrictionGetOffsets_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOrientations", CeedElemRestrictionGetOrientations_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetCurlOrientations", CeedElemRestrictionGetCurlOrientations_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Destroy", CeedElemRestrictionDestroy_Hip));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -130,10 +130,17 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
       } break;
       case CEED_RESTRICTION_ORIENTED: {
         if (use_signs) {
-          kernel       = impl->OrientedTranspose;
-          void *args[] = {&num_elem, &impl->d_ind, &impl->d_orients, &d_u, &d_v};
+          if (impl->OrientedTranspose) {
+            kernel       = impl->OrientedTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &impl->d_orients, &d_u, &d_v};
 
-          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->OrientedTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &impl->d_orients, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          }
         } else {
           if (impl->OffsetTranspose) {
             kernel       = impl->OffsetTranspose;
@@ -150,15 +157,29 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
       } break;
       case CEED_RESTRICTION_CURL_ORIENTED: {
         if (use_signs && use_orients) {
-          kernel       = impl->CurlOrientedTranspose;
-          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+          if (impl->CurlOrientedTranspose) {
+            kernel       = impl->CurlOrientedTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
 
-          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->CurlOrientedTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &impl->d_curl_orients, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          }
         } else if (use_orients) {
-          kernel       = impl->CurlOrientedUnsignedTranspose;
-          void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+          if (impl->CurlOrientedUnsignedTranspose) {
+            kernel       = impl->CurlOrientedUnsignedTranspose;
+            void *args[] = {&num_elem, &impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
 
-          CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          } else {
+            kernel       = impl->CurlOrientedUnsignedTransposeDet;
+            void *args[] = {&impl->d_l_vec_indices, &impl->d_t_indices, &impl->d_t_offsets, &impl->d_curl_orients, &d_u, &d_v};
+
+            CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
+          }
         } else {
           if (impl->OffsetTranspose) {
             kernel       = impl->OffsetTranspose;
@@ -565,17 +586,20 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "StridedNoTranspose", &impl->StridedNoTranspose));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "StridedTranspose", &impl->StridedTranspose));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetNoTranspose", &impl->OffsetNoTranspose));
-  if (!is_deterministic) {
-    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTranspose", &impl->OffsetTranspose));
-  } else {
-    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTransposeDet", &impl->OffsetTransposeDet));
-  }
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedNoTranspose", &impl->OrientedNoTranspose));
-  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedTranspose", &impl->OrientedTranspose));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedNoTranspose", &impl->CurlOrientedNoTranspose));
   CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedNoTranspose", &impl->CurlOrientedUnsignedNoTranspose));
-  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedTranspose", &impl->CurlOrientedTranspose));
-  CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedTranspose", &impl->CurlOrientedUnsignedTranspose));
+  if (!is_deterministic) {
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTranspose", &impl->OffsetTranspose));
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedTranspose", &impl->OrientedTranspose));
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedTranspose", &impl->CurlOrientedTranspose));
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedTranspose", &impl->CurlOrientedUnsignedTranspose));
+  } else {
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTransposeDet", &impl->OffsetTransposeDet));
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedTransposeDet", &impl->OrientedTransposeDet));
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedTransposeDet", &impl->CurlOrientedTransposeDet));
+    CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedTransposeDet", &impl->CurlOrientedUnsignedTransposeDet));
+  }
   CeedCallBackend(CeedFree(&restriction_kernel_path));
   CeedCallBackend(CeedFree(&restriction_kernel_source));
 

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -97,6 +97,11 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
           CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
         }
       } break;
+      case CEED_RESTRICTION_POINTS: {
+        // LCOV_EXCL_START
+        return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement restriction CeedElemRestrictionAtPoints");
+        // LCOV_EXCL_STOP
+      } break;
     }
   } else {
     // E-vector -> L-vector
@@ -167,6 +172,11 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
             CeedCallBackend(CeedRunKernel_Hip(ceed, kernel, grid, block_size, args));
           }
         }
+      } break;
+      case CEED_RESTRICTION_POINTS: {
+        // LCOV_EXCL_START
+        return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement restriction CeedElemRestrictionAtPoints");
+        // LCOV_EXCL_STOP
       } break;
     }
   }

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -102,21 +102,19 @@ typedef struct {
 
 typedef struct {
   hipModule_t         module;
-  hipFunction_t       linearDiagonal;
-  hipFunction_t       linearPointBlock;
-  CeedBasis           basis_in, basis_out;
+  hipFunction_t       LinearDiagonal;
+  hipFunction_t       LinearPointBlock;
   CeedElemRestriction diag_rstr, point_block_diag_rstr;
   CeedVector          elem_diag, point_block_elem_diag;
-  CeedInt             num_e_mode_in, num_e_mode_out, num_modes;
-  CeedEvalMode       *h_e_mode_in, *h_e_mode_out;
-  CeedEvalMode       *d_e_mode_in, *d_e_mode_out;
-  CeedScalar         *d_identity, *d_interp_in, *d_interp_out, *d_grad_in, *d_grad_out;
+  CeedEvalMode       *d_eval_modes_in, *d_eval_modes_out;
+  CeedScalar         *d_identity, *d_interp_in, *d_grad_in, *d_div_in, *d_curl_in;
+  CeedScalar         *d_interp_out, *d_grad_out, *d_div_out, *d_curl_out;
 } CeedOperatorDiag_Hip;
 
 typedef struct {
   hipModule_t   module;
-  hipFunction_t linearAssemble;
-  CeedInt       num_elem, block_size_x, block_size_y, elem_per_block;
+  hipFunction_t LinearAssemble;
+  CeedInt       block_size_x, block_size_y, elems_per_block;
   CeedScalar   *d_B_in, *d_B_out;
 } CeedOperatorAssemble_Hip;
 

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -34,6 +34,12 @@ typedef struct {
   hipFunction_t OffsetNoTranspose;
   hipFunction_t OffsetTranspose;
   hipFunction_t OffsetTransposeDet;
+  hipFunction_t OrientedNoTranspose;
+  hipFunction_t OrientedTranspose;
+  hipFunction_t CurlOrientedNoTranspose;
+  hipFunction_t CurlOrientedTranspose;
+  hipFunction_t CurlOrientedUnsignedNoTranspose;
+  hipFunction_t CurlOrientedUnsignedTranspose;
   CeedInt       num_nodes;
   CeedInt      *h_ind;
   CeedInt      *h_ind_allocated;
@@ -42,6 +48,14 @@ typedef struct {
   CeedInt      *d_t_offsets;
   CeedInt      *d_t_indices;
   CeedInt      *d_l_vec_indices;
+  bool         *h_orients;
+  bool         *h_orients_allocated;
+  bool         *d_orients;
+  bool         *d_orients_allocated;
+  CeedInt8     *h_curl_orients;
+  CeedInt8     *h_curl_orients_allocated;
+  CeedInt8     *d_curl_orients;
+  CeedInt8     *d_curl_orients_allocated;
 } CeedElemRestriction_Hip;
 
 typedef struct {

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -36,10 +36,13 @@ typedef struct {
   hipFunction_t OffsetTransposeDet;
   hipFunction_t OrientedNoTranspose;
   hipFunction_t OrientedTranspose;
+  hipFunction_t OrientedTransposeDet;
   hipFunction_t CurlOrientedNoTranspose;
   hipFunction_t CurlOrientedTranspose;
+  hipFunction_t CurlOrientedTransposeDet;
   hipFunction_t CurlOrientedUnsignedNoTranspose;
   hipFunction_t CurlOrientedUnsignedTranspose;
+  hipFunction_t CurlOrientedUnsignedTransposeDet;
   CeedInt       num_nodes;
   CeedInt      *h_ind;
   CeedInt      *h_ind_allocated;

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -736,7 +736,10 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
   CeedInt layout[3] = {1, elem_size, elem_size * num_comp};
 
   CeedCheck(mem_type == CEED_MEM_HOST, ceed, CEED_ERROR_BACKEND, "Only MemType = HOST supported");
+
   CeedCallBackend(CeedCalloc(1, &impl));
+  CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
+  CeedCallBackend(CeedElemRestrictionSetELayout(rstr, layout));
 
   // Offsets data
   CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
@@ -816,20 +819,6 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
     }
   }
 
-  CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
-  CeedCallBackend(CeedElemRestrictionSetELayout(rstr, layout));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Apply", CeedElemRestrictionApply_Ref));
-  if (rstr_type == CEED_RESTRICTION_POINTS) {
-    CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyAtPointsInElement", CeedElemRestrictionApplyAtPointsInElement_Ref));
-  }
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnsigned", CeedElemRestrictionApplyUnsigned_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnoriented", CeedElemRestrictionApplyUnoriented_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyBlock", CeedElemRestrictionApplyBlock_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOrientations", CeedElemRestrictionGetOrientations_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetCurlOrientations", CeedElemRestrictionGetCurlOrientations_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOffsets", CeedElemRestrictionGetOffsets_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Destroy", CeedElemRestrictionDestroy_Ref));
-
   // Set apply function based upon num_comp, block_size, and comp_stride
   CeedInt index = -1;
 
@@ -879,6 +868,19 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
       impl->Apply = CeedElemRestrictionApply_Ref_Core;
       break;
   }
+
+  // Register backend functions
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Apply", CeedElemRestrictionApply_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnsigned", CeedElemRestrictionApplyUnsigned_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyUnoriented", CeedElemRestrictionApplyUnoriented_Ref));
+  if (rstr_type == CEED_RESTRICTION_POINTS) {
+    CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyAtPointsInElement", CeedElemRestrictionApplyAtPointsInElement_Ref));
+  }
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "ApplyBlock", CeedElemRestrictionApplyBlock_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOffsets", CeedElemRestrictionGetOffsets_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetOrientations", CeedElemRestrictionGetOrientations_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "GetCurlOrientations", CeedElemRestrictionGetCurlOrientations_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "ElemRestriction", rstr, "Destroy", CeedElemRestrictionDestroy_Ref));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1073,28 +1073,14 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
   // Kernel setup
   int elems_per_block   = 1;
   asmb->elems_per_block = elems_per_block;
-  CeedInt block_size    = elem_size * elem_size * elems_per_block;
-
-  /* CeedInt maxThreadsPerBlock = sycl_data->sycl_device.get_info<sycl::info::device::max_work_group_size>();
-  bool    fallback           = block_size > maxThreadsPerBlock;
-  asmb->fallback             = fallback;
-  if (fallback) {
-    // Use fallback kernel with 1D threadblock
-    block_size         = elem_size * elems_per_block;
-    asmb->block_size_x = elem_size;
-    asmb->block_size_y = 1;
-  } else {  // Use kernel with 2D threadblock
-    asmb->block_size_x = elem_size;
-    asmb->block_size_y = elem_size;
-  }*/
-  asmb->block_size_x   = elem_size;
-  asmb->block_size_y   = elem_size;
-  asmb->num_e_mode_in  = num_e_mode_in;
-  asmb->num_e_mode_out = num_e_mode_out;
-  asmb->num_qpts       = num_qpts;
-  asmb->num_nodes      = elem_size;
-  asmb->block_size     = block_size;
-  asmb->num_comp       = num_comp;
+  asmb->block_size_x    = elem_size;
+  asmb->block_size_y    = elem_size;
+  asmb->num_e_mode_in   = num_e_mode_in;
+  asmb->num_e_mode_out  = num_e_mode_out;
+  asmb->num_qpts        = num_qpts;
+  asmb->num_nodes       = elem_size;
+  asmb->block_size      = elem_size * elem_size * elems_per_block;
+  asmb->num_comp        = num_comp;
 
   // Build 'full' B matrices (not 1D arrays used for tensor-product matrices
   CeedCallBackend(CeedBasisGetInterp(basis_in, &interp_in));

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1071,16 +1071,16 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
   CeedCallBackend(CeedGetData(ceed, &sycl_data));
 
   // Kernel setup
-  int elem_per_block   = 1;
-  asmb->elem_per_block = elem_per_block;
-  CeedInt block_size   = elem_size * elem_size * elem_per_block;
+  int elems_per_block   = 1;
+  asmb->elems_per_block = elems_per_block;
+  CeedInt block_size    = elem_size * elem_size * elems_per_block;
 
   /* CeedInt maxThreadsPerBlock = sycl_data->sycl_device.get_info<sycl::info::device::max_work_group_size>();
   bool    fallback           = block_size > maxThreadsPerBlock;
   asmb->fallback             = fallback;
   if (fallback) {
     // Use fallback kernel with 1D threadblock
-    block_size         = elem_size * elem_per_block;
+    block_size         = elem_size * elems_per_block;
     asmb->block_size_x = elem_size;
     asmb->block_size_y = 1;
   } else {  // Use kernel with 2D threadblock
@@ -1250,13 +1250,13 @@ static int CeedOperatorLinearAssembleFallback_Sycl(sycl::queue &sycl_queue, cons
   CeedScalar *B_in, *B_out;
   B_in                        = asmb->d_B_in;
   B_out                       = asmb->d_B_out;
-  const CeedInt elem_per_block = asmb->elem_per_block;
+  const CeedInt elems_per_block = asmb->elems_per_block;
   const CeedInt block_size_x  = asmb->block_size_x;
   const CeedInt block_size_y  = asmb->block_size_y;  // This will be 1 for the fallback kernel
 
-  const CeedInt     grid = num_elem / elem_per_block + ((num_elem / elem_per_block * elem_per_block < num_elem) ? 1 : 0);
-  sycl::range<3>    local_range(block_size_x, block_size_y, elem_per_block);
-  sycl::range<3>    global_range(grid * block_size_x, block_size_y, elem_per_block);
+  const CeedInt     grid = num_elem / elems_per_block + ((num_elem / elems_per_block * elems_per_block < num_elem) ? 1 : 0);
+  sycl::range<3>    local_range(block_size_x, block_size_y, elems_per_block);
+  sycl::range<3>    global_range(grid * block_size_x, block_size_y, elems_per_block);
   sycl::nd_range<3> kernel_range(global_range, local_range);
 
   sycl_queue.parallel_for<CeedOperatorSyclLinearAssembleFallback>(kernel_range, [=](sycl::nd_item<3> work_item) {

--- a/backends/sycl-ref/ceed-sycl-ref.hpp
+++ b/backends/sycl-ref/ceed-sycl-ref.hpp
@@ -94,7 +94,7 @@ typedef struct {
 } CeedOperatorDiag_Sycl;
 
 typedef struct {
-  CeedInt     num_elem, block_size_x, block_size_y, elem_per_block;
+  CeedInt     num_elem, block_size_x, block_size_y, elems_per_block;
   CeedInt     num_e_mode_in, num_e_mode_out, num_qpts, num_nodes, block_size, num_comp;  // Kernel parameters
   bool        fallback;
   CeedScalar *d_B_in, *d_B_out;

--- a/backends/sycl-ref/ceed-sycl-restriction.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-restriction.sycl.cpp
@@ -142,15 +142,15 @@ static int CeedElemRestrictionOffsetTranspose_Sycl(sycl::queue &sycl_queue, cons
 //------------------------------------------------------------------------------
 // Apply restriction
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionApply_Sycl(CeedElemRestriction r, CeedTransposeMode t_mode, CeedVector u, CeedVector v, CeedRequest *request) {
+static int CeedElemRestrictionApply_Sycl(CeedElemRestriction rstr, CeedTransposeMode t_mode, CeedVector u, CeedVector v, CeedRequest *request) {
   Ceed                      ceed;
   Ceed_Sycl                *data;
   const CeedScalar         *d_u;
   CeedScalar               *d_v;
   CeedElemRestriction_Sycl *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
   CeedCallBackend(CeedGetData(ceed, &data));
 
   // Get vectors
@@ -197,12 +197,12 @@ static int CeedElemRestrictionApply_Sycl(CeedElemRestriction r, CeedTransposeMod
 //------------------------------------------------------------------------------
 // Get offsets
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionGetOffsets_Sycl(CeedElemRestriction r, CeedMemType m_type, const CeedInt **offsets) {
+static int CeedElemRestrictionGetOffsets_Sycl(CeedElemRestriction rstr, CeedMemType m_type, const CeedInt **offsets) {
   Ceed                      ceed;
   CeedElemRestriction_Sycl *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
 
   switch (m_type) {
     case CEED_MEM_HOST:
@@ -218,13 +218,13 @@ static int CeedElemRestrictionGetOffsets_Sycl(CeedElemRestriction r, CeedMemType
 //------------------------------------------------------------------------------
 // Destroy restriction
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionDestroy_Sycl(CeedElemRestriction r) {
+static int CeedElemRestrictionDestroy_Sycl(CeedElemRestriction rstr) {
   Ceed                      ceed;
   Ceed_Sycl                *data;
   CeedElemRestriction_Sycl *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
   CeedCallBackend(CeedGetData(ceed, &data));
 
   // Wait for all work to finish before freeing memory
@@ -242,7 +242,7 @@ static int CeedElemRestrictionDestroy_Sycl(CeedElemRestriction r) {
 //------------------------------------------------------------------------------
 // Create transpose offsets and indices
 //------------------------------------------------------------------------------
-static int CeedElemRestrictionOffset_Sycl(const CeedElemRestriction r, const CeedInt *indices) {
+static int CeedElemRestrictionOffset_Sycl(const CeedElemRestriction rstr, const CeedInt *indices) {
   Ceed                      ceed;
   Ceed_Sycl                *data;
   bool                     *is_node;
@@ -250,12 +250,12 @@ static int CeedElemRestrictionOffset_Sycl(const CeedElemRestriction r, const Cee
   CeedInt                   num_elem, elem_size, num_comp, num_nodes = 0, *ind_to_offset, *l_vec_indices, *t_offsets, *t_indices;
   CeedElemRestriction_Sycl *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
-  CeedCallBackend(CeedElemRestrictionGetData(r, &impl));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(r, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
-  CeedCallBackend(CeedElemRestrictionGetLVectorSize(r, &l_size));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(r, &num_comp));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  CeedCallBackend(CeedElemRestrictionGetLVectorSize(rstr, &l_size));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr, &num_comp));
 
   // Count num_nodes
   CeedCallBackend(CeedCalloc(l_size, &is_node));
@@ -330,7 +330,7 @@ static int CeedElemRestrictionOffset_Sycl(const CeedElemRestriction r, const Cee
 // Create restriction
 //------------------------------------------------------------------------------
 int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
-                                   const CeedInt8 *curl_orients, CeedElemRestriction r) {
+                                   const CeedInt8 *curl_orients, CeedElemRestriction rstr) {
   Ceed                      ceed;
   Ceed_Sycl                *data;
   bool                      is_strided;
@@ -338,32 +338,33 @@ int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode,
   CeedRestrictionType       rstr_type;
   CeedElemRestriction_Sycl *impl;
 
-  CeedCallBackend(CeedElemRestrictionGetCeed(r, &ceed));
+  CeedCallBackend(CeedElemRestrictionGetCeed(rstr, &ceed));
   CeedCallBackend(CeedGetData(ceed, &data));
-  CeedCallBackend(CeedCalloc(1, &impl));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(r, &num_elem));
-  CeedCallBackend(CeedElemRestrictionGetNumComponents(r, &num_comp));
-  CeedCallBackend(CeedElemRestrictionGetElementSize(r, &elem_size));
-  CeedInt size       = num_elem * elem_size;
-  CeedInt strides[3] = {1, size, elem_size};
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr, &num_comp));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
+  const CeedInt size       = num_elem * elem_size;
+  CeedInt       strides[3] = {1, size, elem_size};
+  CeedInt       layout[3]  = {1, elem_size * num_elem, elem_size};
 
-  CeedCallBackend(CeedElemRestrictionGetType(r, &rstr_type));
+  CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
   CeedCheck(rstr_type != CEED_RESTRICTION_ORIENTED && rstr_type != CEED_RESTRICTION_CURL_ORIENTED, ceed, CEED_ERROR_BACKEND,
             "Backend does not implement CeedElemRestrictionCreateOriented or CeedElemRestrictionCreateCurlOriented");
 
   // Stride data
-  CeedCallBackend(CeedElemRestrictionIsStrided(r, &is_strided));
+  CeedCallBackend(CeedElemRestrictionIsStrided(rstr, &is_strided));
   if (is_strided) {
     bool has_backend_strides;
 
-    CeedCallBackend(CeedElemRestrictionHasBackendStrides(r, &has_backend_strides));
+    CeedCallBackend(CeedElemRestrictionHasBackendStrides(rstr, &has_backend_strides));
     if (!has_backend_strides) {
-      CeedCallBackend(CeedElemRestrictionGetStrides(r, &strides));
+      CeedCallBackend(CeedElemRestrictionGetStrides(rstr, &strides));
     }
   } else {
-    CeedCallBackend(CeedElemRestrictionGetCompStride(r, &comp_stride));
+    CeedCallBackend(CeedElemRestrictionGetCompStride(rstr, &comp_stride));
   }
 
+  CeedCallBackend(CeedCalloc(1, &impl));
   impl->h_ind           = NULL;
   impl->h_ind_allocated = NULL;
   impl->d_ind           = NULL;
@@ -378,9 +379,8 @@ int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode,
   impl->strides[0]      = strides[0];
   impl->strides[1]      = strides[1];
   impl->strides[2]      = strides[2];
-  CeedCallBackend(CeedElemRestrictionSetData(r, impl));
-  CeedInt layout[3] = {1, elem_size * num_elem, elem_size};
-  CeedCallBackend(CeedElemRestrictionSetELayout(r, layout));
+  CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
+  CeedCallBackend(CeedElemRestrictionSetELayout(rstr, layout));
 
   // Set up device indices/offset arrays
   if (mem_type == CEED_MEM_HOST) {
@@ -409,7 +409,7 @@ int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode,
       sycl::event copy_event = data->sycl_queue.copy<CeedInt>(indices, impl->d_ind, size, {e});
       // Wait for copy to finish and handle exceptions
       CeedCallSycl(ceed, copy_event.wait_and_throw());
-      CeedCallBackend(CeedElemRestrictionOffset_Sycl(r, indices));
+      CeedCallBackend(CeedElemRestrictionOffset_Sycl(rstr, indices));
     }
   } else if (mem_type == CEED_MEM_DEVICE) {
     switch (copy_mode) {
@@ -440,7 +440,7 @@ int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode,
       sycl::event copy_event = data->sycl_queue.copy<CeedInt>(impl->d_ind, impl->h_ind_allocated, elem_size * num_elem, {e});
       CeedCallSycl(ceed, copy_event.wait_and_throw());
       impl->h_ind = impl->h_ind_allocated;
-      CeedCallBackend(CeedElemRestrictionOffset_Sycl(r, indices));
+      CeedCallBackend(CeedElemRestrictionOffset_Sycl(rstr, indices));
     }
   } else {
     // LCOV_EXCL_START
@@ -449,10 +449,10 @@ int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode,
   }
 
   // Register backend functions
-  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", r, "Apply", CeedElemRestrictionApply_Sycl));
-  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", r, "ApplyUnsigned", CeedElemRestrictionApply_Sycl));
-  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", r, "ApplyUnoriented", CeedElemRestrictionApply_Sycl));
-  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", r, "GetOffsets", CeedElemRestrictionGetOffsets_Sycl));
-  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", r, "Destroy", CeedElemRestrictionDestroy_Sycl));
+  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", rstr, "Apply", CeedElemRestrictionApply_Sycl));
+  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", rstr, "ApplyUnsigned", CeedElemRestrictionApply_Sycl));
+  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", rstr, "ApplyUnoriented", CeedElemRestrictionApply_Sycl));
+  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", rstr, "GetOffsets", CeedElemRestrictionGetOffsets_Sycl));
+  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "ElemRestriction", rstr, "Destroy", CeedElemRestrictionDestroy_Sycl));
   return CEED_ERROR_SUCCESS;
 }

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -373,6 +373,7 @@ CEED_EXTERN int CeedQFunctionContextRestoreBooleanRead(CeedQFunctionContext ctx,
 CEED_EXTERN int CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx, CeedMemType *f_mem_type, CeedQFunctionContextDataDestroyUser *f);
 CEED_EXTERN int CeedQFunctionContextReference(CeedQFunctionContext ctx);
 
+CEED_EXTERN int CeedOperatorGetBasisPointer(CeedBasis basis, CeedEvalMode eval_mode, const CeedScalar *identity, const CeedScalar **basis_ptr);
 CEED_EXTERN int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rstr, CeedElemRestriction *pointblock_rstr);
 CEED_EXTERN int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data);
 CEED_EXTERN int CeedQFunctionAssemblyDataReference(CeedQFunctionAssemblyData data);

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h
@@ -19,11 +19,11 @@ typedef CeedInt IndexType;
 #endif
 
 //------------------------------------------------------------------------------
-// Get Basis Emode Pointer
+// Get basis pointer
 //------------------------------------------------------------------------------
-extern "C" __device__ void CeedOperatorGetBasisPointer_Cuda(const CeedScalar **basis_ptr, CeedEvalMode e_mode, const CeedScalar *identity,
-                                                            const CeedScalar *interp, const CeedScalar *grad) {
-  switch (e_mode) {
+static __device__ __inline__ void GetBasisPointer(const CeedScalar **basis_ptr, CeedEvalMode eval_modes, const CeedScalar *identity,
+                                                  const CeedScalar *interp, const CeedScalar *grad, const CeedScalar *div, const CeedScalar *curl) {
+  switch (eval_modes) {
     case CEED_EVAL_NONE:
       *basis_ptr = identity;
       break;
@@ -33,52 +33,67 @@ extern "C" __device__ void CeedOperatorGetBasisPointer_Cuda(const CeedScalar **b
     case CEED_EVAL_GRAD:
       *basis_ptr = grad;
       break;
-    case CEED_EVAL_WEIGHT:
     case CEED_EVAL_DIV:
+      *basis_ptr = div;
+      break;
     case CEED_EVAL_CURL:
-      break;  // Caught by QF Assembly
+      *basis_ptr = curl;
+      break;
+    case CEED_EVAL_WEIGHT:
+      break;  // Caught by QF assembly
   }
 }
 
 //------------------------------------------------------------------------------
 // Core code for diagonal assembly
 //------------------------------------------------------------------------------
-__device__ void diagonalCore(const CeedInt num_elem, const bool is_point_block, const CeedScalar *identity, const CeedScalar *interp_in,
-                             const CeedScalar *grad_in, const CeedScalar *interp_out, const CeedScalar *grad_out, const CeedEvalMode *e_mode_in,
-                             const CeedEvalMode *e_mode_out, const CeedScalar *__restrict__ assembled_qf_array,
-                             CeedScalar *__restrict__ elem_diag_array) {
-  const int tid = threadIdx.x;  // running with P threads, tid is evec node
+static __device__ __inline__ void DiagonalCore(const CeedInt num_elem, const bool is_point_block, const CeedScalar *identity,
+                                               const CeedScalar *interp_in, const CeedScalar *grad_in, const CeedScalar *div_in,
+                                               const CeedScalar *curl_in, const CeedScalar *interp_out, const CeedScalar *grad_out,
+                                               const CeedScalar *div_out, const CeedScalar *curl_out, const CeedEvalMode *eval_modes_in,
+                                               const CeedEvalMode *eval_modes_out, const CeedScalar *__restrict__ assembled_qf_array,
+                                               CeedScalar *__restrict__ elem_diag_array) {
+  const int tid = threadIdx.x;  // Running with P threads
+
   if (tid >= NUM_NODES) return;
 
   // Compute the diagonal of B^T D B
   // Each element
   for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
-    IndexType d_out = -1;
-
     // Each basis eval mode pair
-    for (IndexType e_out = 0; e_out < NUM_E_MODE_OUT; e_out++) {
-      const CeedScalar *b_t = NULL;
+    IndexType    d_out               = 0;
+    CeedEvalMode eval_modes_out_prev = CEED_EVAL_NONE;
 
-      if (e_mode_out[e_out] == CEED_EVAL_GRAD) d_out += 1;
-      CeedOperatorGetBasisPointer_Cuda(&b_t, e_mode_out[e_out], identity, interp_out, &grad_out[d_out * NUM_QPTS * NUM_NODES]);
-      IndexType d_in = -1;
+    for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+      IndexType         d_in               = 0;
+      CeedEvalMode      eval_modes_in_prev = CEED_EVAL_NONE;
+      const CeedScalar *b_t                = NULL;
 
-      for (IndexType e_in = 0; e_in < NUM_E_MODE_IN; e_in++) {
+      GetBasisPointer(&b_t, eval_modes_out[e_out], identity, interp_out, grad_out, div_out, curl_out);
+      if (e_out == 0 || eval_modes_out[e_out] != eval_modes_out_prev) d_out = 0;
+      else b_t = &b_t[(++d_out) * NUM_QPTS * NUM_NODES];
+      eval_modes_out_prev = eval_modes_out[e_out];
+
+      for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
         const CeedScalar *b = NULL;
 
-        if (e_mode_in[e_in] == CEED_EVAL_GRAD) d_in += 1;
-        CeedOperatorGetBasisPointer_Cuda(&b, e_mode_in[e_in], identity, interp_in, &grad_in[d_in * NUM_QPTS * NUM_NODES]);
+        GetBasisPointer(&b, eval_modes_in[e_in], identity, interp_in, grad_in, div_in, curl_in);
+        if (e_in == 0 || eval_modes_in[e_in] != eval_modes_in_prev) d_in = 0;
+        else b = &b[(++d_in) * NUM_QPTS * NUM_NODES];
+        eval_modes_in_prev = eval_modes_in[e_in];
+
         // Each component
         for (IndexType comp_out = 0; comp_out < NUM_COMP; comp_out++) {
           // Each qpoint/node pair
           if (is_point_block) {
-            // Point Block Diagonal
+            // Point block diagonal
             for (IndexType comp_in = 0; comp_in < NUM_COMP; comp_in++) {
               CeedScalar e_value = 0.;
 
               for (IndexType q = 0; q < NUM_QPTS; q++) {
                 const CeedScalar qf_value =
-                    assembled_qf_array[((((e_in * NUM_COMP + comp_in) * NUM_E_MODE_OUT + e_out) * NUM_COMP + comp_out) * num_elem + e) * NUM_QPTS +
+                    assembled_qf_array[((((e_in * NUM_COMP + comp_in) * NUM_EVAL_MODES_OUT + e_out) * NUM_COMP + comp_out) * num_elem + e) *
+                                           NUM_QPTS +
                                        q];
 
                 e_value += b_t[q * NUM_NODES + tid] * qf_value * b[q * NUM_NODES + tid];
@@ -86,12 +101,13 @@ __device__ void diagonalCore(const CeedInt num_elem, const bool is_point_block, 
               elem_diag_array[((comp_out * NUM_COMP + comp_in) * num_elem + e) * NUM_NODES + tid] += e_value;
             }
           } else {
-            // Diagonal Only
+            // Diagonal only
             CeedScalar e_value = 0.;
 
             for (IndexType q = 0; q < NUM_QPTS; q++) {
               const CeedScalar qf_value =
-                  assembled_qf_array[((((e_in * NUM_COMP + comp_out) * NUM_E_MODE_OUT + e_out) * NUM_COMP + comp_out) * num_elem + e) * NUM_QPTS + q];
+                  assembled_qf_array[((((e_in * NUM_COMP + comp_out) * NUM_EVAL_MODES_OUT + e_out) * NUM_COMP + comp_out) * num_elem + e) * NUM_QPTS +
+                                     q];
 
               e_value += b_t[q * NUM_NODES + tid] * qf_value * b[q * NUM_NODES + tid];
             }
@@ -106,21 +122,25 @@ __device__ void diagonalCore(const CeedInt num_elem, const bool is_point_block, 
 //------------------------------------------------------------------------------
 // Linear diagonal
 //------------------------------------------------------------------------------
-extern "C" __global__ void linearDiagonal(const CeedInt num_elem, const CeedScalar *identity, const CeedScalar *interp_in, const CeedScalar *grad_in,
-                                          const CeedScalar *interp_out, const CeedScalar *grad_out, const CeedEvalMode *e_mode_in,
-                                          const CeedEvalMode *e_mode_out, const CeedScalar *__restrict__ assembled_qf_array,
-                                          CeedScalar *__restrict__ elem_diag_array) {
-  diagonalCore(num_elem, false, identity, interp_in, grad_in, interp_out, grad_out, e_mode_in, e_mode_out, assembled_qf_array, elem_diag_array);
+extern "C" __global__ void LinearDiagonal(const CeedInt num_elem, const CeedScalar *identity, const CeedScalar *interp_in, const CeedScalar *grad_in,
+                                          const CeedScalar *div_in, const CeedScalar *curl_in, const CeedScalar *interp_out,
+                                          const CeedScalar *grad_out, const CeedScalar *div_out, const CeedScalar *curl_out,
+                                          const CeedEvalMode *eval_modes_in, const CeedEvalMode *eval_modes_out,
+                                          const CeedScalar *__restrict__ assembled_qf_array, CeedScalar *__restrict__ elem_diag_array) {
+  DiagonalCore(num_elem, false, identity, interp_in, grad_in, div_in, curl_in, interp_out, grad_out, div_out, curl_out, eval_modes_in, eval_modes_out,
+               assembled_qf_array, elem_diag_array);
 }
 
 //------------------------------------------------------------------------------
 // Linear point block diagonal
 //------------------------------------------------------------------------------
-extern "C" __global__ void linearPointBlockDiagonal(const CeedInt num_elem, const CeedScalar *identity, const CeedScalar *interp_in,
-                                                    const CeedScalar *grad_in, const CeedScalar *interp_out, const CeedScalar *grad_out,
-                                                    const CeedEvalMode *e_mode_in, const CeedEvalMode *e_mode_out,
+extern "C" __global__ void LinearPointBlockDiagonal(const CeedInt num_elem, const CeedScalar *identity, const CeedScalar *interp_in,
+                                                    const CeedScalar *grad_in, const CeedScalar *div_in, const CeedScalar *curl_in,
+                                                    const CeedScalar *interp_out, const CeedScalar *grad_out, const CeedScalar *div_out,
+                                                    const CeedScalar *curl_out, const CeedEvalMode *eval_modes_in, const CeedEvalMode *eval_modes_out,
                                                     const CeedScalar *__restrict__ assembled_qf_array, CeedScalar *__restrict__ elem_diag_array) {
-  diagonalCore(num_elem, true, identity, interp_in, grad_in, interp_out, grad_out, e_mode_in, e_mode_out, assembled_qf_array, elem_diag_array);
+  DiagonalCore(num_elem, true, identity, interp_in, grad_in, div_in, curl_in, interp_out, grad_out, div_out, curl_out, eval_modes_in, eval_modes_out,
+               assembled_qf_array, elem_diag_array);
 }
 
 //------------------------------------------------------------------------------

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
@@ -19,108 +19,92 @@ typedef CeedInt IndexType;
 #endif
 
 //------------------------------------------------------------------------------
-// Matrix assembly kernel for low-order elements (2D thread block)
+// Matrix assembly kernel
 //------------------------------------------------------------------------------
 extern "C" __launch_bounds__(BLOCK_SIZE) __global__
-    void linearAssemble(const CeedScalar *B_in, const CeedScalar *B_out, const CeedScalar *__restrict__ qf_array,
-                        CeedScalar *__restrict__ values_array) {
-  // This kernel assumes B_in and B_out have the same number of quadrature points and basis points.
-  // TODO: expand to more general cases
-  const int i = threadIdx.x;  // The output row index of each B^TDB operation
-  const int l = threadIdx.y;  // The output column index of each B^TDB operation
+    void LinearAssemble(const CeedInt num_elem, const CeedScalar *B_in, const CeedScalar *B_out, const bool *orients_in,
+                        const CeedInt8 *curl_orients_in, const bool *orients_out, const CeedInt8 *curl_orients_out,
+                        const CeedScalar *__restrict__ qf_array, CeedScalar *__restrict__ values_array) {
+  extern __shared__ CeedScalar s_CT[];
+  CeedScalar                  *s_C = s_CT + NUM_NODES_OUT * NUM_NODES_IN;
+
+  const int l = threadIdx.x;  // The output column index of each B^T D B operation
                               // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
 
-  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
+  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: e,
   // comp_in, comp_out, node_row, node_col
-  const IndexType comp_out_stride = NUM_NODES * NUM_NODES;
-  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP;
-  const IndexType e_stride        = comp_in_stride * NUM_COMP;
-  // Strides for QF array, slowest --> fastest:  e_mode_in, comp_in, e_mode_out, comp_out, elem, qpt
-  const IndexType q_e_stride          = NUM_QPTS;
-  const IndexType q_comp_out_stride   = NUM_ELEM * q_e_stride;
-  const IndexType q_e_mode_out_stride = q_comp_out_stride * NUM_COMP;
-  const IndexType q_comp_in_stride    = q_e_mode_out_stride * NUM_E_MODE_OUT;
-  const IndexType q_e_mode_in_stride  = q_comp_in_stride * NUM_COMP;
+  const IndexType comp_out_stride = NUM_NODES_OUT * NUM_NODES_IN;
+  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP_OUT;
+  const IndexType e_stride        = comp_in_stride * NUM_COMP_IN;
+
+  // Strides for QF array, slowest --> fastest: e_in, comp_in, e_out, comp_out, e, q
+  const IndexType q_e_stride             = NUM_QPTS;
+  const IndexType q_comp_out_stride      = num_elem * q_e_stride;
+  const IndexType q_eval_mode_out_stride = q_comp_out_stride * NUM_COMP_OUT;
+  const IndexType q_comp_in_stride       = q_eval_mode_out_stride * NUM_EVAL_MODES_OUT;
+  const IndexType q_eval_mode_in_stride  = q_comp_in_stride * NUM_COMP_IN;
 
   // Loop over each element (if necessary)
-  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NUM_ELEM; e += gridDim.x * blockDim.z) {
-    for (IndexType comp_in = 0; comp_in < NUM_COMP; comp_in++) {
-      for (IndexType comp_out = 0; comp_out < NUM_COMP; comp_out++) {
-        CeedScalar result        = 0.0;
-        IndexType  qf_index_comp = q_comp_in_stride * comp_in + q_comp_out_stride * comp_out + q_e_stride * e;
-
-        for (IndexType e_mode_in = 0; e_mode_in < NUM_E_MODE_IN; e_mode_in++) {
-          IndexType b_in_index = e_mode_in * NUM_QPTS * NUM_NODES;
-
-          for (IndexType e_mode_out = 0; e_mode_out < NUM_E_MODE_OUT; e_mode_out++) {
-            IndexType b_out_index = e_mode_out * NUM_QPTS * NUM_NODES;
-            IndexType qf_index    = qf_index_comp + q_e_mode_out_stride * e_mode_out + q_e_mode_in_stride * e_mode_in;
-
-            // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-            for (IndexType j = 0; j < NUM_QPTS; j++) {
-              result += B_out[b_out_index + j * NUM_NODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NUM_NODES + l];
-            }
-          }  // end of e_mode_out
-        }    // end of e_mode_in
-        IndexType val_index = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NUM_NODES * i + l;
-
-        values_array[val_index] = result;
-      }  // end of out component
-    }    // end of in component
-  }      // end of element loop
-}
-
-//------------------------------------------------------------------------------
-// Fallback kernel for larger orders (1D thread block)
-//------------------------------------------------------------------------------
-extern "C" __launch_bounds__(BLOCK_SIZE) __global__
-    void linearAssembleFallback(const CeedScalar *B_in, const CeedScalar *B_out, const CeedScalar *__restrict__ qf_array,
-                                CeedScalar *__restrict__ values_array) {
-  // This kernel assumes B_in and B_out have the same number of quadrature points and basis points.
-  // TODO: expand to more general cases
-  const int l = threadIdx.x;  // The output column index of each B^TDB operation
-                              // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
-
-  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
-  // comp_in, comp_out, node_row, node_col
-  const IndexType comp_out_stride = NUM_NODES * NUM_NODES;
-  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP;
-  const IndexType e_stride        = comp_in_stride * NUM_COMP;
-  // Strides for QF array, slowest --> fastest:  e_mode_in, comp_in, e_mode_out, comp_out, elem, qpt
-  const IndexType q_e_stride          = NUM_QPTS;
-  const IndexType q_comp_out_stride   = NUM_ELEM * q_e_stride;
-  const IndexType q_e_mode_out_stride = q_comp_out_stride * NUM_COMP;
-  const IndexType q_comp_in_stride    = q_e_mode_out_stride * NUM_E_MODE_OUT;
-  const IndexType q_e_mode_in_stride  = q_comp_in_stride * NUM_COMP;
-
-  // Loop over each element (if necessary)
-  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NUM_ELEM; e += gridDim.x * blockDim.z) {
-    for (IndexType comp_in = 0; comp_in < NUM_COMP; comp_in++) {
-      for (IndexType comp_out = 0; comp_out < NUM_COMP; comp_out++) {
-        for (IndexType i = 0; i < NUM_NODES; i++) {
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NUM_COMP_IN; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NUM_COMP_OUT; comp_out++) {
+        for (IndexType i = threadIdx.y; i < NUM_NODES_OUT; i += BLOCK_SIZE_Y) {
           CeedScalar result        = 0.0;
           IndexType  qf_index_comp = q_comp_in_stride * comp_in + q_comp_out_stride * comp_out + q_e_stride * e;
 
-          for (IndexType e_mode_in = 0; e_mode_in < NUM_E_MODE_IN; e_mode_in++) {
-            IndexType b_in_index = e_mode_in * NUM_QPTS * NUM_NODES;
+          for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
+            IndexType b_in_index = e_in * NUM_QPTS * NUM_NODES_IN;
 
-            for (IndexType e_mode_out = 0; e_mode_out < NUM_E_MODE_OUT; e_mode_out++) {
-              IndexType b_out_index = e_mode_out * NUM_QPTS * NUM_NODES;
-              IndexType qf_index    = qf_index_comp + q_e_mode_out_stride * e_mode_out + q_e_mode_in_stride * e_mode_in;
+            for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+              IndexType b_out_index = e_out * NUM_QPTS * NUM_NODES_OUT;
+              IndexType qf_index    = qf_index_comp + q_eval_mode_out_stride * e_out + q_eval_mode_in_stride * e_in;
 
               // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
               for (IndexType j = 0; j < NUM_QPTS; j++) {
-                result += B_out[b_out_index + j * NUM_NODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NUM_NODES + l];
+                result += B_out[b_out_index + j * NUM_NODES_OUT + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NUM_NODES_IN + l];
               }
-            }  // end of e_mode_out
-          }    // end of e_mode_in
-          IndexType val_index = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NUM_NODES * i + l;
+            }  // end of out eval mode
+          }    // end of in eval mode
+          if (orients_in) {
+            result *= orients_in[NUM_NODES_IN * e + l] ? -1.0 : 1.0;
+          }
+          if (orients_out) {
+            result *= orients_out[NUM_NODES_OUT * e + i] ? -1.0 : 1.0;
+          }
+          if (!curl_orients_in && !curl_orients_out) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * i + l;
 
-          values_array[val_index] = result;
+            values_array[val_index] = result;
+          } else if (curl_orients_in) {
+            s_C[NUM_NODES_IN * threadIdx.y + l] = result;
+            __syncthreads();
+            s_CT[NUM_NODES_IN * i + l] =
+                (l > 0 ? s_C[NUM_NODES_IN * threadIdx.y + l - 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l - 1] : 0.0) +
+                s_C[NUM_NODES_IN * threadIdx.y + l] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 1] +
+                (l < (NUM_NODES_IN - 1) ? s_C[NUM_NODES_IN * threadIdx.y + l + 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 3] : 0.0);
+          } else {
+            s_CT[NUM_NODES_IN * i + l] = result;
+          }
         }  // end of loop over element node index, i
-      }    // end of out component
-    }      // end of in component
-  }        // end of element loop
+        if (curl_orients_in || curl_orients_out) {
+          // Compute and store the final T^T (B^T D B T) using the fully computed C T product in shared memory
+          if (curl_orients_out) __syncthreads();
+          for (IndexType i = threadIdx.y; i < NUM_NODES_OUT; i += BLOCK_SIZE_Y) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * i + l;
+
+            if (curl_orients_out) {
+              values_array[val_index] =
+                  (i > 0 ? s_CT[NUM_NODES_IN * (i - 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * i - 1] : 0.0) +
+                  s_CT[NUM_NODES_IN * i + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * i + 1] +
+                  (i < (NUM_NODES_OUT - 1) ? s_CT[NUM_NODES_IN * (i + 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * i + 3] : 0.0);
+            } else {
+              values_array[val_index] = s_CT[NUM_NODES_IN * i + l];
+            }
+          }
+        }
+      }  // end of out component
+    }    // end of in component
+  }      // end of element loop
 }
 
 //------------------------------------------------------------------------------

--- a/include/ceed/jit-source/cuda/cuda-ref-restriction.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-restriction.h
@@ -28,22 +28,7 @@ extern "C" __global__ void StridedNoTranspose(const CeedInt num_elem, const Ceed
 }
 
 //------------------------------------------------------------------------------
-// E-vector -> L-vector, strided
-//------------------------------------------------------------------------------
-extern "C" __global__ void StridedTranspose(const CeedInt num_elem, const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
-  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
-    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
-    const CeedInt elem     = node / RSTR_ELEM_SIZE;
-
-    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
-      v[loc_node * RSTR_STRIDE_NODES + comp * RSTR_STRIDE_COMP + elem * RSTR_STRIDE_ELEM] +=
-          u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE];
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
-// L-vector -> E-vector, offsets provided
+// L-vector -> E-vector, standard (with offsets)
 //------------------------------------------------------------------------------
 extern "C" __global__ void OffsetNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ u,
                                              CeedScalar *__restrict__ v) {
@@ -59,7 +44,91 @@ extern "C" __global__ void OffsetNoTranspose(const CeedInt num_elem, const CeedI
 }
 
 //------------------------------------------------------------------------------
-// E-vector -> L-vector, offsets provided
+// L-vector -> E-vector, oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void OrientedNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const bool *__restrict__ orients,
+                                               const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt ind      = indices[node];
+    const bool    orient   = orients[node];
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = u[ind + comp * RSTR_COMP_STRIDE] * (orient ? -1.0 : 1.0);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                   const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                   CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind_dl         = loc_node > 0 ? indices[node - 1] : 0;
+    const CeedInt  ind_d          = indices[node];
+    const CeedInt  ind_du         = loc_node < (RSTR_ELEM_SIZE - 1) ? indices[node + 1] : 0;
+    const CeedInt8 curl_orient_dl = curl_orients[3 * node + 0];
+    const CeedInt8 curl_orient_d  = curl_orients[3 * node + 1];
+    const CeedInt8 curl_orient_du = curl_orients[3 * node + 2];
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[ind_dl + comp * RSTR_COMP_STRIDE] * curl_orient_dl : 0.0;
+      value += u[ind_d + comp * RSTR_COMP_STRIDE] * curl_orient_d;
+      value += loc_node < (RSTR_ELEM_SIZE - 1) ? u[ind_du + comp * RSTR_COMP_STRIDE] * curl_orient_du : 0.0;
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = value;
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, unsigned curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedUnsignedNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                           const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                           CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind_dl         = loc_node > 0 ? indices[node - 1] : 0;
+    const CeedInt  ind_d          = indices[node];
+    const CeedInt  ind_du         = loc_node < (RSTR_ELEM_SIZE - 1) ? indices[node + 1] : 0;
+    const CeedInt8 curl_orient_dl = abs(curl_orients[3 * node + 0]);
+    const CeedInt8 curl_orient_d  = abs(curl_orients[3 * node + 1]);
+    const CeedInt8 curl_orient_du = abs(curl_orients[3 * node + 2]);
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[ind_dl + comp * RSTR_COMP_STRIDE] * curl_orient_dl : 0.0;
+      value += u[ind_d + comp * RSTR_COMP_STRIDE] * curl_orient_d;
+      value += loc_node < (RSTR_ELEM_SIZE - 1) ? u[ind_du + comp * RSTR_COMP_STRIDE] * curl_orient_du : 0.0;
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = value;
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, strided
+//------------------------------------------------------------------------------
+extern "C" __global__ void StridedTranspose(const CeedInt num_elem, const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      v[loc_node * RSTR_STRIDE_NODES + comp * RSTR_STRIDE_COMP + elem * RSTR_STRIDE_ELEM] +=
+          u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE];
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, standard (with offsets)
 //------------------------------------------------------------------------------
 extern "C" __global__ void OffsetTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ u,
                                            CeedScalar *__restrict__ v) {
@@ -87,8 +156,8 @@ extern "C" __global__ void OffsetTransposeDet(const CeedInt *__restrict__ l_vec_
 
     for (CeedInt j = range_1; j < range_N; j++) {
       const CeedInt t_ind    = t_indices[j];
-      CeedInt       loc_node = t_ind % RSTR_ELEM_SIZE;
-      CeedInt       elem     = t_ind / RSTR_ELEM_SIZE;
+      const CeedInt loc_node = t_ind % RSTR_ELEM_SIZE;
+      const CeedInt elem     = t_ind / RSTR_ELEM_SIZE;
 
       for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
         value[comp] += u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE];
@@ -96,6 +165,74 @@ extern "C" __global__ void OffsetTransposeDet(const CeedInt *__restrict__ l_vec_
     }
 
     for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) v[ind + comp * RSTR_COMP_STRIDE] += value[comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void OrientedTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const bool *__restrict__ orients,
+                                             const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt ind      = indices[node];
+    const bool    orient   = orients[node];
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE,
+                u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * (orient ? -1.0 : 1.0));
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                 const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                 CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind            = indices[node];
+    const CeedInt8 curl_orient_du = loc_node > 0 ? curl_orients[3 * node - 1] : 0.0;
+    const CeedInt8 curl_orient_d  = curl_orients[3 * node + 1];
+    const CeedInt8 curl_orient_dl = loc_node < (RSTR_ELEM_SIZE - 1) ? curl_orients[3 * node + 3] : 0.0;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[loc_node - 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_du : 0.0;
+      value += u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_d;
+      value +=
+          loc_node < (RSTR_ELEM_SIZE - 1) ? u[loc_node + 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_dl : 0.0;
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE, value);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, unsigned curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedUnsignedTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                         const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                         CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind            = indices[node];
+    const CeedInt8 curl_orient_du = loc_node > 0 ? abs(curl_orients[3 * node - 1]) : 0.0;
+    const CeedInt8 curl_orient_d  = abs(curl_orients[3 * node + 1]);
+    const CeedInt8 curl_orient_dl = loc_node < (RSTR_ELEM_SIZE - 1) ? abs(curl_orients[3 * node + 3]) : 0.0;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[loc_node - 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_du : 0.0;
+      value += u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_d;
+      value +=
+          loc_node < (RSTR_ELEM_SIZE - 1) ? u[loc_node + 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_dl : 0.0;
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE, value);
+    }
   }
 }
 

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h
@@ -12,80 +12,106 @@
 
 #include <ceed.h>
 
-#if CEEDSIZE
+#if USE_CEEDSIZE
 typedef CeedSize IndexType;
 #else
 typedef CeedInt IndexType;
 #endif
 
 //------------------------------------------------------------------------------
-// Get Basis Emode Pointer
+// Get basis pointer
 //------------------------------------------------------------------------------
-extern "C" __device__ void CeedOperatorGetBasisPointer_Hip(const CeedScalar **basisptr, CeedEvalMode emode, const CeedScalar *identity,
-                                                           const CeedScalar *interp, const CeedScalar *grad) {
-  switch (emode) {
+static __device__ __inline__ void GetBasisPointer(const CeedScalar **basis_ptr, CeedEvalMode eval_modes, const CeedScalar *identity,
+                                                  const CeedScalar *interp, const CeedScalar *grad, const CeedScalar *div, const CeedScalar *curl) {
+  switch (eval_modes) {
     case CEED_EVAL_NONE:
-      *basisptr = identity;
+      *basis_ptr = identity;
       break;
     case CEED_EVAL_INTERP:
-      *basisptr = interp;
+      *basis_ptr = interp;
       break;
     case CEED_EVAL_GRAD:
-      *basisptr = grad;
+      *basis_ptr = grad;
+      break;
+    case CEED_EVAL_DIV:
+      *basis_ptr = div;
+      break;
+    case CEED_EVAL_CURL:
+      *basis_ptr = curl;
       break;
     case CEED_EVAL_WEIGHT:
-    case CEED_EVAL_DIV:
-    case CEED_EVAL_CURL:
-      break;  // Caught by QF Assembly
+      break;  // Caught by QF assembly
   }
 }
 
 //------------------------------------------------------------------------------
 // Core code for diagonal assembly
 //------------------------------------------------------------------------------
-__device__ void diagonalCore(const CeedInt nelem, const bool pointBlock, const CeedScalar *identity, const CeedScalar *interpin,
-                             const CeedScalar *gradin, const CeedScalar *interpout, const CeedScalar *gradout, const CeedEvalMode *emodein,
-                             const CeedEvalMode *emodeout, const CeedScalar *__restrict__ assembledqfarray, CeedScalar *__restrict__ elemdiagarray) {
-  const int tid = threadIdx.x;  // running with P threads, tid is evec node
-  if (tid >= NNODES) return;
+static __device__ __inline__ void DiagonalCore(const CeedInt num_elem, const bool is_point_block, const CeedScalar *identity,
+                                               const CeedScalar *interp_in, const CeedScalar *grad_in, const CeedScalar *div_in,
+                                               const CeedScalar *curl_in, const CeedScalar *interp_out, const CeedScalar *grad_out,
+                                               const CeedScalar *div_out, const CeedScalar *curl_out, const CeedEvalMode *eval_modes_in,
+                                               const CeedEvalMode *eval_modes_out, const CeedScalar *__restrict__ assembled_qf_array,
+                                               CeedScalar *__restrict__ elem_diag_array) {
+  const int tid = threadIdx.x;  // Running with P threads
+
+  if (tid >= NUM_NODES) return;
 
   // Compute the diagonal of B^T D B
   // Each element
-  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < nelem; e += gridDim.x * blockDim.z) {
-    IndexType dout = -1;
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
     // Each basis eval mode pair
-    for (IndexType eout = 0; eout < NUMEMODEOUT; eout++) {
-      const CeedScalar *bt = NULL;
-      if (emodeout[eout] == CEED_EVAL_GRAD) dout += 1;
-      CeedOperatorGetBasisPointer_Hip(&bt, emodeout[eout], identity, interpout, &gradout[dout * NQPTS * NNODES]);
-      IndexType din = -1;
-      for (IndexType ein = 0; ein < NUMEMODEIN; ein++) {
+    IndexType    d_out               = 0;
+    CeedEvalMode eval_modes_out_prev = CEED_EVAL_NONE;
+
+    for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+      IndexType         d_in               = 0;
+      CeedEvalMode      eval_modes_in_prev = CEED_EVAL_NONE;
+      const CeedScalar *b_t                = NULL;
+
+      GetBasisPointer(&b_t, eval_modes_out[e_out], identity, interp_out, grad_out, div_out, curl_out);
+      if (e_out == 0 || eval_modes_out[e_out] != eval_modes_out_prev) d_out = 0;
+      else b_t = &b_t[(++d_out) * NUM_QPTS * NUM_NODES];
+      eval_modes_out_prev = eval_modes_out[e_out];
+
+      for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
         const CeedScalar *b = NULL;
-        if (emodein[ein] == CEED_EVAL_GRAD) din += 1;
-        CeedOperatorGetBasisPointer_Hip(&b, emodein[ein], identity, interpin, &gradin[din * NQPTS * NNODES]);
+
+        GetBasisPointer(&b, eval_modes_in[e_in], identity, interp_in, grad_in, div_in, curl_in);
+        if (e_in == 0 || eval_modes_in[e_in] != eval_modes_in_prev) d_in = 0;
+        else b = &b[(++d_in) * NUM_QPTS * NUM_NODES];
+        eval_modes_in_prev = eval_modes_in[e_in];
+
         // Each component
-        for (IndexType compOut = 0; compOut < NCOMP; compOut++) {
+        for (IndexType comp_out = 0; comp_out < NUM_COMP; comp_out++) {
           // Each qpoint/node pair
-          if (pointBlock) {
-            // Point Block Diagonal
-            for (IndexType compIn = 0; compIn < NCOMP; compIn++) {
-              CeedScalar evalue = 0.;
-              for (IndexType q = 0; q < NQPTS; q++) {
-                const CeedScalar qfvalue =
-                    assembledqfarray[((((ein * NCOMP + compIn) * NUMEMODEOUT + eout) * NCOMP + compOut) * nelem + e) * NQPTS + q];
-                evalue += bt[q * NNODES + tid] * qfvalue * b[q * NNODES + tid];
+          if (is_point_block) {
+            // Point block diagonal
+            for (IndexType comp_in = 0; comp_in < NUM_COMP; comp_in++) {
+              CeedScalar e_value = 0.;
+
+              for (IndexType q = 0; q < NUM_QPTS; q++) {
+                const CeedScalar qf_value =
+                    assembled_qf_array[((((e_in * NUM_COMP + comp_in) * NUM_EVAL_MODES_OUT + e_out) * NUM_COMP + comp_out) * num_elem + e) *
+                                           NUM_QPTS +
+                                       q];
+
+                e_value += b_t[q * NUM_NODES + tid] * qf_value * b[q * NUM_NODES + tid];
               }
-              elemdiagarray[((compOut * NCOMP + compIn) * nelem + e) * NNODES + tid] += evalue;
+              elem_diag_array[((comp_out * NUM_COMP + comp_in) * num_elem + e) * NUM_NODES + tid] += e_value;
             }
           } else {
-            // Diagonal Only
-            CeedScalar evalue = 0.;
-            for (IndexType q = 0; q < NQPTS; q++) {
-              const CeedScalar qfvalue =
-                  assembledqfarray[((((ein * NCOMP + compOut) * NUMEMODEOUT + eout) * NCOMP + compOut) * nelem + e) * NQPTS + q];
-              evalue += bt[q * NNODES + tid] * qfvalue * b[q * NNODES + tid];
+            // Diagonal only
+            CeedScalar e_value = 0.;
+
+            for (IndexType q = 0; q < NUM_QPTS; q++) {
+              const CeedScalar qf_value =
+                  assembled_qf_array[((((e_in * NUM_COMP + comp_out) * NUM_EVAL_MODES_OUT + e_out) * NUM_COMP + comp_out) * num_elem + e) * NUM_QPTS +
+                                     q];
+
+              e_value += b_t[q * NUM_NODES + tid] * qf_value * b[q * NUM_NODES + tid];
             }
-            elemdiagarray[(compOut * nelem + e) * NNODES + tid] += evalue;
+            elem_diag_array[(comp_out * num_elem + e) * NUM_NODES + tid] += e_value;
           }
         }
       }
@@ -96,21 +122,25 @@ __device__ void diagonalCore(const CeedInt nelem, const bool pointBlock, const C
 //------------------------------------------------------------------------------
 // Linear diagonal
 //------------------------------------------------------------------------------
-extern "C" __global__ void linearDiagonal(const CeedInt nelem, const CeedScalar *identity, const CeedScalar *interpin, const CeedScalar *gradin,
-                                          const CeedScalar *interpout, const CeedScalar *gradout, const CeedEvalMode *emodein,
-                                          const CeedEvalMode *emodeout, const CeedScalar *__restrict__ assembledqfarray,
-                                          CeedScalar *__restrict__ elemdiagarray) {
-  diagonalCore(nelem, false, identity, interpin, gradin, interpout, gradout, emodein, emodeout, assembledqfarray, elemdiagarray);
+extern "C" __global__ void LinearDiagonal(const CeedInt num_elem, const CeedScalar *identity, const CeedScalar *interp_in, const CeedScalar *grad_in,
+                                          const CeedScalar *div_in, const CeedScalar *curl_in, const CeedScalar *interp_out,
+                                          const CeedScalar *grad_out, const CeedScalar *div_out, const CeedScalar *curl_out,
+                                          const CeedEvalMode *eval_modes_in, const CeedEvalMode *eval_modes_out,
+                                          const CeedScalar *__restrict__ assembled_qf_array, CeedScalar *__restrict__ elem_diag_array) {
+  DiagonalCore(num_elem, false, identity, interp_in, grad_in, div_in, curl_in, interp_out, grad_out, div_out, curl_out, eval_modes_in, eval_modes_out,
+               assembled_qf_array, elem_diag_array);
 }
 
 //------------------------------------------------------------------------------
 // Linear point block diagonal
 //------------------------------------------------------------------------------
-extern "C" __global__ void linearPointBlockDiagonal(const CeedInt nelem, const CeedScalar *identity, const CeedScalar *interpin,
-                                                    const CeedScalar *gradin, const CeedScalar *interpout, const CeedScalar *gradout,
-                                                    const CeedEvalMode *emodein, const CeedEvalMode *emodeout,
-                                                    const CeedScalar *__restrict__ assembledqfarray, CeedScalar *__restrict__ elemdiagarray) {
-  diagonalCore(nelem, true, identity, interpin, gradin, interpout, gradout, emodein, emodeout, assembledqfarray, elemdiagarray);
+extern "C" __global__ void LinearPointBlockDiagonal(const CeedInt num_elem, const CeedScalar *identity, const CeedScalar *interp_in,
+                                                    const CeedScalar *grad_in, const CeedScalar *div_in, const CeedScalar *curl_in,
+                                                    const CeedScalar *interp_out, const CeedScalar *grad_out, const CeedScalar *div_out,
+                                                    const CeedScalar *curl_out, const CeedEvalMode *eval_modes_in, const CeedEvalMode *eval_modes_out,
+                                                    const CeedScalar *__restrict__ assembled_qf_array, CeedScalar *__restrict__ elem_diag_array) {
+  DiagonalCore(num_elem, true, identity, interp_in, grad_in, div_in, curl_in, interp_out, grad_out, div_out, curl_out, eval_modes_in, eval_modes_out,
+               assembled_qf_array, elem_diag_array);
 }
 
 //------------------------------------------------------------------------------

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
@@ -12,107 +12,99 @@
 
 #include <ceed.h>
 
-#if CEEDSIZE
+#if USE_CEEDSIZE
 typedef CeedSize IndexType;
 #else
 typedef CeedInt IndexType;
 #endif
 
 //------------------------------------------------------------------------------
-// Matrix assembly kernel for low-order elements (2D thread block)
+// Matrix assembly kernel
 //------------------------------------------------------------------------------
 extern "C" __launch_bounds__(BLOCK_SIZE) __global__
-    void linearAssemble(const CeedScalar *B_in, const CeedScalar *B_out, const CeedScalar *__restrict__ qf_array,
-                        CeedScalar *__restrict__ values_array) {
-  // This kernel assumes B_in and B_out have the same number of quadrature points and basis points.
-  // TODO: expand to more general cases
-  const int i = threadIdx.x;  // The output row index of each B^TDB operation
-  const int l = threadIdx.y;  // The output column index of each B^TDB operation
+    void LinearAssemble(const CeedInt num_elem, const CeedScalar *B_in, const CeedScalar *B_out, const bool *orients_in,
+                        const CeedInt8 *curl_orients_in, const bool *orients_out, const CeedInt8 *curl_orients_out,
+                        const CeedScalar *__restrict__ qf_array, CeedScalar *__restrict__ values_array) {
+  extern __shared__ CeedScalar s_CT[];
+  CeedScalar                  *s_C = s_CT + NUM_NODES_OUT * NUM_NODES_IN;
+
+  const int l = threadIdx.x;  // The output column index of each B^T D B operation
                               // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
 
-  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
+  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: e,
   // comp_in, comp_out, node_row, node_col
-  const IndexType comp_out_stride = NNODES * NNODES;
-  const IndexType comp_in_stride  = comp_out_stride * NCOMP;
-  const IndexType e_stride        = comp_in_stride * NCOMP;
-  // Strides for QF array, slowest --> fastest:  emode_in, comp_in, emode_out, comp_out, elem, qpt
-  const IndexType qe_stride         = NQPTS;
-  const IndexType qcomp_out_stride  = NELEM * qe_stride;
-  const IndexType qemode_out_stride = qcomp_out_stride * NCOMP;
-  const IndexType qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
-  const IndexType qemode_in_stride  = qcomp_in_stride * NCOMP;
+  const IndexType comp_out_stride = NUM_NODES_OUT * NUM_NODES_IN;
+  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP_OUT;
+  const IndexType e_stride        = comp_in_stride * NUM_COMP_IN;
+
+  // Strides for QF array, slowest --> fastest: e_in, comp_in, e_out, comp_out, e, q
+  const IndexType q_e_stride             = NUM_QPTS;
+  const IndexType q_comp_out_stride      = num_elem * q_e_stride;
+  const IndexType q_eval_mode_out_stride = q_comp_out_stride * NUM_COMP_OUT;
+  const IndexType q_comp_in_stride       = q_eval_mode_out_stride * NUM_EVAL_MODES_OUT;
+  const IndexType q_eval_mode_in_stride  = q_comp_in_stride * NUM_COMP_IN;
 
   // Loop over each element (if necessary)
-  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
-    for (IndexType comp_in = 0; comp_in < NCOMP; comp_in++) {
-      for (IndexType comp_out = 0; comp_out < NCOMP; comp_out++) {
-        CeedScalar result        = 0.0;
-        IndexType  qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
-        for (IndexType emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
-          IndexType b_in_index = emode_in * NQPTS * NNODES;
-          for (IndexType emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-            IndexType b_out_index = emode_out * NQPTS * NNODES;
-            IndexType qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
-            // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-            for (IndexType j = 0; j < NQPTS; j++) {
-              result += B_out[b_out_index + j * NNODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NUM_COMP_IN; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NUM_COMP_OUT; comp_out++) {
+        for (IndexType i = threadIdx.y; i < NUM_NODES_OUT; i += BLOCK_SIZE_Y) {
+          CeedScalar result        = 0.0;
+          IndexType  qf_index_comp = q_comp_in_stride * comp_in + q_comp_out_stride * comp_out + q_e_stride * e;
+
+          for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
+            IndexType b_in_index = e_in * NUM_QPTS * NUM_NODES_IN;
+
+            for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+              IndexType b_out_index = e_out * NUM_QPTS * NUM_NODES_OUT;
+              IndexType qf_index    = qf_index_comp + q_eval_mode_out_stride * e_out + q_eval_mode_in_stride * e_in;
+
+              // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+              for (IndexType j = 0; j < NUM_QPTS; j++) {
+                result += B_out[b_out_index + j * NUM_NODES_OUT + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NUM_NODES_IN + l];
+              }
+            }  // end of out eval mode
+          }    // end of in eval mode
+          if (orients_in) {
+            result *= orients_in[NUM_NODES_IN * e + l] ? -1.0 : 1.0;
+          }
+          if (orients_out) {
+            result *= orients_out[NUM_NODES_OUT * e + i] ? -1.0 : 1.0;
+          }
+          if (!curl_orients_in && !curl_orients_out) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * i + l;
+
+            values_array[val_index] = result;
+          } else if (curl_orients_in) {
+            s_C[NUM_NODES_IN * threadIdx.y + l] = result;
+            __syncthreads();
+            s_CT[NUM_NODES_IN * i + l] =
+                (l > 0 ? s_C[NUM_NODES_IN * threadIdx.y + l - 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l - 1] : 0.0) +
+                s_C[NUM_NODES_IN * threadIdx.y + l] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 1] +
+                (l < (NUM_NODES_IN - 1) ? s_C[NUM_NODES_IN * threadIdx.y + l + 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 3] : 0.0);
+          } else {
+            s_CT[NUM_NODES_IN * i + l] = result;
+          }
+        }  // end of loop over element node index, i
+        if (curl_orients_in || curl_orients_out) {
+          // Compute and store the final T^T (B^T D B T) using the fully computed C T product in shared memory
+          if (curl_orients_out) __syncthreads();
+          for (IndexType i = threadIdx.y; i < NUM_NODES_OUT; i += BLOCK_SIZE_Y) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * i + l;
+
+            if (curl_orients_out) {
+              values_array[val_index] =
+                  (i > 0 ? s_CT[NUM_NODES_IN * (i - 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * i - 1] : 0.0) +
+                  s_CT[NUM_NODES_IN * i + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * i + 1] +
+                  (i < (NUM_NODES_OUT - 1) ? s_CT[NUM_NODES_IN * (i + 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * i + 3] : 0.0);
+            } else {
+              values_array[val_index] = s_CT[NUM_NODES_IN * i + l];
             }
-          }  // end of emode_out
-        }    // end of emode_in
-        IndexType val_index     = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
-        values_array[val_index] = result;
+          }
+        }
       }  // end of out component
     }    // end of in component
   }      // end of element loop
-}
-
-//------------------------------------------------------------------------------
-// Fallback kernel for larger orders (1D thread block)
-//------------------------------------------------------------------------------
-extern "C" __launch_bounds__(BLOCK_SIZE) __global__
-    void linearAssembleFallback(const CeedScalar *B_in, const CeedScalar *B_out, const CeedScalar *__restrict__ qf_array,
-                                CeedScalar *__restrict__ values_array) {
-  // This kernel assumes B_in and B_out have the same number of quadrature points and basis points.
-  // TODO: expand to more general cases
-  const int l = threadIdx.x;  // The output column index of each B^TDB operation
-                              // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
-
-  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: element,
-  // comp_in, comp_out, node_row, node_col
-  const IndexType comp_out_stride = NNODES * NNODES;
-  const IndexType comp_in_stride  = comp_out_stride * NCOMP;
-  const IndexType e_stride        = comp_in_stride * NCOMP;
-  // Strides for QF array, slowest --> fastest:  emode_in, comp_in, emode_out, comp_out, elem, qpt
-  const IndexType qe_stride         = NQPTS;
-  const IndexType qcomp_out_stride  = NELEM * qe_stride;
-  const IndexType qemode_out_stride = qcomp_out_stride * NCOMP;
-  const IndexType qcomp_in_stride   = qemode_out_stride * NUMEMODEOUT;
-  const IndexType qemode_in_stride  = qcomp_in_stride * NCOMP;
-
-  // Loop over each element (if necessary)
-  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < NELEM; e += gridDim.x * blockDim.z) {
-    for (IndexType comp_in = 0; comp_in < NCOMP; comp_in++) {
-      for (IndexType comp_out = 0; comp_out < NCOMP; comp_out++) {
-        for (IndexType i = 0; i < NNODES; i++) {
-          CeedScalar result        = 0.0;
-          IndexType  qf_index_comp = qcomp_in_stride * comp_in + qcomp_out_stride * comp_out + qe_stride * e;
-          for (IndexType emode_in = 0; emode_in < NUMEMODEIN; emode_in++) {
-            IndexType b_in_index = emode_in * NQPTS * NNODES;
-            for (IndexType emode_out = 0; emode_out < NUMEMODEOUT; emode_out++) {
-              IndexType b_out_index = emode_out * NQPTS * NNODES;
-              IndexType qf_index    = qf_index_comp + qemode_out_stride * emode_out + qemode_in_stride * emode_in;
-              // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
-              for (IndexType j = 0; j < NQPTS; j++) {
-                result += B_out[b_out_index + j * NNODES + i] * qf_array[qf_index + j] * B_in[b_in_index + j * NNODES + l];
-              }
-            }  // end of emode_out
-          }    // end of emode_in
-          IndexType val_index     = comp_in_stride * comp_in + comp_out_stride * comp_out + e_stride * e + NNODES * i + l;
-          values_array[val_index] = result;
-        }  // end of loop over element node index, i
-      }    // end of out component
-    }      // end of in component
-  }        // end of element loop
 }
 
 //------------------------------------------------------------------------------

--- a/include/ceed/jit-source/hip/hip-ref-restriction.h
+++ b/include/ceed/jit-source/hip/hip-ref-restriction.h
@@ -16,13 +16,98 @@
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 extern "C" __global__ void StridedNoTranspose(const CeedInt num_elem, const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
-  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RESTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
-    const CeedInt loc_node = node % RESTR_ELEM_SIZE;
-    const CeedInt elem     = node / RESTR_ELEM_SIZE;
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
 
-    for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) {
-      v[loc_node + comp * RESTR_ELEM_SIZE * RESTR_NUM_ELEM + elem * RESTR_ELEM_SIZE] =
-          u[loc_node * RESTR_STRIDE_NODES + comp * RESTR_STRIDE_COMP + elem * RESTR_STRIDE_ELEM];
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] =
+          u[loc_node * RSTR_STRIDE_NODES + comp * RSTR_STRIDE_COMP + elem * RSTR_STRIDE_ELEM];
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, standard (with offsets)
+//------------------------------------------------------------------------------
+extern "C" __global__ void OffsetNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ u,
+                                             CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt ind      = indices[node];
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = u[ind + comp * RSTR_COMP_STRIDE];
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void OrientedNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const bool *__restrict__ orients,
+                                               const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt ind      = indices[node];
+    const bool    orient   = orients[node];
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = u[ind + comp * RSTR_COMP_STRIDE] * (orient ? -1.0 : 1.0);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                   const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                   CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind_dl         = loc_node > 0 ? indices[node - 1] : 0;
+    const CeedInt  ind_d          = indices[node];
+    const CeedInt  ind_du         = loc_node < (RSTR_ELEM_SIZE - 1) ? indices[node + 1] : 0;
+    const CeedInt8 curl_orient_dl = curl_orients[3 * node + 0];
+    const CeedInt8 curl_orient_d  = curl_orients[3 * node + 1];
+    const CeedInt8 curl_orient_du = curl_orients[3 * node + 2];
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[ind_dl + comp * RSTR_COMP_STRIDE] * curl_orient_dl : 0.0;
+      value += u[ind_d + comp * RSTR_COMP_STRIDE] * curl_orient_d;
+      value += loc_node < (RSTR_ELEM_SIZE - 1) ? u[ind_du + comp * RSTR_COMP_STRIDE] * curl_orient_du : 0.0;
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = value;
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// L-vector -> E-vector, unsigned curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedUnsignedNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                           const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                           CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind_dl         = loc_node > 0 ? indices[node - 1] : 0;
+    const CeedInt  ind_d          = indices[node];
+    const CeedInt  ind_du         = loc_node < (RSTR_ELEM_SIZE - 1) ? indices[node + 1] : 0;
+    const CeedInt8 curl_orient_dl = abs(curl_orients[3 * node + 0]);
+    const CeedInt8 curl_orient_d  = abs(curl_orients[3 * node + 1]);
+    const CeedInt8 curl_orient_du = abs(curl_orients[3 * node + 2]);
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[ind_dl + comp * RSTR_COMP_STRIDE] * curl_orient_dl : 0.0;
+      value += u[ind_d + comp * RSTR_COMP_STRIDE] * curl_orient_d;
+      value += loc_node < (RSTR_ELEM_SIZE - 1) ? u[ind_du + comp * RSTR_COMP_STRIDE] * curl_orient_du : 0.0;
+      v[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] = value;
     }
   }
 }
@@ -31,71 +116,123 @@ extern "C" __global__ void StridedNoTranspose(const CeedInt num_elem, const Ceed
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 extern "C" __global__ void StridedTranspose(const CeedInt num_elem, const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
-  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RESTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
-    const CeedInt loc_node = node % RESTR_ELEM_SIZE;
-    const CeedInt elem     = node / RESTR_ELEM_SIZE;
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
 
-    for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) {
-      v[loc_node * RESTR_STRIDE_NODES + comp * RESTR_STRIDE_COMP + elem * RESTR_STRIDE_ELEM] +=
-          u[loc_node + comp * RESTR_ELEM_SIZE * RESTR_NUM_ELEM + elem * RESTR_ELEM_SIZE];
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      v[loc_node * RSTR_STRIDE_NODES + comp * RSTR_STRIDE_COMP + elem * RSTR_STRIDE_ELEM] +=
+          u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE];
     }
   }
 }
 
 //------------------------------------------------------------------------------
-// L-vector -> E-vector, offsets provided
-//------------------------------------------------------------------------------
-extern "C" __global__ void OffsetNoTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ u,
-                                             CeedScalar *__restrict__ v) {
-  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RESTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
-    const CeedInt ind      = indices[node];
-    const CeedInt loc_node = node % RESTR_ELEM_SIZE;
-    const CeedInt elem     = node / RESTR_ELEM_SIZE;
-
-    for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) {
-      v[loc_node + comp * RESTR_ELEM_SIZE * RESTR_NUM_ELEM + elem * RESTR_ELEM_SIZE] = u[ind + comp * RESTR_COMP_STRIDE];
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
-// E-vector -> L-vector, offsets provided
+// E-vector -> L-vector, standard (with offsets)
 //------------------------------------------------------------------------------
 extern "C" __global__ void OffsetTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ u,
                                            CeedScalar *__restrict__ v) {
-  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RESTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
     const CeedInt ind      = indices[node];
-    const CeedInt loc_node = node % RESTR_ELEM_SIZE;
-    const CeedInt elem     = node / RESTR_ELEM_SIZE;
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
 
-    for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) {
-      atomicAdd(v + ind + comp * RESTR_COMP_STRIDE, u[loc_node + comp * RESTR_ELEM_SIZE * RESTR_NUM_ELEM + elem * RESTR_ELEM_SIZE]);
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE, u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE]);
     }
   }
 }
 
 extern "C" __global__ void OffsetTransposeDet(const CeedInt *__restrict__ l_vec_indices, const CeedInt *__restrict__ t_indices,
                                               const CeedInt *__restrict__ t_offsets, const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
-  CeedScalar value[RESTR_NUM_COMP];
+  CeedScalar value[RSTR_NUM_COMP];
 
-  for (CeedInt i = blockIdx.x * blockDim.x + threadIdx.x; i < RESTR_NUM_NODES; i += blockDim.x * gridDim.x) {
+  for (CeedInt i = blockIdx.x * blockDim.x + threadIdx.x; i < RSTR_NUM_NODES; i += blockDim.x * gridDim.x) {
     const CeedInt ind     = l_vec_indices[i];
     const CeedInt range_1 = t_offsets[i];
     const CeedInt range_N = t_offsets[i + 1];
 
-    for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) value[comp] = 0.0;
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) value[comp] = 0.0;
 
     for (CeedInt j = range_1; j < range_N; j++) {
       const CeedInt t_ind    = t_indices[j];
-      CeedInt       loc_node = t_ind % RESTR_ELEM_SIZE;
-      CeedInt       elem     = t_ind / RESTR_ELEM_SIZE;
+      const CeedInt loc_node = t_ind % RSTR_ELEM_SIZE;
+      const CeedInt elem     = t_ind / RSTR_ELEM_SIZE;
 
-      for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) {
-        value[comp] += u[loc_node + comp * RESTR_ELEM_SIZE * RESTR_NUM_ELEM + elem * RESTR_ELEM_SIZE];
+      for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+        value[comp] += u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE];
       }
     }
 
-    for (CeedInt comp = 0; comp < RESTR_NUM_COMP; comp++) v[ind + comp * RESTR_COMP_STRIDE] += value[comp];
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) v[ind + comp * RSTR_COMP_STRIDE] += value[comp];
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void OrientedTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices, const bool *__restrict__ orients,
+                                             const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt ind      = indices[node];
+    const bool    orient   = orients[node];
+    const CeedInt loc_node = node % RSTR_ELEM_SIZE;
+    const CeedInt elem     = node / RSTR_ELEM_SIZE;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE,
+                u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * (orient ? -1.0 : 1.0));
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                 const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                 CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind            = indices[node];
+    const CeedInt8 curl_orient_du = loc_node > 0 ? curl_orients[3 * node - 1] : 0.0;
+    const CeedInt8 curl_orient_d  = curl_orients[3 * node + 1];
+    const CeedInt8 curl_orient_dl = loc_node < (RSTR_ELEM_SIZE - 1) ? curl_orients[3 * node + 3] : 0.0;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[loc_node - 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_du : 0.0;
+      value += u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_d;
+      value +=
+          loc_node < (RSTR_ELEM_SIZE - 1) ? u[loc_node + 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_dl : 0.0;
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE, value);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// E-vector -> L-vector, unsigned curl-oriented
+//------------------------------------------------------------------------------
+extern "C" __global__ void CurlOrientedUnsignedTranspose(const CeedInt num_elem, const CeedInt *__restrict__ indices,
+                                                         const CeedInt8 *__restrict__ curl_orients, const CeedScalar *__restrict__ u,
+                                                         CeedScalar *__restrict__ v) {
+  for (CeedInt node = blockIdx.x * blockDim.x + threadIdx.x; node < num_elem * RSTR_ELEM_SIZE; node += blockDim.x * gridDim.x) {
+    const CeedInt  loc_node       = node % RSTR_ELEM_SIZE;
+    const CeedInt  elem           = node / RSTR_ELEM_SIZE;
+    const CeedInt  ind            = indices[node];
+    const CeedInt8 curl_orient_du = loc_node > 0 ? abs(curl_orients[3 * node - 1]) : 0.0;
+    const CeedInt8 curl_orient_d  = abs(curl_orients[3 * node + 1]);
+    const CeedInt8 curl_orient_dl = loc_node < (RSTR_ELEM_SIZE - 1) ? abs(curl_orients[3 * node + 3]) : 0.0;
+
+    for (CeedInt comp = 0; comp < RSTR_NUM_COMP; comp++) {
+      CeedScalar value = 0.0;
+      value += loc_node > 0 ? u[loc_node - 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_du : 0.0;
+      value += u[loc_node + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_d;
+      value +=
+          loc_node < (RSTR_ELEM_SIZE - 1) ? u[loc_node + 1 + comp * RSTR_ELEM_SIZE * RSTR_NUM_ELEM + elem * RSTR_ELEM_SIZE] * curl_orient_dl : 0.0;
+      atomicAdd(v + ind + comp * RSTR_COMP_STRIDE, value);
+    }
   }
 }
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -140,40 +140,6 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
 }
 
 /**
-  @brief Select correct basis matrix pointer based on @ref CeedEvalMode
-
-  @param[in]  basis     `CeedBasis` from which to get the basis matrix
-  @param[in]  eval_mode Current basis evaluation mode
-  @param[in]  identity  Pointer to identity matrix
-  @param[out] basis_ptr `CeedBasis` pointer to set
-
-  @ref Developer
-**/
-static inline int CeedOperatorGetBasisPointer(CeedBasis basis, CeedEvalMode eval_mode, const CeedScalar *identity, const CeedScalar **basis_ptr) {
-  switch (eval_mode) {
-    case CEED_EVAL_NONE:
-      *basis_ptr = identity;
-      break;
-    case CEED_EVAL_INTERP:
-      CeedCall(CeedBasisGetInterp(basis, basis_ptr));
-      break;
-    case CEED_EVAL_GRAD:
-      CeedCall(CeedBasisGetGrad(basis, basis_ptr));
-      break;
-    case CEED_EVAL_DIV:
-      CeedCall(CeedBasisGetDiv(basis, basis_ptr));
-      break;
-    case CEED_EVAL_CURL:
-      CeedCall(CeedBasisGetCurl(basis, basis_ptr));
-      break;
-    case CEED_EVAL_WEIGHT:
-      break;  // Caught by QF Assembly
-  }
-  assert(*basis_ptr != NULL);
-  return CEED_ERROR_SUCCESS;
-}
-
-/**
   @brief Core logic for assembling operator diagonal or point block diagonal
 
   @param[in]  op             `CeedOperator` to assemble point block diagonal
@@ -1001,6 +967,40 @@ CeedPragmaOptimizeOn
 /// @{
 
 /**
+  @brief Select correct basis matrix pointer based on @ref CeedEvalMode
+
+  @param[in]  basis     `CeedBasis` from which to get the basis matrix
+  @param[in]  eval_mode Current basis evaluation mode
+  @param[in]  identity  Pointer to identity matrix
+  @param[out] basis_ptr `CeedBasis` pointer to set
+
+  @ref Backend
+**/
+int CeedOperatorGetBasisPointer(CeedBasis basis, CeedEvalMode eval_mode, const CeedScalar *identity, const CeedScalar **basis_ptr) {
+  switch (eval_mode) {
+    case CEED_EVAL_NONE:
+      *basis_ptr = identity;
+      break;
+    case CEED_EVAL_INTERP:
+      CeedCall(CeedBasisGetInterp(basis, basis_ptr));
+      break;
+    case CEED_EVAL_GRAD:
+      CeedCall(CeedBasisGetGrad(basis, basis_ptr));
+      break;
+    case CEED_EVAL_DIV:
+      CeedCall(CeedBasisGetDiv(basis, basis_ptr));
+      break;
+    case CEED_EVAL_CURL:
+      CeedCall(CeedBasisGetCurl(basis, basis_ptr));
+      break;
+    case CEED_EVAL_WEIGHT:
+      break;  // Caught by QF Assembly
+  }
+  assert(*basis_ptr != NULL);
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Create point block restriction for active `CeedOperatorField`
 
   @param[in]  rstr             Original `CeedElemRestriction` for active field
@@ -1275,10 +1275,10 @@ int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op, CeedOperatorAssem
 
   // Build OperatorAssembly data
   CeedCall(CeedOperatorGetQFunction(op, &qf));
-  CeedCall(CeedQFunctionGetFields(qf, &num_input_fields, &qf_fields, NULL, NULL));
-  CeedCall(CeedOperatorGetFields(op, NULL, &op_fields, NULL, NULL));
 
   // Determine active input basis
+  CeedCall(CeedQFunctionGetFields(qf, &num_input_fields, &qf_fields, NULL, NULL));
+  CeedCall(CeedOperatorGetFields(op, NULL, &op_fields, NULL, NULL));
   for (CeedInt i = 0; i < num_input_fields; i++) {
     CeedVector vec;
 


### PR DESCRIPTION
NOTE: Based on #1316

Follows up #1300 and #1301 to complete H(div) and H(curl) functionality on GPU backends. Implements diagonal assembly and full assembly for the `cuda/ref` and `hip/ref` backends when using H(div) or H(curl) finite element spaces, while also following up #1316 with support for rectangular operator full assembly.

~~This currently does not include deterministic element restriction transpose operations for the GPU backends when the restrictions are created by `ElemRestrictionCreateOriented` or `CreateCurlOriented`. The non-determistic kernels using `atomicAdd` are easier to write. If this is a sticking point I guess we can go ahead and add deterministic variants for the transpose operations for these restrictions. I believe all that's necessary is correctly permuting the `orients` and `curl_orients` arrays for access similar to `offsets` during construction, but I am not fully certain on this and so would welcome any input here on how to go about it/if this should be added or not.~~ UPDATE 11/9: This is now added and `/gpu/[cuda,hip]/magma/det` is implemented for all restriction types.