### PR TITLE
Fix some missing backend consistency from #1315

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,6 +9,7 @@ AlignOperands:                Align
 AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 ColumnLimit:                  150
 CommentPragmas:               'TESTARGS'
+DerivePointerAlignment:       false
 IncludeBlocks:                Preserve
 IncludeCategories:
   - Regex:                    '^<ceed/.*\.h>'
@@ -25,6 +26,7 @@ IncludeCategories:
     Priority:                 6
   - Regex:                    '.*'
     Priority:                 7
+PointerAlignment:             Right
 TabWidth:                     4
 UseTab:                       Never
 StatementMacros:              [CeedPragmaOptimizeOn, CeedPragmaOptimizeOff]

--- a/backends/cuda-shared/ceed-cuda-shared-basis.c
+++ b/backends/cuda-shared/ceed-cuda-shared-basis.c
@@ -146,22 +146,23 @@ int CeedBasisApplyTensor_Cuda_shared(CeedBasis basis, const CeedInt num_elem, Ce
     } break;
     case CEED_EVAL_WEIGHT: {
       CeedInt Q_1d;
+      CeedInt block_size = 32;
 
       CeedCallBackend(CeedBasisGetNumQuadraturePoints1D(basis, &Q_1d));
       void *weight_args[] = {(void *)&num_elem, (void *)&data->d_q_weight_1d, &d_v};
       if (dim == 1) {
-        const CeedInt elems_per_block = 32 / Q_1d;
+        const CeedInt elems_per_block = block_size / Q_1d;
         const CeedInt grid_size       = num_elem / elems_per_block + ((num_elem / elems_per_block * elems_per_block < num_elem) ? 1 : 0);
 
         CeedCallBackend(CeedRunKernelDim_Cuda(ceed, data->Weight, grid_size, Q_1d, elems_per_block, 1, weight_args));
       } else if (dim == 2) {
-        const CeedInt opt_elems       = 32 / (Q_1d * Q_1d);
+        const CeedInt opt_elems       = block_size / (Q_1d * Q_1d);
         const CeedInt elems_per_block = opt_elems > 0 ? opt_elems : 1;
         const CeedInt grid_size       = num_elem / elems_per_block + ((num_elem / elems_per_block * elems_per_block < num_elem) ? 1 : 0);
 
         CeedCallBackend(CeedRunKernelDim_Cuda(ceed, data->Weight, grid_size, Q_1d, Q_1d, elems_per_block, weight_args));
       } else if (dim == 3) {
-        const CeedInt opt_elems       = 32 / (Q_1d * Q_1d);
+        const CeedInt opt_elems       = block_size / (Q_1d * Q_1d);
         const CeedInt elems_per_block = opt_elems > 0 ? opt_elems : 1;
         const CeedInt grid_size       = num_elem / elems_per_block + ((num_elem / elems_per_block * elems_per_block < num_elem) ? 1 : 0);
 

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -275,8 +275,8 @@ int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, 
   Ceed                  ceed;
   char                 *basis_kernel_path, *basis_kernel_source;
   CeedInt               num_comp;
-  const CeedInt         q_bytes = Q_1d * sizeof(CeedScalar);
-  const CeedInt         i_bytes = q_bytes * P_1d;
+  const CeedInt         q_bytes      = Q_1d * sizeof(CeedScalar);
+  const CeedInt         interp_bytes = q_bytes * P_1d;
   CeedBasis_Hip_shared *data;
 
   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
@@ -285,10 +285,10 @@ int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, 
   // Copy basis data to GPU
   CeedCallHip(ceed, hipMalloc((void **)&data->d_q_weight_1d, q_bytes));
   CeedCallHip(ceed, hipMemcpy(data->d_q_weight_1d, q_weight_1d, q_bytes, hipMemcpyHostToDevice));
-  CeedCallHip(ceed, hipMalloc((void **)&data->d_interp_1d, i_bytes));
-  CeedCallHip(ceed, hipMemcpy(data->d_interp_1d, interp_1d, i_bytes, hipMemcpyHostToDevice));
-  CeedCallHip(ceed, hipMalloc((void **)&data->d_grad_1d, i_bytes));
-  CeedCallHip(ceed, hipMemcpy(data->d_grad_1d, grad_1d, i_bytes, hipMemcpyHostToDevice));
+  CeedCallHip(ceed, hipMalloc((void **)&data->d_interp_1d, interp_bytes));
+  CeedCallHip(ceed, hipMemcpy(data->d_interp_1d, interp_1d, interp_bytes, hipMemcpyHostToDevice));
+  CeedCallHip(ceed, hipMalloc((void **)&data->d_grad_1d, interp_bytes));
+  CeedCallHip(ceed, hipMemcpy(data->d_grad_1d, grad_1d, interp_bytes, hipMemcpyHostToDevice));
 
   // Compute collocated gradient and copy to GPU
   data->d_collo_grad_1d    = NULL;

--- a/backends/hip-shared/ceed-hip-shared-basis.c
+++ b/backends/hip-shared/ceed-hip-shared-basis.c
@@ -81,7 +81,6 @@ static int ComputeBasisThreadBlockSizes(const CeedInt dim, const CeedInt P_1d, c
       block_sizes[2] = CeedIntMax(256, ComputeBlockSizeFromRequirement(required));
     }
   }
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/occa/ceed-occa-basis.hpp
+++ b/backends/occa/ceed-occa-basis.hpp
@@ -27,21 +27,21 @@ class Basis : public CeedObject {
 
   virtual ~Basis();
 
-  static Basis* getBasis(CeedBasis basis, const bool assertValid = true);
+  static Basis *getBasis(CeedBasis basis, const bool assertValid = true);
 
-  static Basis* from(CeedBasis basis);
-  static Basis* from(CeedOperatorField operatorField);
+  static Basis *from(CeedBasis basis);
+  static Basis *from(CeedOperatorField operatorField);
 
   int setCeedFields(CeedBasis basis);
 
   virtual bool isTensorBasis() const = 0;
 
-  virtual const char* getFunctionSource() const = 0;
+  virtual const char *getFunctionSource() const = 0;
 
-  virtual int apply(const CeedInt elementCount, CeedTransposeMode tmode, CeedEvalMode emode, Vector* u, Vector* v) = 0;
+  virtual int apply(const CeedInt elementCount, CeedTransposeMode tmode, CeedEvalMode emode, Vector *u, Vector *v) = 0;
 
   //---[ Ceed Callbacks ]-----------
-  static int registerCeedFunction(Ceed ceed, CeedBasis basis, const char* fname, ceed::occa::ceedFunction f);
+  static int registerCeedFunction(Ceed ceed, CeedBasis basis, const char *fname, ceed::occa::ceedFunction f);
 
   static int ceedApply(CeedBasis basis, const CeedInt nelem, CeedTransposeMode tmode, CeedEvalMode emode, CeedVector u, CeedVector v);
 

--- a/backends/occa/ceed-occa-context.cpp
+++ b/backends/occa/ceed-occa-context.cpp
@@ -15,13 +15,13 @@ Context::Context(::occa::device device_) : device(device_) {
   _usingGpuDevice        = (mode == "CUDA" || mode == "HIP" || mode == "OpenCL");
 }
 
-Context* Context::from(Ceed ceed) {
+Context *Context::from(Ceed ceed) {
   if (!ceed) {
     return NULL;
   }
 
-  Context* context;
-  CeedGetData(ceed, (void**)&context);
+  Context *context;
+  CeedGetData(ceed, (void **)&context);
   return context;
 }
 

--- a/backends/occa/ceed-occa-context.hpp
+++ b/backends/occa/ceed-occa-context.hpp
@@ -22,7 +22,7 @@ class Context {
 
   Context(::occa::device device_);
 
-  static Context* from(Ceed ceed);
+  static Context *from(Ceed ceed);
 
   bool usingCpuDevice() const;
   bool usingGpuDevice() const;

--- a/backends/occa/ceed-occa-operator-args.cpp
+++ b/backends/occa/ceed-occa-operator-args.cpp
@@ -39,10 +39,10 @@ void OperatorArgs::setupArgs(CeedOperator op) {
   }
 }
 
-const OperatorField& OperatorArgs::getOpField(const bool isInput, const int index) const { return isInput ? opInputs[index] : opOutputs[index]; }
+const OperatorField &OperatorArgs::getOpField(const bool isInput, const int index) const { return isInput ? opInputs[index] : opOutputs[index]; }
 
-const OperatorField& OperatorArgs::getOpInput(const int index) const { return opInputs[index]; }
+const OperatorField &OperatorArgs::getOpInput(const int index) const { return opInputs[index]; }
 
-const OperatorField& OperatorArgs::getOpOutput(const int index) const { return opOutputs[index]; }
+const OperatorField &OperatorArgs::getOpOutput(const int index) const { return opOutputs[index]; }
 }  // namespace occa
 }  // namespace ceed

--- a/backends/occa/ceed-occa-operator-args.hpp
+++ b/backends/occa/ceed-occa-operator-args.hpp
@@ -28,11 +28,11 @@ class OperatorArgs : public QFunctionArgs {
 
   void setupArgs(CeedOperator op);
 
-  const OperatorField& getOpField(const bool isInput, const int index) const;
+  const OperatorField &getOpField(const bool isInput, const int index) const;
 
-  const OperatorField& getOpInput(const int index) const;
+  const OperatorField &getOpInput(const int index) const;
 
-  const OperatorField& getOpOutput(const int index) const;
+  const OperatorField &getOpOutput(const int index) const;
 };
 }  // namespace occa
 }  // namespace ceed

--- a/backends/occa/ceed-occa-qfunction-args.cpp
+++ b/backends/occa/ceed-occa-qfunction-args.cpp
@@ -43,11 +43,11 @@ int QFunctionArgs::inputCount() const { return _inputCount; }
 
 int QFunctionArgs::outputCount() const { return _outputCount; }
 
-const QFunctionField& QFunctionArgs::getQfField(const bool isInput, const int index) const { return isInput ? qfInputs[index] : qfOutputs[index]; }
+const QFunctionField &QFunctionArgs::getQfField(const bool isInput, const int index) const { return isInput ? qfInputs[index] : qfOutputs[index]; }
 
-const QFunctionField& QFunctionArgs::getQfInput(const int index) const { return qfInputs[index]; }
+const QFunctionField &QFunctionArgs::getQfInput(const int index) const { return qfInputs[index]; }
 
