### PR TITLE
fluids: Change variable name "local" to appease ocloc

### DIFF
--- a/examples/fluids/qfunctions/utils.h
+++ b/examples/fluids/qfunctions/utils.h
@@ -183,17 +183,18 @@ CEED_QFUNCTION_HELPER CeedScalar LinearRampCoefficient(CeedScalar amplitude, Cee
 /**
   @brief Pack stored values at quadrature point
 
-  @param[in]   Q         Number of quadrature points
-  @param[in]   i         Current quadrature point
-  @param[in]   start     Starting index to store components
-  @param[in]   num_comp  Number of components to store
-  @param[in]   local     Local values for quadrature point i
-  @param[out]  stored    Stored values
+  @param[in]   Q              Number of quadrature points
+  @param[in]   i              Current quadrature point
+  @param[in]   start          Starting index to store components
+  @param[in]   num_comp       Number of components to store
+  @param[in]   values_at_qpnt Local values for quadrature point i
+  @param[out]  stored         Stored values
 
   @return An error code: 0 - success, otherwise - failure
 **/
-CEED_QFUNCTION_HELPER int StoredValuesPack(CeedInt Q, CeedInt i, CeedInt start, CeedInt num_comp, const CeedScalar *local, CeedScalar *stored) {
-  for (CeedInt j = 0; j < num_comp; j++) stored[(start + j) * Q + i] = local[j];
+CEED_QFUNCTION_HELPER int StoredValuesPack(CeedInt Q, CeedInt i, CeedInt start, CeedInt num_comp, const CeedScalar *values_at_qpnt,
+                                           CeedScalar *stored) {
+  for (CeedInt j = 0; j < num_comp; j++) stored[(start + j) * Q + i] = values_at_qpnt[j];
 
   return CEED_ERROR_SUCCESS;
 }
@@ -201,17 +202,18 @@ CEED_QFUNCTION_HELPER int StoredValuesPack(CeedInt Q, CeedInt i, CeedInt start, 
 /**
   @brief Unpack stored values at quadrature point
 
-  @param[in]   Q         Number of quadrature points
-  @param[in]   i         Current quadrature point
-  @param[in]   start     Starting index to store components
-  @param[in]   num_comp  Number of components to store
-  @param[in]   stored    Stored values
-  @param[out]  local     Local values for quadrature point i
+  @param[in]   Q              Number of quadrature points
+  @param[in]   i              Current quadrature point
+  @param[in]   start          Starting index to store components
+  @param[in]   num_comp       Number of components to store
+  @param[in]   stored         Stored values
+  @param[out]  values_at_qpnt Local values for quadrature point i
 
   @return An error code: 0 - success, otherwise - failure
 **/
-CEED_QFUNCTION_HELPER int StoredValuesUnpack(CeedInt Q, CeedInt i, CeedInt start, CeedInt num_comp, const CeedScalar *stored, CeedScalar *local) {
-  for (CeedInt j = 0; j < num_comp; j++) local[j] = stored[(start + j) * Q + i];
+CEED_QFUNCTION_HELPER int StoredValuesUnpack(CeedInt Q, CeedInt i, CeedInt start, CeedInt num_comp, const CeedScalar *stored,
+                                             CeedScalar *values_at_qpnt) {
+  for (CeedInt j = 0; j < num_comp; j++) values_at_qpnt[j] = stored[(start + j) * Q + i];
 
   return CEED_ERROR_SUCCESS;
 }


### PR DESCRIPTION
Because reasons, ocloc (online compiler for OpenCL for Intel hardware) doesn't approve of the variable name `local`. It returns:
```
$ build/fluids-navierstokes -ceed /gpu/sycl/ref -options_file examples/fluids/tests-output/stats_test.yaml -test_type solver -compare_final_state_atol 1e-11 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-turb-spanstats-stats.bin
Command was: ocloc -q -spv_only -device pvc -64 -options "-cl-std=CL3.0 -Dint32_t=int" -file main.cl
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: Error in external library
[0]PETSC ERROR: /home/jczhang/libCEED/backends/sycl/ceed-sycl-compile.sycl.cpp:73 in CeedJitCompileSource_Sycl(): ocloc reported compilation errors: {
Build failed with error code: -11
}
```