### PR TITLE
fluids: Use explicit array size for `new_bounds`

### DIFF
--- a/examples/fluids/qfunctions/sgs_dd_model.h
+++ b/examples/fluids/qfunctions/sgs_dd_model.h
@@ -62,8 +62,9 @@ CEED_QFUNCTION_HELPER void DataDrivenInference(const CeedScalar *inputs, CeedSca
 
 CEED_QFUNCTION_HELPER void ComputeSgsDDAnisotropic(const CeedScalar grad_velo_aniso[3][3], const CeedScalar km_A_ij[6], const CeedScalar delta,
                                                    const CeedScalar viscosity, CeedScalar kmsgs_stress[6], SgsDDModelContext sgsdd_ctx) {
-  CeedScalar inputs[6], grad_velo_magnitude, eigenvectors[3][3], sgs_sframe_sym[6] = {0.};
-  const CeedScalar(*new_bounds)[2] = (const CeedScalar(*)[2]) & sgsdd_ctx->data[sgsdd_ctx->offsets.out_scaling];
+  CeedScalar inputs[6], grad_velo_magnitude, eigenvectors[3][3], sgs_sframe_sym[6] = {0.}, new_bounds[6][2];
+  // Copying new_bounds because Sycl online compiler doesn't like direct casting the pointer
+  CopyN(&sgsdd_ctx->data[sgsdd_ctx->offsets.out_scaling], (CeedScalar *)new_bounds, 12);
 
   ComputeSGS_DDAnisotropicInputs(grad_velo_aniso, km_A_ij, delta, viscosity, eigenvectors, inputs, &grad_velo_magnitude);
   DataDrivenInference(inputs, sgs_sframe_sym, sgsdd_ctx);

--- a/examples/fluids/qfunctions/sgs_dd_utils.h
+++ b/examples/fluids/qfunctions/sgs_dd_utils.h
@@ -51,7 +51,7 @@ CEED_QFUNCTION_HELPER void OrientBasisWithVector(CeedScalar basis[3][3], const C
 }
 
 // @brief Denormalize outputs using min-max (de-)normalization
-CEED_QFUNCTION_HELPER void DenormalizeDDOutputs(CeedScalar output[6], const CeedScalar (*new_bounds)[2], const CeedScalar old_bounds[6][2]) {
+CEED_QFUNCTION_HELPER void DenormalizeDDOutputs(CeedScalar output[6], const CeedScalar new_bounds[6][2], const CeedScalar old_bounds[6][2]) {
   CeedScalar bounds_ratio;
   for (int i = 0; i < 6; i++) {
     bounds_ratio = (new_bounds[i][1] - new_bounds[i][0]) / (old_bounds[i][1] - old_bounds[i][0]);
@@ -118,7 +118,7 @@ CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropicInputs(const CeedScalar grad_
  * @param[out]    kmsgs_stress        Physical SGS stresses in Kelvin-Mandel notation
  */
 CEED_QFUNCTION_HELPER void ComputeSGS_DDAnisotropicOutputs(CeedScalar outputs[6], const CeedScalar delta, const CeedScalar eigenvectors[3][3],
-                                                           const CeedScalar (*new_bounds)[2], const CeedScalar grad_velo_magnitude,
+                                                           const CeedScalar new_bounds[6][2], const CeedScalar grad_velo_magnitude,
                                                            CeedScalar kmsgs_stress[6]) {
   CeedScalar old_bounds[6][2] = {{0}};
   for (int j = 0; j < 6; j++) old_bounds[j][1] = 1;


### PR DESCRIPTION
 - `new_bounds` was previously changed to remove the explicit array size declaration because Sycl's online compiler didn't like it.
 - Trying to do a direct cast results in: 
 
 ``` 
/home/jrwrigh/software/libCEED/examples/fluids/problems/../qfunctions/sgs_dd_model.h:67:39: error: used type 'const CeedScalar[6][2]' (aka 'const double[6][2]') where arithmetic or pointer type is required
  const CeedScalar new_bounds[6][2] = (const CeedScalar[6][2]) & sgsdd_ctx->data[sgsdd_ctx->offsets.out_scaling];
                                      ^                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
- This represents the best compromise; can't do a direct pointer cast  (requiring more compiler work to be efficient and obfuscating what's  happening), but can at least keep the explicit array sizes for  `new_bounds`