### PR TITLE
preconditioning: fix realloc use-after-free bug

### DIFF
--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -1250,9 +1250,6 @@ int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op, CeedOperatorAssem
       }
     }
   }
-  (*data)->num_eval_modes_in    = num_eval_modes_in;
-  (*data)->eval_modes_in        = eval_modes_in;
-  (*data)->eval_mode_offsets_in = eval_mode_offsets_in;
 
   // Determine active output basis
   CeedCall(CeedQFunctionGetFields(qf, NULL, NULL, &num_output_fields, &qf_fields));
@@ -1316,6 +1313,9 @@ int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op, CeedOperatorAssem
       }
     }
   }
+  (*data)->num_eval_modes_in     = num_eval_modes_in;
+  (*data)->eval_modes_in         = eval_modes_in;
+  (*data)->eval_mode_offsets_in  = eval_mode_offsets_in;
   (*data)->num_output_components = offset;
   (*data)->num_eval_modes_out    = num_eval_modes_out;
   (*data)->eval_modes_out        = eval_modes_out;


### PR DESCRIPTION
`realloc(&p, size)` may change the value of `p`. In this function, we stored the local variable into a struct, then call `realloc` again on the (untrue) assumption that the value would not change.

```
==31299== Invalid read of size 4
==31299==    at 0x65A38F5: CeedSingleOperatorAssembleAddDiagonal_Core (ceed-preconditioning.c:329)
==31299==    by 0x65A5321: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1751)
==31299==    by 0x65A529E: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1743)
==31299==    by 0x65A52F8: CeedCompositeOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:433)
==31299==    by 0x65A52F8: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1749)
==31299==    by 0x65A54B8: CeedOperatorLinearAssembleDiagonal (ceed-preconditioning.c:1694)
==31299==    by 0x48C6437: RatelGetDiagonal (ratel-petsc-ops.c:71)
==31299==    by 0x558FA59: MatGetDiagonal_Shell (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x55A20A7: MatGetDiagonal (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x5960EF4: PCSetUp_Jacobi (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x59611C1: PCApply_Jacobi (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x5936522: PCApply (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x58F1BE5: KSPSolve_PREONLY (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==  Address 0xaf09f20 is 0 bytes inside a block of size 4 free'd
==31299==    at 0x484DCD3: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==31299==    by 0x6595067: CeedReallocArray (ceed.c:252)
==31299==    by 0x65A2217: CeedOperatorAssemblyDataCreate (ceed-preconditioning.c:1265)
==31299==    by 0x65A2628: CeedOperatorGetOperatorAssemblyData (ceed-preconditioning.c:1129)
==31299==    by 0x65A3526: CeedSingleOperatorAssembleAddDiagonal_Core (ceed-preconditioning.c:295)
==31299==    by 0x65A5321: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1751)
==31299==    by 0x65A529E: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1743)
==31299==    by 0x65A52F8: CeedCompositeOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:433)
==31299==    by 0x65A52F8: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1749)
==31299==    by 0x65A54B8: CeedOperatorLinearAssembleDiagonal (ceed-preconditioning.c:1694)
==31299==    by 0x48C6437: RatelGetDiagonal (ratel-petsc-ops.c:71)
==31299==    by 0x558FA59: MatGetDiagonal_Shell (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x55A20A7: MatGetDiagonal (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==  Block was alloc'd at
==31299==    at 0x48487A9: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==31299==    by 0x6595067: CeedReallocArray (ceed.c:252)
==31299==    by 0x65A1D24: CeedOperatorAssemblyDataCreate (ceed-preconditioning.c:1201)
==31299==    by 0x65A2628: CeedOperatorGetOperatorAssemblyData (ceed-preconditioning.c:1129)
==31299==    by 0x65A3526: CeedSingleOperatorAssembleAddDiagonal_Core (ceed-preconditioning.c:295)
==31299==    by 0x65A5321: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1751)
==31299==    by 0x65A529E: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1743)
==31299==    by 0x65A52F8: CeedCompositeOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:433)
==31299==    by 0x65A52F8: CeedOperatorLinearAssembleAddDiagonal (ceed-preconditioning.c:1749)
==31299==    by 0x65A54B8: CeedOperatorLinearAssembleDiagonal (ceed-preconditioning.c:1694)
==31299==    by 0x48C6437: RatelGetDiagonal (ratel-petsc-ops.c:71)
==31299==    by 0x558FA59: MatGetDiagonal_Shell (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
==31299==    by 0x55A20A7: MatGetDiagonal (in /home/rezgar/petsc/mpich_arch/lib/libpetsc.so.3.019.4)
```

Reported-by: Rezgar Shakeri