### PR TITLE
Add Vermin in CI

### DIFF
--- a/.github/workflows/python-test-with-style.yml
+++ b/.github/workflows/python-test-with-style.yml
@@ -45,3 +45,9 @@ jobs:
         FC: gfortran-11
       run: |
         make format-py && git diff --exit-code
+    - name: Python version
+      env:
+        CC: ${{ matrix.compiler }}
+        FC: gfortran-11
+      run: |
+        make vermin

--- a/Makefile
+++ b/Makefile
@@ -748,10 +748,10 @@ doc-html doc-latexpdf doc-epub doc-livehtml : doc-% : doxygen
 doc : doc-html
 
 # Style/Format
-CLANG_FORMAT ?= clang-format
+CLANG_FORMAT      ?= clang-format
 CLANG_FORMAT_OPTS += -style=file -i
-AUTOPEP8 ?= autopep8
-AUTOPEP8_OPTS += --in-place --aggressive --max-line-length 120
+AUTOPEP8          ?= autopep8
+AUTOPEP8_OPTS     += --in-place --aggressive --max-line-length 120
 
 format.ch := $(filter-out include/ceedf.h $(wildcard tests/t*-f.h), $(shell git ls-files '*.[ch]pp' '*.[ch]'))
 format.py := $(filter-out tests/junit-xml/junit_xml/__init__.py, $(shell git ls-files '*.py'))
@@ -763,6 +763,13 @@ format-py :
 	$(AUTOPEP8) $(AUTOPEP8_OPTS) $(format.py)
 
 format    : format-c format-py
+
+# Vermin - python version requirements
+VERMIN            ?= vermin
+VERMIN_OPTS       += -t=3.7- --violations
+
+vermin    :
+	$(VERMIN) $(VERMIN_OPTS) $(format.py)
 
 # Tidy
 CLANG_TIDY ?= clang-tidy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest
 autopep8
+vermin


### PR DESCRIPTION
This adds `make vermin` and checks for Python 3.8+ compatibility. I used Python 3.8 since 3.7 and older has reached the EOL. We pass for 3.7 but not for 3.6, but I'm not that worried about either.

Closes #1375