### PR TITLE
fluids: Refactor setupgeo*, calculate dXdx directly for strong BC

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -464,7 +464,7 @@ PetscErrorCode GridAnisotropyTensorCalculateCollocatedVector(Ceed ceed, User use
 // -----------------------------------------------------------------------------
 
 // Setup StrongBCs that use QFunctions
-PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData *problem, SimpleBC bc, CeedInt q_data_size_sur);
+PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData *problem, SimpleBC bc);
 
 PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
 PetscErrorCode OutflowBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -325,11 +325,11 @@ PetscErrorCode SetupStrongSTG(DM dm, SimpleBC bc, ProblemData *problem, Physics 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupStrongSTG_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size,
-                                 CeedInt q_data_size_sur, CeedQFunction *qf_strongbc) {
+PetscErrorCode SetupStrongSTG_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size, CeedInt dXdx_size,
+                                 CeedQFunction *qf_strongbc) {
   PetscFunctionBeginUser;
   PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, STGShur14_Inflow_StrongQF, STGShur14_Inflow_StrongQF_loc, qf_strongbc));
-  PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "surface qdata", q_data_size_sur, CEED_EVAL_NONE));
+  PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "dXdx", dXdx_size, CEED_EVAL_NONE));
   PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "x", num_comp_x, CEED_EVAL_NONE));
   PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "scale", 1, CEED_EVAL_NONE));
   PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "stg data", stg_data_size, CEED_EVAL_NONE));
@@ -339,11 +339,11 @@ PetscErrorCode SetupStrongSTG_QF(Ceed ceed, ProblemData *problem, CeedInt num_co
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupStrongSTG_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt q_data_size_sur,
+PetscErrorCode SetupStrongSTG_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
                                             CeedQFunction *qf_strongbc) {
   PetscFunctionBeginUser;
   PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, Preprocess_STGShur14, Preprocess_STGShur14_loc, qf_strongbc));
-  PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "surface qdata", q_data_size_sur, CEED_EVAL_NONE));
+  PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "dXdx", dXdx_size, CEED_EVAL_NONE));
   PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_strongbc, "x", num_comp_x, CEED_EVAL_NONE));
   PetscCallCeed(ceed, CeedQFunctionAddOutput(*qf_strongbc, "stg data", stg_data_size, CEED_EVAL_NONE));
 

--- a/examples/fluids/problems/stg_shur14.h
+++ b/examples/fluids/problems/stg_shur14.h
@@ -17,7 +17,7 @@ extern PetscErrorCode SetupSTG(const MPI_Comm comm, const DM dm, ProblemData *pr
 extern PetscErrorCode SetupStrongSTG(DM dm, SimpleBC bc, ProblemData *problem, Physics phys);
 
 extern PetscErrorCode SetupStrongSTG_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size,
-                                        CeedInt q_data_size_sur, CeedQFunction *qf_strongbc);
+                                        CeedInt dXdx_size, CeedQFunction *qf_strongbc);
 
-extern PetscErrorCode SetupStrongSTG_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size,
-                                                   CeedInt q_data_size_sur, CeedQFunction *pqf_strongbc);
+extern PetscErrorCode SetupStrongSTG_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
+                                                   CeedQFunction *pqf_strongbc);

--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -14,6 +14,8 @@
 #include <ceed.h>
 #include <math.h>
 
