### PR TITLE
Update clang-format version to v16

### DIFF
--- a/.github/workflows/c-fortran-test-style.yml
+++ b/.github/workflows/c-fortran-test-style.yml
@@ -19,7 +19,10 @@ jobs:
     - name: Environment setup
       uses: actions/checkout@v3
     - name: Install clang-format
-      run: sudo apt update && sudo apt install clang-format-16
+      run: |
+          wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-16 main'
+          sudo apt update && sudo apt install clang-format-16
     - name: C style
       env:
         CC: ${{ matrix.compiler }}

--- a/.github/workflows/c-fortran-test-style.yml
+++ b/.github/workflows/c-fortran-test-style.yml
@@ -19,11 +19,11 @@ jobs:
     - name: Environment setup
       uses: actions/checkout@v3
     - name: Install clang-format
-      run: sudo apt update && sudo apt install clang-format-15
+      run: sudo apt update && sudo apt install clang-format-16
     - name: C style
       env:
         CC: ${{ matrix.compiler }}
         FC: gfortran-11
       run: |
         make info
-        make format-c -j2 CLANG_FORMAT=clang-format-15 && git diff --exit-code
+        make format-c -j2 CLANG_FORMAT=clang-format-16 && git diff --exit-code

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -28,10 +28,8 @@ static struct {
 } backends[32];
 static size_t num_backends;
 
-#define CEED_FTABLE_ENTRY(class, method)                     \
-  {                                                          \
-#class #method, offsetof(struct class##_private, method) \
-  }
+#define CEED_FTABLE_ENTRY(class, method) \
+  { #class #method, offsetof(struct class##_private, method) }
 /// @endcond
 
 /// @file


### PR DESCRIPTION
Version 16 catches one minor formatting change in `interface/ceed.c` which is somewhat tedious to have to keep restoring after every `make format`. Homebrew's default `clang` version is 16 since Spring of 2023. If other developers are running into the same issue, then this PR would provide a minor fix if desired.

Alternatively if this change is undesired I could look into what fixes are needed in `.clang-format` to keep the current formatting.