### PR TITLE
fluids: Fix 64bit Int typing issues

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -387,10 +387,10 @@ PetscErrorCode CreateDM(MPI_Comm comm, ProblemData *problem, MatType, VecType, D
 // Set up DM
 PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_extra, SimpleBC bc, Physics phys);
 PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_coords, PetscInt degree, PetscInt coord_order, PetscInt q_extra,
-                                       CeedInt num_fields, const CeedInt *field_sizes, DM dm);
+                                       PetscInt num_fields, const PetscInt *field_sizes, DM dm);
 PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm);
 PetscErrorCode DMSetupByOrder_FEM(PetscBool setup_faces, PetscBool setup_coords, PetscInt degree, PetscInt coord_order, PetscInt q_extra,
-                                  CeedInt num_fields, const CeedInt *field_sizes, DM dm);
+                                  PetscInt num_fields, const PetscInt *field_sizes, DM dm);
 
 // Refine DM for high-order viz
 PetscErrorCode VizRefineDM(DM dm, User user, ProblemData *problem, SimpleBC bc, Physics phys);

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -193,18 +193,21 @@ PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data,
     PetscCall(PetscMalloc1(diff_filter->num_filtered_fields, &diff_filter->num_field_components));
 
     if (diff_filter->do_mms_test) {
-      diff_filter->num_field_components[0] = 1;
+      PetscInt field_components;
+      diff_filter->num_field_components[0] = field_components = 1;
       PetscCall(DMSetupByOrder_FEM(PETSC_TRUE, PETSC_TRUE, user->app_ctx->degree, 1, user->app_ctx->q_extra, diff_filter->num_filtered_fields,
-                                   diff_filter->num_field_components, diff_filter->dm_filter));
+                                   &field_components, diff_filter->dm_filter));
 
       PetscCall(DMGetLocalSection(diff_filter->dm_filter, &section));
       PetscCall(PetscSectionSetFieldName(section, 0, ""));
       PetscCall(PetscSectionSetComponentName(section, 0, 0, "FilteredPhi"));
     } else {
+      PetscInt *field_components;
       diff_filter->num_field_components[0] = DIFF_FILTER_STATE_NUM;
       diff_filter->num_field_components[1] = DIFF_FILTER_VELOCITY_SQUARED_NUM;
+      IntArrayC2P(2, &diff_filter->num_field_components, &field_components);
       PetscCall(DMSetupByOrder_FEM(PETSC_TRUE, PETSC_TRUE, user->app_ctx->degree, 1, user->app_ctx->q_extra, diff_filter->num_filtered_fields,
-                                   diff_filter->num_field_components, diff_filter->dm_filter));
+                                   field_components, diff_filter->dm_filter));
 
       PetscCall(DMGetLocalSection(diff_filter->dm_filter, &section));
       PetscCall(PetscSectionSetFieldName(section, 0, "Filtered Primitive State Variables"));

--- a/examples/fluids/src/dm_utils.c
+++ b/examples/fluids/src/dm_utils.c
@@ -415,7 +415,7 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
   @return An error code: 0 - success, otherwise - failure
 **/
 PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_coords, PetscInt degree, PetscInt coord_order, PetscInt q_extra,
-                                       CeedInt num_fields, const CeedInt *field_sizes, DM dm) {
+                                       PetscInt num_fields, const PetscInt *field_sizes, DM dm) {
   PetscInt  dim, q_order = degree + q_extra;
   PetscBool is_simplex = PETSC_TRUE;
   PetscFE   fe;
@@ -453,8 +453,8 @@ PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_co
     PetscCall(PetscDualSpaceGetOrder(fe_coord_dual_space, &fe_coord_order));
 
     // Create FE for coordinates
-    PetscCheck(fe_coord_order == 1 || coord_order == 1, comm, PETSC_ERR_USER_INPUT, "Only linear mesh geometry supported. Recieved %d order",
-               fe_coord_order);
+    PetscCheck(fe_coord_order == 1 || coord_order == 1, comm, PETSC_ERR_USER_INPUT,
+               "Only linear mesh geometry supported. Recieved %" PetscInt_FMT " order", fe_coord_order);
     PetscCall(PetscFECreateLagrange(comm, dim, num_comp_coord, is_simplex, fe_coord_order, q_order, &fe_coord_new));
     if (setup_faces) PetscCall(PetscFEGetHeightSubspace(fe_coord_new, 1, &fe_coord_face_new));
     PetscCall(DMProjectCoordinates(dm, fe_coord_new));
@@ -511,7 +511,7 @@ PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm) {
   @return An error code: 0 - success, otherwise - failure
 **/
 PetscErrorCode DMSetupByOrder_FEM(PetscBool setup_faces, PetscBool setup_coords, PetscInt degree, PetscInt coord_order, PetscInt q_extra,
-                                  CeedInt num_fields, const CeedInt *field_sizes, DM dm) {
+                                  PetscInt num_fields, const PetscInt *field_sizes, DM dm) {
   PetscFunctionBeginUser;
   PetscCall(DMSetupByOrderBegin_FEM(setup_faces, setup_coords, degree, coord_order, q_extra, num_fields, field_sizes, dm));
   PetscCall(DMSetupByOrderEnd_FEM(setup_coords, dm));


### PR DESCRIPTION
Accidentally leaked a few issues with handling 64bit `PetscInt` here, so addressing that here.