### PR TITLE
Fix compiler vendor detection for `cc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ endif
 AFLAGS ?= -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
 # Note: Intel oneAPI C/C++ compiler is now icx/icpx
-CC_VENDOR := $(subst icc_orig,icc,$(firstword $(filter gcc clang icc icc_orig oneAPI XL emcc,$(subst -, ,$(shell $(CC) --version)))))
+CC_VENDOR := $(firstword $(filter gcc (GCC) clang icc icc_orig oneAPI XL emcc,$(subst -, ,$(shell $(CC) --version))))
+CC_VENDOR := $(subst (GCC),gcc,$(subst icc_orig,icc,$(CC_VENDOR)))
 FC_VENDOR := $(if $(FC),$(firstword $(filter GNU ifort ifx XL,$(shell $(FC) --version 2>&1 || $(FC) -qversion))))
 
 # Default extra flags by vendor


### PR DESCRIPTION
On my RHEL machine, the output of `cc` is:

```
$ cc --version
cc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-17)
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

This doesn't get picked up by the `CC_VENDOR` definition in the `Makefile`. This PR fixes this.