### PR TITLE
Change coordinate ordering to be consistent with tensor basis application

### DIFF
--- a/tests/t313-basis-f.f90
+++ b/tests/t313-basis-f.f90
@@ -54,7 +54,7 @@
 
         do d=0,dimn-1
           do i=1,xdim
-            if ((mod(i-1,2**(dimn-d))/(2**(dimn-d-1))).ne.0) then
+            if ((mod(i-1,2**(d+1))/(2**(d))).ne.0) then
               xx(d*xdim+i)=1
             else
               xx(d*xdim+i)=-1

--- a/tests/t313-basis.c
+++ b/tests/t313-basis.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
       CeedScalar x_array[x_dim * dim];
 
       for (CeedInt d = 0; d < dim; d++) {
-        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, dim - d)) / CeedIntPow(2, dim - d - 1) ? 1 : -1;
+        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, d + 1)) / CeedIntPow(2, d) ? 1 : -1;
       }
       CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
     }

--- a/tests/t314-basis-f.f90
+++ b/tests/t314-basis-f.f90
@@ -63,7 +63,7 @@
 
         do d=0,dimn-1
           do i=1,xdim
-            if ((mod(i-1,2**(dimn-d))/(2**(dimn-d-1))).ne.0) then
+            if ((mod(i-1,2**(d+1))/(2**(d))).ne.0) then
               xx(d*xdim+i)=1
             else
               xx(d*xdim+i)=-1

--- a/tests/t314-basis.c
+++ b/tests/t314-basis.c
@@ -18,7 +18,7 @@ static CeedScalar GetTolerance(CeedScalarType scalar_type, int dim) {
     if (dim == 3) tol = 0.05;
     else tol = 1.e-3;
   } else {
-    tol = 1.e-11;
+    tol = 1.e-10;
   }
   return tol;
 }
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
       CeedScalar x_array[x_dim * dim];
 
       for (CeedInt d = 0; d < dim; d++) {
-        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, dim - d)) / CeedIntPow(2, dim - d - 1) ? 1 : -1;
+        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, d + 1)) / CeedIntPow(2, d) ? 1 : -1;
       }
       CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
     }
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
       CeedVectorRestoreArrayRead(u_q, &u_q_array);
     }
     CeedScalar tol = GetTolerance(CEED_SCALAR_TYPE, dim);
-    if (fabs(sum_1 - sum_2) > tol) printf("[%" CeedInt_FMT "] %f != %f\n", dim, sum_1, sum_2);
+    if (fabs(sum_1 - sum_2) > tol) printf("[%" CeedInt_FMT "] %0.12f != %0.12f\n", dim, sum_1, sum_2);
 
     CeedVectorDestroy(&x);
     CeedVectorDestroy(&x_q);

--- a/tests/t315-basis.c
+++ b/tests/t315-basis.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
       CeedScalar x_array[x_dim * dim];
 
       for (CeedInt d = 0; d < dim; d++) {
-        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, dim - d)) / CeedIntPow(2, dim - d - 1) ? 1 : -1;
+        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, d + 1)) / CeedIntPow(2, d) ? 1 : -1;
       }
       CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
     }

--- a/tests/t315-basis.c
+++ b/tests/t315-basis.c
@@ -15,7 +15,7 @@ static CeedScalar Eval(CeedInt dim, const CeedScalar x[]) {
 static CeedScalar GetTolerance(CeedScalarType scalar_type, int dim) {
   CeedScalar tol;
   if (scalar_type == CEED_SCALAR_FP32) {
-    if (dim == 3) tol = 1.e-3;
+    if (dim == 3) tol = 5.e-3;
     else tol = 1.e-4;
   } else {
     tol = 1.e-11;

--- a/tests/t316-basis.c
+++ b/tests/t316-basis.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
       CeedScalar x_array[x_dim * dim];
 
       for (CeedInt d = 0; d < dim; d++) {
-        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, dim - d)) / CeedIntPow(2, dim - d - 1) ? 1 : -1;
+        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, d + 1)) / CeedIntPow(2, d) ? 1 : -1;
       }
       CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
     }

--- a/tests/t318-basis.c
+++ b/tests/t318-basis.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
       CeedScalar x_array[x_dim * dim];
 
       for (CeedInt d = 0; d < dim; d++) {
-        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, dim - d)) / CeedIntPow(2, dim - d - 1) ? 1 : -1;
+        for (CeedInt i = 0; i < x_dim; i++) x_array[d * x_dim + i] = (i % CeedIntPow(2, d + 1)) / CeedIntPow(2, d) ? 1 : -1;
       }
       CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
     }

--- a/tests/t319-basis.c
+++ b/tests/t319-basis.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
       CeedScalar x_array[x_dim * dim];
 
       for (CeedInt d = 0; d < dim; d++) {
-        for (CeedInt i = 0; i < x_dim; i++) x_array[x_dim * d + i] = (i % CeedIntPow(2, dim - d)) / CeedIntPow(2, dim - d - 1) ? 1 : -1;
+        for (CeedInt i = 0; i < x_dim; i++) x_array[x_dim * d + i] = (i % CeedIntPow(2, d + 1)) / CeedIntPow(2, d) ? 1 : -1;
       }
       CeedVectorSetArray(x_corners, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
     }
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
         for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[p_to_dim * d + i];
         for (CeedInt d = 0; d < dim; d++) {
           const CeedScalar du = EvalGrad(d, coord);
-          if (fabs(du - du_array[p_to_dim * (dim - 1 - d) + i]) > tol) {
+          if (fabs(du - du_array[p_to_dim * d + i]) > tol) {
             // LCOV_EXCL_START
             printf("[%" CeedInt_FMT ", %" CeedInt_FMT ", %" CeedInt_FMT "] %f != %f\n", dim, i, d, du_array[p_to_dim * (dim - 1 - d) + i], du);
             // LCOV_EXCL_STOP


### PR DESCRIPTION
Changes the order of coordinates in basis tests to be consistent with changes in #1324. Due to test setup, this required little or no additional changes to most of the tests. The main exception is `t319`, which also required a change in the indexing of the output `du_to` array from `du_array[p_to_dim * (dim - 1 - d) + i]` to `du_array[p_to_dim * d + i]` (the fact this permutation was ever necessary seems like an indicator that the old ordering was incorrect).