### PR TITLE
fix(fluids): Don't use IntArrayC2P in diff filter

### DIFF
--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -202,10 +202,9 @@ PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data,
       PetscCall(PetscSectionSetFieldName(section, 0, ""));
       PetscCall(PetscSectionSetComponentName(section, 0, 0, "FilteredPhi"));
     } else {
-      PetscInt *field_components;
-      diff_filter->num_field_components[0] = DIFF_FILTER_STATE_NUM;
-      diff_filter->num_field_components[1] = DIFF_FILTER_VELOCITY_SQUARED_NUM;
-      IntArrayC2P(2, &diff_filter->num_field_components, &field_components);
+      PetscInt field_components[2];
+      diff_filter->num_field_components[0] = field_components[0] = DIFF_FILTER_STATE_NUM;
+      diff_filter->num_field_components[1] = field_components[1] = DIFF_FILTER_VELOCITY_SQUARED_NUM;
       PetscCall(DMSetupByOrder_FEM(PETSC_TRUE, PETSC_TRUE, user->app_ctx->degree, 1, user->app_ctx->q_extra, diff_filter->num_filtered_fields,
                                    field_components, diff_filter->dm_filter));
 


### PR DESCRIPTION
IntArrayC2P frees the input array, when I need both the `PetscInt` array and the `CeedInt` array.

Fixes #1348 