### PR TITLE
Flag assembly data as stale if ctx data changed

### DIFF
--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -309,6 +309,7 @@ static int CeedOperatorContextSetGeneric(CeedOperator op, CeedContextFieldLabel 
     CeedCheck(op->qf->ctx, op->ceed, CEED_ERROR_UNSUPPORTED, "QFunction does not have context data");
     CeedCall(CeedQFunctionContextSetGeneric(op->qf->ctx, field_label, field_type, values));
   }
+  CeedCall(CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(op, true));
   return CEED_ERROR_SUCCESS;
 }
 


### PR DESCRIPTION
If context data changes, then the `QFunctionAssemblyData` for an operator will be stale.

Its easy for the user to forget this, so this is a bit of belt-and-suspenders.