### PR TITLE
chore: Fix format.ch command to grab all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -753,7 +753,7 @@ CLANG_FORMAT ?= clang-format
 
 FORMAT_OPTS += -style=file -i
 
-format.ch := $(filter-out include/ceedf.h $(wildcard tests/t*-f.h), $(shell git ls-files *.[ch]pp *.[ch]))
+format.ch := $(filter-out include/ceedf.h $(wildcard tests/t*-f.h), $(shell git ls-files '*.[ch]pp' '*.[ch]'))
 
 format-c  :
 	$(CLANG_FORMAT) $(FORMAT_OPTS) $(format.ch)


### PR DESCRIPTION
- For some reason, on my system (zsh, Manjaro), `format-c` will only run on `backends/*` and `examples/mfem/*`. This change successfully globs all files now.

Before:
```
clang-format -style=file -i backends/cuda-gen/ceed-cuda-gen-operator-build.cpp backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp backends/cuda/ceed-cuda-compile.cpp backends/hip-gen/ceed-hip-gen-operator-build.cpp backends/hip-ref/ceed-hip-ref-qfunction-load.cpp backends/hip-ref/kernels/hip-ref-vector.hip.cpp backends/hip/ceed-hip-compile.cpp backends/magma/gemm_selector.cpp backends/magma/kernels/hip/weight_generic.hip.cpp backends/occa/ceed-occa-basis.cpp backends/occa/ceed-occa-basis.hpp backends/occa/ceed-occa-ceed-object.cpp backends/occa/ceed-occa-ceed-object.hpp backends/occa/ceed-occa-context.cpp backends/occa/ceed-occa-context.hpp backends/occa/ceed-occa-cpu-operator.cpp backends/occa/ceed-occa-cpu-operator.hpp backends/occa/ceed-occa-elem-restriction.cpp backends/occa/ceed-occa-elem-restriction.hpp backends/occa/ceed-occa-gpu-operator.cpp backends/occa/ceed-occa-gpu-operator.hpp backends/occa/ceed-occa-kernels.hpp backends/occa/ceed-occa-operator-args.cpp backends/occa/ceed-occa-operator-args.hpp backends/occa/ceed-occa-operator-field.cpp backends/occa/ceed-occa-operator-field.hpp backends/occa/ceed-occa-operator.cpp backends/occa/ceed-occa-operator.hpp backends/occa/ceed-occa-qfunction-args.cpp backends/occa/ceed-occa-qfunction-args.hpp backends/occa/ceed-occa-qfunction-field.cpp backends/occa/ceed-occa-qfunction-field.hpp backends/occa/ceed-occa-qfunction.cpp backends/occa/ceed-occa-qfunction.hpp backends/occa/ceed-occa-qfunctioncontext.cpp backends/occa/ceed-occa-qfunctioncontext.hpp backends/occa/ceed-occa-simplex-basis.cpp backends/occa/ceed-occa-simplex-basis.hpp backends/occa/ceed-occa-tensor-basis.cpp backends/occa/ceed-occa-tensor-basis.hpp backends/occa/ceed-occa-types.hpp backends/occa/ceed-occa-vector.cpp backends/occa/ceed-occa-vector.hpp backends/occa/ceed-occa.cpp backends/occa/kernels/elem-restriction.cpp backends/occa/kernels/elem-restriction.hpp backends/occa/kernels/kernel-defines.hpp backends/occa/kernels/set-value.cpp backends/occa/kernels/set-value.hpp backends/occa/kernels/simplex-basis.hpp backends/occa/kernels/simplex-basis/cpu-simplex-basis.cpp backends/occa/kernels/simplex-basis/gpu-simplex-basis.cpp backends/occa/kernels/tensor-basis.hpp backends/occa/kernels/tensor-basis/cpu/tensor-basis-1d.cpp backends/occa/kernels/tensor-basis/cpu/tensor-basis-2d.cpp backends/occa/kernels/tensor-basis/cpu/tensor-basis-3d.cpp backends/occa/kernels/tensor-basis/gpu/tensor-basis-1d.cpp backends/occa/kernels/tensor-basis/gpu/tensor-basis-2d.cpp backends/occa/kernels/tensor-basis/gpu/tensor-basis-3d.cpp backends/sycl-gen/ceed-sycl-gen-operator-build.hpp backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp backends/sycl-gen/ceed-sycl-gen-qfunction.sycl.cpp backends/sycl-gen/ceed-sycl-gen.hpp backends/sycl-gen/ceed-sycl-gen.sycl.cpp backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp backends/sycl-ref/ceed-sycl-ref-qfunction-load.hpp backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp backends/sycl-ref/ceed-sycl-ref-qfunction.sycl.cpp backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp backends/sycl-ref/ceed-sycl-ref.hpp backends/sycl-ref/ceed-sycl-ref.sycl.cpp backends/sycl-ref/ceed-sycl-restriction.sycl.cpp backends/sycl-ref/ceed-sycl-vector.sycl.cpp backends/sycl-ref/kernels/sycl-ref-vector.cpp backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp backends/sycl-shared/ceed-sycl-shared.hpp backends/sycl-shared/ceed-sycl-shared.sycl.cpp backends/sycl/ceed-sycl-common.hpp backends/sycl/ceed-sycl-common.sycl.cpp backends/sycl/ceed-sycl-compile.hpp backends/sycl/ceed-sycl-compile.sycl.cpp backends/sycl/online_compiler.hpp backends/sycl/online_compiler.sycl.cpp examples/mfem/bp1.cpp examples/mfem/bp1.hpp examples/mfem/bp3.cpp examples/mfem/bp3.hpp
```


