### PR TITLE
fluids: Add DMPlexCeedElemRestriction*Create

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -339,10 +339,14 @@ PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData *problem, M
 PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height, DMLabel domain_label, CeedInt label_value, PetscInt dm_field,
                                          CeedElemRestriction *elem_restr);
 
-// Utility function to get Ceed Restriction for each domain
-PetscErrorCode GetRestrictionForDomain(Ceed ceed, DM dm, CeedInt height, DMLabel domain_label, PetscInt label_value, PetscInt dm_field, CeedInt Q,
-                                       CeedInt q_data_size, CeedElemRestriction *elem_restr_q, CeedElemRestriction *elem_restr_x,
-                                       CeedElemRestriction *elem_restr_qd_i);
+PetscErrorCode DMPlexCeedElemRestrictionCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height, PetscInt dm_field,
+                                               CeedElemRestriction *restriction);
+PetscErrorCode DMPlexCeedElemRestrictionCoordinateCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                         CeedElemRestriction *restriction);
+PetscErrorCode DMPlexCeedElemRestrictionQDataCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                    PetscInt q_data_size, CeedElemRestriction *restriction);
+PetscErrorCode DMPlexCeedElemRestrictionCollocatedCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                         PetscInt q_data_size, CeedElemRestriction *restriction);
 
 PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedInt label_value, CeedInt height, CeedInt dm_field, CeedBasis *basis);
 

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -58,14 +58,16 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
     PetscCallCeed(ceed, CeedOperatorSetField(op_rhs, "q", ceed_data->elem_restr_q, ceed_data->basis_q, CEED_VECTOR_ACTIVE));
     PetscCallCeed(ceed, CeedOperatorSetField(op_rhs, "qdata", ceed_data->elem_restr_qd_i, CEED_BASIS_COLLOCATED, ceed_data->q_data));
     PetscCallCeed(ceed, CeedOperatorSetField(op_rhs, "x", ceed_data->elem_restr_x, ceed_data->basis_x, ceed_data->x_coord));
