### PR TITLE
Makefile updates for formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -739,6 +739,7 @@ distclean : clean
 
 # Documentation
 DOXYGEN ?= doxygen
+
 doxygen :
 	$(DOXYGEN) -q Doxyfile
 
@@ -749,18 +750,18 @@ doc : doc-html
 
 # Style/Format
 CLANG_FORMAT ?= clang-format
-
-FORMAT_OPTS += -style=file -i
+CLANG_FORMAT_OPTS += -style=file -i
+AUTOPEP8 ?= autopep8
+AUTOPEP8_OPTS += --in-place --aggressive
 
 format.ch := $(filter-out include/ceedf.h $(wildcard tests/t*-f.h), $(shell git ls-files '*.[ch]pp' '*.[ch]'))
+format.py := $(filter-out tests/junit-xml/junit_xml/__init__.py $(wildcard tests/*.py), $(shell git ls-files '*.py'))
 
 format-c  :
-	$(CLANG_FORMAT) $(FORMAT_OPTS) $(format.ch)
+	$(CLANG_FORMAT) $(CLANG_FORMAT_OPTS) $(format.ch)
 
-AUTOPEP8 = autopep8
-format-py  : AUTOPEP8_ARGS = --in-place --aggressive
-format-py  :
-	@$(AUTOPEP8) $(AUTOPEP8_ARGS) $(wildcard *.py python**/*.py python/tests/*.py examples**/*.py doc/sphinx/source**/*.py benchmarks/*.py)
+format-py :
+	$(AUTOPEP8) $(AUTOPEP8_OPTS) $(format.py)
 
 format    : format-c format-py
 

--- a/benchmarks/petsc-bps.sh
+++ b/benchmarks/petsc-bps.sh
@@ -14,7 +14,6 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
-
 function run_tests()
 {
    $dry_run cd "$test_exe_dir"

--- a/benchmarks/petsc-bpsraw.sh
+++ b/benchmarks/petsc-bpsraw.sh
@@ -14,7 +14,6 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
-
 function run_tests()
 {
    $dry_run cd "$test_exe_dir"

--- a/benchmarks/postprocess_base.py
+++ b/benchmarks/postprocess_base.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
 # All Rights reserved. See files LICENSE and NOTICE for details.
@@ -15,12 +16,12 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
+# Read all input files specified on the command line, or stdin and parse
+# the content, storing it as a pandas dataframe
+
 import pandas as pd
 import fileinput
 import pprint
-
-# Read all input files specified on the command line, or stdin and parse
-# the content, storing it as a pandas dataframe
 
 
 def read_logs(files=None):

--- a/benchmarks/postprocess_plot.py
+++ b/benchmarks/postprocess_plot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
 # All Rights reserved. See files LICENSE and NOTICE for details.
@@ -15,12 +16,12 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
-
-# Adjustable plot parameters:
 from pylab import *
 from matplotlib import use
 from postprocess_base import read_logs
 import pandas as pd
+
+# Adjustable plot parameters
 log_y = 0               # use log scale on the y-axis?
 x_range = (1e1, 4e6)     # plot range for the x-axis; comment out for auto
 y_range = (0, 2e9)       # plot range for the y-axis; comment out for auto
@@ -31,9 +32,7 @@ legend_ncol = (2 if log_y else 1)   # number of columns in the legend
 write_figures = 1       # save the figures to files?
 show_figures = 1        # display the figures on the screen?
 
-
 # Load the data
-
 runs = read_logs()
 
 # Sample plot output

--- a/benchmarks/postprocess_table.py
+++ b/benchmarks/postprocess_table.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory. LLNL-CODE-734707.
 # All Rights reserved. See files LICENSE and NOTICE for details.
@@ -15,11 +16,10 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
-
-# Load the data
 import pandas as pd
 from postprocess_base import read_logs
 
+# Load the data
 runs = read_logs()
 
 # Data output

--- a/examples/fluids/conv_plot.py
+++ b/examples/fluids/conv_plot.py
@@ -45,9 +45,9 @@ def plot():
         data = group[1]
         data = data.sort_values('rel_error')
         p = data['degree'].values[0]
-        h = 1/data[res]
+        h = 1 / data[res]
         E = data['rel_error']
-        H =  amin(E) * (h/amin(h))**p
+        H = amin(E) * (h / amin(h))**p
         ax.loglog(h, E, 'o', color=colors[i])
         ax.loglog(h, H, '--', color=colors[i], label='O(h$^' + str(p) + '$)')
         i = i + 1

--- a/examples/fluids/postprocess/vortexshedding.py
+++ b/examples/fluids/postprocess/vortexshedding.py
@@ -27,8 +27,18 @@ palette = sns.color_palette()
 fig, ax_drag = plt.subplots()
 ax_lift = ax_drag.twinx()
 
-sns.lineplot(data=df, x="Time", y="Drag Coefficient", ax=ax_drag, color=palette[0])
-sns.lineplot(data=df, x="Time", y="Lift Coefficient", ax=ax_lift, color=palette[1])
+sns.lineplot(
+    data=df,
+    x="Time",
+    y="Drag Coefficient",
+    ax=ax_drag,
+    color=palette[0])
+sns.lineplot(
+    data=df,
+    x="Time",
+    y="Lift Coefficient",
+    ax=ax_lift,
+    color=palette[1])
 ax_drag.set_title(f"Shedding period {period}")
 ax_drag.set_ylim(0.41, 0.49)
 ax_drag.tick_params(axis="y", colors=palette[0])


### PR DESCRIPTION
In preparation for adding some new Python code to do autotuning, I wanted to make sure the formatter was being run correctly on it so I've increased the coverage of Python formatting with `autopep8`. Also a few Bash whitespace changes for consistency.