### PR TITLE
Remove unused parameter from CeedTensorContractCreate

### DIFF
--- a/backends/avx/ceed-avx-tensor.c
+++ b/backends/avx/ceed-avx-tensor.c
@@ -290,7 +290,7 @@ static int CeedTensorContractApply_Avx(CeedTensorContract contract, CeedInt A, C
 //------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
-int CeedTensorContractCreate_Avx(CeedBasis basis, CeedTensorContract contract) {
+int CeedTensorContractCreate_Avx(CeedTensorContract contract) {
   Ceed ceed;
 
   CeedCallBackend(CeedTensorContractGetCeed(contract, &ceed));

--- a/backends/avx/ceed-avx.h
+++ b/backends/avx/ceed-avx.h
@@ -11,6 +11,6 @@
 #include <ceed.h>
 #include <ceed/backend.h>
 
-CEED_INTERN int CeedTensorContractCreate_Avx(CeedBasis basis, CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Avx(CeedTensorContract contract);
 
 #endif  // CEED_AVX_H

--- a/backends/opt/ceed-opt-tensor.c
+++ b/backends/opt/ceed-opt-tensor.c
@@ -51,7 +51,7 @@ static int CeedTensorContractApply_Opt(CeedTensorContract contract, CeedInt A, C
 //------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
-int CeedTensorContractCreate_Opt(CeedBasis basis, CeedTensorContract contract) {
+int CeedTensorContractCreate_Opt(CeedTensorContract contract) {
   Ceed ceed;
 
   CeedCallBackend(CeedTensorContractGetCeed(contract, &ceed));

--- a/backends/opt/ceed-opt.h
+++ b/backends/opt/ceed-opt.h
@@ -37,7 +37,7 @@ typedef struct {
   CeedElemRestriction  qf_block_rstr;
 } CeedOperator_Opt;
 
-CEED_INTERN int CeedTensorContractCreate_Opt(CeedBasis basis, CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Opt(CeedTensorContract contract);
 
 CEED_INTERN int CeedOperatorCreate_Opt(CeedOperator op);
 

--- a/backends/ref/ceed-ref-basis.c
+++ b/backends/ref/ceed-ref-basis.c
@@ -298,7 +298,7 @@ int CeedBasisCreateTensorH1_Ref(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const C
   }
   CeedCallBackend(CeedBasisSetData(basis, impl));
 
-  CeedCallBackend(CeedTensorContractCreate(ceed_parent, basis, &contract));
+  CeedCallBackend(CeedTensorContractCreate(ceed_parent, &contract));
   CeedCallBackend(CeedBasisSetTensorContract(basis, contract));
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApply_Ref));
@@ -317,7 +317,7 @@ int CeedBasisCreateH1_Ref(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes,
   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
   CeedCallBackend(CeedGetParent(ceed, &ceed_parent));
 
-  CeedCallBackend(CeedTensorContractCreate(ceed_parent, basis, &contract));
+  CeedCallBackend(CeedTensorContractCreate(ceed_parent, &contract));
   CeedCallBackend(CeedBasisSetTensorContract(basis, contract));
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApply_Ref));
@@ -335,7 +335,7 @@ int CeedBasisCreateHdiv_Ref(CeedElemTopology topo, CeedInt dim, CeedInt num_node
   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
   CeedCallBackend(CeedGetParent(ceed, &ceed_parent));
 
-  CeedCallBackend(CeedTensorContractCreate(ceed_parent, basis, &contract));
+  CeedCallBackend(CeedTensorContractCreate(ceed_parent, &contract));
   CeedCallBackend(CeedBasisSetTensorContract(basis, contract));
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApply_Ref));
@@ -353,7 +353,7 @@ int CeedBasisCreateHcurl_Ref(CeedElemTopology topo, CeedInt dim, CeedInt num_nod
   CeedCallBackend(CeedBasisGetCeed(basis, &ceed));
   CeedCallBackend(CeedGetParent(ceed, &ceed_parent));
 
-  CeedCallBackend(CeedTensorContractCreate(ceed_parent, basis, &contract));
+  CeedCallBackend(CeedTensorContractCreate(ceed_parent, &contract));
   CeedCallBackend(CeedBasisSetTensorContract(basis, contract));
 
   CeedCallBackend(CeedSetBackendFunction(ceed, "Basis", basis, "Apply", CeedBasisApply_Ref));

--- a/backends/ref/ceed-ref-tensor.c
+++ b/backends/ref/ceed-ref-tensor.c
@@ -45,7 +45,7 @@ static int CeedTensorContractDestroy_Ref(CeedTensorContract contract) { return C
 //------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
-int CeedTensorContractCreate_Ref(CeedBasis basis, CeedTensorContract contract) {
+int CeedTensorContractCreate_Ref(CeedTensorContract contract) {
   Ceed ceed;
 
   CeedCallBackend(CeedTensorContractGetCeed(contract, &ceed));

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -73,7 +73,7 @@ CEED_INTERN int CeedBasisCreateHdiv_Ref(CeedElemTopology topo, CeedInt dim, Ceed
 CEED_INTERN int CeedBasisCreateHcurl_Ref(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes, CeedInt num_qpts, const CeedScalar *interp,
                                          const CeedScalar *curl, const CeedScalar *q_ref, const CeedScalar *q_weight, CeedBasis basis);
 
-CEED_INTERN int CeedTensorContractCreate_Ref(CeedBasis basis, CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Ref(CeedTensorContract contract);
 
 CEED_INTERN int CeedQFunctionCreate_Ref(CeedQFunction qf);
 

--- a/backends/xsmm/ceed-xsmm-tensor.c
+++ b/backends/xsmm/ceed-xsmm-tensor.c
@@ -69,7 +69,7 @@ static int CeedTensorContractApply_Xsmm(CeedTensorContract contract, CeedInt A, 
 //------------------------------------------------------------------------------
 // Tensor Contract Create
 //------------------------------------------------------------------------------
-int CeedTensorContractCreate_Xsmm(CeedBasis basis, CeedTensorContract contract) {
+int CeedTensorContractCreate_Xsmm(CeedTensorContract contract) {
   Ceed ceed;
 
   CeedCallBackend(CeedTensorContractGetCeed(contract, &ceed));

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -11,6 +11,6 @@
 #include <ceed.h>
 #include <ceed/backend.h>
 
-CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedBasis basis, CeedTensorContract contract);
+CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedTensorContract contract);
 
 #endif  // CEED_XSMM_H

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -108,7 +108,7 @@ struct Ceed_private {
                          CeedBasis);
   int (*BasisCreateHcurl)(CeedElemTopology, CeedInt, CeedInt, CeedInt, const CeedScalar *, const CeedScalar *, const CeedScalar *, const CeedScalar *,
                           CeedBasis);
-  int (*TensorContractCreate)(CeedBasis, CeedTensorContract);
+  int (*TensorContractCreate)(CeedTensorContract);
   int (*QFunctionCreate)(CeedQFunction);
   int (*QFunctionContextCreate)(CeedQFunctionContext);
   int (*OperatorCreate)(CeedOperator);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -310,7 +310,7 @@ CEED_EXTERN int CeedBasisGetTopologyDimension(CeedElemTopology topo, CeedInt *di
 CEED_EXTERN int CeedBasisGetTensorContract(CeedBasis basis, CeedTensorContract *contract);
 CEED_EXTERN int CeedBasisSetTensorContract(CeedBasis basis, CeedTensorContract contract);
 
-CEED_EXTERN int CeedTensorContractCreate(Ceed ceed, CeedBasis basis, CeedTensorContract *contract);
+CEED_EXTERN int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract);
 CEED_EXTERN int CeedTensorContractApply(CeedTensorContract contract, CeedInt A, CeedInt B, CeedInt C, CeedInt J, const CeedScalar *__restrict__ t,
                                         CeedTransposeMode t_mode, const CeedInt Add, const CeedScalar *__restrict__ u, CeedScalar *__restrict__ v);
 CEED_EXTERN int CeedTensorContractStridedApply(CeedTensorContract contract, CeedInt A, CeedInt B, CeedInt C, CeedInt D, CeedInt J,

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -23,26 +23,25 @@
   @brief Create a CeedTensorContract object for a CeedBasis
 
   @param[in]  ceed     Ceed object where the CeedTensorContract will be created
-  @param[in]  basis    CeedBasis for which the tensor contraction will be used
   @param[out] contract Address of the variable where the newly created CeedTensorContract will be stored.
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Backend
 **/
-int CeedTensorContractCreate(Ceed ceed, CeedBasis basis, CeedTensorContract *contract) {
+int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
   if (!ceed->TensorContractCreate) {
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "TensorContract"));
     CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TensorContractCreate");
-    CeedCall(CeedTensorContractCreate(delegate, basis, contract));
+    CeedCall(CeedTensorContractCreate(delegate, contract));
     return CEED_ERROR_SUCCESS;
   }
 
   CeedCall(CeedCalloc(1, contract));
   CeedCall(CeedReferenceCopy(ceed, &(*contract)->ceed));
-  CeedCall(ceed->TensorContractCreate(basis, *contract));
+  CeedCall(ceed->TensorContractCreate(*contract));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -78,10 +77,10 @@ int CeedTensorContractApply(CeedTensorContract contract, CeedInt A, CeedInt B, C
 /**
   @brief Apply tensor contraction
 
-    Contracts on the middle index
-    NOTRANSPOSE: v_dajc = t_djb u_abc
-    TRANSPOSE:   v_ajc  = t_dbj u_dabc
-    If add != 0, "=" is replaced by "+="
+  Contracts on the middle index
+  NOTRANSPOSE: v_dajc = t_djb u_abc
+  TRANSPOSE:   v_ajc  = t_dbj u_dabc
+  If add != 0, "=" is replaced by "+="
 
   @param[in]  contract CeedTensorContract to use
   @param[in]  A        First index of u, second index of v

--- a/julia/LibCEED.jl/src/generated/libceed_bindings.jl
+++ b/julia/LibCEED.jl/src/generated/libceed_bindings.jl
@@ -1106,8 +1106,8 @@ function CeedBasisSetTensorContract(basis, contract)
     ccall((:CeedBasisSetTensorContract, libceed), Cint, (CeedBasis, CeedTensorContract), basis, contract)
 end
 
-function CeedTensorContractCreate(ceed, basis, contract)
-    ccall((:CeedTensorContractCreate, libceed), Cint, (Ceed, CeedBasis, Ptr{CeedTensorContract}), ceed, basis, contract)
+function CeedTensorContractCreate(ceed, contract)
+    ccall((:CeedTensorContractCreate, libceed), Cint, (Ceed, Ptr{CeedTensorContract}), ceed, contract)
 end
 
 function CeedTensorContractApply(contract, A, B, C, J, t, t_mode, Add, u, v)


### PR DESCRIPTION
Pulled out of https://github.com/CEED/libCEED/pull/1359.