+#include "utils.h"
+
 typedef struct SetupContextAdv_ *SetupContextAdv;
 struct SetupContextAdv_ {
   CeedScalar rc;
@@ -35,8 +37,6 @@ struct AdvectionContext_ {
   bool       implicit;
   int        stabilization;  // See StabilizationType: 0=none, 1=SU, 2=SUPG
 };
-
-CEED_QFUNCTION_HELPER CeedScalar Square(CeedScalar x) { return x * x; }
 
 // *****************************************************************************
 // This QFunction sets the initial conditions and the boundary conditions

--- a/examples/fluids/qfunctions/setupgeo.h
+++ b/examples/fluids/qfunctions/setupgeo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and other CEED contributors.
 // All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
 //
 // SPDX-License-Identifier: BSD-2-Clause
@@ -13,6 +13,8 @@
 
 #include <ceed.h>
 #include <math.h>
+
+#include "setupgeo_helpers.h"
 
 // *****************************************************************************
 // This QFunction sets up the geometric factors required for integration and coordinate transformations
@@ -29,7 +31,7 @@
 // Determinant of Jacobian:
 //   detJ = J11*A11 + J21*A12 + J31*A13
 //     Jij = Jacobian entry ij
-//     Aij = Adjoint ij
+//     Aij = Adjugate ij
 //
 // Stored: w detJ
 //   in q_data[0]
@@ -46,55 +48,24 @@
 //               [A31 A32 A33]
 // *****************************************************************************
 CEED_QFUNCTION(Setup)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  // Inputs
   const CeedScalar(*J)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
   const CeedScalar(*w)                = in[1];
+  CeedScalar(*q_data)[CEED_Q_VLA]     = (CeedScalar(*)[CEED_Q_VLA])out[0];
 
-  // Outputs
-  CeedScalar(*q_data)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
-
-  CeedPragmaSIMD
-      // Quadrature Point Loop
-      for (CeedInt i = 0; i < Q; i++) {
-    // Setup
-    const CeedScalar J11  = J[0][0][i];
-    const CeedScalar J21  = J[0][1][i];
-    const CeedScalar J31  = J[0][2][i];
-    const CeedScalar J12  = J[1][0][i];
-    const CeedScalar J22  = J[1][1][i];
-    const CeedScalar J32  = J[1][2][i];
-    const CeedScalar J13  = J[2][0][i];
-    const CeedScalar J23  = J[2][1][i];
-    const CeedScalar J33  = J[2][2][i];
-    const CeedScalar A11  = J22 * J33 - J23 * J32;
-    const CeedScalar A12  = J13 * J32 - J12 * J33;
-    const CeedScalar A13  = J12 * J23 - J13 * J22;
-    const CeedScalar A21  = J23 * J31 - J21 * J33;
-    const CeedScalar A22  = J11 * J33 - J13 * J31;
-    const CeedScalar A23  = J13 * J21 - J11 * J23;
-    const CeedScalar A31  = J21 * J32 - J22 * J31;
-    const CeedScalar A32  = J12 * J31 - J11 * J32;
-    const CeedScalar A33  = J11 * J22 - J12 * J21;
-    const CeedScalar detJ = J11 * A11 + J21 * A12 + J31 * A13;
-
-    // Qdata
-    // -- Interp-to-Interp q_data
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
+    CeedScalar detJ, dXdx[3][3];
+    InvertMappingJacobian_3D(Q, i, J, dXdx, &detJ);
     q_data[0][i] = w[i] * detJ;
-    // -- Interp-to-Grad q_data
-    // Inverse of change of coordinate matrix: X_i,j
-    q_data[1][i] = A11 / detJ;
-    q_data[2][i] = A12 / detJ;
-    q_data[3][i] = A13 / detJ;
-    q_data[4][i] = A21 / detJ;
-    q_data[5][i] = A22 / detJ;
-    q_data[6][i] = A23 / detJ;
-    q_data[7][i] = A31 / detJ;
-    q_data[8][i] = A32 / detJ;
-    q_data[9][i] = A33 / detJ;
-
-  }  // End of Quadrature Point Loop
-
-  // Return
+    q_data[1][i] = dXdx[0][0];
+    q_data[2][i] = dXdx[0][1];
+    q_data[3][i] = dXdx[0][2];
+    q_data[4][i] = dXdx[1][0];
+    q_data[5][i] = dXdx[1][1];
+    q_data[6][i] = dXdx[1][2];
+    q_data[7][i] = dXdx[2][0];
+    q_data[8][i] = dXdx[2][1];
+    q_data[9][i] = dXdx[2][2];
+  }
   return 0;
 }
 