-    for (PetscInt i = 0; i < diff_filter->num_filtered_fields; i++) {
+    for (PetscInt dm_field = 0; dm_field < diff_filter->num_filtered_fields; dm_field++) {
       char                field_name[PETSC_MAX_PATH_LEN];
       CeedElemRestriction elem_restr_filter;
       CeedBasis           basis_filter;
-      PetscCall(GetRestrictionForDomain(ceed, dm_filter, 0, 0, 0, i, -1, 0, &elem_restr_filter, NULL, NULL));
-      PetscCall(CreateBasisFromPlex(ceed, dm_filter, 0, 0, 0, i, &basis_filter));
+      DMLabel             domain_label = NULL;
+      PetscInt            label_value = 0, height = 0;
+      PetscCall(DMPlexCeedElemRestrictionCreate(ceed, dm_filter, domain_label, label_value, height, dm_field, &elem_restr_filter));
+      PetscCall(CreateBasisFromPlex(ceed, dm_filter, domain_label, label_value, height, dm_field, &basis_filter));
 
-      PetscCall(PetscSNPrintf(field_name, PETSC_MAX_PATH_LEN, "v%" PetscInt_FMT, i));
+      PetscCall(PetscSNPrintf(field_name, PETSC_MAX_PATH_LEN, "v%" PetscInt_FMT, dm_field));
       PetscCallCeed(ceed, CeedOperatorSetField(op_rhs, field_name, elem_restr_filter, basis_filter, CEED_VECTOR_ACTIVE));
     }
 

--- a/examples/fluids/src/dm_utils.c
+++ b/examples/fluids/src/dm_utils.c
@@ -14,54 +14,6 @@
 
 #include "../navierstokes.h"
 
-// Utility function to create local CEED restriction
-PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height, DMLabel domain_label, CeedInt label_value, PetscInt dm_field,
-                                         CeedElemRestriction *elem_restr) {
-  PetscInt num_elem, elem_size, num_dof, num_comp, *elem_restr_offsets_petsc;
-  CeedInt *elem_restr_offsets_ceed;
-
-  PetscFunctionBeginUser;
-  PetscCall(
-      DMPlexGetLocalOffsets(dm, domain_label, label_value, height, dm_field, &num_elem, &elem_size, &num_comp, &num_dof, &elem_restr_offsets_petsc));
-
-  PetscCall(IntArrayP2C(num_elem * elem_size, &elem_restr_offsets_petsc, &elem_restr_offsets_ceed));
-  PetscCallCeed(ceed, CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp, 1, num_dof, CEED_MEM_HOST, CEED_COPY_VALUES,
-                                                elem_restr_offsets_ceed, elem_restr));
-  PetscCall(PetscFree(elem_restr_offsets_ceed));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-// Utility function to get Ceed Restriction for each domain
-PetscErrorCode GetRestrictionForDomain(Ceed ceed, DM dm, CeedInt height, DMLabel domain_label, PetscInt label_value, PetscInt dm_field, CeedInt Q,
-                                       CeedInt q_data_size, CeedElemRestriction *elem_restr_q, CeedElemRestriction *elem_restr_x,
-                                       CeedElemRestriction *elem_restr_qd_i) {
-  DM                  dm_coord;
-  CeedInt             loc_num_elem;
-  PetscInt            dim;
-  CeedElemRestriction elem_restr_tmp;
-
-  PetscFunctionBeginUser;
-  PetscCall(DMGetDimension(dm, &dim));
-  dim -= height;
-  PetscCall(CreateRestrictionFromPlex(ceed, dm, height, domain_label, label_value, dm_field, &elem_restr_tmp));
-  if (elem_restr_q) *elem_restr_q = elem_restr_tmp;
-  if (elem_restr_x) {
-    PetscCall(DMGetCellCoordinateDM(dm, &dm_coord));
-    if (!dm_coord) {
-      PetscCall(DMGetCoordinateDM(dm, &dm_coord));
-    }
-    PetscCall(DMPlexSetClosurePermutationTensor(dm_coord, PETSC_DETERMINE, NULL));
-    PetscCall(CreateRestrictionFromPlex(ceed, dm_coord, height, domain_label, label_value, dm_field, elem_restr_x));
-  }
-  if (elem_restr_qd_i) {
-    PetscCallCeed(ceed, CeedElemRestrictionGetNumElements(elem_restr_tmp, &loc_num_elem));
-    PetscCallCeed(ceed, CeedElemRestrictionCreateStrided(ceed, loc_num_elem, Q, q_data_size, q_data_size * loc_num_elem * Q, CEED_STRIDES_BACKEND,
-                                                         elem_restr_qd_i));
-  }
-  if (!elem_restr_q) PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_tmp));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 /**
   @brief Convert `DM` field to `DS` field.
 
@@ -91,6 +43,202 @@ PetscErrorCode DMFieldToDSField(DM dm, DMLabel domain_label, PetscInt dm_field, 
   PetscCall(ISRestoreIndices(field_is, &fields));
 
   if (*ds_field == -1) SETERRQ(PetscObjectComm((PetscObject)dm), PETSC_ERR_SUP, "Could not find dm_field %" PetscInt_FMT " in DS", dm_field);
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Create `CeedElemRestriction` from `DMPlex`.
+
+  Not collective across MPI processes.
+
+  @param[in]   ceed          `Ceed` context
+  @param[in]   dm            `DMPlex` holding mesh
+  @param[in]   domain_label  `DMLabel` for `DMPlex` domain
+  @param[in]   label_value   Stratum value
+  @param[in]   height        Height of `DMPlex` topology
+  @param[in]   dm_field      Index of `DMPlex` field
+  @param[out]  restriction   `CeedElemRestriction` for `DMPlex`
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+PetscErrorCode DMPlexCeedElemRestrictionCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height, PetscInt dm_field,
+                                               CeedElemRestriction *restriction) {
+  PetscInt num_elem, elem_size, num_dof, num_comp, *restriction_offsets_petsc;
+  CeedInt *restriction_offsets_ceed = NULL;
+
+  PetscFunctionBeginUser;
+  PetscCall(
+      DMPlexGetLocalOffsets(dm, domain_label, label_value, height, dm_field, &num_elem, &elem_size, &num_comp, &num_dof, &restriction_offsets_petsc));
+  PetscCall(IntArrayP2C(num_elem * elem_size, &restriction_offsets_petsc, &restriction_offsets_ceed));
+  PetscCallCeed(ceed, CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp, 1, num_dof, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                                restriction_offsets_ceed, restriction));
+  PetscCall(PetscFree(restriction_offsets_ceed));
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Create `CeedElemRestriction` from `DMPlex` domain for mesh coordinates.
+
+  Not collective across MPI processes.
+
+  @param[in]   ceed          `Ceed` context
+  @param[in]   dm            `DMPlex` holding mesh
+  @param[in]   domain_label  Label for `DMPlex` domain
+  @param[in]   label_value   Stratum value
+  @param[in]   height        Height of `DMPlex` topology
+  @param[out]  restriction   `CeedElemRestriction` for mesh
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+PetscErrorCode DMPlexCeedElemRestrictionCoordinateCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                         CeedElemRestriction *restriction) {
+  DM        dm_coord;
+  PetscBool is_simplex = PETSC_FALSE;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMGetCellCoordinateDM(dm, &dm_coord));
+  if (!dm_coord) {
+    PetscCall(DMGetCoordinateDM(dm, &dm_coord));
+  }
+  PetscCall(DMPlexIsSimplex(dm_coord, &is_simplex));
+  if (!is_simplex) PetscCall(DMPlexSetClosurePermutationTensor(dm_coord, PETSC_DETERMINE, NULL));
+  PetscCall(DMPlexCeedElemRestrictionCreate(ceed, dm_coord, domain_label, label_value, height, 0, restriction));
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Create `CeedElemRestriction` from `DMPlex` domain for auxilury `QFunction` data.
+
+  Not collective across MPI processes.
+
+  @param[in]   ceed           `Ceed` context
+  @param[in]   dm             `DMPlex` holding mesh
+  @param[in]   domain_label   Label for `DMPlex` domain
+  @param[in]   label_value    Stratum value
+  @param[in]   height         Height of `DMPlex` topology
+  @param[in]   q_data_size    Number of components for `QFunction` data
+  @param[in]   is_collocated  Boolean flag indicating if the data is collocated on the nodes (`PETSC_TRUE`) on on quadrature points (`PETSC_FALSE`)
+  @param[out]  restriction    Strided `CeedElemRestriction` for `QFunction` data
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static PetscErrorCode DMPlexCeedElemRestrictionStridedCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                             PetscInt q_data_size, PetscBool is_collocated, CeedElemRestriction *restriction) {
+  PetscInt num_elem, num_qpts, dm_field = 0;
+
+  PetscFunctionBeginUser;
+  {  // Get number of elements
+    PetscInt depth;
+    DMLabel  depth_label;
+    IS       point_is, depth_is;
+
+    PetscCall(DMPlexGetDepth(dm, &depth));
+    PetscCall(DMPlexGetDepthLabel(dm, &depth_label));
+    PetscCall(DMLabelGetStratumIS(depth_label, depth - height, &depth_is));
+    if (domain_label) {
+      IS domain_is;
+
+      PetscCall(DMLabelGetStratumIS(domain_label, label_value, &domain_is));
+      if (domain_is) {
+        PetscCall(ISIntersect(depth_is, domain_is, &point_is));
+        PetscCall(ISDestroy(&domain_is));
+      } else {
+        point_is = NULL;
+      }
+      PetscCall(ISDestroy(&depth_is));
+    } else {
+      point_is = depth_is;
+    }
+    if (point_is) {
+      PetscCall(ISGetLocalSize(point_is, &num_elem));
+    } else {
+      num_elem = 0;
+    }
+    PetscCall(ISDestroy(&point_is));
+  }
+
+  {  // Get number of quadrature points
+    PetscDS  ds;
+    PetscFE  fe;
+    PetscInt ds_field = -1;
+
+    PetscCall(DMGetRegionDS(dm, domain_label, NULL, &ds, NULL));
+    PetscCall(DMFieldToDSField(dm, domain_label, dm_field, &ds_field));
+    PetscCall(PetscDSGetDiscretization(ds, ds_field, (PetscObject *)&fe));
+    PetscCall(PetscFEGetHeightSubspace(fe, height, &fe));
+    if (is_collocated) {
+      PetscDualSpace dual_space;
+      PetscInt       num_dual_basis_vectors, dim, num_comp;
+
+      PetscCall(PetscFEGetSpatialDimension(fe, &dim));
+      PetscCall(PetscFEGetNumComponents(fe, &num_comp));
+      PetscCall(PetscFEGetDualSpace(fe, &dual_space));
+      PetscCall(PetscDualSpaceGetDimension(dual_space, &num_dual_basis_vectors));
+      num_qpts = num_dual_basis_vectors / num_comp;
+    } else {
+      PetscQuadrature quadrature;
+
+      PetscCall(DMGetRegionDS(dm, domain_label, NULL, &ds, NULL));
+      PetscCall(DMFieldToDSField(dm, domain_label, dm_field, &ds_field));
+      PetscCall(PetscDSGetDiscretization(ds, ds_field, (PetscObject *)&fe));
+      PetscCall(PetscFEGetHeightSubspace(fe, height, &fe));
+      PetscCall(PetscFEGetQuadrature(fe, &quadrature));
+      PetscCall(PetscQuadratureGetData(quadrature, NULL, NULL, &num_qpts, NULL, NULL));
+    }
+  }
+
+  // Create the restriction
+  PetscCallCeed(ceed, CeedElemRestrictionCreateStrided(ceed, num_elem, num_qpts, q_data_size, num_elem * num_qpts * q_data_size, CEED_STRIDES_BACKEND,
+                                                       restriction));
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Create `CeedElemRestriction` from `DMPlex` domain for auxilury `QFunction` data.
+
+  Not collective across MPI processes.
+
+  @param[in]   ceed           `Ceed` context
+  @param[in]   dm             `DMPlex` holding mesh
+  @param[in]   domain_label   Label for `DMPlex` domain
+  @param[in]   label_value    Stratum value
+  @param[in]   height         Height of `DMPlex` topology
+  @param[in]   q_data_size    Number of components for `QFunction` data
+  @param[out]  restriction    Strided `CeedElemRestriction` for `QFunction` data
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+PetscErrorCode DMPlexCeedElemRestrictionQDataCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                    PetscInt q_data_size, CeedElemRestriction *restriction) {
+  PetscFunctionBeginUser;
+  PetscCall(DMPlexCeedElemRestrictionStridedCreate(ceed, dm, domain_label, label_value, height, q_data_size, PETSC_FALSE, restriction));
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Create `CeedElemRestriction` from `DMPlex` domain for nodally collocated auxilury `QFunction` data.
+
+  Not collective across MPI processes.
+
+  @param[in]   ceed           `Ceed` context
+  @param[in]   dm             `DMPlex` holding mesh
+  @param[in]   domain_label   Label for `DMPlex` domain
+  @param[in]   label_value    Stratum value
+  @param[in]   height         Height of `DMPlex` topology
+  @param[in]   q_data_size    Number of components for `QFunction` data
+  @param[out]  restriction    Strided `CeedElemRestriction` for `QFunction` data
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+PetscErrorCode DMPlexCeedElemRestrictionCollocatedCreate(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, PetscInt height,
+                                                         PetscInt q_data_size, CeedElemRestriction *restriction) {
+  PetscFunctionBeginUser;
+  PetscCall(DMPlexCeedElemRestrictionStridedCreate(ceed, dm, domain_label, label_value, height, q_data_size, PETSC_TRUE, restriction));
+
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -5,7 +5,11 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 /// @file
-/// Functions for setting up and performing statistics collection
+/// Functions for setting up and performing spanwise-statistics collection
+///
+/// "Parent" refers to the 2D plane on which statistics are collected *onto*.
+/// "Child" refers to the 3D domain where statistics are gathered *from*.
+/// Each quadrature point on the parent plane has several children in the child domain that it performs spanwise averaging with.
 
 #include "../qfunctions/turb_spanstats.h"
 
@@ -120,10 +124,12 @@ PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-// Create CeedElemRestriction for collocated data based on associated CeedBasis and CeedElemRestriction
-// Number of quadrature points is used from the CeedBasis, and number of elements is used from the CeedElemRestriction
-PetscErrorCode CreateElemRestrColloc(Ceed ceed, CeedInt num_comp, CeedBasis basis, CeedElemRestriction elem_restr_base,
-                                     CeedElemRestriction *elem_restr_collocated) {
+/** @brief Create CeedElemRestriction for collocated data in component-major order.
+a. Sets the strides of the restriction to component-major order
+ Number of quadrature points is used from the CeedBasis, and number of elements is used from the CeedElemRestriction.
+*/
+static PetscErrorCode CreateElemRestrColloc_CompMajor(Ceed ceed, CeedInt num_comp, CeedBasis basis, CeedElemRestriction elem_restr_base,
+                                                      CeedElemRestriction *elem_restr_collocated) {
   CeedInt num_elem_qpts, loc_num_elem;
 
   PetscFunctionBeginUser;
@@ -142,16 +148,15 @@ PetscErrorCode GetQuadratureCoords(Ceed ceed, DM dm, CeedElemRestriction elem_re
   CeedElemRestriction  elem_restr_qx;
   CeedQFunction        qf_quad_coords;
   CeedOperator         op_quad_coords;
-  CeedInt              num_comp_x, loc_num_elem, num_elem_qpts;
+  CeedInt              num_comp_x;
+  CeedSize             l_vec_size;
   OperatorApplyContext op_quad_coords_ctx;
 
   PetscFunctionBeginUser;
-  // Create Element Restriction and CeedVector for quadrature coordinates
-  PetscCallCeed(ceed, CeedBasisGetNumQuadraturePoints(basis_x, &num_elem_qpts));
-  PetscCallCeed(ceed, CeedElemRestrictionGetNumElements(elem_restr_x, &loc_num_elem));
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_x, &num_comp_x));
-  *total_nqpnts = num_elem_qpts * loc_num_elem;
-  PetscCall(CreateElemRestrColloc(ceed, num_comp_x, basis_x, elem_restr_x, &elem_restr_qx));
+  PetscCall(CreateElemRestrColloc_CompMajor(ceed, num_comp_x, basis_x, elem_restr_x, &elem_restr_qx));
+  PetscCallCeed(ceed, CeedElemRestrictionGetLVectorSize(elem_restr_qx, &l_vec_size));
+  *total_nqpnts = l_vec_size / num_comp_x;
 
   // Create QFunction
   PetscCallCeed(ceed, CeedQFunctionCreateIdentity(ceed, num_comp_x, CEED_EVAL_INTERP, CEED_EVAL_NONE, &qf_quad_coords));
