### PR TITLE
Fix CEED_COPY_VALUES for ref rstr at points

### DIFF
--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -695,7 +695,7 @@ static int CeedElemRestrictionDestroy_Ref(CeedElemRestriction rstr) {
 int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *offsets, const bool *orients,
                                   const CeedInt8 *curl_orients, CeedElemRestriction rstr) {
   Ceed                     ceed;
-  CeedInt                  num_elem, elem_size, num_block, block_size, num_comp, comp_stride;
+  CeedInt                  num_elem, elem_size, num_block, block_size, num_comp, comp_stride, num_points = 0, num_offsets;
   CeedRestrictionType      rstr_type;
   CeedElemRestriction_Ref *impl;
 
@@ -730,10 +730,12 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
     }
 
     // Copy data
+    if (rstr_type == CEED_RESTRICTION_POINTS) CeedCallBackend(CeedElemRestrictionGetNumPoints(rstr, &num_points));
+    num_offsets = rstr_type == CEED_RESTRICTION_POINTS ? (num_elem + 1 + num_points) : (num_elem * elem_size);
     switch (copy_mode) {
       case CEED_COPY_VALUES:
-        CeedCallBackend(CeedMalloc(num_elem * elem_size, &impl->offsets_allocated));
-        memcpy(impl->offsets_allocated, offsets, num_elem * elem_size * sizeof(offsets[0]));
+        CeedCallBackend(CeedMalloc(num_offsets, &impl->offsets_allocated));
+        memcpy(impl->offsets_allocated, offsets, num_offsets * sizeof(offsets[0]));
         impl->offsets = impl->offsets_allocated;
         break;
       case CEED_OWN_POINTER:
@@ -749,8 +751,8 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
       CeedCheck(orients != NULL, ceed, CEED_ERROR_BACKEND, "No orients array provided for oriented restriction");
       switch (copy_mode) {
         case CEED_COPY_VALUES:
-          CeedCallBackend(CeedMalloc(num_elem * elem_size, &impl->orients_allocated));
-          memcpy(impl->orients_allocated, orients, num_elem * elem_size * sizeof(orients[0]));
+          CeedCallBackend(CeedMalloc(num_offsets, &impl->orients_allocated));
+          memcpy(impl->orients_allocated, orients, num_offsets * sizeof(orients[0]));
           impl->orients = impl->orients_allocated;
           break;
         case CEED_OWN_POINTER:
@@ -764,8 +766,8 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
       CeedCheck(curl_orients != NULL, ceed, CEED_ERROR_BACKEND, "No curl_orients array provided for oriented restriction");
       switch (copy_mode) {
         case CEED_COPY_VALUES:
-          CeedCallBackend(CeedMalloc(num_elem * 3 * elem_size, &impl->curl_orients_allocated));
-          memcpy(impl->curl_orients_allocated, curl_orients, num_elem * 3 * elem_size * sizeof(curl_orients[0]));
+          CeedCallBackend(CeedMalloc(3 * num_offsets, &impl->curl_orients_allocated));
+          memcpy(impl->curl_orients_allocated, curl_orients, 3 * num_offsets * sizeof(curl_orients[0]));
           impl->curl_orients = impl->curl_orients_allocated;
           break;
         case CEED_OWN_POINTER:

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -262,7 +262,6 @@ CEED_EXTERN int CeedElemRestrictionGetOrientations(CeedElemRestriction rstr, Cee
 CEED_EXTERN int CeedElemRestrictionRestoreOrientations(CeedElemRestriction rstr, const bool **orients);
 CEED_EXTERN int CeedElemRestrictionGetCurlOrientations(CeedElemRestriction rstr, CeedMemType mem_type, const CeedInt8 **curl_orients);
 CEED_EXTERN int CeedElemRestrictionRestoreCurlOrientations(CeedElemRestriction rstr, const CeedInt8 **curl_orients);
-CEED_EXTERN int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points);
 CEED_EXTERN int CeedElemRestrictionGetELayout(CeedElemRestriction rstr, CeedInt (*layout)[3]);
 CEED_EXTERN int CeedElemRestrictionSetELayout(CeedElemRestriction rstr, CeedInt layout[3]);
 CEED_EXTERN int CeedElemRestrictionGetData(CeedElemRestriction rstr, void *data);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -270,6 +270,8 @@ CEED_EXTERN int CeedElemRestrictionGetCeed(CeedElemRestriction rstr, Ceed *ceed)
 CEED_EXTERN int CeedElemRestrictionGetCompStride(CeedElemRestriction rstr, CeedInt *comp_stride);
 CEED_EXTERN int CeedElemRestrictionGetNumElements(CeedElemRestriction rstr, CeedInt *num_elem);
 CEED_EXTERN int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr, CeedInt *elem_size);
+CEED_EXTERN int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_points);
+CEED_EXTERN int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points);
 CEED_EXTERN int CeedElemRestrictionGetMaxPointsInElement(CeedElemRestriction rstr, CeedInt *max_points);
 CEED_EXTERN int CeedElemRestrictionGetLVectorSize(CeedElemRestriction rstr, CeedSize *l_size);
 CEED_EXTERN int CeedElemRestrictionGetNumComponents(CeedElemRestriction rstr, CeedInt *num_comp);

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -1272,7 +1272,7 @@ int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr, CeedInt *elem_si
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref Backend
+  @ref User
 **/
 int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_points) {
   Ceed ceed;
@@ -1295,7 +1295,7 @@ int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_point
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref Backend
+  @ref User
 **/
 int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points) {
   Ceed           ceed;

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -291,32 +291,6 @@ int CeedElemRestrictionRestoreCurlOrientations(CeedElemRestriction rstr, const C
 
 /**
 
-  @brief Get the number of points in an element of a points CeedElemRestriction
-
-  @param[in]  rstr       CeedElemRestriction
-  @param[in]  elem       Index number of element to retrieve the number of points for
-  @param[out] num_points The number of points in the element at index elem
-
-  @return An error code: 0 - success, otherwise - failure
-
-  @ref Backend
-**/
-int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points) {
-  Ceed           ceed;
-  const CeedInt *offsets;
-
-  CeedCall(CeedElemRestrictionGetCeed(rstr, &ceed));
-  CeedCheck(rstr->rstr_type == CEED_RESTRICTION_POINTS, ceed, CEED_ERROR_INCOMPATIBLE,
-            "Can only retrieve the number of points for a points CeedElemRestriction");
-
-  CeedCall(CeedElemRestrictionGetOffsets(rstr, CEED_MEM_HOST, &offsets));
-  *num_points = offsets[elem + 1] - offsets[elem];
-  CeedCall(CeedElemRestrictionRestoreOffsets(rstr, &offsets));
-  return CEED_ERROR_SUCCESS;
-}
-
-/**
-
   @brief Get the E-vector layout of a CeedElemRestriction
 
   @param[in]  rstr    CeedElemRestriction
@@ -1286,6 +1260,54 @@ int CeedElemRestrictionGetNumElements(CeedElemRestriction rstr, CeedInt *num_ele
 **/
 int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr, CeedInt *elem_size) {
   *elem_size = rstr->elem_size;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+
+  @brief Get the number of points in the l-vector for a points CeedElemRestriction
+
+  @param[in]  rstr       CeedElemRestriction
+  @param[out] num_points The number of points in the l-vector
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_points) {
+  Ceed ceed;
+
+  CeedCall(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCheck(rstr->rstr_type == CEED_RESTRICTION_POINTS, ceed, CEED_ERROR_INCOMPATIBLE,
+            "Can only retrieve the number of points for a points CeedElemRestriction");
+
+  *num_points = rstr->num_points;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+
+  @brief Get the number of points in an element of a points CeedElemRestriction
+
+  @param[in]  rstr       CeedElemRestriction
+  @param[in]  elem       Index number of element to retrieve the number of points for
+  @param[out] num_points The number of points in the element at index elem
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points) {
+  Ceed           ceed;
+  const CeedInt *offsets;
+
+  CeedCall(CeedElemRestrictionGetCeed(rstr, &ceed));
+  CeedCheck(rstr->rstr_type == CEED_RESTRICTION_POINTS, ceed, CEED_ERROR_INCOMPATIBLE,
+            "Can only retrieve the number of points for a points CeedElemRestriction");
+
+  CeedCall(CeedElemRestrictionGetOffsets(rstr, CEED_MEM_HOST, &offsets));
+  *num_points = offsets[elem + 1] - offsets[elem];
+  CeedCall(CeedElemRestrictionRestoreOffsets(rstr, &offsets));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/tests/t233-elemrestriction.c
+++ b/tests/t233-elemrestriction.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
     }
     ind[num_elem] = offset;
   }
-  CeedElemRestrictionCreateAtPoints(ceed, num_elem, num_points, 1, num_points, CEED_MEM_HOST, CEED_USE_POINTER, ind, &elem_restriction);
+  CeedElemRestrictionCreateAtPoints(ceed, num_elem, num_points, 1, num_points, CEED_MEM_HOST, CEED_COPY_VALUES, ind, &elem_restriction);
 
   {
     CeedInt max_points;


### PR DESCRIPTION
Previously, because `elem_size == 0`, using `CEED_COPY_VALUES` for an "AtPoints' restriction would result in attempting to read from unallocated memory.