@@ -128,6 +99,7 @@ CEED_QFUNCTION(Setup)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSca
 // Normal vector = (J1,J2,J3) / detJb
 //
 //   - TODO Could possibly remove normal vector, as it could be calculated in the Qfunction from dXdx
+//    See https://github.com/CEED/libCEED/pull/868#discussion_r871979484
 // Stored: (J1,J2,J3) / detJb
 //   in q_data_sur[1:3] as
 //   (detJb^-1) * [ J1 ]
@@ -140,71 +112,27 @@ CEED_QFUNCTION(Setup)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSca
 //    [dXdx_21 dXdx_22 dXdx_23]
 // *****************************************************************************
 CEED_QFUNCTION(SetupBoundary)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  // Inputs
   const CeedScalar(*J)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
   const CeedScalar(*w)                = in[1];
-
-  // Outputs
   CeedScalar(*q_data_sur)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
 
-  CeedPragmaSIMD
-      // Quadrature Point Loop
-      for (CeedInt i = 0; i < Q; i++) {
-    // Setup
-    const CeedScalar dxdX[3][2] = {
-        {J[0][0][i], J[1][0][i]},
-        {J[0][1][i], J[1][1][i]},
-        {J[0][2][i], J[1][2][i]}
-    };
-    // J1, J2, and J3 are given by the cross product of the columns of dxdX
-    const CeedScalar J1 = dxdX[1][0] * dxdX[2][1] - dxdX[2][0] * dxdX[1][1];
-    const CeedScalar J2 = dxdX[2][0] * dxdX[0][1] - dxdX[0][0] * dxdX[2][1];
-    const CeedScalar J3 = dxdX[0][0] * dxdX[1][1] - dxdX[1][0] * dxdX[0][1];
+  CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
+    CeedScalar detJb, normal[3], dXdx[2][3];
 
-    const CeedScalar detJb = sqrt(J1 * J1 + J2 * J2 + J3 * J3);
-
-    // q_data_sur
-    // -- Interp-to-Interp q_data_sur
+    NormalVectorFromdxdX_3D(Q, i, J, normal, &detJb);
     q_data_sur[0][i] = w[i] * detJb;
-    q_data_sur[1][i] = J1 / detJb;
-    q_data_sur[2][i] = J2 / detJb;
-    q_data_sur[3][i] = J3 / detJb;
+    q_data_sur[1][i] = normal[0];
+    q_data_sur[2][i] = normal[1];
+    q_data_sur[3][i] = normal[2];
 
-    // dxdX_k,j * dxdX_j,k
-    CeedScalar dxdXTdxdX[2][2] = {{0.}};
-    for (CeedInt j = 0; j < 2; j++) {
-      for (CeedInt k = 0; k < 2; k++) {
-        for (CeedInt l = 0; l < 3; l++) dxdXTdxdX[j][k] += dxdX[l][j] * dxdX[l][k];
-      }
-    }
-
-    const CeedScalar detdxdXTdxdX = dxdXTdxdX[0][0] * dxdXTdxdX[1][1] - dxdXTdxdX[1][0] * dxdXTdxdX[0][1];
-
-    // Compute inverse of dxdXTdxdX
-    CeedScalar dxdXTdxdX_inv[2][2];
-    dxdXTdxdX_inv[0][0] = dxdXTdxdX[1][1] / detdxdXTdxdX;
-    dxdXTdxdX_inv[0][1] = -dxdXTdxdX[0][1] / detdxdXTdxdX;
-    dxdXTdxdX_inv[1][0] = -dxdXTdxdX[1][0] / detdxdXTdxdX;
-    dxdXTdxdX_inv[1][1] = dxdXTdxdX[0][0] / detdxdXTdxdX;
-
-    // Compute dXdx from dxdXTdxdX^-1 and dxdX
-    CeedScalar dXdx[2][3] = {{0.}};
-    for (CeedInt j = 0; j < 2; j++) {
-      for (CeedInt k = 0; k < 3; k++) {
-        for (CeedInt l = 0; l < 2; l++) dXdx[j][k] += dxdXTdxdX_inv[l][j] * dxdX[k][l];
-      }
-    }
-
+    InvertBoundaryMappingJacobian_3D(Q, i, J, dXdx);
     q_data_sur[4][i] = dXdx[0][0];
     q_data_sur[5][i] = dXdx[0][1];
     q_data_sur[6][i] = dXdx[0][2];
     q_data_sur[7][i] = dXdx[1][0];
     q_data_sur[8][i] = dXdx[1][1];
     q_data_sur[9][i] = dXdx[1][2];
-
-  }  // End of Quadrature Point Loop
-
-  // Return
+  }
   return 0;
 }
 

