### PR TITLE
fix: Add `CEED_BASIS_COLLOCATED` to ceed.h

### DIFF
--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -216,6 +216,8 @@ CEED_EXTERN const CeedVector CEED_VECTOR_NONE;
 /// @ingroup CeedBasis
 CEED_EXTERN const CeedBasis CEED_BASIS_NONE;
 
+CEED_EXTERN const CeedBasis CEED_BASIS_COLLOCATED;
+
 /// Argument for CeedOperatorSetField to use no ElemRestriction.
 /// Only use this option with CeedEvalMode CEED_EVAL_WEIGHT.
 /// @ingroup CeedElemRestriction


### PR DESCRIPTION
- `CEED_BASIS_COLLOCATED` is deprecated, so should still be available to use

Fixup of #1270 