### PR TITLE
Interface consistency fixes

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -158,7 +158,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
       if (eval_mode == CEED_EVAL_GRAD) {
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         CeedCallBackend(CeedBasisGetData(basis, &basis_data));
-        use_collograd_parallelization = !!basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
+        use_collograd_parallelization = basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
       }
     }
@@ -167,7 +167,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
       if (eval_mode == CEED_EVAL_GRAD) {
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
         CeedCallBackend(CeedBasisGetData(basis, &basis_data));
-        use_collograd_parallelization = !!basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
+        use_collograd_parallelization = basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
       }
     }
@@ -254,7 +254,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
           code << "  __shared__ CeedScalar s_G_in_" << i << "[" << Q_1d * Q_1d << "];\n";
           code << "  loadMatrix<Q_1d,Q_1d>(data, G.inputs[" << i << "], s_G_in_" << i << ");\n";
         } else {
-          bool has_collo_grad = !!basis_data->d_collo_grad_1d;
+          bool has_collo_grad = basis_data->d_collo_grad_1d;
           data->G.inputs[i]   = has_collo_grad ? basis_data->d_collo_grad_1d : basis_data->d_grad_1d;
           code << "  __shared__ CeedScalar s_G_in_" << i << "[" << Q_1d * (has_collo_grad ? Q_1d : P_1d) << "];\n";
           code << "  loadMatrix<" << (has_collo_grad ? "Q_1d" : ("P_in_" + std::to_string(i))) << ",Q_1d>(data, G.inputs[" << i << "], s_G_in_" << i
@@ -310,7 +310,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
           code << "  __shared__ CeedScalar s_G_out_" << i << "[" << Q_1d * Q_1d << "];\n";
           code << "  loadMatrix<Q_1d,Q_1d>(data, G.outputs[" << i << "], s_G_out_" << i << ");\n";
         } else {
-          bool has_collo_grad = !!basis_data->d_collo_grad_1d;
+          bool has_collo_grad = basis_data->d_collo_grad_1d;
           data->G.outputs[i]  = has_collo_grad ? basis_data->d_collo_grad_1d : basis_data->d_grad_1d;
           code << "  __shared__ CeedScalar s_G_out_" << i << "[" << Q_1d * (has_collo_grad ? Q_1d : P_1d) << "];\n";
           code << "  loadMatrix<" << (has_collo_grad ? "Q_1d" : ("P_out_" + std::to_string(i))) << ",Q_1d>(data, G.outputs[" << i << "], s_G_out_"

--- a/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
@@ -103,7 +103,7 @@ static inline int CeedQFunctionContextHasValidData_Cuda(const CeedQFunctionConte
   CeedQFunctionContext_Cuda *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  *has_valid_data = impl && (!!impl->h_data || !!impl->d_data);
+  *has_valid_data = impl && (impl->h_data || impl->d_data);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -118,10 +118,10 @@ static inline int CeedQFunctionContextHasBorrowedDataOfType_Cuda(const CeedQFunc
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_data_of_type = !!impl->h_data_borrowed;
+      *has_borrowed_data_of_type = impl->h_data_borrowed;
       break;
     case CEED_MEM_DEVICE:
-      *has_borrowed_data_of_type = !!impl->d_data_borrowed;
+      *has_borrowed_data_of_type = impl->d_data_borrowed;
       break;
   }
 

--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -133,7 +133,7 @@ static inline int CeedVectorHasValidArray_Cuda(const CeedVector vec, bool *has_v
   CeedVector_Cuda *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  *has_valid_array = !!impl->h_array || !!impl->d_array;
+  *has_valid_array = impl->h_array || impl->d_array;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -147,10 +147,10 @@ static inline int CeedVectorHasArrayOfType_Cuda(const CeedVector vec, CeedMemTyp
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_array_of_type = !!impl->h_array_borrowed || !!impl->h_array_owned;
+      *has_array_of_type = impl->h_array_borrowed || impl->h_array_owned;
       break;
     case CEED_MEM_DEVICE:
-      *has_array_of_type = !!impl->d_array_borrowed || !!impl->d_array_owned;
+      *has_array_of_type = impl->d_array_borrowed || impl->d_array_owned;
       break;
   }
 
@@ -166,10 +166,10 @@ static inline int CeedVectorHasBorrowedArrayOfType_Cuda(const CeedVector vec, Ce
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_array_of_type = !!impl->h_array_borrowed;
+      *has_borrowed_array_of_type = impl->h_array_borrowed;
       break;
     case CEED_MEM_DEVICE:
-      *has_borrowed_array_of_type = !!impl->d_array_borrowed;
+      *has_borrowed_array_of_type = impl->d_array_borrowed;
       break;
   }
 

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -166,7 +166,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
       if (eval_mode == CEED_EVAL_GRAD) {
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         CeedCallBackend(CeedBasisGetData(basis, &basis_data));
-        use_collograd_parallelization = !!basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
+        use_collograd_parallelization = basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
       }
     }
@@ -175,7 +175,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
       if (eval_mode == CEED_EVAL_GRAD) {
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
         CeedCallBackend(CeedBasisGetData(basis, &basis_data));
-        use_collograd_parallelization = !!basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
+        use_collograd_parallelization = basis_data->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
       }
     }
@@ -263,7 +263,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
           code << "  __shared__ CeedScalar s_G_in_" << i << "[" << Q_1d * Q_1d << "];\n";
           code << "  loadMatrix<Q_1d,Q_1d>(data, G.inputs[" << i << "], s_G_in_" << i << ");\n";
         } else {
-          bool has_collo_grad = !!basis_data->d_collo_grad_1d;
+          bool has_collo_grad = basis_data->d_collo_grad_1d;
           data->G.inputs[i]   = has_collo_grad ? basis_data->d_collo_grad_1d : basis_data->d_grad_1d;
           code << "  __shared__ CeedScalar s_G_in_" << i << "[" << Q_1d * (has_collo_grad ? Q_1d : P_1d) << "];\n";
           code << "  loadMatrix<" << (has_collo_grad ? "Q_1d" : ("P_in_" + std::to_string(i))) << ",Q_1d>(data, G.inputs[" << i << "], s_G_in_" << i
@@ -319,7 +319,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
           code << "  __shared__ CeedScalar s_G_out_" << i << "[" << Q_1d * Q_1d << "];\n";
           code << "  loadMatrix<Q_1d,Q_1d>(data, G.outputs[" << i << "], s_G_out_" << i << ");\n";
         } else {
-          bool has_collo_grad = !!basis_data->d_collo_grad_1d;
+          bool has_collo_grad = basis_data->d_collo_grad_1d;
           data->G.outputs[i]  = has_collo_grad ? basis_data->d_collo_grad_1d : basis_data->d_grad_1d;
           code << "  __shared__ CeedScalar s_G_out_" << i << "[" << Q_1d * (has_collo_grad ? Q_1d : P_1d) << "];\n";
           code << "  loadMatrix<" << (has_collo_grad ? "Q_1d" : ("P_out_" + std::to_string(i))) << ",Q_1d>(data, G.outputs[" << i << "], s_G_out_"

--- a/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
+++ b/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
@@ -103,7 +103,7 @@ static inline int CeedQFunctionContextHasValidData_Hip(const CeedQFunctionContex
   CeedQFunctionContext_Hip *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  *has_valid_data = impl && (!!impl->h_data || !!impl->d_data);
+  *has_valid_data = impl && (impl->h_data || impl->d_data);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -118,10 +118,10 @@ static inline int CeedQFunctionContextHasBorrowedDataOfType_Hip(const CeedQFunct
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_data_of_type = !!impl->h_data_borrowed;
+      *has_borrowed_data_of_type = impl->h_data_borrowed;
       break;
     case CEED_MEM_DEVICE:
-      *has_borrowed_data_of_type = !!impl->d_data_borrowed;
+      *has_borrowed_data_of_type = impl->d_data_borrowed;
       break;
   }
 

--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -133,7 +133,7 @@ static inline int CeedVectorHasValidArray_Hip(const CeedVector vec, bool *has_va
   CeedVector_Hip *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  *has_valid_array = !!impl->h_array || !!impl->d_array;
+  *has_valid_array = impl->h_array || impl->d_array;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -147,10 +147,10 @@ static inline int CeedVectorHasArrayOfType_Hip(const CeedVector vec, CeedMemType
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_array_of_type = !!impl->h_array_borrowed || !!impl->h_array_owned;
+      *has_array_of_type = impl->h_array_borrowed || impl->h_array_owned;
       break;
     case CEED_MEM_DEVICE:
-      *has_array_of_type = !!impl->d_array_borrowed || !!impl->d_array_owned;
+      *has_array_of_type = impl->d_array_borrowed || impl->d_array_owned;
       break;
   }
 
@@ -166,10 +166,10 @@ static inline int CeedVectorHasBorrowedArrayOfType_Hip(const CeedVector vec, Cee
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_array_of_type = !!impl->h_array_borrowed;
+      *has_borrowed_array_of_type = impl->h_array_borrowed;
       break;
     case CEED_MEM_DEVICE:
-      *has_borrowed_array_of_type = !!impl->d_array_borrowed;
+      *has_borrowed_array_of_type = impl->d_array_borrowed;
       break;
   }
 

--- a/backends/magma/ceed-magma-basis.c
+++ b/backends/magma/ceed-magma-basis.c
@@ -141,7 +141,8 @@ CEED_INTERN "C"
       // dv is (Q^dim x nc x dim), column-major layout (nc = ncomp)
       // In CEED_TRANSPOSE mode, the sizes of du and dv are switched.
       if (tmode == CEED_TRANSPOSE) {
-        P = Q1d, Q = P1d;
+        P = Q1d;
+        Q = P1d;
       }
 
       // Define element sizes for dofs/quad

--- a/backends/memcheck/ceed-memcheck-qfunctioncontext.c
+++ b/backends/memcheck/ceed-memcheck-qfunctioncontext.c
@@ -20,7 +20,7 @@ static int CeedQFunctionContextHasValidData_Memcheck(CeedQFunctionContext ctx, b
   CeedQFunctionContext_Memcheck *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, (void *)&impl));
 
-  *has_valid_data = !!impl->data;
+  *has_valid_data = impl->data;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -36,7 +36,7 @@ static int CeedQFunctionContextHasBorrowedDataOfType_Memcheck(CeedQFunctionConte
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_data_of_type = !!impl->data_borrowed;
+      *has_borrowed_data_of_type = impl->data_borrowed;
       break;
     default:
       // LCOV_EXCL_START

--- a/backends/memcheck/ceed-memcheck-vector.c
+++ b/backends/memcheck/ceed-memcheck-vector.c
@@ -21,7 +21,7 @@ static int CeedVectorHasValidArray_Memcheck(CeedVector vec, bool *has_valid_arra
   CeedVector_Memcheck *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  *has_valid_array = !!impl->array;
+  *has_valid_array = impl->array;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -37,7 +37,7 @@ static inline int CeedVectorHasBorrowedArrayOfType_Memcheck(const CeedVector vec
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_array_of_type = !!impl->array_borrowed;
+      *has_borrowed_array_of_type = impl->array_borrowed;
       break;
     default:
       // LCOV_EXCL_START

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -121,7 +121,7 @@ static int CeedOperatorSetupFields_Opt(CeedQFunction qf, CeedOperator op, bool i
         CeedCallBackend(CeedBasisApply(basis, blk_size, CEED_NOTRANSPOSE, CEED_EVAL_WEIGHT, CEED_VECTOR_NONE, q_vecs[i]));
         break;
     }
-    if (is_input && !!e_vecs[i]) {
+    if (is_input && e_vecs[i]) {
       CeedCallBackend(CeedVectorSetArray(e_vecs[i], CEED_MEM_HOST, CEED_COPY_VALUES, NULL));
     }
   }

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -79,7 +79,8 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem, CeedTransposeMo
         // In CEED_TRANSPOSE mode, the sizes of u and v are switched.
         CeedInt P = P_1d, Q = Q_1d;
         if (t_mode == CEED_TRANSPOSE) {
-          P = Q_1d, Q = Q_1d;
+          P = Q_1d;
+          Q = Q_1d;
         }
         CeedBasis_Ref *impl;
         CeedCallBackend(CeedBasisGetData(basis, &impl));
@@ -103,7 +104,8 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem, CeedTransposeMo
           //  or Interpolate to nodes (Transpose)
           P = Q_1d, Q = Q_1d;
           if (t_mode == CEED_TRANSPOSE) {
-            P = Q_1d, Q = P_1d;
+            P = Q_1d;
+            Q = P_1d;
           }
           pre = num_comp * CeedIntPow(P, dim - 1), post = num_elem;
           for (CeedInt d = 0; d < dim; d++) {
@@ -132,7 +134,8 @@ static int CeedBasisApply_Ref(CeedBasis basis, CeedInt num_elem, CeedTransposeMo
           CeedCallBackend(CeedBasisGetGrad1D(basis, &grad_1d));
 
           if (t_mode == CEED_TRANSPOSE) {
-            P = Q_1d, Q = P_1d;
+            P = Q_1d;
+            Q = P_1d;
           }
           CeedScalar tmp[2][num_elem * num_comp * Q * CeedIntPow(P > Q ? P : Q, dim - 1)];
 

--- a/backends/ref/ceed-ref-qfunctioncontext.c
+++ b/backends/ref/ceed-ref-qfunctioncontext.c
@@ -19,7 +19,7 @@ static int CeedQFunctionContextHasValidData_Ref(CeedQFunctionContext ctx, bool *
   CeedQFunctionContext_Ref *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, (void *)&impl));
 
-  *has_valid_data = !!impl->data;
+  *has_valid_data = impl->data;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -35,7 +35,7 @@ static int CeedQFunctionContextHasBorrowedDataOfType_Ref(CeedQFunctionContext ct
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_data_of_type = !!impl->data_borrowed;
+      *has_borrowed_data_of_type = impl->data_borrowed;
       break;
     default:
       // LCOV_EXCL_START

--- a/backends/ref/ceed-ref-vector.c
+++ b/backends/ref/ceed-ref-vector.c
@@ -19,7 +19,7 @@ static int CeedVectorHasValidArray_Ref(CeedVector vec, bool *has_valid_array) {
   CeedVector_Ref *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  *has_valid_array = !!impl->array;
+  *has_valid_array = impl->array;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -35,7 +35,7 @@ static inline int CeedVectorHasBorrowedArrayOfType_Ref(const CeedVector vec, Cee
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_array_of_type = !!impl->array_borrowed;
+      *has_borrowed_array_of_type = impl->array_borrowed;
       break;
     default:
       // LCOV_EXCL_START

--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
@@ -185,7 +185,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
       if (eval_mode == CEED_EVAL_GRAD) {
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         CeedCallBackend(CeedBasisGetData(basis, &basis_impl));
-        use_collograd_parallelization = !!basis_impl->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
+        use_collograd_parallelization = basis_impl->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
       }
     }
@@ -194,7 +194,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
       if (eval_mode == CEED_EVAL_GRAD) {
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
         CeedCallBackend(CeedBasisGetData(basis, &basis_impl));
-        use_collograd_parallelization = !!basis_impl->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
+        use_collograd_parallelization = basis_impl->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
       }
     }
@@ -298,7 +298,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
           code << "  local CeedScalar s_G_in_" << i << "[" << Q_1d * Q_1d << "];\n";
           code << "  loadMatrix(Q_1D*Q_1D, G->inputs[" << i << "], s_G_in_" << i << ");\n";
         } else {
-          bool has_collo_grad = !!basis_impl->d_collo_grad_1d;
+          bool has_collo_grad = basis_impl->d_collo_grad_1d;
           h_G.inputs[i]       = has_collo_grad ? basis_impl->d_collo_grad_1d : basis_impl->d_grad_1d;
           code << "  local CeedScalar s_G_in_" << i << "[" << Q_1d * (has_collo_grad ? Q_1d : P_1d) << "];\n";
           code << "  loadMatrix(" << (has_collo_grad ? "Q_1D" : ("P_in_" + std::to_string(i))) << "*Q_1D, G->inputs[" << i << "], s_G_in_" << i
@@ -354,7 +354,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
           code << "  local CeedScalar s_G_out_" << i << "[" << Q_1d * Q_1d << "];\n";
           code << "  loadMatrix(Q_1D*Q_1D, G->outputs[" << i << "], s_G_out_" << i << ");\n";
         } else {
-          bool has_collo_grad = !!basis_impl->d_collo_grad_1d;
+          bool has_collo_grad = basis_impl->d_collo_grad_1d;
           h_G.outputs[i]      = has_collo_grad ? basis_impl->d_collo_grad_1d : basis_impl->d_grad_1d;
           code << "  local CeedScalar s_G_out_" << i << "[" << Q_1d * (has_collo_grad ? Q_1d : P_1d) << "];\n";
           code << "  loadMatrix(" << (has_collo_grad ? "Q_1D" : ("P_out_" + std::to_string(i))) << "*Q_1D, G->outputs[" << i << "], s_G_out_" << i

--- a/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
@@ -119,7 +119,7 @@ static inline int CeedQFunctionContextHasValidData_Sycl(const CeedQFunctionConte
   CeedQFunctionContext_Sycl *impl;
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
 
-  *has_valid_data = impl && (!!impl->h_data || !!impl->d_data);
+  *has_valid_data = impl && (impl->h_data || impl->d_data);
 
   return CEED_ERROR_SUCCESS;
 }
@@ -134,10 +134,10 @@ static inline int CeedQFunctionContextHasBorrowedDataOfType_Sycl(const CeedQFunc
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_data_of_type = !!impl->h_data_borrowed;
+      *has_borrowed_data_of_type = impl->h_data_borrowed;
       break;
     case CEED_MEM_DEVICE:
-      *has_borrowed_data_of_type = !!impl->d_data_borrowed;
+      *has_borrowed_data_of_type = impl->d_data_borrowed;
       break;
   }
 

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -147,7 +147,7 @@ static inline int CeedVectorHasValidArray_Sycl(const CeedVector vec, bool *has_v
   CeedVector_Sycl *impl;
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  *has_valid_array = !!impl->h_array || !!impl->d_array;
+  *has_valid_array = impl->h_array || impl->d_array;
 
   return CEED_ERROR_SUCCESS;
 }
@@ -161,10 +161,10 @@ static inline int CeedVectorHasArrayOfType_Sycl(const CeedVector vec, CeedMemTyp
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_array_of_type = !!impl->h_array_borrowed || !!impl->h_array_owned;
+      *has_array_of_type = impl->h_array_borrowed || impl->h_array_owned;
       break;
     case CEED_MEM_DEVICE:
-      *has_array_of_type = !!impl->d_array_borrowed || !!impl->d_array_owned;
+      *has_array_of_type = impl->d_array_borrowed || impl->d_array_owned;
       break;
   }
 
@@ -180,10 +180,10 @@ static inline int CeedVectorHasBorrowedArrayOfType_Sycl(const CeedVector vec, Ce
 
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *has_borrowed_array_of_type = !!impl->h_array_borrowed;
+      *has_borrowed_array_of_type = impl->h_array_borrowed;
       break;
     case CEED_MEM_DEVICE:
-      *has_borrowed_array_of_type = !!impl->d_array_borrowed;
+      *has_borrowed_array_of_type = impl->d_array_borrowed;
       break;
   }
 

--- a/examples/ceed/ex2-surface.c
+++ b/examples/ceed/ex2-surface.c
@@ -26,9 +26,9 @@
 //     ./ex2-surface -ceed /gpu/cuda
 //
 // Test in 1D-3D
-//TESTARGS(name="1D user QFunction") -ceed {ceed_resource} -d 1 -t
-//TESTARGS(name="2D user QFunction") -ceed {ceed_resource} -d 2 -t
-//TESTARGS(name="3D user QFunction") -ceed {ceed_resource} -d 3 -t
+//TESTARGS(name="1D User QFunction") -ceed {ceed_resource} -d 1 -t
+//TESTARGS(name="2D User QFunction") -ceed {ceed_resource} -d 2 -t
+//TESTARGS(name="3D User QFunction") -ceed {ceed_resource} -d 3 -t
 //TESTARGS(name="1D Gallery QFunction") -ceed {ceed_resource} -d 1 -t -g
 //TESTARGS(name="2D Gallery QFunction") -ceed {ceed_resource} -d 2 -t -g
 //TESTARGS(name="3D Gallery QFunction") -ceed {ceed_resource} -d 3 -t -g

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -129,6 +129,22 @@ CEED_EXTERN bool CeedDebugFlagEnv(void);
 #define CeedWarn(...) \
   { CeedDebugImpl256(CEED_DEBUG_COLOR_WARNING, ##__VA_ARGS__); }
 
+/**
+  Swap the values of two CeedScalars
+
+  @param[in,out] a  First CeedScalar
+  @param[in,out] b  Second CeedScalar
+
+  @ingroup Ceed
+  @ref     Backend
+**/
+#define CeedScalarSwap(a, b)        \
+  {                                 \
+    const CeedScalar temp_ = a;     \
+    a                      = b;     \
+    b                      = temp_; \
+  }
+
 /// Handle for object handling TensorContraction
 /// @ingroup CeedBasis
 typedef struct CeedTensorContract_private *CeedTensorContract;

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -871,15 +871,8 @@ int CeedSimultaneousDiagonalization(Ceed ceed, CeedScalar *mat_A, CeedScalar *ma
   for (CeedInt i = n - 1; i >= 0; i--) {
     for (CeedInt j = 0; j < i; j++) {
       if (fabs(vec_D[j]) > fabs(vec_D[j + 1])) {
-        CeedScalar temp = vec_D[j];
-
-        vec_D[j]     = vec_D[j + 1];
-        vec_D[j + 1] = temp;
-        for (CeedInt k = 0; k < n; k++) {
-          temp                 = mat_G[k * n + j];
-          mat_G[k * n + j]     = mat_G[k * n + j + 1];
-          mat_G[k * n + j + 1] = temp;
-        }
+        CeedScalarSwap(vec_D[j], vec_D[j + 1]);
+        for (CeedInt k = 0; k < n; k++) CeedScalarSwap(mat_G[k * n + j], mat_G[k * n + j + 1]);
       }
     }
   }
@@ -908,15 +901,8 @@ int CeedSimultaneousDiagonalization(Ceed ceed, CeedScalar *mat_A, CeedScalar *ma
   for (CeedInt i = n - 1; i >= 0; i--) {
     for (CeedInt j = 0; j < i; j++) {
       if (fabs(lambda[j]) > fabs(lambda[j + 1])) {
-        CeedScalar temp = lambda[j];
-
-        lambda[j]     = lambda[j + 1];
-        lambda[j + 1] = temp;
-        for (CeedInt k = 0; k < n; k++) {
-          temp                 = mat_C[k * n + j];
-          mat_C[k * n + j]     = mat_C[k * n + j + 1];
-          mat_C[k * n + j + 1] = temp;
-        }
+        CeedScalarSwap(lambda[j], lambda[j + 1]);
+        for (CeedInt k = 0; k < n; k++) CeedScalarSwap(mat_C[k * n + j], mat_C[k * n + j + 1]);
       }
     }
   }

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -802,11 +802,13 @@ int CeedSymmetricSchurDecomposition(Ceed ceed, CeedScalar *mat, CeedScalar *lamb
         if (fabs(z) > fabs(x)) {
           const CeedScalar tau = -x / z;
 
-          s = 1 / sqrt(1 + tau * tau), c = s * tau;
+          s = 1 / sqrt(1 + tau * tau);
+          c = s * tau;
         } else {
           const CeedScalar tau = -z / x;
 
-          c = 1 / sqrt(1 + tau * tau), s = c * tau;
+          c = 1 / sqrt(1 + tau * tau);
+          s = c * tau;
         }
       }
 

--- a/interface/ceed-cuda.c
+++ b/interface/ceed-cuda.c
@@ -24,6 +24,7 @@
 int CeedQFunctionSetCUDAUserFunction(CeedQFunction qf, CUfunction f) {
   if (!qf->SetCUDAUserFunction) {
     Ceed ceed;
+
     CeedCall(CeedQFunctionGetCeed(qf, &ceed));
     CeedDebug(ceed, "Backend does not support CUfunction pointers for QFunctions.");
   } else {

--- a/interface/ceed-hip.c
+++ b/interface/ceed-hip.c
@@ -24,6 +24,7 @@
 int CeedQFunctionSetHIPUserFunction(CeedQFunction qf, hipFunction_t f) {
   if (!qf->SetHIPUserFunction) {
     Ceed ceed;
+
     CeedCall(CeedQFunctionGetCeed(qf, &ceed));
     CeedDebug(ceed, "Backend does not support hipFunction_t pointers for QFunctions.");
   } else {

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -46,7 +46,7 @@ int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid) {
   // Check for valid file path
   FILE *source_file;
   source_file = fopen(source_file_path_only, "rb");
-  *is_valid   = !!source_file;
+  *is_valid   = source_file;
 
   if (*is_valid) {
     // Debug

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -1089,7 +1089,7 @@ int CeedOperatorSetName(CeedOperator op, const char *name) {
   @ref User
 **/
 int CeedOperatorView(CeedOperator op, FILE *stream) {
-  bool has_name = !!op->name;
+  bool has_name = op->name;
 
   if (op->is_composite) {
     fprintf(stream, "Composite CeedOperator%s%s\n", has_name ? " - " : "", has_name ? op->name : "");

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -792,7 +792,7 @@ static int CeedSingleOperatorMultigridLevel(CeedOperator op_fine, CeedVector p_m
   }
 
   // Clone name
-  bool   has_name = !!op_fine->name;
+  bool   has_name = op_fine->name;
   size_t name_len = op_fine->name ? strlen(op_fine->name) : 0;
   CeedCall(CeedOperatorSetName(*op_coarse, op_fine->name));
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -326,7 +326,7 @@ int CeedIsDebug(Ceed ceed, bool *is_debug) {
 
   @param[in]  ceed          Ceed context to get resource name of
   @param[in]  resource      ull user specified resource
-  @param[in]  delineator    Delinator to break resource_root and resource_spec
+  @param[in]  delineator    Delineator to break resource_root and resource_spec
   @param[out] resource_root Variable to store resource root
 
   @return An error code: 0 - success, otherwise - failure
@@ -336,9 +336,9 @@ int CeedIsDebug(Ceed ceed, bool *is_debug) {
 int CeedGetResourceRoot(Ceed ceed, const char *resource, const char *delineator, char **resource_root) {
   char  *device_spec       = strstr(resource, delineator);
   size_t resource_root_len = device_spec ? (size_t)(device_spec - resource) + 1 : strlen(resource) + 1;
+
   CeedCall(CeedCalloc(resource_root_len, resource_root));
   memcpy(*resource_root, resource, resource_root_len - 1);
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -425,10 +425,10 @@ int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *obj_name) {
 
   This function allows a Ceed context to set a delegate Ceed context for a given type of Ceed object.
   All backend implementations default to the delegate Ceed context for this object.
-  For example, CeedSetObjectDelegate(ceed, refceed, "Basis") uses refceed implementations for all CeedBasis backend functions.
+  For example, CeedSetObjectDelegate(ceed, refceed, "Basis") uses delegate implementations for all CeedBasis backend functions.
 
   @param[in,out] ceed     Ceed context to set delegate of
-  @param[out]    delegate Address to set the delegate to
+  @param[in]     delegate Ceed context to use for delegation
   @param[in]     obj_name Name of the object type to set delegate for
 
   @return An error code: 0 - success, otherwise - failure
@@ -500,7 +500,6 @@ int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed) {
     ceed->op_fallback_ceed            = fallback_ceed;
   }
   *fallback_ceed = ceed->op_fallback_ceed;
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -526,7 +525,6 @@ int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource) {
 
   // Check validity
   ceed->has_valid_op_fallback_resource = ceed->op_fallback_resource && ceed->resource && strcmp(ceed->op_fallback_resource, ceed->resource);
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -591,7 +589,8 @@ int CeedSetBackendFunction(Ceed ceed, const char *type, void *object, const char
     if (!strcmp(ceed->f_offsets[i].func_name, lookup_name)) {
       size_t offset          = ceed->f_offsets[i].offset;
       int (**fpointer)(void) = (int (**)(void))((char *)object + offset);  // *NOPAD*
-      *fpointer              = f;
+
+      *fpointer = f;
       return CEED_ERROR_SUCCESS;
     }
   }
@@ -1022,11 +1021,11 @@ int CeedAddJitSourceRoot(Ceed ceed, const char *jit_source_root) {
 
   CeedInt index       = ceed_parent->num_jit_source_roots;
   size_t  path_length = strlen(jit_source_root);
+
   CeedCall(CeedRealloc(index + 1, &ceed_parent->jit_source_roots));
   CeedCall(CeedCalloc(path_length + 1, &ceed_parent->jit_source_roots[index]));
   memcpy(ceed_parent->jit_source_roots[index], jit_source_root, path_length);
   ceed_parent->num_jit_source_roots++;
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -1110,6 +1109,7 @@ const char *CeedErrorFormat(Ceed ceed, const char *format, va_list *args) {
 int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func, int ecode, const char *format, ...) {
   va_list args;
   int     ret_val;
+
   va_start(args, format);
   if (ceed) {
     ret_val = ceed->Error(ceed, filename, lineno, func, ecode, format, &args);
@@ -1153,8 +1153,7 @@ int CeedErrorStore(Ceed ceed, const char *filename, int line_no, const char *fun
   if (ceed->op_fallback_parent) return CeedErrorStore(ceed->op_fallback_parent, filename, line_no, func, err_code, format, args);
 
   // Build message
-  int len;
-  len = snprintf(ceed->err_msg, CEED_MAX_RESOURCE_LEN, "%s:%d in %s(): ", filename, line_no, func);
+  int len = snprintf(ceed->err_msg, CEED_MAX_RESOURCE_LEN, "%s:%d in %s(): ", filename, line_no, func);
   // Using pointer to va_list for better FFI, but clang-tidy can't verify va_list is initalized
   vsnprintf(ceed->err_msg + len, CEED_MAX_RESOURCE_LEN - len, format, *args);  // NOLINT
   return err_code;

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -165,7 +165,7 @@ bool CeedDebugFlag(const Ceed ceed) { return ceed->is_debug; }
   @ref Backend
 **/
 // LCOV_EXCL_START
-bool CeedDebugFlagEnv(void) { return !!getenv("CEED_DEBUG") || !!getenv("DEBUG") || !!getenv("DBG"); }
+bool CeedDebugFlagEnv(void) { return getenv("CEED_DEBUG") || getenv("DEBUG") || getenv("DBG"); }
 // LCOV_EXCL_STOP
 
 /**
@@ -887,7 +887,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
   CeedCall(CeedSetOperatorFallbackResource(*ceed, fallbackresource));
 
   // Record env variables CEED_DEBUG or DBG
-  (*ceed)->is_debug = !!getenv("CEED_DEBUG") || !!getenv("DEBUG") || !!getenv("DBG");
+  (*ceed)->is_debug = getenv("CEED_DEBUG") || getenv("DEBUG") || getenv("DBG");
 
   // Copy resource prefix, if backend setup successful
   CeedCall(CeedStringAllocCopy(backends[match_index].prefix, (char **)&(*ceed)->resource));


### PR DESCRIPTION
This pulls a bunch of variable declarations up to the tops of their scopes and deletes the lines before return statements.

I can also do this in the backends, but after #1281 merges