### PR TITLE
Update CeedContextFieldLabelGetDescription with offset

### DIFF
--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -382,8 +382,8 @@ CEED_EXTERN int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx, con
 CEED_EXTERN int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                                   const char *field_description);
 CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx, const CeedContextFieldLabel **field_labels, CeedInt *num_fields);
-CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char **field_name, const char **field_description,
-                                                    size_t *num_values, CeedContextFieldType *field_type);
+CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char **field_name, size_t *field_offset, size_t *num_values,
+                                                    const char **field_description, CeedContextFieldType *field_type);
 CEED_EXTERN int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx, size_t *ctx_size);
 CEED_EXTERN int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream);
 CEED_EXTERN int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_mem_type, CeedQFunctionContextDataDestroyUser f);

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -741,19 +741,21 @@ int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx, const CeedCo
 
   @param[in]  label             CeedContextFieldLabel
   @param[out] field_name        Name of labeled field
-  @param[out] field_description Description of field, or NULL for none
+  @param[out] field_offset      Offset of field registered
   @param[out] num_values        Number of values registered
+  @param[out] field_description Description of field, or NULL for none
   @param[out] field_type        CeedContextFieldType
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
-int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char **field_name, const char **field_description, size_t *num_values,
-                                        CeedContextFieldType *field_type) {
+int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char **field_name, size_t *field_offset, size_t *num_values,
+                                        const char **field_description, CeedContextFieldType *field_type) {
   if (field_name) *field_name = label->name;
-  if (field_description) *field_description = label->description;
+  if (field_offset) *field_offset = label->offset;
   if (num_values) *num_values = label->num_values;
+  if (field_description) *field_description = label->description;
   if (field_type) *field_type = label->type;
   return CEED_ERROR_SUCCESS;
 }

--- a/tests/t407-qfunction.c
+++ b/tests/t407-qfunction.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
   const char          *name;
   size_t               num_values;
   CeedContextFieldType type;
-  CeedContextFieldLabelGetDescription(field_labels[0], &name, NULL, &num_values, &type);
+  CeedContextFieldLabelGetDescription(field_labels[0], &name, NULL, &num_values, NULL, &type);
   if (strcmp(name, "time")) printf("Incorrect context field description for time: \"%s\" != \"time\"\n", name);
   if (num_values != 1) printf("Incorrect context field number of values for time: \"%ld\" != 1\n", num_values);
   if (type != CEED_CONTEXT_FIELD_DOUBLE) {
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     // LCOV_EXCL_STOP
   }
 
-  CeedContextFieldLabelGetDescription(field_labels[1], &name, NULL, &num_values, &type);
+  CeedContextFieldLabelGetDescription(field_labels[1], &name, NULL, &num_values, NULL, &type);
   if (strcmp(name, "count")) printf("Incorrect context field description for count: \"%s\" != \"count\"\n", name);
   if (num_values != 2) printf("Incorrect context field number of values for count: \"%ld\" != 2\n", num_values);
   if (type != CEED_CONTEXT_FIELD_INT32) {


### PR DESCRIPTION
In order to clone a `CeedQFunctionContext` fully, we need to clone the labels. To clone the labels, we need the offsets. Since this is only used by us, this interface update in minor.