--- a/examples/fluids/qfunctions/setupgeo_helpers.h
+++ b/examples/fluids/qfunctions/setupgeo_helpers.h
@@ -1,0 +1,176 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Geometric factors (3D) for Navier-Stokes example using PETSc
+
+#ifndef setupgeo_helpers_h
+#define setupgeo_helpers_h
+
+#include <ceed.h>
+#include <math.h>
+
+#include "utils.h"
+
+/**
+ * @brief Calculate dXdx from dxdX for 3D elements
+ *
+ * Reference (parent) coordinates: X
+ * Physical (current) coordinates: x
+ * Change of coordinate matrix: dxdX_{i,j} = x_{i,j} (indicial notation)
+ * Inverse of change of coordinate matrix: dXdx_{i,j} = (detJ^-1) * X_{i,j}
+ *
+ * Determinant of Jacobian:
+ *   detJ = J11*A11 + J21*A12 + J31*A13
+ *     Jij = Jacobian entry ij
+ *     Aij = Adjugate ij
+ *
+ * Inverse of Jacobian:
+ *   dXdx_i,j = Aij / detJ
+ *
+ * @param[in]  Q        Number of quadrature points
+ * @param[in]  i        Current quadrature point
+ * @param[in]  dxdX_q   Mapping Jacobian (gradient of the coordinate space)
+ * @param[out] dXdx     Inverse of mapping Jacobian at quadrature point i
+ * @param[out] detJ_ptr Determinate of the Jacobian, may be NULL is not desired
+ */
+CEED_QFUNCTION_HELPER void InvertMappingJacobian_3D(CeedInt Q, CeedInt i, const CeedScalar (*dxdX_q)[3][CEED_Q_VLA], CeedScalar dXdx[3][3],
+                                                    CeedScalar *detJ_ptr) {
+  const CeedScalar dxdX_11 = dxdX_q[0][0][i];
+  const CeedScalar dxdX_21 = dxdX_q[0][1][i];
+  const CeedScalar dxdX_31 = dxdX_q[0][2][i];
+  const CeedScalar dxdX_12 = dxdX_q[1][0][i];
+  const CeedScalar dxdX_22 = dxdX_q[1][1][i];
+  const CeedScalar dxdX_32 = dxdX_q[1][2][i];
+  const CeedScalar dxdX_13 = dxdX_q[2][0][i];
+  const CeedScalar dxdX_23 = dxdX_q[2][1][i];
+  const CeedScalar dxdX_33 = dxdX_q[2][2][i];
+  const CeedScalar A11     = dxdX_22 * dxdX_33 - dxdX_23 * dxdX_32;
+  const CeedScalar A12     = dxdX_13 * dxdX_32 - dxdX_12 * dxdX_33;
+  const CeedScalar A13     = dxdX_12 * dxdX_23 - dxdX_13 * dxdX_22;
+  const CeedScalar A21     = dxdX_23 * dxdX_31 - dxdX_21 * dxdX_33;
+  const CeedScalar A22     = dxdX_11 * dxdX_33 - dxdX_13 * dxdX_31;
+  const CeedScalar A23     = dxdX_13 * dxdX_21 - dxdX_11 * dxdX_23;
+  const CeedScalar A31     = dxdX_21 * dxdX_32 - dxdX_22 * dxdX_31;
+  const CeedScalar A32     = dxdX_12 * dxdX_31 - dxdX_11 * dxdX_32;
+  const CeedScalar A33     = dxdX_11 * dxdX_22 - dxdX_12 * dxdX_21;
+  const CeedScalar detJ    = dxdX_11 * A11 + dxdX_21 * A12 + dxdX_31 * A13;
+
+  dXdx[0][0] = A11 / detJ;
+  dXdx[0][1] = A12 / detJ;
+  dXdx[0][2] = A13 / detJ;
+  dXdx[1][0] = A21 / detJ;
+  dXdx[1][1] = A22 / detJ;
+  dXdx[1][2] = A23 / detJ;
+  dXdx[2][0] = A31 / detJ;
+  dXdx[2][1] = A32 / detJ;
+  dXdx[2][2] = A33 / detJ;
+  if (detJ_ptr) *detJ_ptr = detJ;
+}
+
+/**
+ * @brief Calculate face element's normal vector from dxdX
+ *
+ * Reference (parent) 2D coordinates: X
+ * Physical (current) 3D coordinates: x
+ * Change of coordinate matrix:
+ *   dxdX_{i,j} = dx_i/dX_j (indicial notation) [3 * 2]
+ * Inverse change of coordinate matrix:
+ *   dXdx_{i,j} = dX_i/dx_j (indicial notation) [2 * 3]
+ *
+ * (J1,J2,J3) is given by the cross product of the columns of dxdX_{i,j}
+ *
+ * detJb is the magnitude of (J1,J2,J3)
+ *
+ * Normal vector = (J1,J2,J3) / detJb
+ *
+ * Stored: (J1,J2,J3) / detJb
+ *   in q_data_sur[1:3] as
+ *   (detJb^-1) * [ J1 ]
+ *                [ J2 ]
+ *                [ J3 ]
+ *
+ * @param[in]  Q        Number of quadrature points
+ * @param[in]  i        Current quadrature point
+ * @param[in]  dxdX_q   Mapping Jacobian (gradient of the coordinate space)
+ * @param[out] normal   Inverse of mapping Jacobian at quadrature point i
+ * @param[out] detJ_ptr Determinate of the Jacobian, may be NULL is not desired
+ */
+CEED_QFUNCTION_HELPER void NormalVectorFromdxdX_3D(CeedInt Q, CeedInt i, const CeedScalar dxdX_q[][3][CEED_Q_VLA], CeedScalar normal[3],
+                                                   CeedScalar *detJ_ptr) {
+  const CeedScalar dxdX[3][2] = {
+      {dxdX_q[0][0][i], dxdX_q[1][0][i]},
+      {dxdX_q[0][1][i], dxdX_q[1][1][i]},
+      {dxdX_q[0][2][i], dxdX_q[1][2][i]}
+  };
+  // J1, J2, and J3 are given by the cross product of the columns of dxdX
+  const CeedScalar J1 = dxdX[1][0] * dxdX[2][1] - dxdX[2][0] * dxdX[1][1];
+  const CeedScalar J2 = dxdX[2][0] * dxdX[0][1] - dxdX[0][0] * dxdX[2][1];
+  const CeedScalar J3 = dxdX[0][0] * dxdX[1][1] - dxdX[1][0] * dxdX[0][1];
+
+  const CeedScalar detJ = sqrt(J1 * J1 + J2 * J2 + J3 * J3);
+
+  normal[0] = J1 / detJ;
+  normal[1] = J2 / detJ;
+  normal[2] = J3 / detJ;
+  if (detJ_ptr) *detJ_ptr = detJ;
+}
+
+/**
+ * @brief Calculate inverse of mapping Jacobian, (dxdX)^-1
+ *
+ * Reference (parent) 2D coordinates: X
+ * Physical (current) 3D coordinates: x
+ * Change of coordinate matrix:
+ *   dxdX_{i,j} = dx_i/dX_j (indicial notation) [3 * 2]
+ * Inverse change of coordinate matrix:
+ *   dXdx_{i,j} = dX_i/dx_j (indicial notation) [2 * 3]
+ *
+ * dXdx is calculated via Moore–Penrose inverse:
+ *
+ *   dX_i/dx_j = (dxdX^T dxdX)^(-1) dxdX
+ *             = (dx_l/dX_i * dx_l/dX_k)^(-1) dx_j/dX_k
+ *
+ * @param[in]  Q      Number of quadrature points
+ * @param[in]  i      Current quadrature point
+ * @param[in]  dxdX_q Mapping Jacobian (gradient of the coordinate space)
+ * @param[out] dXdx   Inverse of mapping Jacobian at quadrature point i
+ */
+CEED_QFUNCTION_HELPER void InvertBoundaryMappingJacobian_3D(CeedInt Q, CeedInt i, const CeedScalar (*dxdX_q)[3][CEED_Q_VLA], CeedScalar dXdx[2][3]) {
+  const CeedScalar dxdX[3][2] = {
+      {dxdX_q[0][0][i], dxdX_q[1][0][i]},
+      {dxdX_q[0][1][i], dxdX_q[1][1][i]},
+      {dxdX_q[0][2][i], dxdX_q[1][2][i]}
+  };
+
+  // dxdX_k,j * dxdX_j,k
+  CeedScalar dxdXTdxdX[2][2] = {{0.}};
+  for (CeedInt j = 0; j < 2; j++) {
+    for (CeedInt k = 0; k < 2; k++) {
+      for (CeedInt l = 0; l < 3; l++) dxdXTdxdX[j][k] += dxdX[l][j] * dxdX[l][k];
+    }
+  }
+
+  const CeedScalar detdxdXTdxdX = dxdXTdxdX[0][0] * dxdXTdxdX[1][1] - dxdXTdxdX[1][0] * dxdXTdxdX[0][1];
+
+  // Compute inverse of dxdXTdxdX
+  CeedScalar dxdXTdxdX_inv[2][2];
+  dxdXTdxdX_inv[0][0] = dxdXTdxdX[1][1] / detdxdXTdxdX;
+  dxdXTdxdX_inv[0][1] = -dxdXTdxdX[0][1] / detdxdXTdxdX;
+  dxdXTdxdX_inv[1][0] = -dxdXTdxdX[1][0] / detdxdXTdxdX;
+  dxdXTdxdX_inv[1][1] = dxdXTdxdX[0][0] / detdxdXTdxdX;
+
+  // Compute dXdx from dxdXTdxdX^-1 and dxdX
+  for (CeedInt j = 0; j < 2; j++) {
+    for (CeedInt k = 0; k < 3; k++) {
+      dXdx[j][k] = 0;
+      for (CeedInt l = 0; l < 2; l++) dXdx[j][k] += dxdXTdxdX_inv[l][j] * dxdX[k][l];
+    }
+  }
+}
+
+#endif  // setupgeo_helpers_h

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -233,8 +233,8 @@ CEED_QFUNCTION_HELPER void STGShur14_Calc_PrecompEktot(const CeedScalar X[3], co
 //
 // stg_data[0] = 1 / Ektot (inverse of total spectrum energy)
 CEED_QFUNCTION(Preprocess_STGShur14)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar(*q_data_sur)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
-  const CeedScalar(*x)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*dXdx_q)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
+  const CeedScalar(*x)[CEED_Q_VLA]         = (const CeedScalar(*)[CEED_Q_VLA])in[1];
 
   CeedScalar(*stg_data) = (CeedScalar(*))out[0];
 