-const QFunctionField& QFunctionArgs::getQfOutput(const int index) const { return qfOutputs[index]; }
+const QFunctionField &QFunctionArgs::getQfOutput(const int index) const { return qfOutputs[index]; }
 
 CeedEvalMode QFunctionArgs::getEvalMode(const bool isInput, const int index) const {
   return isInput ? qfInputs[index].evalMode : qfOutputs[index].evalMode;

--- a/backends/occa/ceed-occa-qfunction-args.hpp
+++ b/backends/occa/ceed-occa-qfunction-args.hpp
@@ -37,11 +37,11 @@ class QFunctionArgs : public CeedObject {
   int inputCount() const;
   int outputCount() const;
 
-  const QFunctionField& getQfField(const bool isInput, const int index) const;
+  const QFunctionField &getQfField(const bool isInput, const int index) const;
 
-  const QFunctionField& getQfInput(const int index) const;
+  const QFunctionField &getQfInput(const int index) const;
 
-  const QFunctionField& getQfOutput(const int index) const;
+  const QFunctionField &getQfOutput(const int index) const;
 
   CeedEvalMode getEvalMode(const bool isInput, const int index) const;
 

--- a/backends/occa/ceed-occa-types.hpp
+++ b/backends/occa/ceed-occa-types.hpp
@@ -45,7 +45,7 @@
     return CeedError(ceed, CEED_ERROR_BACKEND, error.c_str()); \
   } while (0)
 
-#define CeedOccaCastRegisterFunction(func) (ceed::occa::ceedFunction)(void*) func
+#define CeedOccaCastRegisterFunction(func) (ceed::occa::ceedFunction)(void *) func
 
 #define CeedOccaRegisterBaseFunction(name, func) CeedCallBackend(registerCeedFunction(ceed, name, CeedOccaCastRegisterFunction(func)));
 

--- a/backends/occa/kernels/set-value.cpp
+++ b/backends/occa/kernels/set-value.cpp
@@ -14,9 +14,9 @@
 // Expects the following constants to be defined:
 // - BLOCK_SIZE : CeedInt
 
-const char* occa_set_value_source = STRINGIFY_SOURCE(
+const char *occa_set_value_source = STRINGIFY_SOURCE(
 
-    @kernel void setValue(CeedScalar* ptr, const CeedScalar value, const CeedInt count) {
+    @kernel void setValue(CeedScalar *ptr, const CeedScalar value, const CeedInt count) {
       @tile(BLOCK_SIZE, @outer, @inner) for (CeedInt i = 0; i < count; ++i) {
         ptr[i] = value;
       }

--- a/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
@@ -524,7 +524,6 @@ static int CeedBasisDestroy_Sycl(CeedBasis basis) {
   CeedCallSycl(ceed, sycl::free(impl->d_grad_1d, data->sycl_context));
 
   CeedCallBackend(CeedFree(&impl));
-
   return CEED_ERROR_SUCCESS;
 }
 
@@ -547,7 +546,6 @@ static int CeedBasisDestroyNonTensor_Sycl(CeedBasis basis) {
   CeedCallSycl(ceed, sycl::free(impl->d_grad, data->sycl_context));
 
   CeedCallBackend(CeedFree(&impl));
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp
@@ -28,13 +28,13 @@
 //------------------------------------------------------------------------------
 extern "C" int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf) {
   Ceed                ceed;
-  Ceed_Sycl*          data;
-  char *              qfunction_name, *qfunction_source, *read_write_kernel_path, *read_write_kernel_source;
+  Ceed_Sycl          *data;
+  char               *qfunction_name, *qfunction_source, *read_write_kernel_path, *read_write_kernel_source;
   CeedInt             num_input_fields, num_output_fields;
   CeedQFunctionField *input_fields, *output_fields;
-  CeedQFunction_Sycl* impl;
+  CeedQFunction_Sycl *impl;
 
-  CeedCallBackend(CeedQFunctionGetData(qf, (void**)&impl));
+  CeedCallBackend(CeedQFunctionGetData(qf, (void **)&impl));
   // QFunction is built
   if (impl->QFunction) return CEED_ERROR_SUCCESS;
 
@@ -45,17 +45,17 @@ extern "C" int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf) {
   CeedCallBackend(CeedQFunctionGetFields(qf, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
 
   std::vector<CeedInt> input_sizes(num_input_fields);
-  CeedQFunctionField*  input_i = input_fields;
+  CeedQFunctionField  *input_i = input_fields;
 
-  for (auto& size_i : input_sizes) {
+  for (auto &size_i : input_sizes) {
     CeedCallBackend(CeedQFunctionFieldGetSize(*input_i, &size_i));
     ++input_i;
   }
 
   std::vector<CeedInt> output_sizes(num_output_fields);
-  CeedQFunctionField*  output_i = output_fields;
+  CeedQFunctionField  *output_i = output_fields;
 
-  for (auto& size_i : output_sizes) {
+  for (auto &size_i : output_sizes) {
     CeedCallBackend(CeedQFunctionFieldGetSize(*output_i, &size_i));
     ++output_i;
   }

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -202,10 +202,10 @@ static int CeedVectorSetArrayHost_Sycl(const CeedVector vec, const CeedCopyMode 
       impl->h_array          = impl->h_array_owned;
       if (array) {
         CeedSize length;
+        size_t   bytes;
 
         CeedCallBackend(CeedVectorGetLength(vec, &length));
-        size_t bytes = length * sizeof(CeedScalar);
-
+        bytes = length * sizeof(CeedScalar);
         memcpy(impl->h_array, array, bytes);
       }
     } break;
@@ -221,7 +221,6 @@ static int CeedVectorSetArrayHost_Sycl(const CeedVector vec, const CeedCopyMode 
       impl->h_array          = array;
       break;
   }
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -219,7 +219,7 @@ CEED_EXTERN int CeedGetDelegate(Ceed ceed, Ceed *delegate);
 CEED_EXTERN int CeedSetDelegate(Ceed ceed, Ceed delegate);
 CEED_EXTERN int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *obj_name);
 CEED_EXTERN int CeedSetObjectDelegate(Ceed ceed, Ceed delegate, const char *obj_name);
-CEED_EXTERN int CeedGetOperatorfallback_resource(Ceed ceed, const char **resource);
+CEED_EXTERN int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource);
 CEED_EXTERN int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed);
 CEED_EXTERN int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource);
 CEED_EXTERN int CeedSetDeterministic(Ceed ceed, bool is_deterministic);

--- a/include/ceed/jit-source/cuda/cuda-gen-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-gen-templates.h
@@ -29,7 +29,7 @@ inline __device__ void loadMatrix(SharedData_Cuda &data, const CeedScalar *__res
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int COMP_STRIDE, int P_1d>
 inline __device__ void readDofsOffset1d(SharedData_Cuda &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
-                                        const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+                                        const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = indices[node + elem * P_1d];
@@ -42,7 +42,8 @@ inline __device__ void readDofsOffset1d(SharedData_Cuda &data, const CeedInt num
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readDofsStrided1d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+inline __device__ void readDofsStrided1d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ d_u,
+                                         CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
@@ -56,7 +57,7 @@ inline __device__ void readDofsStrided1d(SharedData_Cuda &data, const CeedInt el
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int COMP_STRIDE, int P_1d>
 inline __device__ void writeDofsOffset1d(SharedData_Cuda &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
-                                         const CeedScalar *r_v, CeedScalar *d_v) {
+                                         const CeedScalar *__restrict__ r_v, CeedScalar *__restrict__ d_v) {
   if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = indices[node + elem * P_1d];
@@ -69,7 +70,8 @@ inline __device__ void writeDofsOffset1d(SharedData_Cuda &data, const CeedInt nu
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void writeDofsStrided1d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *r_v, CeedScalar *d_v) {
+inline __device__ void writeDofsStrided1d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ r_v,
+                                          CeedScalar *__restrict__ d_v) {
   if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
@@ -87,7 +89,7 @@ inline __device__ void writeDofsStrided1d(SharedData_Cuda &data, const CeedInt e
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int COMP_STRIDE, int P_1d>
 inline __device__ void readDofsOffset2d(SharedData_Cuda &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
-                                        const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+                                        const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
     const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
     const CeedInt ind  = indices[node + elem * P_1d * P_1d];
@@ -100,7 +102,8 @@ inline __device__ void readDofsOffset2d(SharedData_Cuda &data, const CeedInt num
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readDofsStrided2d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+inline __device__ void readDofsStrided2d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ d_u,
+                                         CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
     const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
@@ -114,7 +117,7 @@ inline __device__ void readDofsStrided2d(SharedData_Cuda &data, const CeedInt el
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int COMP_STRIDE, int P_1d>
 inline __device__ void writeDofsOffset2d(SharedData_Cuda &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
-                                         const CeedScalar *r_v, CeedScalar *d_v) {
+                                         const CeedScalar *__restrict__ r_v, CeedScalar *__restrict__ d_v) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
     const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
     const CeedInt ind  = indices[node + elem * P_1d * P_1d];
@@ -127,7 +130,8 @@ inline __device__ void writeDofsOffset2d(SharedData_Cuda &data, const CeedInt nu
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void writeDofsStrided2d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *r_v, CeedScalar *d_v) {
+inline __device__ void writeDofsStrided2d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ r_v,
+                                          CeedScalar *__restrict__ d_v) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
     const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
@@ -152,7 +156,7 @@ inline __device__ void writeDofsStrided2d(SharedData_Cuda &data, const CeedInt e
 //   - writeDofsStrided3d -> writeStrided3d ?
 template <int NUM_COMP, int COMP_STRIDE, int P_1d>
 inline __device__ void readDofsOffset3d(SharedData_Cuda &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
-                                        const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+                                        const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d)
     for (CeedInt z = 0; z < P_1d; z++) {
       const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
@@ -166,7 +170,8 @@ inline __device__ void readDofsOffset3d(SharedData_Cuda &data, const CeedInt num
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readDofsStrided3d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+inline __device__ void readDofsStrided3d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ d_u,
+                                         CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d)
     for (CeedInt z = 0; z < P_1d; z++) {
       const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
@@ -181,7 +186,7 @@ inline __device__ void readDofsStrided3d(SharedData_Cuda &data, const CeedInt el
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int COMP_STRIDE, int Q_1d>
 inline __device__ void readSliceQuadsOffset3d(SharedData_Cuda &data, const CeedInt nquads, const CeedInt elem, const CeedInt q,
-                                              const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ d_u, CeedScalar *r_u) {
+                                              const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < Q_1d && data.t_id_y < Q_1d) {
     const CeedInt node = data.t_id_x + data.t_id_y * Q_1d + q * Q_1d * Q_1d;
     const CeedInt ind  = indices[node + elem * Q_1d * Q_1d * Q_1d];
@@ -195,7 +200,7 @@ inline __device__ void readSliceQuadsOffset3d(SharedData_Cuda &data, const CeedI
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int Q_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
 inline __device__ void readSliceQuadsStrided3d(SharedData_Cuda &data, const CeedInt elem, const CeedInt q, const CeedScalar *__restrict__ d_u,
-                                               CeedScalar *r_u) {
+                                               CeedScalar *__restrict__ r_u) {
   if (data.t_id_x < Q_1d && data.t_id_y < Q_1d) {
     const CeedInt node = data.t_id_x + data.t_id_y * Q_1d + q * Q_1d * Q_1d;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
@@ -209,7 +214,7 @@ inline __device__ void readSliceQuadsStrided3d(SharedData_Cuda &data, const Ceed
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int COMP_STRIDE, int P_1d>
 inline __device__ void writeDofsOffset3d(SharedData_Cuda &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
-                                         const CeedScalar *r_v, CeedScalar *d_v) {
+                                         const CeedScalar *__restrict__ r_v, CeedScalar *__restrict__ d_v) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d)
     for (CeedInt z = 0; z < P_1d; z++) {
       const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
@@ -223,7 +228,8 @@ inline __device__ void writeDofsOffset3d(SharedData_Cuda &data, const CeedInt nu
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void writeDofsStrided3d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *r_v, CeedScalar *d_v) {
+inline __device__ void writeDofsStrided3d(SharedData_Cuda &data, const CeedInt elem, const CeedScalar *__restrict__ r_v,
+                                          CeedScalar *__restrict__ d_v) {
   if (data.t_id_x < P_1d && data.t_id_y < P_1d)
     for (CeedInt z = 0; z < P_1d; z++) {
       const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;

--- a/include/ceed/jit-source/cuda/cuda-jit.h
+++ b/include/ceed/jit-source/cuda/cuda-jit.h
@@ -17,4 +17,4 @@
 
 #include "cuda-types.h"
 
-#endif  // CEED_CUDA_JIT_DEFS_H
+#endif  // CEED_CUDA_JIT_H

--- a/include/ceed/jit-source/cuda/cuda-ref-basis-tensor.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-basis-tensor.h
@@ -46,28 +46,27 @@ extern "C" __global__ void Interp(const CeedInt num_elem, const CeedInt transpos
     for (CeedInt comp = 0; comp < BASIS_NUM_COMP; comp++) {
       const CeedScalar *cur_u = u + elem * u_stride + comp * u_comp_stride;
       CeedScalar       *cur_v = v + elem * v_stride + comp * v_comp_stride;
+      CeedInt           pre   = u_size;
+      CeedInt           post  = 1;
 
       for (CeedInt k = i; k < u_size; k += blockDim.x) {
         s_buffer_1[k] = cur_u[k];
       }
-      CeedInt pre  = u_size;
-      CeedInt post = 1;
-
       for (CeedInt d = 0; d < BASIS_DIM; d++) {
         __syncthreads();
         // Update buffers used
         pre /= P;
-        const CeedScalar *in  = d % 2 ? s_buffer_2 : s_buffer_1;
-        CeedScalar       *out = d == BASIS_DIM - 1 ? cur_v : (d % 2 ? s_buffer_1 : s_buffer_2);
+        const CeedScalar *in       = d % 2 ? s_buffer_2 : s_buffer_1;
+        CeedScalar       *out      = d == BASIS_DIM - 1 ? cur_v : (d % 2 ? s_buffer_1 : s_buffer_2);
+        const CeedInt     writeLen = pre * post * Q;
 
         // Contract along middle index
-        const CeedInt writeLen = pre * post * Q;
         for (CeedInt k = i; k < writeLen; k += blockDim.x) {
-          const CeedInt c = k % post;
-          const CeedInt j = (k / post) % Q;
-          const CeedInt a = k / (post * Q);
+          const CeedInt c  = k % post;
+          const CeedInt j  = (k / post) % Q;
+          const CeedInt a  = k / (post * Q);
+          CeedScalar    vk = 0;
 
-          CeedScalar vk = 0;
           for (CeedInt b = 0; b < P; b++) vk += s_interp_1d[j * stride_0 + b * stride_1] * in[(a * P + b) * post + c];
           out[k] = vk;
         }
@@ -119,12 +118,12 @@ extern "C" __global__ void Grad(const CeedInt num_elem, const CeedInt transpose,
           __syncthreads();
           // Update buffers used
           pre /= P;
-          const CeedScalar *op  = dim_1 == dim_2 ? s_grad_1d : s_interp_1d;
-          const CeedScalar *in  = dim_2 == 0 ? cur_u : (dim_2 % 2 ? s_buffer_2 : s_buffer_1);
-          CeedScalar       *out = dim_2 == BASIS_DIM - 1 ? cur_v : (dim_2 % 2 ? s_buffer_1 : s_buffer_2);
+          const CeedScalar *op       = dim_1 == dim_2 ? s_grad_1d : s_interp_1d;
+          const CeedScalar *in       = dim_2 == 0 ? cur_u : (dim_2 % 2 ? s_buffer_2 : s_buffer_1);
+          CeedScalar       *out      = dim_2 == BASIS_DIM - 1 ? cur_v : (dim_2 % 2 ? s_buffer_1 : s_buffer_2);
+          const CeedInt     writeLen = pre * post * Q;
 
           // Contract along middle index
-          const CeedInt writeLen = pre * post * Q;
           for (CeedInt k = i; k < writeLen; k += blockDim.x) {
             const CeedInt c   = k % post;
             const CeedInt j   = (k / post) % Q;
@@ -132,7 +131,6 @@ extern "C" __global__ void Grad(const CeedInt num_elem, const CeedInt transpose,
             CeedScalar    v_k = 0;
 
             for (CeedInt b = 0; b < P; b++) v_k += op[j * stride_0 + b * stride_1] * in[(a * P + b) * post + c];
-
             if (transpose && dim_2 == BASIS_DIM - 1) out[k] += v_k;
             else out[k] = v_k;
           }

--- a/include/ceed/jit-source/cuda/cuda-ref-qfunction.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-qfunction.h
@@ -16,7 +16,7 @@
 // Read from quadrature points
 //------------------------------------------------------------------------------
 template <int SIZE>
-inline __device__ void readQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar* d_u, CeedScalar* r_u) {
+inline __device__ void readQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar *d_u, CeedScalar *r_u) {
   for (CeedInt comp = 0; comp < SIZE; comp++) {
     r_u[comp] = d_u[quad + num_qpts * comp];
   }
@@ -26,7 +26,7 @@ inline __device__ void readQuads(const CeedInt quad, const CeedInt num_qpts, con
 // Write at quadrature points
 //------------------------------------------------------------------------------
 template <int SIZE>
-inline __device__ void writeQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar* r_v, CeedScalar* d_v) {
+inline __device__ void writeQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar *r_v, CeedScalar *d_v) {
   for (CeedInt comp = 0; comp < SIZE; comp++) {
     d_v[quad + num_qpts * comp] = r_v[comp];
   }

--- a/include/ceed/jit-source/cuda/cuda-types.h
+++ b/include/ceed/jit-source/cuda/cuda-types.h
@@ -15,13 +15,13 @@
 #define CEED_CUDA_NUMBER_FIELDS 16
 
 typedef struct {
-  const CeedScalar* inputs[CEED_CUDA_NUMBER_FIELDS];
-  CeedScalar*       outputs[CEED_CUDA_NUMBER_FIELDS];
+  const CeedScalar *inputs[CEED_CUDA_NUMBER_FIELDS];
+  CeedScalar       *outputs[CEED_CUDA_NUMBER_FIELDS];
 } Fields_Cuda;
 
 typedef struct {
-  CeedInt* inputs[CEED_CUDA_NUMBER_FIELDS];
-  CeedInt* outputs[CEED_CUDA_NUMBER_FIELDS];
+  CeedInt *inputs[CEED_CUDA_NUMBER_FIELDS];
+  CeedInt *outputs[CEED_CUDA_NUMBER_FIELDS];
 } FieldsInt_Cuda;
 
 typedef struct {
@@ -29,7 +29,7 @@ typedef struct {
   CeedInt     t_id_y;
   CeedInt     t_id_z;
   CeedInt     t_id;
-  CeedScalar* slice;
+  CeedScalar *slice;
 } SharedData_Cuda;
 
 #endif  // CEED_CUDA_TYPES_H

--- a/include/ceed/jit-source/hip/hip-gen-templates.h
+++ b/include/ceed/jit-source/hip/hip-gen-templates.h
@@ -16,7 +16,7 @@
 // Load matrices for basis actions
 //------------------------------------------------------------------------------
 template <int P, int Q>
-inline __device__ void loadMatrix(SharedData_Hip& data, const CeedScalar* d_B, CeedScalar* B) {
+inline __device__ void loadMatrix(SharedData_Hip &data, const CeedScalar *__restrict__ d_B, CeedScalar *B) {
   for (CeedInt i = data.t_id; i < P * Q; i += blockDim.x * blockDim.y * blockDim.z) B[i] = d_B[i];
 }
 
@@ -27,50 +27,55 @@ inline __device__ void loadMatrix(SharedData_Hip& data, const CeedScalar* d_B, C
 //------------------------------------------------------------------------------
 // L-vector -> E-vector, offsets provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int P1d>
-inline __device__ void readDofsOffset1d(SharedData_Hip& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* d_u,
-                                        CeedScalar* r_u) {
-  if (data.t_id_x < P1d) {
+template <int NUM_COMP, int COMP_STRIDE, int P_1d>
+inline __device__ void readDofsOffset1d(SharedData_Hip &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
+                                        const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
-    const CeedInt ind  = indices[node + elem * P1d];
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+    const CeedInt ind  = indices[node + elem * P_1d];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[comp] = d_u[ind + COMP_STRIDE * comp];
   }
 }
 
 //------------------------------------------------------------------------------
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readDofsStrided1d(SharedData_Hip& data, const CeedInt elem, const CeedScalar* d_u, CeedScalar* r_u) {
-  if (data.t_id_x < P1d) {
+template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readDofsStrided1d(SharedData_Hip &data, const CeedInt elem, const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[comp] = d_u[ind + comp * STRIDES_COMP];
   }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> L-vector, offsets provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int P1d>
-inline __device__ void writeDofsOffset1d(SharedData_Hip& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices,
-                                         const CeedScalar* r_v, CeedScalar* d_v) {
-  if (data.t_id_x < P1d) {
+template <int NUM_COMP, int COMP_STRIDE, int P_1d>
+inline __device__ void writeDofsOffset1d(SharedData_Hip &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
+                                         const CeedScalar *__restrict__ r_v, CeedScalar *__restrict__ d_v) {
+  if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
-    const CeedInt ind  = indices[node + elem * P1d];
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) atomicAdd(&d_v[ind + COMPSTRIDE * comp], r_v[comp]);
+    const CeedInt ind  = indices[node + elem * P_1d];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) atomicAdd(&d_v[ind + COMP_STRIDE * comp], r_v[comp]);
   }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void writeDofsStrided1d(SharedData_Hip& data, const CeedInt elem, const CeedScalar* r_v, CeedScalar* d_v) {
-  if (data.t_id_x < P1d) {
+template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void writeDofsStrided1d(SharedData_Hip &data, const CeedInt elem, const CeedScalar *__restrict__ r_v,
+                                          CeedScalar *__restrict__ d_v) {
+  if (data.t_id_x < P_1d) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) d_v[ind + comp * STRIDES_COMP] += r_v[comp];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) d_v[ind + comp * STRIDES_COMP] += r_v[comp];
   }
 }
 
@@ -81,50 +86,55 @@ inline __device__ void writeDofsStrided1d(SharedData_Hip& data, const CeedInt el
 //------------------------------------------------------------------------------
 // L-vector -> E-vector, offsets provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int P1d>
-inline __device__ void readDofsOffset2d(SharedData_Hip& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* d_u,
-                                        CeedScalar* r_u) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d) {
-    const CeedInt node = data.t_id_x + data.t_id_y * P1d;
-    const CeedInt ind  = indices[node + elem * P1d * P1d];
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+template <int NUM_COMP, int COMP_STRIDE, int P_1d>
+inline __device__ void readDofsOffset2d(SharedData_Hip &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
+                                        const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
+    const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
+    const CeedInt ind  = indices[node + elem * P_1d * P_1d];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[comp] = d_u[ind + COMP_STRIDE * comp];
   }
 }
 
 //------------------------------------------------------------------------------
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readDofsStrided2d(SharedData_Hip& data, const CeedInt elem, const CeedScalar* d_u, CeedScalar* r_u) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d) {
-    const CeedInt node = data.t_id_x + data.t_id_y * P1d;
+template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readDofsStrided2d(SharedData_Hip &data, const CeedInt elem, const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
+    const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[comp] = d_u[ind + comp * STRIDES_COMP];
   }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> L-vector, offsets provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int P1d>
-inline __device__ void writeDofsOffset2d(SharedData_Hip& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices,
-                                         const CeedScalar* r_v, CeedScalar* d_v) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d) {
-    const CeedInt node = data.t_id_x + data.t_id_y * P1d;
-    const CeedInt ind  = indices[node + elem * P1d * P1d];
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) atomicAdd(&d_v[ind + COMPSTRIDE * comp], r_v[comp]);
+template <int NUM_COMP, int COMP_STRIDE, int P_1d>
+inline __device__ void writeDofsOffset2d(SharedData_Hip &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
+                                         const CeedScalar *__restrict__ r_v, CeedScalar *__restrict__ d_v) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
+    const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
+    const CeedInt ind  = indices[node + elem * P_1d * P_1d];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) atomicAdd(&d_v[ind + COMP_STRIDE * comp], r_v[comp]);
   }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void writeDofsStrided2d(SharedData_Hip& data, const CeedInt elem, const CeedScalar* r_v, CeedScalar* d_v) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d) {
-    const CeedInt node = data.t_id_x + data.t_id_y * P1d;
+template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void writeDofsStrided2d(SharedData_Hip &data, const CeedInt elem, const CeedScalar *__restrict__ r_v,
+                                          CeedScalar *__restrict__ d_v) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d) {
+    const CeedInt node = data.t_id_x + data.t_id_y * P_1d;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) d_v[ind + comp * STRIDES_COMP] += r_v[comp];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) d_v[ind + comp * STRIDES_COMP] += r_v[comp];
   }
 }
 
@@ -135,104 +145,118 @@ inline __device__ void writeDofsStrided2d(SharedData_Hip& data, const CeedInt el
 //------------------------------------------------------------------------------
 // L-vector -> E-vector, offsets provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int P1d>
-inline __device__ void readDofsOffset3d(SharedData_Hip& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices, const CeedScalar* d_u,
-                                        CeedScalar* r_u) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d)
-    for (CeedInt z = 0; z < P1d; ++z) {
-      const CeedInt node = data.t_id_x + data.t_id_y * P1d + z * P1d * P1d;
-      const CeedInt ind  = indices[node + elem * P1d * P1d * P1d];
-      for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[z + comp * P1d] = d_u[ind + COMPSTRIDE * comp];
+// TODO: remove "Dofs" and "Quads" in the following function names?
+//   - readDofsOffset3d -> readOffset3d ?
+//   - readDofsStrided3d -> readStrided3d ?
+//   - readSliceQuadsOffset3d -> readSliceOffset3d ?
+//   - readSliceQuadsStrided3d -> readSliceStrided3d ?
+//   - writeDofsOffset3d -> writeOffset3d ?
+//   - writeDofsStrided3d -> writeStrided3d ?
+template <int NUM_COMP, int COMP_STRIDE, int P_1d>
+inline __device__ void readDofsOffset3d(SharedData_Hip &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
+                                        const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d)
+    for (CeedInt z = 0; z < P_1d; z++) {
+      const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
+      const CeedInt ind  = indices[node + elem * P_1d * P_1d * P_1d];
+
+      for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[z + comp * P_1d] = d_u[ind + COMP_STRIDE * comp];
     }
 }
 
 //------------------------------------------------------------------------------
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readDofsStrided3d(SharedData_Hip& data, const CeedInt elem, const CeedScalar* d_u, CeedScalar* r_u) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d)
-    for (CeedInt z = 0; z < P1d; ++z) {
-      const CeedInt node = data.t_id_x + data.t_id_y * P1d + z * P1d * P1d;
+template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readDofsStrided3d(SharedData_Hip &data, const CeedInt elem, const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d)
+    for (CeedInt z = 0; z < P_1d; z++) {
+      const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
       const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-      for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[z + comp * P1d] = d_u[ind + comp * STRIDES_COMP];
+
+      for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[z + comp * P_1d] = d_u[ind + comp * STRIDES_COMP];
     }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> Q-vector, offests provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int Q1d>
-inline __device__ void readSliceQuadsOffset3d(SharedData_Hip& data, const CeedInt nquads, const CeedInt elem, const CeedInt q, const CeedInt* indices,
-                                              const CeedScalar* d_u, CeedScalar* r_u) {
-  if (data.t_id_x < Q1d && data.t_id_y < Q1d) {
-    const CeedInt node = data.t_id_x + data.t_id_y * Q1d + q * Q1d * Q1d;
-    const CeedInt ind  = indices[node + elem * Q1d * Q1d * Q1d];
-    ;
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[comp] = d_u[ind + COMPSTRIDE * comp];
+template <int NUM_COMP, int COMP_STRIDE, int Q_1d>
+inline __device__ void readSliceQuadsOffset3d(SharedData_Hip &data, const CeedInt nquads, const CeedInt elem, const CeedInt q,
+                                              const CeedInt *__restrict__ indices, const CeedScalar *__restrict__ d_u, CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < Q_1d && data.t_id_y < Q_1d) {
+    const CeedInt node = data.t_id_x + data.t_id_y * Q_1d + q * Q_1d * Q_1d;
+    const CeedInt ind  = indices[node + elem * Q_1d * Q_1d * Q_1d];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[comp] = d_u[ind + COMP_STRIDE * comp];
   }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> Q-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int Q1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void readSliceQuadsStrided3d(SharedData_Hip& data, const CeedInt elem, const CeedInt q, const CeedScalar* d_u, CeedScalar* r_u) {
-  if (data.t_id_x < Q1d && data.t_id_y < Q1d) {
-    const CeedInt node = data.t_id_x + data.t_id_y * Q1d + q * Q1d * Q1d;
+template <int NUM_COMP, int Q_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void readSliceQuadsStrided3d(SharedData_Hip &data, const CeedInt elem, const CeedInt q, const CeedScalar *__restrict__ d_u,
+                                               CeedScalar *__restrict__ r_u) {
+  if (data.t_id_x < Q_1d && data.t_id_y < Q_1d) {
+    const CeedInt node = data.t_id_x + data.t_id_y * Q_1d + q * Q_1d * Q_1d;
     const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) r_u[comp] = d_u[ind + comp * STRIDES_COMP];
+
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) r_u[comp] = d_u[ind + comp * STRIDES_COMP];
   }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> L-vector, offsets provided
 //------------------------------------------------------------------------------
-template <int NCOMP, int COMPSTRIDE, int P1d>
-inline __device__ void writeDofsOffset3d(SharedData_Hip& data, const CeedInt nnodes, const CeedInt elem, const CeedInt* indices,
-                                         const CeedScalar* r_v, CeedScalar* d_v) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d)
-    for (CeedInt z = 0; z < P1d; ++z) {
-      const CeedInt node = data.t_id_x + data.t_id_y * P1d + z * P1d * P1d;
-      const CeedInt ind  = indices[node + elem * P1d * P1d * P1d];
-      for (CeedInt comp = 0; comp < NCOMP; ++comp) atomicAdd(&d_v[ind + COMPSTRIDE * comp], r_v[z + comp * P1d]);
+template <int NUM_COMP, int COMP_STRIDE, int P_1d>
+inline __device__ void writeDofsOffset3d(SharedData_Hip &data, const CeedInt num_nodes, const CeedInt elem, const CeedInt *__restrict__ indices,
+                                         const CeedScalar *__restrict__ r_v, CeedScalar *__restrict__ d_v) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d)
+    for (CeedInt z = 0; z < P_1d; z++) {
+      const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
+      const CeedInt ind  = indices[node + elem * P_1d * P_1d * P_1d];
+
+      for (CeedInt comp = 0; comp < NUM_COMP; comp++) atomicAdd(&d_v[ind + COMP_STRIDE * comp], r_v[z + comp * P_1d]);
     }
 }
 
 //------------------------------------------------------------------------------
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
-template <int NCOMP, int P1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
-inline __device__ void writeDofsStrided3d(SharedData_Hip& data, const CeedInt elem, const CeedScalar* r_v, CeedScalar* d_v) {
-  if (data.t_id_x < P1d && data.t_id_y < P1d)
-    for (CeedInt z = 0; z < P1d; ++z) {
-      const CeedInt node = data.t_id_x + data.t_id_y * P1d + z * P1d * P1d;
+template <int NUM_COMP, int P_1d, int STRIDES_NODE, int STRIDES_COMP, int STRIDES_ELEM>
+inline __device__ void writeDofsStrided3d(SharedData_Hip &data, const CeedInt elem, const CeedScalar *__restrict__ r_v,
+                                          CeedScalar *__restrict__ d_v) {
+  if (data.t_id_x < P_1d && data.t_id_y < P_1d)
+    for (CeedInt z = 0; z < P_1d; z++) {
+      const CeedInt node = data.t_id_x + data.t_id_y * P_1d + z * P_1d * P_1d;
       const CeedInt ind  = node * STRIDES_NODE + elem * STRIDES_ELEM;
-      for (CeedInt comp = 0; comp < NCOMP; ++comp) d_v[ind + comp * STRIDES_COMP] += r_v[z + comp * P1d];
+
+      for (CeedInt comp = 0; comp < NUM_COMP; comp++) d_v[ind + comp * STRIDES_COMP] += r_v[z + comp * P_1d];
     }
 }
 
 //------------------------------------------------------------------------------
 // 3D collocated derivatives computation
 //------------------------------------------------------------------------------
-template <int NCOMP, int Q1d>
-inline __device__ void gradCollo3d(SharedData_Hip& data, const CeedInt q, const CeedScalar* __restrict__ r_U, const CeedScalar* c_G,
-                                   CeedScalar* __restrict__ r_V) {
-  if (data.t_id_x < Q1d && data.t_id_y < Q1d) {
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) {
-      data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[q + comp * Q1d];
+template <int NUM_COMP, int Q_1d>
+inline __device__ void gradCollo3d(SharedData_Hip &data, const CeedInt q, const CeedScalar *__restrict__ r_U, const CeedScalar *c_G,
+                                   CeedScalar *__restrict__ r_V) {
+  if (data.t_id_x < Q_1d && data.t_id_y < Q_1d) {
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+      data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[q + comp * Q_1d];
       __syncthreads();
       // X derivative
-      r_V[comp + 0 * NCOMP] = 0.0;
-      for (CeedInt i = 0; i < Q1d; ++i)
-        r_V[comp + 0 * NCOMP] += c_G[i + data.t_id_x * Q1d] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction (X derivative)
+      r_V[comp + 0 * NUM_COMP] = 0.0;
+      for (CeedInt i = 0; i < Q_1d; i++)
+        r_V[comp + 0 * NUM_COMP] += c_G[i + data.t_id_x * Q_1d] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction (X derivative)
       // Y derivative
-      r_V[comp + 1 * NCOMP] = 0.0;
-      for (CeedInt i = 0; i < Q1d; ++i)
-        r_V[comp + 1 * NCOMP] += c_G[i + data.t_id_y * Q1d] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction (Y derivative)
+      r_V[comp + 1 * NUM_COMP] = 0.0;
+      for (CeedInt i = 0; i < Q_1d; i++)
+        r_V[comp + 1 * NUM_COMP] += c_G[i + data.t_id_y * Q_1d] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction (Y derivative)
       // Z derivative
-      r_V[comp + 2 * NCOMP] = 0.0;
-      for (CeedInt i = 0; i < Q1d; ++i) r_V[comp + 2 * NCOMP] += c_G[i + q * Q1d] * r_U[i + comp * Q1d];  // Contract z direction (Z derivative)
+      r_V[comp + 2 * NUM_COMP] = 0.0;
+      for (CeedInt i = 0; i < Q_1d; i++) r_V[comp + 2 * NUM_COMP] += c_G[i + q * Q_1d] * r_U[i + comp * Q_1d];  // Contract z direction (Z derivative)
       __syncthreads();
     }
   }
@@ -241,26 +265,26 @@ inline __device__ void gradCollo3d(SharedData_Hip& data, const CeedInt q, const 
 //------------------------------------------------------------------------------
 // 3D collocated derivatives transpose
 //------------------------------------------------------------------------------
-template <int NCOMP, int Q1d>
-inline __device__ void gradColloTranspose3d(SharedData_Hip& data, const CeedInt q, const CeedScalar* __restrict__ r_U, const CeedScalar* c_G,
-                                            CeedScalar* __restrict__ r_V) {
-  if (data.t_id_x < Q1d && data.t_id_y < Q1d) {
-    for (CeedInt comp = 0; comp < NCOMP; ++comp) {
+template <int NUM_COMP, int Q_1d>
+inline __device__ void gradColloTranspose3d(SharedData_Hip &data, const CeedInt q, const CeedScalar *__restrict__ r_U, const CeedScalar *c_G,
+                                            CeedScalar *__restrict__ r_V) {
+  if (data.t_id_x < Q_1d && data.t_id_y < Q_1d) {
+    for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
       // X derivative
-      data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 0 * NCOMP];
+      data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 0 * NUM_COMP];
       __syncthreads();
-      for (CeedInt i = 0; i < Q1d; ++i)
-        r_V[q + comp * Q1d] += c_G[data.t_id_x + i * Q1d] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction (X derivative)
+      for (CeedInt i = 0; i < Q_1d; i++)
+        r_V[q + comp * Q_1d] += c_G[data.t_id_x + i * Q_1d] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction (X derivative)
       __syncthreads();
       // Y derivative
-      data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 1 * NCOMP];
+      data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 1 * NUM_COMP];
       __syncthreads();
-      for (CeedInt i = 0; i < Q1d; ++i)
-        r_V[q + comp * Q1d] += c_G[data.t_id_y + i * Q1d] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction (Y derivative)
+      for (CeedInt i = 0; i < Q_1d; i++)
+        r_V[q + comp * Q_1d] += c_G[data.t_id_y + i * Q_1d] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction (Y derivative)
       __syncthreads();
       // Z derivative
-      for (CeedInt i = 0; i < Q1d; ++i)
-        r_V[i + comp * Q1d] += c_G[i + q * Q1d] * r_U[comp + 2 * NCOMP];  // PARTIAL contract z direction (Z derivative)
+      for (CeedInt i = 0; i < Q_1d; i++)
+        r_V[i + comp * Q_1d] += c_G[i + q * Q_1d] * r_U[comp + 2 * NUM_COMP];  // PARTIAL contract z direction (Z derivative)
     }
   }
 }

--- a/include/ceed/jit-source/hip/hip-ref-qfunction.h
+++ b/include/ceed/jit-source/hip/hip-ref-qfunction.h
@@ -16,7 +16,7 @@
 // Read from quadrature points
 //------------------------------------------------------------------------------
 template <int SIZE>
-inline __device__ void readQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar* d_u, CeedScalar* r_u) {
+inline __device__ void readQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar *d_u, CeedScalar *r_u) {
   for (CeedInt comp = 0; comp < SIZE; comp++) {
     r_u[comp] = d_u[quad + num_qpts * comp];
   }
@@ -26,7 +26,7 @@ inline __device__ void readQuads(const CeedInt quad, const CeedInt num_qpts, con
 // Write at quadrature points
 //------------------------------------------------------------------------------
 template <int SIZE>
-inline __device__ void writeQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar* r_v, CeedScalar* d_v) {
+inline __device__ void writeQuads(const CeedInt quad, const CeedInt num_qpts, const CeedScalar *r_v, CeedScalar *d_v) {
   for (CeedInt comp = 0; comp < SIZE; comp++) {
     d_v[quad + num_qpts * comp] = r_v[comp];
   }

--- a/include/ceed/jit-source/hip/hip-shared-basis-read-write-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-read-write-templates.h
@@ -18,6 +18,7 @@
 template <int SIZE>
 inline __device__ void loadMatrix(const CeedScalar *d_B, CeedScalar *B) {
   CeedInt tid = threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.y * blockDim.x;
+
   for (CeedInt i = tid; i < SIZE; i += blockDim.x * blockDim.y * blockDim.z) B[i] = d_B[i];
 }
 
@@ -34,6 +35,7 @@ inline __device__ void ReadElementStrided1d(SharedData_Hip &data, const CeedInt 
   if (data.t_id_x < P_1D) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = node * strides_node + elem * strides_elem;
+
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
       r_u[comp] = d_u[ind + comp * strides_comp];
     }
@@ -49,6 +51,7 @@ inline __device__ void WriteElementStrided1d(SharedData_Hip &data, const CeedInt
   if (data.t_id_x < P_1D) {
     const CeedInt node = data.t_id_x;
     const CeedInt ind  = node * strides_node + elem * strides_elem;
+
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
       d_v[ind + comp * strides_comp] = r_v[comp];
     }
@@ -68,6 +71,7 @@ inline __device__ void ReadElementStrided2d(SharedData_Hip &data, const CeedInt 
   if (data.t_id_x < P_1D && data.t_id_y < P_1D) {
     const CeedInt node = data.t_id_x + data.t_id_y * P_1D;
     const CeedInt ind  = node * strides_node + elem * strides_elem;
+
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
       r_u[comp] = d_u[ind + comp * strides_comp];
     }
@@ -83,6 +87,7 @@ inline __device__ void WriteElementStrided2d(SharedData_Hip &data, const CeedInt
   if (data.t_id_x < P_1D && data.t_id_y < P_1D) {
     const CeedInt node = data.t_id_x + data.t_id_y * P_1D;
     const CeedInt ind  = node * strides_node + elem * strides_elem;
+
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
       d_v[ind + comp * strides_comp] = r_v[comp];
     }
@@ -103,6 +108,7 @@ inline __device__ void ReadElementStrided3d(SharedData_Hip &data, const CeedInt 
     for (CeedInt z = 0; z < P_1D; z++) {
       const CeedInt node = data.t_id_x + data.t_id_y * P_1D + z * P_1D * P_1D;
       const CeedInt ind  = node * strides_node + elem * strides_elem;
+
       for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
         r_u[z + comp * P_1D] = d_u[ind + comp * strides_comp];
       }
@@ -120,6 +126,7 @@ inline __device__ void WriteElementStrided3d(SharedData_Hip &data, const CeedInt
     for (CeedInt z = 0; z < P_1D; z++) {
       const CeedInt node = data.t_id_x + data.t_id_y * P_1D + z * P_1D * P_1D;
       const CeedInt ind  = node * strides_node + elem * strides_elem;
+
       for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
         d_v[ind + comp * strides_comp] = r_v[z + comp * P_1D];
       }

--- a/include/ceed/jit-source/hip/hip-types.h
+++ b/include/ceed/jit-source/hip/hip-types.h
@@ -15,13 +15,13 @@
 #define CEED_HIP_NUMBER_FIELDS 16
 
 typedef struct {
-  const CeedScalar* inputs[CEED_HIP_NUMBER_FIELDS];
-  CeedScalar*       outputs[CEED_HIP_NUMBER_FIELDS];
+  const CeedScalar *inputs[CEED_HIP_NUMBER_FIELDS];
+  CeedScalar       *outputs[CEED_HIP_NUMBER_FIELDS];
 } Fields_Hip;
 
 typedef struct {
-  CeedInt* inputs[CEED_HIP_NUMBER_FIELDS];
-  CeedInt* outputs[CEED_HIP_NUMBER_FIELDS];
+  CeedInt *inputs[CEED_HIP_NUMBER_FIELDS];
+  CeedInt *outputs[CEED_HIP_NUMBER_FIELDS];
 } FieldsInt_Hip;
 
 typedef struct {
@@ -29,7 +29,7 @@ typedef struct {
   CeedInt     t_id_y;
   CeedInt     t_id_z;
   CeedInt     t_id;
-  CeedScalar* slice;
+  CeedScalar *slice;
 } SharedData_Hip;
 
 #endif  // CEED_HIP_TYPES_H

--- a/include/ceed/jit-source/magma/grad-1d.h
+++ b/include/ceed/jit-source/magma/grad-1d.h
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // grad basis action (1D)
 template <typename T, int DIM_, int NCOMP_, int P_, int Q_>
-static __device__ __inline__ void magma_grad_1d_device(const T* sT, magma_trans_t transT, T* sU[NCOMP_], T* sV[NCOMP_], const int tx) {
+static __device__ __inline__ void magma_grad_1d_device(const T *sT, magma_trans_t transT, T *sU[NCOMP_], T *sV[NCOMP_], const int tx) {
   // Assumptions
   // 1. 1D threads of size max(P_,Q_)
   // 2. sU[i] is 1xP_: in shared memory
@@ -35,8 +35,8 @@ static __device__ __inline__ void magma_grad_1d_device(const T* sT, magma_trans_
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __global__
-    void magma_gradn_1d_kernel(const CeedScalar* dTinterp, const CeedScalar* dTgrad, const CeedScalar* dU, const int estrdU, const int cstrdU,
-                               const int dstrdU, CeedScalar* dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
+    void magma_gradn_1d_kernel(const CeedScalar *dTinterp, const CeedScalar *dTgrad, const CeedScalar *dU, const int estrdU, const int cstrdU,
+                               const int dstrdU, CeedScalar *dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int     tx      = threadIdx.x;
@@ -46,16 +46,16 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __g
 
   if (elem_id >= nelem) return;
 
-  CeedScalar* sU[NCOMP];
-  CeedScalar* sV[NCOMP];
+  CeedScalar *sU[NCOMP];
+  CeedScalar *sV[NCOMP];
 
   // shift global memory pointers by elem stride
   dU += elem_id * estrdU;
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT = (CeedScalar*)(shared_data);
-  CeedScalar* sW = sT + P * Q;
+  CeedScalar *sT = (CeedScalar *)(shared_data);
+  CeedScalar *sW = sT + P * Q;
   sU[0]          = sW + ty * NCOMP * (P + Q);
   sV[0]          = sU[0] + (NCOMP * 1 * P);
   for (int icomp = 1; icomp < NCOMP; icomp++) {
@@ -81,8 +81,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __g
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __global__
-    void magma_gradt_1d_kernel(const CeedScalar* dTinterp, const CeedScalar* dTgrad, const CeedScalar* dU, const int estrdU, const int cstrdU,
-                               const int dstrdU, CeedScalar* dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
+    void magma_gradt_1d_kernel(const CeedScalar *dTinterp, const CeedScalar *dTgrad, const CeedScalar *dU, const int estrdU, const int cstrdU,
+                               const int dstrdU, CeedScalar *dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int     tx      = threadIdx.x;
@@ -92,16 +92,16 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __g
 
   if (elem_id >= nelem) return;
 
-  CeedScalar* sU[NCOMP];
-  CeedScalar* sV[NCOMP];
+  CeedScalar *sU[NCOMP];
+  CeedScalar *sV[NCOMP];
 
   // shift global memory pointers by elem stride
   dU += elem_id * estrdU;
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT = (CeedScalar*)(shared_data);
-  CeedScalar* sW = sT + Q * P;
+  CeedScalar *sT = (CeedScalar *)(shared_data);
+  CeedScalar *sW = sT + Q * P;
   sU[0]          = sW + ty * NCOMP * (Q + P);
   sV[0]          = sU[0] + (NCOMP * 1 * Q);
   for (int icomp = 1; icomp < NCOMP; icomp++) {

--- a/include/ceed/jit-source/magma/grad-3d.h
+++ b/include/ceed/jit-source/magma/grad-3d.h
@@ -20,8 +20,8 @@
 // iDIM_V -- which dim index of rV is accessed (0, 1, or 2 for notrans, always 0 for trans)
 // the scalar beta is used to specify whether to accumulate to rV, or overwrite it
 template <typename T, int DIM_U, int DIM_V, int NCOMP_, int P_, int Q_, int rUsize, int rVsize, int iDIM_, int iDIM_U, int iDIM_V>
-static __device__ __inline__ void magma_grad_3d_device(const T* sTinterp, const T* sTgrad, T rU[DIM_U][NCOMP_][rUsize], T rV[DIM_V][NCOMP_][rVsize],
-                                                       T beta, const int tx, T rTmp, T* swork) {
+static __device__ __inline__ void magma_grad_3d_device(const T *sTinterp, const T *sTgrad, T rU[DIM_U][NCOMP_][rUsize], T rV[DIM_V][NCOMP_][rVsize],
+                                                       T beta, const int tx, T rTmp, T *swork) {
   // Assumptions
   // 0. This device routine applies grad for one dim only (iDIM_), so it should be thrice for 3D
   // 1. 1D threads of size max(P_,Q_)^2
@@ -34,15 +34,15 @@ static __device__ __inline__ void magma_grad_3d_device(const T* sTinterp, const 
   // 6. Each thread computes one row of the output of each product
   // 7. Sync is recommended before and after the call
 
-  T* sW1 = swork;
-  T* sW2 = sW1 + P_ * P_ * Q_;
+  T *sW1 = swork;
+  T *sW2 = sW1 + P_ * P_ * Q_;
   for (int icomp = 0; icomp < NCOMP_; icomp++) {
     // Batch P_^2 of (1xP_) matrices [reg] times (P_xQ_) matrix [shmem] => Batch P_^2 of (1xQ_) matrices [shmem]
     if (tx < (P_ * P_)) {
       const int batchid = tx;
       const int sld     = 1;
-      const T*  sT      = (iDIM_ == 0) ? sTgrad : sTinterp;
-      T*        sTmp    = sW1 + batchid * (1 * Q_);
+      const T  *sT      = (iDIM_ == 0) ? sTgrad : sTinterp;
+      T        *sTmp    = sW1 + batchid * (1 * Q_);
       for (int j = 0; j < Q_; j++) {
         rTmp = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -58,9 +58,9 @@ static __device__ __inline__ void magma_grad_3d_device(const T* sTinterp, const 
       const int batchid = tx / Q_;
       const int tx_     = tx % Q_;
       const int sld     = Q_;
-      const T*  sT      = (iDIM_ == 1) ? sTgrad : sTinterp;
-      T*        sTmp    = sW1 + batchid * (Q_ * P_);  // sTmp is input
-      T*        sTmp2   = sW2 + batchid * (Q_ * Q_);  // sTmp2 is output
+      const T  *sT      = (iDIM_ == 1) ? sTgrad : sTinterp;
+      T        *sTmp    = sW1 + batchid * (Q_ * P_);  // sTmp is input
+      T        *sTmp2   = sW2 + batchid * (Q_ * Q_);  // sTmp2 is output
       for (int j = 0; j < Q_; j++) {
         rTmp = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -76,8 +76,8 @@ static __device__ __inline__ void magma_grad_3d_device(const T* sTinterp, const 
       // No need to declare batchid = (tx  / Q_^2) = always zero
       // No need to declare tx_     = (tx_ % Q_^2) = always tx
       const int sld  = Q_ * Q_;
-      const T*  sT   = (iDIM_ == 2) ? sTgrad : sTinterp;
-      T*        sTmp = sW2;  // sTmp is input
+      const T  *sT   = (iDIM_ == 2) ? sTgrad : sTinterp;
+      T        *sTmp = sW2;  // sTmp is input
       for (int j = 0; j < Q_; j++) {
         rTmp = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -92,9 +92,9 @@ static __device__ __inline__ void magma_grad_3d_device(const T* sTinterp, const 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
-    void magma_gradn_3d_kernel(const CeedScalar* dinterp1d, const CeedScalar* dgrad1d, const CeedScalar* dU, const int estrdU, const int cstrdU,
-                               const int dstrdU, CeedScalar* dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
+extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ *MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
+    void magma_gradn_3d_kernel(const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, const CeedScalar *dU, const int estrdU, const int cstrdU,
+                               const int dstrdU, CeedScalar *dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int     tx      = threadIdx.x;
@@ -113,9 +113,9 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sTinterp = (CeedScalar*)(shared_data);
-  CeedScalar* sTgrad   = sTinterp + P * Q;
-  CeedScalar* sTmp     = sTgrad + P * Q;
+  CeedScalar *sTinterp = (CeedScalar *)(shared_data);
+  CeedScalar *sTgrad   = sTinterp + P * Q;
+  CeedScalar *sTmp     = sTgrad + P * Q;
   sTmp += ty * (max(P * P * P, (P * P * Q) + (P * Q * Q)));
 
   // read T
@@ -152,9 +152,9 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
-    void magma_gradt_3d_kernel(const CeedScalar* dinterp1d, const CeedScalar* dgrad1d, const CeedScalar* dU, const int estrdU, const int cstrdU,
-                               const int dstrdU, CeedScalar* dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
+extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ *MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
+    void magma_gradt_3d_kernel(const CeedScalar *dinterp1d, const CeedScalar *dgrad1d, const CeedScalar *dU, const int estrdU, const int cstrdU,
+                               const int dstrdU, CeedScalar *dV, const int estrdV, const int cstrdV, const int dstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int     tx      = threadIdx.x;
@@ -173,9 +173,9 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sTinterp = (CeedScalar*)(shared_data);
-  CeedScalar* sTgrad   = sTinterp + Q * P;
-  CeedScalar* sTmp     = sTgrad + Q * P;
+  CeedScalar *sTinterp = (CeedScalar *)(shared_data);
+  CeedScalar *sTgrad   = sTinterp + Q * P;
+  CeedScalar *sTmp     = sTgrad + Q * P;
   sTmp += ty * (max(Q * Q * Q, (Q * Q * P) + (Q * P * P)));
 
   // read T

--- a/include/ceed/jit-source/magma/grad-nontensor.h
+++ b/include/ceed/jit-source/magma/grad-nontensor.h
@@ -10,9 +10,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 // Different A's and C's, same B
-extern "C" __global__ __launch_bounds__(Q* MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void magma_grad_nontensor_n(magma_trans_t transA, magma_trans_t transB,
-                                                                                                       int n, CeedScalar const* dA, int ldda,
-                                                                                                       CeedScalar const* dB, int lddb, CeedScalar* dC,
+extern "C" __global__ __launch_bounds__(Q *MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void magma_grad_nontensor_n(magma_trans_t transA, magma_trans_t transB,
+                                                                                                       int n, CeedScalar const *dA, int ldda,
+                                                                                                       CeedScalar const *dB, int lddb, CeedScalar *dC,
                                                                                                        int lddc) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data);
 
@@ -31,8 +31,8 @@ extern "C" __global__ __launch_bounds__(Q* MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void 
   // A is P x Q
   const int   slda = P;
   const int   sldb = P;
-  CeedScalar* sA   = (CeedScalar*)(shared_data);
-  CeedScalar* sB   = sA + Q * P;
+  CeedScalar *sA   = (CeedScalar *)(shared_data);
+  CeedScalar *sB   = sA + Q * P;
   sB += ty * sldb * NB_GRAD_N;
 
   // read B once for all C's
@@ -68,9 +68,9 @@ extern "C" __global__ __launch_bounds__(Q* MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void 
 
 ////////////////////////////////////////////////////////////////////////////////
 // Different A's and B's, same C
-extern "C" __global__ __launch_bounds__(P* MAGMA_NONTENSOR_BASIS_NTCOL(P)) void magma_grad_nontensor_t(magma_trans_t transA, magma_trans_t transB,
-                                                                                                       int n, CeedScalar const* dA, int ldda,
-                                                                                                       CeedScalar const* dB, int lddb, CeedScalar* dC,
+extern "C" __global__ __launch_bounds__(P *MAGMA_NONTENSOR_BASIS_NTCOL(P)) void magma_grad_nontensor_t(magma_trans_t transA, magma_trans_t transB,
+                                                                                                       int n, CeedScalar const *dA, int ldda,
+                                                                                                       CeedScalar const *dB, int lddb, CeedScalar *dC,
                                                                                                        int lddc) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data);
 
@@ -89,7 +89,7 @@ extern "C" __global__ __launch_bounds__(P* MAGMA_NONTENSOR_BASIS_NTCOL(P)) void 
 
   // A is P x Q
   const int   sldb = Q;
-  CeedScalar* sB   = (CeedScalar*)(shared_data);
+  CeedScalar *sB   = (CeedScalar *)(shared_data);
   sB += ty * sldb * NB_GRAD_T;
 
   // init rC

--- a/include/ceed/jit-source/magma/interp-1d.h
+++ b/include/ceed/jit-source/magma/interp-1d.h
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // interp basis action (1D)
 template <typename T, int DIM_, int NCOMP_, int P_, int Q_>
-static __device__ __inline__ void magma_interp_1d_device(const T* sT, magma_trans_t transT, T* sU[NCOMP_], T* sV[NCOMP_], const int tx) {
+static __device__ __inline__ void magma_interp_1d_device(const T *sT, magma_trans_t transT, T *sU[NCOMP_], T *sV[NCOMP_], const int tx) {
   // Assumptions
   // 1. 1D threads of size max(P_,Q_)
   // 2. sU[i] is 1xP_: in shared memory
@@ -35,7 +35,7 @@ static __device__ __inline__ void magma_interp_1d_device(const T* sT, magma_tran
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __global__
-    void magma_interpn_1d_kernel(const CeedScalar* dT, const CeedScalar* dU, const int estrdU, const int cstrdU, CeedScalar* dV, const int estrdV,
+    void magma_interpn_1d_kernel(const CeedScalar *dT, const CeedScalar *dU, const int estrdU, const int cstrdU, CeedScalar *dV, const int estrdV,
                                  const int cstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
@@ -46,16 +46,16 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __g
 
   if (elem_id >= nelem) return;
 
-  CeedScalar* sU[NCOMP];
-  CeedScalar* sV[NCOMP];
+  CeedScalar *sU[NCOMP];
+  CeedScalar *sV[NCOMP];
 
   // shift global memory pointers by elem stride
   dU += elem_id * estrdU;
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT = (CeedScalar*)(shared_data);
-  CeedScalar* sW = sT + P * Q;
+  CeedScalar *sT = (CeedScalar *)(shared_data);
+  CeedScalar *sW = sT + P * Q;
   sU[0]          = sW + ty * NCOMP * (P + Q);
   sV[0]          = sU[0] + (NCOMP * 1 * P);
   for (int icomp = 1; icomp < NCOMP; icomp++) {
@@ -81,7 +81,7 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __g
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __global__
-    void magma_interpt_1d_kernel(const CeedScalar* dT, const CeedScalar* dU, const int estrdU, const int cstrdU, CeedScalar* dV, const int estrdV,
+    void magma_interpt_1d_kernel(const CeedScalar *dT, const CeedScalar *dU, const int estrdU, const int cstrdU, CeedScalar *dV, const int estrdV,
                                  const int cstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
@@ -92,16 +92,16 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_1D)) __g
 
   if (elem_id >= nelem) return;
 
-  CeedScalar* sU[NCOMP];
-  CeedScalar* sV[NCOMP];
+  CeedScalar *sU[NCOMP];
+  CeedScalar *sV[NCOMP];
 
   // shift global memory pointers by elem stride
   dU += elem_id * estrdU;
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT = (CeedScalar*)(shared_data);
-  CeedScalar* sW = sT + Q * P;
+  CeedScalar *sT = (CeedScalar *)(shared_data);
+  CeedScalar *sW = sT + Q * P;
   sU[0]          = sW + ty * NCOMP * (Q + P);
   sV[0]          = sU[0] + (NCOMP * 1 * Q);
   for (int icomp = 1; icomp < NCOMP; icomp++) {

--- a/include/ceed/jit-source/magma/interp-2d.h
+++ b/include/ceed/jit-source/magma/interp-2d.h
@@ -12,8 +12,8 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // interp basis action (2D)
 template <typename T, int DIM_U, int DIM_V, int NCOMP_, int P_, int Q_, int rUsize, int rVsize>
-static __device__ __inline__ void magma_interp_2d_device(const T* sT, magma_trans_t transT, T rU[DIM_U][NCOMP_][rUsize], T rV[DIM_V][NCOMP_][rVsize],
-                                                         const int tx, T rTmp, T* swork) {
+static __device__ __inline__ void magma_interp_2d_device(const T *sT, magma_trans_t transT, T rU[DIM_U][NCOMP_][rUsize], T rV[DIM_V][NCOMP_][rVsize],
+                                                         const int tx, T rTmp, T *swork) {
   // Assumptions
   // 1. 1D threads of size max(P_,Q_)
   // 2. input:  rU[DIM_U x NCOMP_ x rUsize] in registers (per thread)
@@ -30,7 +30,7 @@ static __device__ __inline__ void magma_interp_2d_device(const T* sT, magma_tran
     if (tx < P_) {
       const int batchid = tx;
       const int sld     = 1;
-      T*        sTmp    = swork + batchid * (1 * Q_);
+      T        *sTmp    = swork + batchid * (1 * Q_);
       for (int j = 0; j < Q_; j++) {
         rTmp = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -45,7 +45,7 @@ static __device__ __inline__ void magma_interp_2d_device(const T* sT, magma_tran
     if (tx < Q_) {
       const int batchid = 0;
       const int sld     = Q_;
-      T*        sTmp    = swork + batchid * (Q_ * P_);
+      T        *sTmp    = swork + batchid * (Q_ * P_);
       for (int j = 0; j < Q_; j++) {
         rTmp = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -60,7 +60,7 @@ static __device__ __inline__ void magma_interp_2d_device(const T* sT, magma_tran
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __global__
-    void magma_interpn_2d_kernel(const CeedScalar* dT, const CeedScalar* dU, const int estrdU, const int cstrdU, CeedScalar* dV, const int estrdV,
+    void magma_interpn_2d_kernel(const CeedScalar *dT, const CeedScalar *dU, const int estrdU, const int cstrdU, CeedScalar *dV, const int estrdV,
                                  const int cstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
@@ -80,8 +80,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __g
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT   = (CeedScalar*)(shared_data);
-  CeedScalar* sTmp = sT + P * Q;
+  CeedScalar *sT   = (CeedScalar *)(shared_data);
+  CeedScalar *sTmp = sT + P * Q;
   sTmp += ty * (P * MAXPQ);
 
   // read T
@@ -102,7 +102,7 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __g
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __global__
-    void magma_interpt_2d_kernel(const CeedScalar* dT, const CeedScalar* dU, const int estrdU, const int cstrdU, CeedScalar* dV, const int estrdV,
+    void magma_interpt_2d_kernel(const CeedScalar *dT, const CeedScalar *dU, const int estrdU, const int cstrdU, CeedScalar *dV, const int estrdV,
                                  const int cstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
@@ -122,8 +122,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ, MAGMA_MAXTHREADS_2D)) __g
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT   = (CeedScalar*)(shared_data);
-  CeedScalar* sTmp = sT + Q * P;
+  CeedScalar *sT   = (CeedScalar *)(shared_data);
+  CeedScalar *sTmp = sT + Q * P;
   sTmp += ty * (Q * MAXPQ);
 
   // read T

--- a/include/ceed/jit-source/magma/interp-3d.h
+++ b/include/ceed/jit-source/magma/interp-3d.h
@@ -12,8 +12,8 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // interp basis action (3D)
 template <typename T, int DIM_U, int DIM_V, int NCOMP_, int P_, int Q_, int rUsize, int rVsize>
-static __device__ __inline__ void magma_interp_3d_device(const T* sT, magma_trans_t transT, T rU[DIM_U][NCOMP_][rUsize], T rV[DIM_V][NCOMP_][rVsize],
-                                                         const int tx, T rTmp[Q_], T* swork) {
+static __device__ __inline__ void magma_interp_3d_device(const T *sT, magma_trans_t transT, T rU[DIM_U][NCOMP_][rUsize], T rV[DIM_V][NCOMP_][rVsize],
+                                                         const int tx, T rTmp[Q_], T *swork) {
   // Assumptions
   // 1. 1D threads of size max(P_,Q_)^2
   // 2. input:  rU[DIM_U x NCOMP_ x rUsize] in registers (per thread)
@@ -30,7 +30,7 @@ static __device__ __inline__ void magma_interp_3d_device(const T* sT, magma_tran
     if (tx < (P_ * P_)) {
       const int batchid = tx;
       const int sld     = 1;
-      T*        sTmp    = swork + batchid * (1 * Q_);
+      T        *sTmp    = swork + batchid * (1 * Q_);
       for (int j = 0; j < Q_; j++) {
         rTmp[0] = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -46,7 +46,7 @@ static __device__ __inline__ void magma_interp_3d_device(const T* sT, magma_tran
       const int batchid = tx / Q_;
       const int tx_     = tx % Q_;
       const int sld     = Q_;
-      T*        sTmp    = swork + batchid * (Q_ * P_);  // sTmp is input
+      T        *sTmp    = swork + batchid * (Q_ * P_);  // sTmp is input
       for (int j = 0; j < Q_; j++) {
         rTmp[j] = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -61,7 +61,7 @@ static __device__ __inline__ void magma_interp_3d_device(const T* sT, magma_tran
       const int batchid = tx / Q_;
       const int tx_     = tx % Q_;
       const int sld     = Q_;
-      T*        sTmp    = swork + batchid * (Q_ * Q_);
+      T        *sTmp    = swork + batchid * (Q_ * Q_);
       for (int j = 0; j < Q_; j++) {
         sTmp(tx_, j, sld) = rTmp[j];
       }
@@ -73,7 +73,7 @@ static __device__ __inline__ void magma_interp_3d_device(const T* sT, magma_tran
       // No need to declare batchid = (tx  / Q_^2) = always zero
       // No need to declare tx_     = (tx_ % Q_^2) = always tx
       const int sld  = Q_ * Q_;
-      T*        sTmp = swork;
+      T        *sTmp = swork;
       for (int j = 0; j < Q_; j++) {
         rTmp[0] = 0.0;
         for (int i = 0; i < P_; i++) {
@@ -87,8 +87,8 @@ static __device__ __inline__ void magma_interp_3d_device(const T* sT, magma_tran
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
-    void magma_interpn_3d_kernel(const CeedScalar* dT, const CeedScalar* dU, const int estrdU, const int cstrdU, CeedScalar* dV, const int estrdV,
+extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ *MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
+    void magma_interpn_3d_kernel(const CeedScalar *dT, const CeedScalar *dU, const int estrdU, const int cstrdU, CeedScalar *dV, const int estrdV,
                                  const int cstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
@@ -108,8 +108,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT   = (CeedScalar*)(shared_data);
-  CeedScalar* sTmp = sT + P * Q;
+  CeedScalar *sT   = (CeedScalar *)(shared_data);
+  CeedScalar *sTmp = sT + P * Q;
   sTmp += ty * (max(P * P * MAXPQ, P * Q * Q));
 
   // read T
@@ -129,8 +129,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
-    void magma_interpt_3d_kernel(const CeedScalar* dT, const CeedScalar* dU, const int estrdU, const int cstrdU, CeedScalar* dV, const int estrdV,
+extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ *MAXPQ, MAGMA_MAXTHREADS_3D)) __global__
+    void magma_interpt_3d_kernel(const CeedScalar *dT, const CeedScalar *dU, const int estrdU, const int cstrdU, CeedScalar *dV, const int estrdV,
                                  const int cstrdV, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
@@ -150,8 +150,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(MAXPQ* MAXPQ, MAGMA_MAXTHREADS_3
   dV += elem_id * estrdV;
 
   // assign shared memory pointers
-  CeedScalar* sT   = (CeedScalar*)(shared_data);
-  CeedScalar* sTmp = sT + Q * P;
+  CeedScalar *sT   = (CeedScalar *)(shared_data);
+  CeedScalar *sTmp = sT + Q * P;
   sTmp += ty * (max(Q * Q * MAXPQ, Q * P * P));
 
   // read T

--- a/include/ceed/jit-source/magma/interp-nontensor.h
+++ b/include/ceed/jit-source/magma/interp-nontensor.h
@@ -9,9 +9,9 @@
 #define CEED_MAGMA_INTERP_NONTENSOR_H
 
 ////////////////////////////////////////////////////////////////////////////////
-extern "C" __global__ __launch_bounds__(Q* MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void magma_interp_nontensor_n(
-    magma_trans_t transA, magma_trans_t transB, int n, const CeedScalar alpha, CeedScalar const* dA, int ldda, CeedScalar const* dB, int lddb,
-    const CeedScalar beta, CeedScalar* dC, int lddc) {
+extern "C" __global__ __launch_bounds__(Q *MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void magma_interp_nontensor_n(
+    magma_trans_t transA, magma_trans_t transB, int n, const CeedScalar alpha, CeedScalar const *dA, int ldda, CeedScalar const *dB, int lddb,
+    const CeedScalar beta, CeedScalar *dC, int lddc) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data);
 
   const int tx      = threadIdx.x;
@@ -28,8 +28,8 @@ extern "C" __global__ __launch_bounds__(Q* MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void 
 
   const int   slda = P;
   const int   sldb = P;
-  CeedScalar* sA   = (CeedScalar*)(shared_data);
-  CeedScalar* sB   = sA;
+  CeedScalar *sA   = (CeedScalar *)(shared_data);
+  CeedScalar *sB   = sA;
   sB += ty * sldb * NB_INTERP_N;
 
   // read A using all threads
@@ -53,9 +53,9 @@ extern "C" __global__ __launch_bounds__(Q* MAGMA_NONTENSOR_BASIS_NTCOL(Q)) void 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-extern "C" __global__ __launch_bounds__(P* MAGMA_NONTENSOR_BASIS_NTCOL(P)) void magma_interp_nontensor_t(
-    magma_trans_t transA, magma_trans_t transB, int n, const CeedScalar alpha, CeedScalar const* dA, int ldda, CeedScalar const* dB, int lddb,
-    const CeedScalar beta, CeedScalar* dC, int lddc) {
+extern "C" __global__ __launch_bounds__(P *MAGMA_NONTENSOR_BASIS_NTCOL(P)) void magma_interp_nontensor_t(
+    magma_trans_t transA, magma_trans_t transB, int n, const CeedScalar alpha, CeedScalar const *dA, int ldda, CeedScalar const *dB, int lddb,
+    const CeedScalar beta, CeedScalar *dC, int lddc) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data);
 
   const int tx      = threadIdx.x;
@@ -71,7 +71,7 @@ extern "C" __global__ __launch_bounds__(P* MAGMA_NONTENSOR_BASIS_NTCOL(P)) void 
 
   // A is P x Q
   const int   sldb = Q;
-  CeedScalar* sB   = (CeedScalar*)(shared_data);
+  CeedScalar *sB   = (CeedScalar *)(shared_data);
   sB += ty * sldb * NB_INTERP_T;
 
   // init rC

--- a/include/ceed/jit-source/magma/magma_common_nontensor.h
+++ b/include/ceed/jit-source/magma/magma_common_nontensor.h
@@ -32,7 +32,7 @@
 // 1D thread config. with (Mx1) threads
 // no sync at the end of the function
 template <typename T, int P_, int NB_, int Q_>
-static __device__ __inline__ void read_C_g2r_1D_nosync(const int tx, const int n, T* dC, int lddc, const T& beta, T rC[NB_]) {
+static __device__ __inline__ void read_C_g2r_1D_nosync(const int tx, const int n, T *dC, int lddc, const T &beta, T rC[NB_]) {
   if (n != NB_) {
 #pragma unroll
     for (int j = 0; j < NB_; j++) {
@@ -52,7 +52,7 @@ static __device__ __inline__ void read_C_g2r_1D_nosync(const int tx, const int n
 // 1D thread config. with (Mx1) threads
 // no sync at the end of the function
 template <typename T, int P_, int NB_, int Q_>
-static __device__ __inline__ void write_C_r2g_1D_nosync(const int tx, const int n, T rC[NB_], T* dC, int lddc) {
+static __device__ __inline__ void write_C_r2g_1D_nosync(const int tx, const int n, T rC[NB_], T *dC, int lddc) {
   if (n != NB_) {
 #pragma unroll
     for (int j = 0; j < NB_; j++) {
@@ -74,7 +74,7 @@ static __device__ __inline__ void write_C_r2g_1D_nosync(const int tx, const int 
 // 1D thread config. with (Mx1) threads
 // no sync at the end of the function
 template <typename T, int P_, int NB_, int Q_>
-static __device__ __inline__ void read_A_notrans_g2r_1D_nosync(const int tx, const T* dA, int ldda, T* sA, int slda, T rA[Q_]) {
+static __device__ __inline__ void read_A_notrans_g2r_1D_nosync(const int tx, const T *dA, int ldda, T *sA, int slda, T rA[Q_]) {
 #pragma unroll
   for (int j = 0; j < Q_; j++) {
     rA[j] = dA(tx, j);
@@ -87,7 +87,7 @@ static __device__ __inline__ void read_A_notrans_g2r_1D_nosync(const int tx, con
 // 1D thread config. with (Mx1) threads
 // no sync at the end of the function
 template <typename T, int P_, int NB_, int Q_>
-static __device__ __inline__ void read_A_trans_g2r_1D_nosync(const int tx, const int ty, const T* dA, int ldda, T* sA, int slda, T rA[Q_]) {
+static __device__ __inline__ void read_A_trans_g2r_1D_nosync(const int tx, const int ty, const T *dA, int ldda, T *sA, int slda, T rA[Q_]) {
   int       ix  = 0;
   const int nTH = P_ * MAGMA_NONTENSOR_BASIS_NTCOL(P_);
   const int tid = ty * blockDim.x + tx;
@@ -114,7 +114,7 @@ static __device__ __inline__ void read_A_trans_g2r_1D_nosync(const int tx, const
 // 1D thread config. with (Mx1) threads
 // no sync at the end of the function
 template <typename T, int P_, int NB_, int Q_>
-static __device__ __inline__ void read_B_g2s_1D_nosync(const int tx, int n, const T* dB, int lddb, T* sB, int sldb) {
+static __device__ __inline__ void read_B_g2s_1D_nosync(const int tx, int n, const T *dB, int lddb, T *sB, int sldb) {
   if (n != NB_) {
     for (int i = 0; i < (Q_ * n) - P_; i += P_) {
       sB[i + tx] = dB[i + tx];
@@ -140,7 +140,7 @@ static __device__ __inline__ void read_B_g2s_1D_nosync(const int tx, int n, cons
 // C in registers -- one row per thread
 // no sync at the end of the function
 template <typename T, int P_, int NB_, int Q_>
-static __device__ __inline__ void mul_rAsBrC_1D_nosync(const int tx, const T& alpha, T rA[Q_], T* sB, int sldb, T rC[NB_]) {
+static __device__ __inline__ void mul_rAsBrC_1D_nosync(const int tx, const T &alpha, T rA[Q_], T *sB, int sldb, T rC[NB_]) {
   T rB[Q_] = {0};
 #pragma unroll
   for (int i = 0; i < NB_; i++) {

--- a/include/ceed/jit-source/magma/magma_common_tensor.h
+++ b/include/ceed/jit-source/magma/magma_common_tensor.h
@@ -23,7 +23,7 @@
 // the devptr is assumed to point directly to the element
 // must sync after call
 template <typename T, int LENGTH, int NCOMP_>
-__device__ __inline__ void read_1d(const T* devptr, const int compstride, T* sBuffer[NCOMP_], const int tx) {
+__device__ __inline__ void read_1d(const T *devptr, const int compstride, T *sBuffer[NCOMP_], const int tx) {
   if (tx < LENGTH) {
     for (int icomp = 0; icomp < NCOMP_; icomp++) {
       sBuffer[icomp][tx] = devptr[icomp * compstride + tx];
@@ -35,7 +35,7 @@ __device__ __inline__ void read_1d(const T* devptr, const int compstride, T* sBu
 // write V of a 1D element into global memory from sV[][] --  for all components
 // the devptr is assumed to point directly to the element
 template <typename T, int LENGTH, int NCOMP_>
-__device__ __inline__ void write_1d(T* sBuffer[NCOMP_], T* devptr, const int compstride, const int tx) {
+__device__ __inline__ void write_1d(T *sBuffer[NCOMP_], T *devptr, const int compstride, const int tx) {
   if (tx < LENGTH) {
     for (int icomp = 0; icomp < NCOMP_; icomp++) {
       devptr[icomp * compstride + tx] = sBuffer[icomp][tx];
@@ -51,7 +51,7 @@ __device__ __inline__ void write_1d(T* sBuffer[NCOMP_], T* devptr, const int com
 // rUsize can be different from P_ (e.g. MAXP_Q)
 // sTmp is a shared memory workspace of size P_^2
 template <typename T, int P_, int DIMU, int NCOMP_, int rUsize, int iDIM>
-__device__ __inline__ void readU_2d(const T* dU, const int compstride, T rU[DIMU][NCOMP_][rUsize], T* sTmp, const int tx) {
+__device__ __inline__ void readU_2d(const T *dU, const int compstride, T rU[DIMU][NCOMP_][rUsize], T *sTmp, const int tx) {
   // read U as a batch P_ of (1xP_) vectors
   // vec 0  : [u0, u1, u2, ... u_(P_-1)] -- contiguous in memory
   // vec 1  : [u0, u1, u2, ... u_(P_-1)] -- contiguous in memory
@@ -87,7 +87,7 @@ __device__ __inline__ void readU_2d(const T* dU, const int compstride, T rU[DIMU
 // iDIM specifies which dimension is being read into in rV
 // rVsize can be different from P_ (e.g. MAXP_Q)
 template <typename T, int Q_, int DIMV, int NCOMP_, int rVsize, int iDIM>
-__device__ __inline__ void readV_2d(const T* dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
+__device__ __inline__ void readV_2d(const T *dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
   if (tx < Q_) {
     for (int icomp = 0; icomp < NCOMP_; icomp++) {
       for (int j = 0; j < Q_; j++) {
@@ -105,7 +105,7 @@ __device__ __inline__ void readV_2d(const T* dV, const int compstride, T rV[DIMV
 // idim specifies which dimension is being written to in dV
 // rVsize can be different from P_ (e.g. MAXP_Q)
 template <typename T, int Q_, int DIMV, int NCOMP_, int rVsize, int iDIM>
-__device__ __inline__ void writeV_2d(T* dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
+__device__ __inline__ void writeV_2d(T *dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
   if (tx < Q_) {
     for (int icomp = 0; icomp < NCOMP_; icomp++) {
       for (int j = 0; j < Q_; j++) {
@@ -123,7 +123,7 @@ __device__ __inline__ void writeV_2d(T* dV, const int compstride, T rV[DIMV][NCO
 // rUsize can be different from P_ (e.g. MAXP_Q)
 // sTmp is a shared memory workspace of size P_^3
 template <typename T, int P_, int DIMU, int NCOMP_, int rUsize, int iDIM>
-__device__ __inline__ void readU_3d(const T* dU, const int compstride, T rU[DIMU][NCOMP_][rUsize], T* sTmp, const int tx) {
+__device__ __inline__ void readU_3d(const T *dU, const int compstride, T rU[DIMU][NCOMP_][rUsize], T *sTmp, const int tx) {
   // read U as a batch P_^2 of (1xP_) vectors
   // vec 0    : [u0, u1, u2, ... u_(P_-1)] -- contiguous in memory
   // vec 1    : [u0, u1, u2, ... u_(P_-1)] -- contiguous in memory
@@ -159,7 +159,7 @@ __device__ __inline__ void readU_3d(const T* dU, const int compstride, T rU[DIMU
 // iDIM specifies which dimension is being read into in rV
 // rVsize can be different from P_ (e.g. MAXP_Q)
 template <typename T, int Q_, int DIMV, int NCOMP_, int rVsize, int iDIM>
-__device__ __inline__ void readV_3d(const T* dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
+__device__ __inline__ void readV_3d(const T *dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
   if (tx < Q_ * Q_) {
     for (int icomp = 0; icomp < NCOMP_; icomp++) {
       for (int j = 0; j < Q_; j++) {
@@ -177,7 +177,7 @@ __device__ __inline__ void readV_3d(const T* dV, const int compstride, T rV[DIMV
 // idim specifies which dimension is being written to in dV
 // rVsize can be different from P_ (e.g. MAXP_Q)
 template <typename T, int Q_, int DIMV, int NCOMP_, int rVsize, int iDIM>
-__device__ __inline__ void writeV_3d(T* dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
+__device__ __inline__ void writeV_3d(T *dV, const int compstride, T rV[DIMV][NCOMP_][rVsize], const int tx) {
   if (tx < (Q_ * Q_)) {
     for (int icomp = 0; icomp < NCOMP_; icomp++) {
       for (int j = 0; j < Q_; j++) {
@@ -191,7 +191,7 @@ __device__ __inline__ void writeV_3d(T* dV, const int compstride, T rV[DIMV][NCO
 // reads T into shared memory
 // must sync after call
 template <int B, int J>
-__device__ __inline__ void dread_T_gm2sm(const int tx, const magma_trans_t transT, const CeedScalar* dT, CeedScalar* sT) {
+__device__ __inline__ void dread_T_gm2sm(const int tx, const magma_trans_t transT, const CeedScalar *dT, CeedScalar *sT) {
   if (transT == MagmaNoTrans) {
     // T is B x J
     if (tx < B) {
@@ -214,7 +214,7 @@ __device__ __inline__ void dread_T_gm2sm(const int tx, const magma_trans_t trans
 // reads a slice of U from shared/global memory into registers
 // the correct pointer U must be precomputed
 template <int B>
-__device__ __inline__ void dread_U_gsm2reg(const int C, const int tx_, const CeedScalar* U, CeedScalar rU[B]) {
+__device__ __inline__ void dread_U_gsm2reg(const int C, const int tx_, const CeedScalar *U, CeedScalar rU[B]) {
   for (int i = 0; i < B; i++) {
     rU[i] = U[i * C + tx_];
   }
@@ -224,7 +224,7 @@ __device__ __inline__ void dread_U_gsm2reg(const int C, const int tx_, const Cee
 // reads a slice of V from shared/global memory into registers with scaling
 // the correct pointer V must be precomputed
 template <int J>
-__device__ __inline__ void dread_V_gsm2reg(const int C, const int tx_, const CeedScalar* V, CeedScalar rV[J]) {
+__device__ __inline__ void dread_V_gsm2reg(const int C, const int tx_, const CeedScalar *V, CeedScalar rV[J]) {
   for (int i = 0; i < J; i++) {
     rV[i] = V[i * C + tx_];
   }
@@ -234,7 +234,7 @@ __device__ __inline__ void dread_V_gsm2reg(const int C, const int tx_, const Cee
 // writes a slice of V from reg to shared/global memory
 // the correct pointer V must be precomputed
 template <int J>
-__device__ __inline__ void dwrite_V_reg2gsm(const int C, const int tx_, CeedScalar rV[J], CeedScalar* V) {
+__device__ __inline__ void dwrite_V_reg2gsm(const int C, const int tx_, CeedScalar rV[J], CeedScalar *V) {
   for (int i = 0; i < J; i++) {
     V[i * C + tx_] = rV[i];
   }
@@ -243,7 +243,7 @@ __device__ __inline__ void dwrite_V_reg2gsm(const int C, const int tx_, CeedScal
 //////////////////////////////////////////////////////////////////////////////////////////
 // multiply a slice of U times T to produce a slice of V
 template <int B, int J>
-__device__ __inline__ void dgemm_slice(CeedScalar alpha, CeedScalar* sT, CeedScalar rU[B], CeedScalar beta, CeedScalar rV[J]) {
+__device__ __inline__ void dgemm_slice(CeedScalar alpha, CeedScalar *sT, CeedScalar rU[B], CeedScalar beta, CeedScalar rV[J]) {
   CeedScalar rTmp;
   for (int j = 0; j < J; j++) {
     rTmp = 0.0;
@@ -257,8 +257,8 @@ __device__ __inline__ void dgemm_slice(CeedScalar alpha, CeedScalar* sT, CeedSca
 
 //////////////////////////////////////////////////////////////////////////////////////////
 template <int B, int J>
-__device__ __inline__ void dgemm_ceed_device(const int tx, const int A, const int C, magma_trans_t transT, CeedScalar* sT, const CeedScalar alpha,
-                                             const CeedScalar beta, const CeedScalar* dU, CeedScalar* dV, CeedScalar rU[B], CeedScalar rV[J]) {
+__device__ __inline__ void dgemm_ceed_device(const int tx, const int A, const int C, magma_trans_t transT, CeedScalar *sT, const CeedScalar alpha,
+                                             const CeedScalar beta, const CeedScalar *dU, CeedScalar *dV, CeedScalar rU[B], CeedScalar rV[J]) {
   const int tx_      = tx % C;
   const int slice_id = tx / C;
 
@@ -268,7 +268,7 @@ __device__ __inline__ void dgemm_ceed_device(const int tx, const int A, const in
 
   // read V if beta is non-zero
   if (beta != 0.0) {
-    dread_V_gsm2reg<J>(C, tx_, (const CeedScalar*)dV, rV);
+    dread_V_gsm2reg<J>(C, tx_, (const CeedScalar *)dV, rV);
   }
 
   // read U

--- a/include/ceed/jit-source/magma/weight-1d.h
+++ b/include/ceed/jit-source/magma/weight-1d.h
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // weight basis action -- 1D
 template <typename T, int Q_>
-__device__ __inline__ void magma_weight_1d_device(const T* sTweight, T* sV, const int tx) {
+__device__ __inline__ void magma_weight_1d_device(const T *sTweight, T *sV, const int tx) {
   // Assumptions
   // 1. 1D thread configuration of size Q_
   // 2. The output sV is in shared memory -- size 1xQ_
@@ -19,7 +19,7 @@ __device__ __inline__ void magma_weight_1d_device(const T* sTweight, T* sV, cons
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q, MAGMA_MAXTHREADS_1D)) __global__
-    void magma_weight_1d_kernel(const CeedScalar* dqweight1d, CeedScalar* dV, const int v_stride, const int nelem) {
+    void magma_weight_1d_kernel(const CeedScalar *dqweight1d, CeedScalar *dV, const int v_stride, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int tx      = threadIdx.x;
@@ -32,8 +32,8 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q, MAGMA_MAXTHREADS_1D)) __globa
   dV += elem_id * v_stride;
 
   // shared memory pointers
-  CeedScalar* sTweight = (CeedScalar*)shared_data;
-  CeedScalar* sV       = sTweight + Q;
+  CeedScalar *sTweight = (CeedScalar *)shared_data;
+  CeedScalar *sV       = sTweight + Q;
   sV += ty * Q;
 
   // read dqweight_1d

--- a/include/ceed/jit-source/magma/weight-2d.h
+++ b/include/ceed/jit-source/magma/weight-2d.h
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // weight basis action -- 2D
 template <typename T, int DIM_, int NCOMP_, int Q_, int iDIM, int iCOMP>
-__device__ __inline__ void magma_weight_2d_device(const T* sTweight, T rV[DIM_][NCOMP_][Q_], const int tx) {
+__device__ __inline__ void magma_weight_2d_device(const T *sTweight, T rV[DIM_][NCOMP_][Q_], const int tx) {
   // Assumptions
   // 1. 1D thread configuration of size Q_
   // 2. rV[][][] matches the storage used in other actions (interp, grad, ... etc)
@@ -27,7 +27,7 @@ __device__ __inline__ void magma_weight_2d_device(const T* sTweight, T rV[DIM_][
 
 //////////////////////////////////////////////////////////////////////////////////////////
 extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q, MAGMA_MAXTHREADS_2D)) __global__
-    void magma_weight_2d_kernel(const CeedScalar* dqweight1d, CeedScalar* dV, const int v_stride, const int nelem) {
+    void magma_weight_2d_kernel(const CeedScalar *dqweight1d, CeedScalar *dV, const int v_stride, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int tx      = threadIdx.x;
@@ -41,7 +41,7 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q, MAGMA_MAXTHREADS_2D)) __globa
   dV += elem_id * v_stride;
 
   // shared memory pointers
-  CeedScalar* sTweight = (CeedScalar*)shared_data;
+  CeedScalar *sTweight = (CeedScalar *)shared_data;
 
   // read dqweight_1d
   if (ty == 0 && tx < Q) {

--- a/include/ceed/jit-source/magma/weight-3d.h
+++ b/include/ceed/jit-source/magma/weight-3d.h
@@ -8,7 +8,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // weight basis action -- 3D
 template <typename T, int DIM_, int NCOMP_, int Q_, int iDIM, int iCOMP>
-__device__ __inline__ void magma_weight_3d_device(const T* sTweight, T rV[DIM_][NCOMP_][Q_], const int tx) {
+__device__ __inline__ void magma_weight_3d_device(const T *sTweight, T rV[DIM_][NCOMP_][Q_], const int tx) {
   // Assumptions
   // 1. 1D thread configuration of size Q_^2
   // 2. rV[][][] matches the storage used in other actions (interp, grad, ... etc)
@@ -27,8 +27,8 @@ __device__ __inline__ void magma_weight_3d_device(const T* sTweight, T rV[DIM_][
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q* Q, MAGMA_MAXTHREADS_3D)) __global__
-    void magma_weight_3d_kernel(const CeedScalar* dqweight1d, CeedScalar* dV, const int v_stride, const int nelem) {
+extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q *Q, MAGMA_MAXTHREADS_3D)) __global__
+    void magma_weight_3d_kernel(const CeedScalar *dqweight1d, CeedScalar *dV, const int v_stride, const int nelem) {
   MAGMA_DEVICE_SHARED(CeedScalar, shared_data)
 
   const int tx      = threadIdx.x;
@@ -42,7 +42,7 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(Q* Q, MAGMA_MAXTHREADS_3D)) __gl
   dV += elem_id * v_stride;
 
   // shared memory pointers
-  CeedScalar* sTweight = (CeedScalar*)shared_data;
+  CeedScalar *sTweight = (CeedScalar *)shared_data;
 
   // read dqweight_1d
   if (tx < Q) {

--- a/include/ceed/jit-source/sycl/sycl-gen-templates.h
+++ b/include/ceed/jit-source/sycl/sycl-gen-templates.h
@@ -20,7 +20,7 @@ typedef atomic_double CeedAtomicScalar;
 //------------------------------------------------------------------------------
 // Load matrices for basis actions
 //------------------------------------------------------------------------------
-inline void loadMatrix(const CeedInt N, const CeedScalar* restrict d_B, CeedScalar* restrict B) {
+inline void loadMatrix(const CeedInt N, const CeedScalar *restrict d_B, CeedScalar *restrict B) {
   const CeedInt item_id    = get_local_linear_id();
   const CeedInt group_size = get_local_size(0) * get_local_size(1) * get_local_size(2);
   for (CeedInt i = item_id; i < N; i += group_size) B[i] = d_B[i];
@@ -34,7 +34,7 @@ inline void loadMatrix(const CeedInt N, const CeedScalar* restrict d_B, CeedScal
 // L-vector -> E-vector, offsets provided
 //------------------------------------------------------------------------------
 inline void readDofsOffset1d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt P_1D, const CeedInt num_elem,
-                             const global CeedInt* restrict indices, const global CeedScalar* restrict d_u, private CeedScalar* restrict r_u) {
+                             const global CeedInt *restrict indices, const global CeedScalar *restrict d_u, private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt elem      = get_global_id(2);
 
@@ -51,8 +51,8 @@ inline void readDofsOffset1d(const CeedInt num_comp, const CeedInt strides_comp,
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 inline void readDofsStrided1d(const CeedInt num_comp, const CeedInt P_1D, const CeedInt strides_node, const CeedInt strides_comp,
-                              const CeedInt strides_elem, const CeedInt num_elem, global const CeedScalar* restrict d_u,
-                              private CeedScalar* restrict r_u) {
+                              const CeedInt strides_elem, const CeedInt num_elem, global const CeedScalar *restrict d_u,
+                              private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt elem      = get_global_id(2);
 
@@ -69,7 +69,7 @@ inline void readDofsStrided1d(const CeedInt num_comp, const CeedInt P_1D, const 
 // E-vector -> L-vector, offsets provided
 //------------------------------------------------------------------------------
 inline void writeDofsOffset1d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt P_1D, const CeedInt num_elem,
-                              const global CeedInt* restrict indices, const private CeedScalar* restrict r_v, global CeedAtomicScalar* restrict d_v) {
+                              const global CeedInt *restrict indices, const private CeedScalar *restrict r_v, global CeedAtomicScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt elem      = get_global_id(2);
 
@@ -85,8 +85,8 @@ inline void writeDofsOffset1d(const CeedInt num_comp, const CeedInt strides_comp
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 inline void writeDofsStrided1d(const CeedInt num_comp, const CeedInt P_1D, const CeedInt strides_node, const CeedInt strides_comp,
-                               const CeedInt strides_elem, const CeedInt num_elem, private const CeedScalar* restrict r_v,
-                               global CeedScalar* restrict d_v) {
+                               const CeedInt strides_elem, const CeedInt num_elem, private const CeedScalar *restrict r_v,
+                               global CeedScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt elem      = get_global_id(2);
 
@@ -107,7 +107,7 @@ inline void writeDofsStrided1d(const CeedInt num_comp, const CeedInt P_1D, const
 // L-vector -> E-vector, offsets provided
 //------------------------------------------------------------------------------
 inline void readDofsOffset2d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt P_1D, const CeedInt num_elem,
-                             const global CeedInt* restrict indices, const global CeedScalar* restrict d_u, private CeedScalar* restrict r_u) {
+                             const global CeedInt *restrict indices, const global CeedScalar *restrict d_u, private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -123,8 +123,8 @@ inline void readDofsOffset2d(const CeedInt num_comp, const CeedInt strides_comp,
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 inline void readDofsStrided2d(const CeedInt num_comp, const CeedInt P_1D, const CeedInt strides_node, const CeedInt strides_comp,
-                              const CeedInt strides_elem, const CeedInt num_elem, const global CeedScalar* restrict d_u,
-                              private CeedScalar* restrict r_u) {
+                              const CeedInt strides_elem, const CeedInt num_elem, const global CeedScalar *restrict d_u,
+                              private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -140,7 +140,7 @@ inline void readDofsStrided2d(const CeedInt num_comp, const CeedInt P_1D, const 
 // E-vector -> L-vector, offsets provided
 //------------------------------------------------------------------------------
 inline void writeDofsOffset2d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt P_1D, const CeedInt num_elem,
-                              const global CeedInt* restrict indices, const private CeedScalar* restrict r_v, global CeedAtomicScalar* restrict d_v) {
+                              const global CeedInt *restrict indices, const private CeedScalar *restrict r_v, global CeedAtomicScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -157,8 +157,8 @@ inline void writeDofsOffset2d(const CeedInt num_comp, const CeedInt strides_comp
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 inline void writeDofsStrided2d(const CeedInt num_comp, const CeedInt P_1D, const CeedInt strides_node, const CeedInt strides_comp,
-                               const CeedInt strides_elem, const CeedInt num_elem, const private CeedScalar* restrict r_v,
-                               global CeedScalar* restrict d_v) {
+                               const CeedInt strides_elem, const CeedInt num_elem, const private CeedScalar *restrict r_v,
+                               global CeedScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -178,7 +178,7 @@ inline void writeDofsStrided2d(const CeedInt num_comp, const CeedInt P_1D, const
 // L-vector -> E-vector, offsets provided
 //------------------------------------------------------------------------------
 inline void readDofsOffset3d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt P_1D, const CeedInt num_elem,
-                             const global CeedInt* restrict indices, const global CeedScalar* restrict d_u, private CeedScalar* restrict r_u) {
+                             const global CeedInt *restrict indices, const global CeedScalar *restrict d_u, private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -196,8 +196,8 @@ inline void readDofsOffset3d(const CeedInt num_comp, const CeedInt strides_comp,
 // L-vector -> E-vector, strided
 //------------------------------------------------------------------------------
 inline void readDofsStrided3d(const CeedInt num_comp, const CeedInt P_1D, const CeedInt strides_node, const CeedInt strides_comp,
-                              const CeedInt strides_elem, const CeedInt num_elem, const global CeedScalar* restrict d_u,
-                              private CeedScalar* restrict r_u) {
+                              const CeedInt strides_elem, const CeedInt num_elem, const global CeedScalar *restrict d_u,
+                              private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -215,7 +215,7 @@ inline void readDofsStrided3d(const CeedInt num_comp, const CeedInt P_1D, const 
 // E-vector -> Q-vector, offests provided
 //------------------------------------------------------------------------------
 inline void readSliceQuadsOffset3d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt Q_1D, const CeedInt num_elem, const CeedInt q,
-                                   const global CeedInt* restrict indices, const global CeedScalar* restrict d_u, private CeedScalar* restrict r_u) {
+                                   const global CeedInt *restrict indices, const global CeedScalar *restrict d_u, private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -231,8 +231,8 @@ inline void readSliceQuadsOffset3d(const CeedInt num_comp, const CeedInt strides
 // E-vector -> Q-vector, strided
 //------------------------------------------------------------------------------
 inline void readSliceQuadsStrided3d(const CeedInt num_comp, const CeedInt Q_1D, CeedInt strides_node, CeedInt strides_comp, CeedInt strides_elem,
-                                    const CeedInt num_elem, const CeedInt q, const global CeedScalar* restrict d_u,
-                                    private CeedScalar* restrict r_u) {
+                                    const CeedInt num_elem, const CeedInt q, const global CeedScalar *restrict d_u,
+                                    private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -248,7 +248,7 @@ inline void readSliceQuadsStrided3d(const CeedInt num_comp, const CeedInt Q_1D, 
 // E-vector -> L-vector, offsets provided
 //------------------------------------------------------------------------------
 inline void writeDofsOffset3d(const CeedInt num_comp, const CeedInt strides_comp, const CeedInt P_1D, const CeedInt num_elem,
-                              const global CeedInt* restrict indices, const private CeedScalar* restrict r_v, global CeedAtomicScalar* restrict d_v) {
+                              const global CeedInt *restrict indices, const private CeedScalar *restrict r_v, global CeedAtomicScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -267,8 +267,8 @@ inline void writeDofsOffset3d(const CeedInt num_comp, const CeedInt strides_comp
 // E-vector -> L-vector, strided
 //------------------------------------------------------------------------------
 inline void writeDofsStrided3d(const CeedInt num_comp, const CeedInt P_1D, const CeedInt strides_node, const CeedInt strides_comp,
-                               const CeedInt strides_elem, const CeedInt num_elem, const private CeedScalar* restrict r_v,
-                               global CeedScalar* restrict d_v) {
+                               const CeedInt strides_elem, const CeedInt num_elem, const private CeedScalar *restrict r_v,
+                               global CeedScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -285,8 +285,8 @@ inline void writeDofsStrided3d(const CeedInt num_comp, const CeedInt P_1D, const
 //------------------------------------------------------------------------------
 // 3D collocated derivatives computation
 //------------------------------------------------------------------------------
-inline void gradCollo3d(const CeedInt num_comp, const CeedInt Q_1D, const CeedInt q, const private CeedScalar* restrict r_U,
-                        const local CeedScalar* s_G, private CeedScalar* restrict r_V, local CeedScalar* restrict scratch) {
+inline void gradCollo3d(const CeedInt num_comp, const CeedInt Q_1D, const CeedInt q, const private CeedScalar *restrict r_U,
+                        const local CeedScalar *s_G, private CeedScalar *restrict r_V, local CeedScalar *restrict scratch) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
 
@@ -319,8 +319,8 @@ inline void gradCollo3d(const CeedInt num_comp, const CeedInt Q_1D, const CeedIn
 //------------------------------------------------------------------------------
 // 3D collocated derivatives transpose
 //------------------------------------------------------------------------------
-inline void gradColloTranspose3d(const CeedInt num_comp, const CeedInt Q_1D, const CeedInt q, const private CeedScalar* restrict r_U,
-                                 const local CeedScalar* restrict s_G, private CeedScalar* restrict r_V, local CeedScalar* restrict scratch) {
+inline void gradColloTranspose3d(const CeedInt num_comp, const CeedInt Q_1D, const CeedInt q, const private CeedScalar *restrict r_U,
+                                 const local CeedScalar *restrict s_G, private CeedScalar *restrict r_V, local CeedScalar *restrict scratch) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
 

--- a/include/ceed/jit-source/sycl/sycl-shared-basis-read-write-templates.h
+++ b/include/ceed/jit-source/sycl/sycl-shared-basis-read-write-templates.h
@@ -16,7 +16,7 @@
 //------------------------------------------------------------------------------
 // Helper function: load matrices for basis actions
 //------------------------------------------------------------------------------
-inline void loadMatrix(const CeedInt N, const CeedScalar* restrict d_B, CeedScalar* restrict B) {
+inline void loadMatrix(const CeedInt N, const CeedScalar *restrict d_B, CeedScalar *restrict B) {
   const CeedInt item_id    = get_local_linear_id();
   const CeedInt group_size = get_local_size(0) * get_local_size(1) * get_local_size(2);
   for (CeedInt i = item_id; i < N; i += group_size) B[i] = d_B[i];
@@ -30,8 +30,8 @@ inline void loadMatrix(const CeedInt N, const CeedScalar* restrict d_B, CeedScal
 // E-vector -> single element
 //------------------------------------------------------------------------------
 inline void ReadElementStrided1d(const CeedInt NUM_COMP, const CeedInt P_1D, const CeedInt num_elem, const CeedInt strides_node,
-                                 const CeedInt strides_comp, const CeedInt strides_elem, global const CeedScalar* restrict d_u,
-                                 private CeedScalar* restrict r_u) {
+                                 const CeedInt strides_comp, const CeedInt strides_elem, global const CeedScalar *restrict d_u,
+                                 private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt elem      = get_global_id(2);
 
@@ -48,8 +48,8 @@ inline void ReadElementStrided1d(const CeedInt NUM_COMP, const CeedInt P_1D, con
 // Single element -> E-vector
 //------------------------------------------------------------------------------
 inline void WriteElementStrided1d(const CeedInt NUM_COMP, const CeedInt P_1D, const CeedInt num_elem, const CeedInt strides_node,
-                                  const CeedInt strides_comp, const CeedInt strides_elem, private const CeedScalar* restrict r_v,
-                                  global CeedScalar* restrict d_v) {
+                                  const CeedInt strides_comp, const CeedInt strides_elem, private const CeedScalar *restrict r_v,
+                                  global CeedScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt elem      = get_global_id(2);
 
@@ -70,8 +70,8 @@ inline void WriteElementStrided1d(const CeedInt NUM_COMP, const CeedInt P_1D, co
 // E-vector -> single element
 //------------------------------------------------------------------------------
 inline void ReadElementStrided2d(const CeedInt NUM_COMP, const CeedInt P_1D, const CeedInt num_elem, const CeedInt strides_node,
-                                 const CeedInt strides_comp, const CeedInt strides_elem, global const CeedScalar* restrict d_u,
-                                 private CeedScalar* restrict r_u) {
+                                 const CeedInt strides_comp, const CeedInt strides_elem, global const CeedScalar *restrict d_u,
+                                 private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -89,8 +89,8 @@ inline void ReadElementStrided2d(const CeedInt NUM_COMP, const CeedInt P_1D, con
 // Single element -> E-vector
 //------------------------------------------------------------------------------
 inline void WriteElementStrided2d(const CeedInt NUM_COMP, const CeedInt P_1D, const CeedInt num_elem, const CeedInt strides_node,
-                                  const CeedInt strides_comp, const CeedInt strides_elem, private const CeedScalar* restrict r_v,
-                                  global CeedScalar* restrict d_v) {
+                                  const CeedInt strides_comp, const CeedInt strides_elem, private const CeedScalar *restrict r_v,
+                                  global CeedScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -112,8 +112,8 @@ inline void WriteElementStrided2d(const CeedInt NUM_COMP, const CeedInt P_1D, co
 // E-vector -> single element
 //------------------------------------------------------------------------------
 inline void ReadElementStrided3d(const CeedInt NUM_COMP, const CeedInt P_1D, const CeedInt num_elem, const CeedInt strides_node,
-                                 const CeedInt strides_comp, const CeedInt strides_elem, global const CeedScalar* restrict d_u,
-                                 private CeedScalar* restrict r_u) {
+                                 const CeedInt strides_comp, const CeedInt strides_elem, global const CeedScalar *restrict d_u,
+                                 private CeedScalar *restrict r_u) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);
@@ -133,8 +133,8 @@ inline void ReadElementStrided3d(const CeedInt NUM_COMP, const CeedInt P_1D, con
 // Single element -> E-vector
 //------------------------------------------------------------------------------
 inline void WriteElementStrided3d(const CeedInt NUM_COMP, const CeedInt P_1D, const CeedInt num_elem, const CeedInt strides_node,
-                                  const CeedInt strides_comp, const CeedInt strides_elem, private const CeedScalar* restrict r_v,
-                                  global CeedScalar* restrict d_v) {
+                                  const CeedInt strides_comp, const CeedInt strides_elem, private const CeedScalar *restrict r_v,
+                                  global CeedScalar *restrict d_v) {
   const CeedInt item_id_x = get_local_id(0);
   const CeedInt item_id_y = get_local_id(1);
   const CeedInt elem      = get_global_id(2);

--- a/include/ceed/jit-source/sycl/sycl-shared-basis-tensor.h
+++ b/include/ceed/jit-source/sycl/sycl-shared-basis-tensor.h
@@ -22,8 +22,8 @@
 //------------------------------------------------------------------------------
 // Interp kernel by dim
 //------------------------------------------------------------------------------
-kernel void Interp(const CeedInt num_elem, global const CeedScalar* restrict d_interp_1d, global const CeedScalar* restrict d_U,
-                   global CeedScalar* restrict d_V) {
+kernel void Interp(const CeedInt num_elem, global const CeedScalar *restrict d_interp_1d, global const CeedScalar *restrict d_U,
+                   global CeedScalar *restrict d_V) {
   local CeedScalar s_B[BASIS_P_1D * BASIS_Q_1D];
  private
   CeedScalar r_U[BASIS_NUM_COMP * (BASIS_DIM > 2 ? BASIS_P_1D : 1)];
@@ -31,7 +31,7 @@ kernel void Interp(const CeedInt num_elem, global const CeedScalar* restrict d_i
   CeedScalar r_V[BASIS_NUM_COMP * (BASIS_DIM > 2 ? BASIS_Q_1D : 1)];
 
   local CeedScalar  scratch[BASIS_INTERP_SCRATCH_SIZE];
-  local CeedScalar* elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
+  local CeedScalar *elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
 
   loadMatrix(BASIS_P_1D * BASIS_Q_1D, d_interp_1d, s_B);
   work_group_barrier(CLK_LOCAL_MEM_FENCE);
@@ -53,8 +53,8 @@ kernel void Interp(const CeedInt num_elem, global const CeedScalar* restrict d_i
   }
 }
 
-kernel void InterpTranspose(const CeedInt num_elem, global const CeedScalar* restrict d_interp_1d, global const CeedScalar* restrict d_U,
-                            global CeedScalar* restrict d_V) {
+kernel void InterpTranspose(const CeedInt num_elem, global const CeedScalar *restrict d_interp_1d, global const CeedScalar *restrict d_U,
+                            global CeedScalar *restrict d_V) {
   // local size:
   // 1d: elems_per_block * T_1d
   // 2d,3d: elems_per_block * T_1d * T_1d
@@ -65,7 +65,7 @@ kernel void InterpTranspose(const CeedInt num_elem, global const CeedScalar* res
   CeedScalar r_V[BASIS_NUM_COMP * (BASIS_DIM > 2 ? BASIS_P_1D : 1)];
 
   local CeedScalar  scratch[BASIS_INTERP_SCRATCH_SIZE];
-  local CeedScalar* elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
+  local CeedScalar *elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
 
   loadMatrix(BASIS_P_1D * BASIS_Q_1D, d_interp_1d, s_B);
   work_group_barrier(CLK_LOCAL_MEM_FENCE);
@@ -90,8 +90,8 @@ kernel void InterpTranspose(const CeedInt num_elem, global const CeedScalar* res
 //------------------------------------------------------------------------------
 // Grad kernel by dim
 //------------------------------------------------------------------------------
-kernel void Grad(const CeedInt num_elem, global const CeedScalar* restrict d_interp_1d, global const CeedScalar* restrict d_grad_1d,
-                 global const CeedScalar* restrict d_U, global CeedScalar* restrict d_V) {
+kernel void Grad(const CeedInt num_elem, global const CeedScalar *restrict d_interp_1d, global const CeedScalar *restrict d_grad_1d,
+                 global const CeedScalar *restrict d_U, global CeedScalar *restrict d_V) {
   local CeedScalar s_B[BASIS_P_1D * BASIS_Q_1D];  // Todo, don't allocate s_B for dimension 1
   local CeedScalar s_G[BASIS_Q_1D * (BASIS_HAS_COLLOCATED_GRAD ? BASIS_Q_1D : BASIS_P_1D)];
 
@@ -101,7 +101,7 @@ kernel void Grad(const CeedInt num_elem, global const CeedScalar* restrict d_int
   CeedScalar r_V[BASIS_NUM_COMP * BASIS_DIM * (BASIS_DIM > 2 ? BASIS_Q_1D : 1)];
 
   local CeedScalar  scratch[BASIS_GRAD_SCRATCH_SIZE];
-  local CeedScalar* elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
+  local CeedScalar *elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
 
   loadMatrix(BASIS_P_1D * BASIS_Q_1D, d_interp_1d, s_B);
   loadMatrix(BASIS_Q_1D * (BASIS_HAS_COLLOCATED_GRAD ? BASIS_Q_1D : BASIS_P_1D), d_grad_1d, s_G);
@@ -125,8 +125,8 @@ kernel void Grad(const CeedInt num_elem, global const CeedScalar* restrict d_int
   }
 }
 
-kernel void GradTranspose(const CeedInt num_elem, global const CeedScalar* restrict d_interp_1d, global const CeedScalar* restrict d_grad_1d,
-                          global const CeedScalar* restrict d_U, global CeedScalar* restrict d_V) {
+kernel void GradTranspose(const CeedInt num_elem, global const CeedScalar *restrict d_interp_1d, global const CeedScalar *restrict d_grad_1d,
+                          global const CeedScalar *restrict d_U, global CeedScalar *restrict d_V) {
   local CeedScalar s_B[BASIS_P_1D * BASIS_Q_1D];  // Todo, don't allocate s_B for dimension 1
   local CeedScalar s_G[BASIS_Q_1D * (BASIS_HAS_COLLOCATED_GRAD ? BASIS_Q_1D : BASIS_P_1D)];
 
@@ -136,7 +136,7 @@ kernel void GradTranspose(const CeedInt num_elem, global const CeedScalar* restr
   CeedScalar r_V[BASIS_NUM_COMP * (BASIS_DIM > 2 ? BASIS_P_1D : 1)];
 
   local CeedScalar  scratch[BASIS_GRAD_SCRATCH_SIZE];
-  local CeedScalar* elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
+  local CeedScalar *elem_scratch = scratch + get_local_id(2) * T_1D * (BASIS_DIM > 1 ? T_1D : 1);
 
   loadMatrix(BASIS_P_1D * BASIS_Q_1D, d_interp_1d, s_B);
   loadMatrix(BASIS_Q_1D * (BASIS_HAS_COLLOCATED_GRAD ? BASIS_Q_1D : BASIS_P_1D), d_grad_1d, s_G);
@@ -163,7 +163,7 @@ kernel void GradTranspose(const CeedInt num_elem, global const CeedScalar* restr
 //------------------------------------------------------------------------------
 // Weight kernels by dim
 //------------------------------------------------------------------------------
-kernel void Weight(const CeedInt num_elem, global const CeedScalar* restrict q_weight_1d, global CeedScalar* restrict d_W) {
+kernel void Weight(const CeedInt num_elem, global const CeedScalar *restrict q_weight_1d, global CeedScalar *restrict d_W) {
  private
   CeedScalar r_W[BASIS_DIM > 2 ? BASIS_Q_1D : 1];
 

--- a/include/ceed/jit-source/sycl/sycl-types.h
+++ b/include/ceed/jit-source/sycl/sycl-types.h
@@ -16,23 +16,23 @@
 
 #ifdef __OPENCL_C_VERSION__
 typedef struct {
-  global const CeedScalar* inputs[CEED_SYCL_NUMBER_FIELDS];
-  global CeedScalar*       outputs[CEED_SYCL_NUMBER_FIELDS];
+  global const CeedScalar *inputs[CEED_SYCL_NUMBER_FIELDS];
+  global CeedScalar       *outputs[CEED_SYCL_NUMBER_FIELDS];
 } Fields_Sycl;
 
 typedef struct {
-  global const CeedInt* inputs[CEED_SYCL_NUMBER_FIELDS];
-  global CeedInt*       outputs[CEED_SYCL_NUMBER_FIELDS];
+  global const CeedInt *inputs[CEED_SYCL_NUMBER_FIELDS];
+  global CeedInt       *outputs[CEED_SYCL_NUMBER_FIELDS];
 } FieldsInt_Sycl;
 #else
 typedef struct {
-  const CeedScalar* inputs[CEED_SYCL_NUMBER_FIELDS];
-  CeedScalar*       outputs[CEED_SYCL_NUMBER_FIELDS];
+  const CeedScalar *inputs[CEED_SYCL_NUMBER_FIELDS];
+  CeedScalar       *outputs[CEED_SYCL_NUMBER_FIELDS];
 } Fields_Sycl;
 
 typedef struct {
-  const CeedInt* inputs[CEED_SYCL_NUMBER_FIELDS];
-  CeedInt*       outputs[CEED_SYCL_NUMBER_FIELDS];
+  const CeedInt *inputs[CEED_SYCL_NUMBER_FIELDS];
+  CeedInt       *outputs[CEED_SYCL_NUMBER_FIELDS];
 } FieldsInt_Sycl;
 #endif
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -242,16 +242,16 @@ static inline int CeedOperatorGetBasisPointer(CeedBasis basis, CeedEvalMode eval
 /**
   @brief Create point block restriction for active operator field
 
-  @param[in]  rstr            Original CeedElemRestriction for active field
-  @param[out] pointblock_rstr Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  rstr             Original CeedElemRestriction for active field
+  @param[out] point_block_rstr Address of the variable where the newly created CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
-static int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rstr, CeedElemRestriction *pointblock_rstr) {
+static int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rstr, CeedElemRestriction *point_block_rstr) {
   Ceed           ceed;
-  CeedInt        num_elem, num_comp, shift, elem_size, comp_stride, *pointblock_offsets;
+  CeedInt        num_elem, num_comp, shift, elem_size, comp_stride, *point_block_offsets;
   CeedSize       l_size;
   const CeedInt *offsets;
 
@@ -266,14 +266,14 @@ static int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rst
   CeedCall(CeedElemRestrictionGetLVectorSize(rstr, &l_size));
   shift = num_comp;
   if (comp_stride != 1) shift *= num_comp;
-  CeedCall(CeedCalloc(num_elem * elem_size, &pointblock_offsets));
+  CeedCall(CeedCalloc(num_elem * elem_size, &point_block_offsets));
   for (CeedInt i = 0; i < num_elem * elem_size; i++) {
-    pointblock_offsets[i] = offsets[i] * shift;
+    point_block_offsets[i] = offsets[i] * shift;
   }
 
   // Create new restriction
   CeedCall(CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp * num_comp, 1, l_size * num_comp, CEED_MEM_HOST, CEED_OWN_POINTER,
-                                     pointblock_offsets, pointblock_rstr));
+                                     point_block_offsets, point_block_rstr));
 
   // Cleanup
   CeedCall(CeedElemRestrictionRestoreOffsets(rstr, &offsets));
@@ -283,16 +283,16 @@ static int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rst
 /**
   @brief Core logic for assembling operator diagonal or point block diagonal
 
-  @param[in]  op            CeedOperator to assemble point block diagonal
-  @param[in]  request       Address of CeedRequest for non-blocking completion, else CEED_REQUEST_IMMEDIATE
-  @param[in]  is_pointblock Boolean flag to assemble diagonal or point block diagonal
-  @param[out] assembled     CeedVector to store assembled diagonal
+  @param[in]  op             CeedOperator to assemble point block diagonal
+  @param[in]  request        Address of CeedRequest for non-blocking completion, else CEED_REQUEST_IMMEDIATE
+  @param[in]  is_point_block Boolean flag to assemble diagonal or point block diagonal
+  @param[out] assembled      CeedVector to store assembled diagonal
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
-static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, CeedRequest *request, const bool is_pointblock, CeedVector assembled) {
+static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, CeedRequest *request, const bool is_point_block, CeedVector assembled) {
   Ceed                ceed;
   CeedInt             num_input_fields, num_output_fields;
   CeedInt             layout[3];
@@ -334,7 +334,7 @@ static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, Ce
     CeedElemRestriction diag_elem_rstr;
 
     // Assemble point block diagonal restriction, if needed
-    if (is_pointblock) {
+    if (is_point_block) {
       CeedCall(CeedOperatorCreateActivePointBlockRestriction(active_elem_rstrs[b], &diag_elem_rstr));
     } else {
       CeedCall(CeedElemRestrictionCreateUnsignedCopy(active_elem_rstrs[b], &diag_elem_rstr));
@@ -398,7 +398,7 @@ static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, Ce
           for (CeedInt c_out = 0; c_out < num_components; c_out++) {
             // Each qpt/node pair
             for (CeedInt q = 0; q < num_qpts; q++) {
-              if (is_pointblock) {
+              if (is_point_block) {
                 // Point Block Diagonal
                 for (CeedInt c_in = 0; c_in < num_components; c_in++) {
                   const CeedSize c_offset = (eval_mode_offsets_in[b][e_in] + c_in) * num_output_components + eval_mode_offsets_out[b][e_out] + c_out;
@@ -441,16 +441,16 @@ static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, Ce
 /**
   @brief Core logic for assembling composite operator diagonal
 
-  @param[in]  op            CeedOperator to assemble point block diagonal
-  @param[in]  request       Address of CeedRequest for non-blocking completion, else CEED_REQUEST_IMMEDIATE
-  @param[in]  is_pointblock Boolean flag to assemble diagonal or point block diagonal
-  @param[out] assembled     CeedVector to store assembled diagonal
+  @param[in]  op             CeedOperator to assemble point block diagonal
+  @param[in]  request        Address of CeedRequest for non-blocking completion, else CEED_REQUEST_IMMEDIATE
+  @param[in]  is_point_block Boolean flag to assemble diagonal or point block diagonal
+  @param[out] assembled      CeedVector to store assembled diagonal
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
-static inline int CeedCompositeOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedRequest *request, const bool is_pointblock,
+static inline int CeedCompositeOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedRequest *request, const bool is_point_block,
                                                                  CeedVector assembled) {
   CeedInt       num_sub;
   CeedOperator *suboperators;
@@ -458,7 +458,7 @@ static inline int CeedCompositeOperatorLinearAssembleAddDiagonal(CeedOperator op
   CeedCall(CeedCompositeOperatorGetNumSub(op, &num_sub));
   CeedCall(CeedCompositeOperatorGetSubList(op, &suboperators));
   for (CeedInt i = 0; i < num_sub; i++) {
-    if (is_pointblock) {
+    if (is_point_block) {
       CeedCall(CeedOperatorLinearAssembleAddPointBlockDiagonal(suboperators[i], assembled, request));
     } else {
       CeedCall(CeedOperatorLinearAssembleAddDiagonal(suboperators[i], assembled, request));

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -832,7 +832,6 @@ int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx) {
   CeedCall(CeedFree(&(*ctx)->field_labels));
   CeedCall(CeedDestroy(&(*ctx)->ceed));
   CeedCall(CeedFree(ctx));
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -850,7 +850,6 @@ int CeedVectorViewRange(CeedVector vec, CeedSize start, CeedSize stop, CeedInt s
   for (CeedSize i = start; step > 0 ? (i < stop) : (i > stop); i += step) fprintf(stream, fmt, x[i]);
   CeedCall(CeedVectorRestoreArrayRead(vec, &x));
   if (stop != vec->length) fprintf(stream, "  ...\n");
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -881,7 +881,6 @@ int CeedInit(const char *resource, Ceed *ceed) {
 
   // Backend specific setup
   CeedCall(backends[match_index].init(&resource[match_help], *ceed));
-
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -463,7 +463,7 @@ int CeedSetObjectDelegate(Ceed ceed, Ceed delegate, const char *obj_name) {
 
   @ref Backend
 **/
-int CeedGetOperatorfallback_resource(Ceed ceed, const char **resource) {
+int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource) {
   *resource = (const char *)ceed->op_fallback_resource;
   return CEED_ERROR_SUCCESS;
 }
@@ -491,7 +491,7 @@ int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed) {
     Ceed        fallback_ceed;
     const char *fallback_resource;
 
-    CeedCall(CeedGetOperatorfallback_resource(ceed, &fallback_resource));
+    CeedCall(CeedGetOperatorFallbackResource(ceed, &fallback_resource));
     CeedCall(CeedInit(fallback_resource, &fallback_ceed));
     fallback_ceed->op_fallback_parent = ceed;
     fallback_ceed->Error              = ceed->Error;


### PR DESCRIPTION
#1315 made some changes to the CUDA backends without addressing similar spots in the HIP ones. This PR catches some of those (surely not all, but a step in the right direction).

This PR also introduces pointer alignment formatting via clang-format (previously this was a source of inconsistency across backends).