After:
```
clang-format -style=file -i backends/avx/ceed-avx-blocked.c backends/avx/ceed-avx-serial.c backends/avx/ceed-avx-tensor.c backends/avx/ceed-avx.h backends/blocked/ceed-blocked-operator.c backends/blocked/ceed-blocked.c backends/blocked/ceed-blocked.h backends/ceed-backend-list.h backends/ceed-backend-weak.c backends/cuda-gen/ceed-cuda-gen-operator-build.cpp backends/cuda-gen/ceed-cuda-gen-operator-build.h backends/cuda-gen/ceed-cuda-gen-operator.c backends/cuda-gen/ceed-cuda-gen-qfunction.c backends/cuda-gen/ceed-cuda-gen.c backends/cuda-gen/ceed-cuda-gen.h backends/cuda-ref/ceed-cuda-ref-basis.c backends/cuda-ref/ceed-cuda-ref-operator.c backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp backends/cuda-ref/ceed-cuda-ref-qfunction-load.h backends/cuda-ref/ceed-cuda-ref-qfunction.c backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c backends/cuda-ref/ceed-cuda-ref-restriction.c backends/cuda-ref/ceed-cuda-ref-vector.c backends/cuda-ref/ceed-cuda-ref.c backends/cuda-ref/ceed-cuda-ref.h backends/cuda-shared/ceed-cuda-shared-basis.c backends/cuda-shared/ceed-cuda-shared.c backends/cuda-shared/ceed-cuda-shared.h backends/cuda/ceed-cuda-common.c backends/cuda/ceed-cuda-common.h backends/cuda/ceed-cuda-compile.cpp backends/cuda/ceed-cuda-compile.h backends/hip-gen/ceed-hip-gen-operator-build.cpp backends/hip-gen/ceed-hip-gen-operator-build.h backends/hip-gen/ceed-hip-gen-operator.c backends/hip-gen/ceed-hip-gen-qfunction.c backends/hip-gen/ceed-hip-gen.c backends/hip-gen/ceed-hip-gen.h backends/hip-ref/ceed-hip-ref-basis.c backends/hip-ref/ceed-hip-ref-operator.c backends/hip-ref/ceed-hip-ref-qfunction-load.cpp backends/hip-ref/ceed-hip-ref-qfunction-load.h backends/hip-ref/ceed-hip-ref-qfunction.c backends/hip-ref/ceed-hip-ref-qfunctioncontext.c backends/hip-ref/ceed-hip-ref-restriction.c backends/hip-ref/ceed-hip-ref-vector.c backends/hip-ref/ceed-hip-ref.c backends/hip-ref/ceed-hip-ref.h backends/hip-ref/kernels/hip-ref-vector.hip.cpp backends/hip-shared/ceed-hip-shared-basis.c backends/hip-shared/ceed-hip-shared.c backends/hip-shared/ceed-hip-shared.h backends/hip/ceed-hip-common.c backends/hip/ceed-hip-common.h backends/hip/ceed-hip-compile.cpp backends/hip/ceed-hip-compile.h backends/magma/ceed-magma-basis.c backends/magma/ceed-magma-common.c backends/magma/ceed-magma-common.h backends/magma/ceed-magma-det.c backends/magma/ceed-magma.c backends/magma/ceed-magma.h backends/magma/gemm_selector.cpp backends/magma/gemm_tuning/a100.h backends/magma/gemm_tuning/a100_grad_rtc.h backends/magma/gemm_tuning/a100_interp_rtc.h backends/magma/gemm_tuning/indices.h backends/magma/gemm_tuning/mi100.h backends/magma/gemm_tuning/mi250x.h backends/magma/gemm_tuning/mi250x_grad_rtc.h backends/magma/gemm_tuning/mi250x_interp_rtc.h backends/magma/gemm_tuning/v100.h backends/magma/kernels/common/weight.h backends/magma/kernels/hip/weight_generic.hip.cpp backends/magma/magma_gemm_nontensor.c backends/memcheck/ceed-memcheck-blocked.c backends/memcheck/ceed-memcheck-qfunction.c backends/memcheck/ceed-memcheck-qfunctioncontext.c backends/memcheck/ceed-memcheck-serial.c backends/memcheck/ceed-memcheck-vector.c backends/memcheck/ceed-memcheck.h backends/occa/ceed-occa-basis.cpp backends/occa/ceed-occa-basis.hpp backends/occa/ceed-occa-ceed-object.cpp backends/occa/ceed-occa-ceed-object.hpp backends/occa/ceed-occa-context.cpp backends/occa/ceed-occa-context.hpp backends/occa/ceed-occa-cpu-operator.cpp backends/occa/ceed-occa-cpu-operator.hpp backends/occa/ceed-occa-elem-restriction.cpp backends/occa/ceed-occa-elem-restriction.hpp backends/occa/ceed-occa-gpu-operator.cpp backends/occa/ceed-occa-gpu-operator.hpp backends/occa/ceed-occa-kernels.hpp backends/occa/ceed-occa-operator-args.cpp backends/occa/ceed-occa-operator-args.hpp backends/occa/ceed-occa-operator-field.cpp backends/occa/ceed-occa-operator-field.hpp backends/occa/ceed-occa-operator.cpp backends/occa/ceed-occa-operator.hpp backends/occa/ceed-occa-qfunction-args.cpp backends/occa/ceed-occa-qfunction-args.hpp backends/occa/ceed-occa-qfunction-field.cpp backends/occa/ceed-occa-qfunction-field.hpp backends/occa/ceed-occa-qfunction.cpp backends/occa/ceed-occa-qfunction.hpp backends/occa/ceed-occa-qfunctioncontext.cpp backends/occa/ceed-occa-qfunctioncontext.hpp backends/occa/ceed-occa-simplex-basis.cpp backends/occa/ceed-occa-simplex-basis.hpp backends/occa/ceed-occa-tensor-basis.cpp backends/occa/ceed-occa-tensor-basis.hpp backends/occa/ceed-occa-types.hpp backends/occa/ceed-occa-vector.cpp backends/occa/ceed-occa-vector.hpp backends/occa/ceed-occa.cpp backends/occa/ceed-occa.h backends/occa/kernels/elem-restriction.cpp backends/occa/kernels/elem-restriction.hpp backends/occa/kernels/kernel-defines.hpp backends/occa/kernels/set-value.cpp backends/occa/kernels/set-value.hpp backends/occa/kernels/simplex-basis.hpp backends/occa/kernels/simplex-basis/cpu-simplex-basis.cpp backends/occa/kernels/simplex-basis/gpu-simplex-basis.cpp backends/occa/kernels/tensor-basis.hpp backends/occa/kernels/tensor-basis/cpu/tensor-basis-1d.cpp backends/occa/kernels/tensor-basis/cpu/tensor-basis-2d.cpp backends/occa/kernels/tensor-basis/cpu/tensor-basis-3d.cpp backends/occa/kernels/tensor-basis/gpu/tensor-basis-1d.cpp backends/occa/kernels/tensor-basis/gpu/tensor-basis-2d.cpp backends/occa/kernels/tensor-basis/gpu/tensor-basis-3d.cpp backends/opt/ceed-opt-blocked.c backends/opt/ceed-opt-operator.c backends/opt/ceed-opt-serial.c backends/opt/ceed-opt-tensor.c backends/opt/ceed-opt.h backends/ref/ceed-ref-basis.c backends/ref/ceed-ref-operator.c backends/ref/ceed-ref-qfunction.c backends/ref/ceed-ref-qfunctioncontext.c backends/ref/ceed-ref-restriction.c backends/ref/ceed-ref-tensor.c backends/ref/ceed-ref-vector.c backends/ref/ceed-ref.c backends/ref/ceed-ref.h backends/sycl-gen/ceed-sycl-gen-operator-build.hpp backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp backends/sycl-gen/ceed-sycl-gen-qfunction.sycl.cpp backends/sycl-gen/ceed-sycl-gen.hpp backends/sycl-gen/ceed-sycl-gen.sycl.cpp backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp backends/sycl-ref/ceed-sycl-ref-qfunction-load.hpp backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp backends/sycl-ref/ceed-sycl-ref-qfunction.sycl.cpp backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp backends/sycl-ref/ceed-sycl-ref.hpp backends/sycl-ref/ceed-sycl-ref.sycl.cpp backends/sycl-ref/ceed-sycl-restriction.sycl.cpp backends/sycl-ref/ceed-sycl-vector.sycl.cpp backends/sycl-ref/kernels/sycl-ref-vector.cpp backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp backends/sycl-shared/ceed-sycl-shared.hpp backends/sycl-shared/ceed-sycl-shared.sycl.cpp backends/sycl/ceed-sycl-common.hpp backends/sycl/ceed-sycl-common.sycl.cpp backends/sycl/ceed-sycl-compile.hpp backends/sycl/ceed-sycl-compile.sycl.cpp backends/sycl/ocloc_api.h backends/sycl/online_compiler.hpp backends/sycl/online_compiler.sycl.cpp backends/xsmm/ceed-xsmm-blocked.c backends/xsmm/ceed-xsmm-serial.c backends/xsmm/ceed-xsmm-tensor.c backends/xsmm/ceed-xsmm.h examples/ceed/ex1-volume.c examples/ceed/ex1-volume.h examples/ceed/ex2-surface.c examples/ceed/ex2-surface.h examples/fluids/include/petsc_ops.h examples/fluids/navierstokes.c examples/fluids/navierstokes.h examples/fluids/problems/advection.c examples/fluids/problems/advection2d.c examples/fluids/problems/blasius.c examples/fluids/problems/channel.c examples/fluids/problems/densitycurrent.c examples/fluids/problems/eulervortex.c examples/fluids/problems/freestream_bc.c examples/fluids/problems/gaussianwave.c examples/fluids/problems/newtonian.c examples/fluids/problems/sgs_dd_model.c examples/fluids/problems/shocktube.c examples/fluids/problems/stg_shur14.c examples/fluids/problems/stg_shur14.h examples/fluids/problems/taylorgreen.c examples/fluids/qfunctions/advection.h examples/fluids/qfunctions/advection2d.h examples/fluids/qfunctions/blasius.h examples/fluids/qfunctions/channel.h examples/fluids/qfunctions/densitycurrent.h examples/fluids/qfunctions/differential_filter.h examples/fluids/qfunctions/eulervortex.h examples/fluids/qfunctions/freestream_bc.h examples/fluids/qfunctions/freestream_bc_type.h examples/fluids/qfunctions/gaussianwave.h examples/fluids/qfunctions/grid_anisotropy_tensor.h examples/fluids/qfunctions/mass.h examples/fluids/qfunctions/newtonian.h examples/fluids/qfunctions/newtonian_state.h examples/fluids/qfunctions/newtonian_types.h examples/fluids/qfunctions/setupgeo.h examples/fluids/qfunctions/setupgeo2d.h examples/fluids/qfunctions/setupgeo_helpers.h examples/fluids/qfunctions/sgs_dd_model.h examples/fluids/qfunctions/sgs_dd_utils.h examples/fluids/qfunctions/shocktube.h examples/fluids/qfunctions/stabilization.h examples/fluids/qfunctions/stabilization_types.h examples/fluids/qfunctions/stg_shur14.h examples/fluids/qfunctions/stg_shur14_type.h examples/fluids/qfunctions/strong_boundary_conditions.h examples/fluids/qfunctions/taylorgreen.h examples/fluids/qfunctions/turb_spanstats.h examples/fluids/qfunctions/turb_stats_types.h examples/fluids/qfunctions/utils.h examples/fluids/qfunctions/utils_eigensolver_jacobi.h examples/fluids/qfunctions/velocity_gradient_projection.h examples/fluids/src/cloptions.c examples/fluids/src/differential_filter.c examples/fluids/src/dm_utils.c examples/fluids/src/grid_anisotropy_tensor.c examples/fluids/src/misc.c examples/fluids/src/petsc_ops.c examples/fluids/src/setupdm.c examples/fluids/src/setuplibceed.c examples/fluids/src/setupts.c examples/fluids/src/strong_boundary_conditions.c examples/fluids/src/turb_spanstats.c examples/fluids/src/velocity_gradient_projection.c examples/mfem/bp1.cpp examples/mfem/bp1.h examples/mfem/bp1.hpp examples/mfem/bp3.cpp examples/mfem/bp3.h examples/mfem/bp3.hpp examples/nek/bps/bps.h examples/petsc/area.c examples/petsc/area.h examples/petsc/bps.c examples/petsc/bps.h examples/petsc/bpsraw.c examples/petsc/bpssphere.c examples/petsc/bpssphere.h examples/petsc/dmswarm.c examples/petsc/include/areaproblemdata.h examples/petsc/include/bpsproblemdata.h examples/petsc/include/libceedsetup.h examples/petsc/include/matops.h examples/petsc/include/petscutils.h examples/petsc/include/petscversion.h examples/petsc/include/sphereproblemdata.h examples/petsc/include/structs.h examples/petsc/multigrid.c examples/petsc/qfunctions/area/areacube.h examples/petsc/qfunctions/area/areasphere.h examples/petsc/qfunctions/bps/bp1.h examples/petsc/qfunctions/bps/bp1sphere.h examples/petsc/qfunctions/bps/bp2.h examples/petsc/qfunctions/bps/bp2sphere.h examples/petsc/qfunctions/bps/bp3.h examples/petsc/qfunctions/bps/bp3sphere.h examples/petsc/qfunctions/bps/bp4.h examples/petsc/qfunctions/bps/bp4sphere.h examples/petsc/qfunctions/bps/common.h examples/petsc/src/libceedsetup.c examples/petsc/src/matops.c examples/petsc/src/petscutils.c examples/solids/elasticity.c examples/solids/elasticity.h examples/solids/include/boundary.h examples/solids/include/cl-options.h examples/solids/include/matops.h examples/solids/include/misc.h examples/solids/include/setup-dm.h examples/solids/include/setup-libceed.h examples/solids/include/structs.h examples/solids/include/utils.h examples/solids/problems/cl-problems.h examples/solids/problems/finite-strain-mooney-rivlin-initial-1.c examples/solids/problems/finite-strain-neo-hookean-current-1.c examples/solids/problems/finite-strain-neo-hookean-current-2.c examples/solids/problems/finite-strain-neo-hookean-initial-1.c examples/solids/problems/finite-strain-neo-hookean-initial-2.c examples/solids/problems/linear.c examples/solids/problems/mooney-rivlin.c examples/solids/problems/mooney-rivlin.h examples/solids/problems/neo-hookean.c examples/solids/problems/neo-hookean.h examples/solids/problems/problems.c examples/solids/problems/problems.h examples/solids/problems/small-strain-neo-hookean.c examples/solids/qfunctions/common.h examples/solids/qfunctions/constant-force.h examples/solids/qfunctions/finite-strain-mooney-rivlin-initial-1.h examples/solids/qfunctions/finite-strain-neo-hookean-current-1.h examples/solids/qfunctions/finite-strain-neo-hookean-current-2.h examples/solids/qfunctions/finite-strain-neo-hookean-initial-1.h examples/solids/qfunctions/finite-strain-neo-hookean-initial-2.h examples/solids/qfunctions/linear.h examples/solids/qfunctions/manufactured-force.h examples/solids/qfunctions/manufactured-true.h examples/solids/qfunctions/small-strain-neo-hookean.h examples/solids/qfunctions/traction-boundary.h examples/solids/src/boundary.c examples/solids/src/cl-options.c examples/solids/src/matops.c examples/solids/src/misc.c examples/solids/src/setup-dm.c examples/solids/src/setup-libceed.c gallery/ceed-gallery-list.h gallery/ceed-gallery-weak.c gallery/identity/ceed-identity.c gallery/mass-vector/ceed-vectormassapply.c gallery/mass/ceed-mass1dbuild.c gallery/mass/ceed-mass2dbuild.c gallery/mass/ceed-mass3dbuild.c gallery/mass/ceed-massapply.c gallery/poisson-vector/ceed-vectorpoisson1dapply.c gallery/poisson-vector/ceed-vectorpoisson2dapply.c gallery/poisson-vector/ceed-vectorpoisson3dapply.c gallery/poisson/ceed-poisson1dapply.c gallery/poisson/ceed-poisson1dbuild.c gallery/poisson/ceed-poisson2dapply.c gallery/poisson/ceed-poisson2dbuild.c gallery/poisson/ceed-poisson3dapply.c gallery/poisson/ceed-poisson3dbuild.c gallery/scale/ceed-scale.c include/ceed-fortran-name.h include/ceed-impl.h include/ceed.h include/ceed/backend.h include/ceed/ceed-f32.h include/ceed/ceed-f64.h include/ceed/ceed.h include/ceed/cuda.h include/ceed/fortran.h include/ceed/hip.h include/ceed/jit-source/cuda/cuda-atomic-add-fallback.h include/ceed/jit-source/cuda/cuda-gen-templates.h include/ceed/jit-source/cuda/cuda-jit.h include/ceed/jit-source/cuda/cuda-ref-basis-nontensor.h include/ceed/jit-source/cuda/cuda-ref-basis-tensor.h include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h include/ceed/jit-source/cuda/cuda-ref-qfunction.h include/ceed/jit-source/cuda/cuda-ref-restriction.h include/ceed/jit-source/cuda/cuda-shared-basis-read-write-templates.h include/ceed/jit-source/cuda/cuda-shared-basis-tensor-templates.h include/ceed/jit-source/cuda/cuda-shared-basis-tensor.h include/ceed/jit-source/cuda/cuda-types.h include/ceed/jit-source/gallery/ceed-identity.h include/ceed/jit-source/gallery/ceed-mass1dbuild.h include/ceed/jit-source/gallery/ceed-mass2dbuild.h include/ceed/jit-source/gallery/ceed-mass3dbuild.h include/ceed/jit-source/gallery/ceed-massapply.h include/ceed/jit-source/gallery/ceed-poisson1dapply.h include/ceed/jit-source/gallery/ceed-poisson1dbuild.h include/ceed/jit-source/gallery/ceed-poisson2dapply.h include/ceed/jit-source/gallery/ceed-poisson2dbuild.h include/ceed/jit-source/gallery/ceed-poisson3dapply.h include/ceed/jit-source/gallery/ceed-poisson3dbuild.h include/ceed/jit-source/gallery/ceed-scale.h include/ceed/jit-source/gallery/ceed-vectormassapply.h include/ceed/jit-source/gallery/ceed-vectorpoisson1dapply.h include/ceed/jit-source/gallery/ceed-vectorpoisson2dapply.h include/ceed/jit-source/gallery/ceed-vectorpoisson3dapply.h include/ceed/jit-source/hip/hip-gen-templates.h include/ceed/jit-source/hip/hip-jit.h include/ceed/jit-source/hip/hip-ref-basis-nontensor.h include/ceed/jit-source/hip/hip-ref-basis-tensor.h include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h include/ceed/jit-source/hip/hip-ref-operator-assemble.h include/ceed/jit-source/hip/hip-ref-qfunction.h include/ceed/jit-source/hip/hip-ref-restriction.h include/ceed/jit-source/hip/hip-shared-basis-read-write-templates.h include/ceed/jit-source/hip/hip-shared-basis-tensor-templates.h include/ceed/jit-source/hip/hip-shared-basis-tensor.h include/ceed/jit-source/hip/hip-types.h include/ceed/jit-source/magma/grad-1d.h include/ceed/jit-source/magma/grad-2d.h include/ceed/jit-source/magma/grad-3d.h include/ceed/jit-source/magma/grad-nontensor.h include/ceed/jit-source/magma/interp-1d.h include/ceed/jit-source/magma/interp-2d.h include/ceed/jit-source/magma/interp-3d.h include/ceed/jit-source/magma/interp-nontensor.h include/ceed/jit-source/magma/magma_common_defs.h include/ceed/jit-source/magma/magma_common_nontensor.h include/ceed/jit-source/magma/magma_common_tensor.h include/ceed/jit-source/magma/weight-1d.h include/ceed/jit-source/magma/weight-2d.h include/ceed/jit-source/magma/weight-3d.h include/ceed/jit-source/sycl/sycl-gen-templates.h include/ceed/jit-source/sycl/sycl-jit.h include/ceed/jit-source/sycl/sycl-ref-qfunction.h include/ceed/jit-source/sycl/sycl-shared-basis-read-write-templates.h include/ceed/jit-source/sycl/sycl-shared-basis-tensor-templates.h include/ceed/jit-source/sycl/sycl-shared-basis-tensor.h include/ceed/jit-source/sycl/sycl-types.h include/ceed/jit-tools.h include/ceed/types.h interface/ceed-basis.c interface/ceed-cuda.c interface/ceed-elemrestriction.c interface/ceed-fortran.c interface/ceed-hip.c interface/ceed-jit-source-root-default.c interface/ceed-jit-source-root-install.c interface/ceed-jit-tools.c interface/ceed-operator.c interface/ceed-preconditioning.c interface/ceed-qfunction-register.c interface/ceed-qfunction.c interface/ceed-qfunctioncontext.c interface/ceed-register.c interface/ceed-tensor.c interface/ceed-types.c interface/ceed-vector.c interface/ceed.c python/tests/libceed-qfunctions.c python/tests/test-qfunctions.h tests/t000-ceed.c tests/t001-ceed.c tests/t002-ceed.c tests/t003-ceed.c tests/t004-ceed.c tests/t005-ceed.c tests/t006-ceed.c tests/t007-ceed.c tests/t008-ceed.c tests/t009-ceed.c tests/t100-vector.c tests/t101-vector.c tests/t102-vector.c tests/t103-vector.c tests/t104-vector.c tests/t105-vector.c tests/t106-vector.c tests/t107-vector.c tests/t108-vector.c tests/t109-vector.c tests/t110-vector.c tests/t111-vector.c tests/t112-vector.c tests/t113-vector.c tests/t114-vector.c tests/t115-vector.c tests/t116-vector.c tests/t117-vector.c tests/t118-vector.c tests/t119-vector.c tests/t120-vector.c tests/t121-vector.c tests/t122-vector.c tests/t123-vector.c tests/t124-vector.c tests/t125-vector.c tests/t126-vector.c tests/t200-elemrestriction.c tests/t201-elemrestriction.c tests/t202-elemrestriction.c tests/t203-elemrestriction.c tests/t204-elemrestriction.c tests/t205-elemrestriction.c tests/t206-elemrestriction.c tests/t207-elemrestriction.c tests/t208-elemrestriction.c tests/t209-elemrestriction.c tests/t210-elemrestriction.c tests/t211-elemrestriction.c tests/t212-elemrestriction.c tests/t213-elemrestriction.c tests/t214-elemrestriction.c tests/t215-elemrestriction.c tests/t216-elemrestriction.c tests/t217-elemrestriction.c tests/t218-elemrestriction.c tests/t219-elemrestriction.c tests/t220-elemrestriction.c tests/t230-elemrestriction.c tests/t231-elemrestriction.c tests/t232-elemrestriction.c tests/t233-elemrestriction.c tests/t300-basis.c tests/t301-basis.c tests/t302-basis.c tests/t303-basis.c tests/t304-basis.c tests/t305-basis.c tests/t306-basis.c tests/t307-basis.c tests/t310-basis.c tests/t311-basis.c tests/t312-basis.c tests/t313-basis.c tests/t314-basis.c tests/t315-basis.c tests/t316-basis.c tests/t317-basis.c tests/t318-basis.c tests/t319-basis.c tests/t320-basis.c tests/t320-basis.h tests/t321-basis.c tests/t322-basis.c tests/t323-basis.c tests/t324-basis.c tests/t325-basis.c tests/t330-basis.c tests/t330-basis.h tests/t331-basis.c tests/t332-basis.c tests/t340-basis.c tests/t340-basis.h tests/t341-basis.c tests/t342-basis.c tests/t350-basis.c tests/t351-basis.c tests/t352-basis.c tests/t353-basis.c tests/t354-basis.c tests/t355-basis.c tests/t356-basis.c tests/t400-qfunction.c tests/t400-qfunction.h tests/t401-qfunction.c tests/t401-qfunction.h tests/t402-qfunction.c tests/t403-qfunction.c tests/t404-qfunction.c tests/t405-qfunction.c tests/t405-qfunction.h tests/t406-qfunction-helper.h tests/t406-qfunction-scales.h tests/t406-qfunction.c tests/t406-qfunction.h tests/t407-qfunction.c tests/t408-qfunction.c tests/t409-qfunction.c tests/t409-qfunction.h tests/t410-qfunction.c tests/t411-qfunction.c tests/t412-qfunction.c tests/t413-qfunction.c tests/t414-qfunction.c tests/t415-qfunction.c tests/t500-operator.c tests/t500-operator.h tests/t501-operator.c tests/t502-operator.c tests/t502-operator.h tests/t503-operator.c tests/t504-operator.c tests/t505-operator.c tests/t506-operator.c tests/t507-operator.c tests/t507-operator.h tests/t508-operator.c tests/t509-operator.c tests/t510-operator.c tests/t510-operator.h tests/t511-operator.c tests/t520-operator.c tests/t521-operator.c tests/t522-operator.c tests/t522-operator.h tests/t523-operator.c tests/t524-operator.c tests/t525-operator.c tests/t526-operator.c tests/t530-operator.c tests/t530-operator.h tests/t531-operator.c tests/t531-operator.h tests/t532-operator.c tests/t532-operator.h tests/t533-operator.c tests/t534-operator.c tests/t534-operator.h tests/t535-operator.c tests/t535-operator.h tests/t536-operator.c tests/t537-operator.c tests/t537-operator.h tests/t538-operator.c tests/t539-operator.c tests/t539-operator.h tests/t540-operator.c tests/t540-operator.h tests/t541-operator.c tests/t541-operator.h tests/t550-operator.c tests/t551-operator.c tests/t552-operator.c tests/t553-operator.c tests/t554-operator.c tests/t560-operator.c tests/t561-operator.c tests/t562-operator.c tests/t563-operator.c tests/t564-operator.c tests/t565-operator.c tests/t566-operator.c tests/t566-operator.h tests/t567-operator.c tests/t567-operator.h tests/t568-operator.c tests/t568-operator.h tests/t569-operator.c tests/t570-operator.c tests/t580-operator.c tests/t580-operator.h tests/t581-operator.c tests/t582-operator.c tests/t583-operator.c
```