@@ -200,9 +205,10 @@ PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data
     PetscCall(CreateBasisFromPlex(ceed, dm, domain_label, label_value, height, dm_field, &(*stats_data)->basis_stats));
   }
 
-  PetscCall(CreateElemRestrColloc(ceed, num_comp_stats, (*stats_data)->basis_stats, (*stats_data)->elem_restr_parent_stats,
-                                  &(*stats_data)->elem_restr_parent_colloc));
-  PetscCall(CreateElemRestrColloc(ceed, num_comp_stats, ceed_data->basis_q, ceed_data->elem_restr_q, &(*stats_data)->elem_restr_child_colloc));
+  PetscCall(CreateElemRestrColloc_CompMajor(ceed, num_comp_stats, (*stats_data)->basis_stats, (*stats_data)->elem_restr_parent_stats,
+                                            &(*stats_data)->elem_restr_parent_colloc));
+  PetscCall(
+      CreateElemRestrColloc_CompMajor(ceed, num_comp_stats, ceed_data->basis_q, ceed_data->elem_restr_q, &(*stats_data)->elem_restr_child_colloc));
 
   {  // -- Copy DM coordinates into CeedVector
     DM cdm;

--- a/examples/fluids/src/velocity_gradient_projection.c
+++ b/examples/fluids/src/velocity_gradient_projection.c
@@ -45,8 +45,9 @@ PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ce
   CeedQFunction        qf_rhs_assemble, qf_mass;
   CeedBasis            basis_grad_velo;
   CeedElemRestriction  elem_restr_grad_velo;
-  PetscInt             dim;
+  PetscInt             dim, label_value = 0, height = 0, dm_field = 0;
   CeedInt              num_comp_x, num_comp_q, q_data_size;
+  DMLabel              domain_label = NULL;
 
   PetscFunctionBeginUser;
   PetscCall(PetscNew(&user->grad_velo_proj));
@@ -59,9 +60,9 @@ PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ce
   PetscCallCeed(ceed, CeedBasisGetNumComponents(ceed_data->basis_x, &num_comp_x));
   PetscCallCeed(ceed, CeedBasisGetNumComponents(ceed_data->basis_q, &num_comp_q));
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(ceed_data->elem_restr_qd_i, &q_data_size));
-  PetscCall(GetRestrictionForDomain(ceed, grad_velo_proj->dm, 0, 0, 0, 0, -1, 0, &elem_restr_grad_velo, NULL, NULL));
+  PetscCall(DMPlexCeedElemRestrictionCreate(ceed, grad_velo_proj->dm, domain_label, label_value, height, dm_field, &elem_restr_grad_velo));
 
-  PetscCall(CreateBasisFromPlex(ceed, grad_velo_proj->dm, 0, 0, 0, 0, &basis_grad_velo));
+  PetscCall(CreateBasisFromPlex(ceed, grad_velo_proj->dm, domain_label, label_value, height, dm_field, &basis_grad_velo));
 
   // -- Build RHS operator
   switch (user->phys->state_var) {


### PR DESCRIPTION
Replaces CreateRestrictionFromPlex and GetRestrictionForDomain

Dependent on #1308, mostly because I wanted to put these functions in `src/dm_utils.c`

Todos:
- [x] Scan through for manually created strided element restrictions to replace with these new functions
- [x] Clean out `num_elem` and `num_qpnts` from the code using the afore mentioned manual strided restriction creation.