@@ -255,8 +255,8 @@ CEED_QFUNCTION(Preprocess_STGShur14)(void *ctx, CeedInt Q, const CeedScalar *con
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     const CeedScalar wall_dist  = x[1][i];
     const CeedScalar dXdx[2][3] = {
-        {q_data_sur[4][i], q_data_sur[5][i], q_data_sur[6][i]},
-        {q_data_sur[7][i], q_data_sur[8][i], q_data_sur[9][i]}
+        {dXdx_q[0][0][i], dXdx_q[0][1][i], dXdx_q[0][2][i]},
+        {dXdx_q[1][0][i], dXdx_q[1][1][i], dXdx_q[1][2][i]},
     };
 
     CeedScalar h[3];
@@ -490,10 +490,10 @@ CEED_QFUNCTION(STGShur14_Inflow_Jacobian)(void *ctx, CeedInt Q, const CeedScalar
  * through the native PETSc `DMAddBoundary` -> `bcFunc` method.
  */
 CEED_QFUNCTION(STGShur14_Inflow_StrongQF)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  const CeedScalar(*q_data_sur)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
-  const CeedScalar(*coords)[CEED_Q_VLA]     = (const CeedScalar(*)[CEED_Q_VLA])in[1];
-  const CeedScalar(*scale)                  = (const CeedScalar(*))in[2];
-  const CeedScalar(*inv_Ektotal)            = (const CeedScalar(*))in[3];
+  const CeedScalar(*dXdx_q)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
+  const CeedScalar(*coords)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*scale)                 = (const CeedScalar(*))in[2];
+  const CeedScalar(*inv_Ektotal)           = (const CeedScalar(*))in[3];
 
   CeedScalar(*bcval)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
 
@@ -510,8 +510,8 @@ CEED_QFUNCTION(STGShur14_Inflow_StrongQF)(void *ctx, CeedInt Q, const CeedScalar
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     const CeedScalar x[]        = {coords[0][i], coords[1][i], coords[2][i]};
     const CeedScalar dXdx[2][3] = {
-        {q_data_sur[4][i], q_data_sur[5][i], q_data_sur[6][i]},
-        {q_data_sur[7][i], q_data_sur[8][i], q_data_sur[9][i]}
+        {dXdx_q[0][0][i], dXdx_q[0][1][i], dXdx_q[0][2][i]},
+        {dXdx_q[1][0][i], dXdx_q[1][1][i], dXdx_q[1][2][i]},
     };
 
     CeedScalar h[3];

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 
 #include "newtonian_state.h"
+#include "setupgeo_helpers.h"
 #include "stg_shur14_type.h"
 #include "utils.h"
 
@@ -299,38 +300,7 @@ CEED_QFUNCTION(ICsSTG)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSc
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     const CeedScalar x_i[3] = {x[0][i], x[1][i], x[2][i]};
     CeedScalar       dXdx[3][3];
-    {
-      const CeedScalar J11  = J[0][0][i];
-      const CeedScalar J21  = J[0][1][i];
-      const CeedScalar J31  = J[0][2][i];
-      const CeedScalar J12  = J[1][0][i];
-      const CeedScalar J22  = J[1][1][i];
-      const CeedScalar J32  = J[1][2][i];
-      const CeedScalar J13  = J[2][0][i];
-      const CeedScalar J23  = J[2][1][i];
-      const CeedScalar J33  = J[2][2][i];
-      const CeedScalar A11  = J22 * J33 - J23 * J32;
-      const CeedScalar A12  = J13 * J32 - J12 * J33;
-      const CeedScalar A13  = J12 * J23 - J13 * J22;
-      const CeedScalar A21  = J23 * J31 - J21 * J33;
-      const CeedScalar A22  = J11 * J33 - J13 * J31;
-      const CeedScalar A23  = J13 * J21 - J11 * J23;
-      const CeedScalar A31  = J21 * J32 - J22 * J31;
-      const CeedScalar A32  = J12 * J31 - J11 * J32;
-      const CeedScalar A33  = J11 * J22 - J12 * J21;
-      const CeedScalar detJ = J11 * A11 + J21 * A12 + J31 * A13;
-
-      dXdx[0][0] = A11 / detJ;
-      dXdx[0][1] = A12 / detJ;
-      dXdx[0][2] = A13 / detJ;
-      dXdx[1][0] = A21 / detJ;
-      dXdx[1][1] = A22 / detJ;
-      dXdx[1][2] = A23 / detJ;
-      dXdx[2][0] = A31 / detJ;
-      dXdx[2][1] = A32 / detJ;
-      dXdx[2][2] = A33 / detJ;
-    }
-
+    InvertMappingJacobian_3D(Q, i, J, dXdx, NULL);
     CeedScalar h[3];
     h[0] = dx;
     for (CeedInt j = 1; j < 3; j++) h[j] = 2 / sqrt(Square(dXdx[0][j]) + Square(dXdx[1][j]) + Square(dXdx[2][j]));

--- a/examples/fluids/qfunctions/strong_boundary_conditions.h
+++ b/examples/fluids/qfunctions/strong_boundary_conditions.h
@@ -10,18 +10,30 @@
 
 #include <ceed.h>
 
+#include "setupgeo_helpers.h"
+
 CEED_QFUNCTION(SetupStrongBC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   // Inputs
   const CeedScalar(*coords)[CEED_Q_VLA]       = (const CeedScalar(*)[CEED_Q_VLA])in[0];
-  const CeedScalar(*multiplicity)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*dxdX_q)[3][CEED_Q_VLA]    = (const CeedScalar(*)[3][CEED_Q_VLA])in[1];
+  const CeedScalar(*multiplicity)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];
 
   // Outputs
   CeedScalar(*coords_stored)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
-  CeedScalar(*scale_stored)              = (CeedScalar(*))out[1];
+  CeedScalar(*scale_stored)              = out[1];
+  CeedScalar(*dXdx_q)[CEED_Q_VLA]        = (CeedScalar(*)[CEED_Q_VLA])out[2];
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     for (int j = 0; j < 3; j++) coords_stored[j][i] = coords[j][i];
     scale_stored[i] = 1.0 / multiplicity[0][i];
+    CeedScalar dXdx[2][3];
+    InvertBoundaryMappingJacobian_3D(Q, i, dxdX_q, dXdx);
+    dXdx_q[0][i] = dXdx[0][0];
+    dXdx_q[1][i] = dXdx[0][1];
+    dXdx_q[2][i] = dXdx[0][2];
+    dXdx_q[3][i] = dXdx[1][0];
+    dXdx_q[4][i] = dXdx[1][1];
+    dXdx_q[5][i] = dXdx[1][2];
   }
   return 0;
 }

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -648,7 +648,7 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     if (user->op_ijacobian) {
       PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(user->op_ijacobian, "ijacobian time shift", &user->phys->ijacobian_time_shift_label));
     }
-    if (problem->use_strong_bc_ceed) PetscCall(SetupStrongBC_Ceed(ceed, ceed_data, dm, user, problem, bc, q_data_size_sur));
+    if (problem->use_strong_bc_ceed) PetscCall(SetupStrongBC_Ceed(ceed, ceed_data, dm, user, problem, bc));
     if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SGS_DD_ModelSetup(ceed, user, ceed_data, problem));
   }
 


### PR DESCRIPTION
This PR does two different, but related things:
- Refactor the `setupgeo.h` functions into helpers
- Refactor the strong boundary condition setup to use those helpers

There is not change to functionality here, just cleaning things up a bit.