### PR TITLE
Remove legacy `CeedChk` and `CeedChkBackend`

### DIFF
--- a/backends/ceed-backend-weak.c
+++ b/backends/ceed-backend-weak.c
@@ -27,8 +27,10 @@ static int CeedRegister_Weak(const char *name, int num_prefixes, ...) {
 
     CeedDebugEnv("Weak Register   : %s", prefix);
     ierr = CeedRegisterImpl(prefix, CeedInit_Weak, CEED_MAX_BACKEND_PRIORITY);
-    if (ierr) va_end(prefixes);  // Prevent leak on error
-    CeedChk(ierr);
+    if (ierr) {
+      va_end(prefixes);  // Prevent leak on error
+      return ierr;
+    }
   }
   va_end(prefixes);
   return CEED_ERROR_SUCCESS;

--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -179,8 +179,8 @@ static int CeedOperatorApplyAdd_Cuda_gen(CeedOperator op, CeedVector input_vec, 
       },
       grid;
 
-  CeedChkBackend(BlockGridCalculate(num_elem, min_grid_size / cuda_data->device_prop.multiProcessorCount, max_threads_per_block,
-                                    cuda_data->device_prop.maxThreadsDim[2], cuda_data->device_prop.warpSize, block, &grid));
+  CeedCallBackend(BlockGridCalculate(num_elem, min_grid_size / cuda_data->device_prop.multiProcessorCount, max_threads_per_block,
+                                     cuda_data->device_prop.maxThreadsDim[2], cuda_data->device_prop.warpSize, block, &grid));
   CeedInt shared_mem = block[0] * block[1] * block[2] * sizeof(CeedScalar);
 
   CeedCallBackend(CeedRunKernelDimShared_Cuda(ceed, data->op, grid, block[0], block[1], block[2], shared_mem, opargs));

--- a/backends/occa/ceed-occa-elem-restriction.cpp
+++ b/backends/occa/ceed-occa-elem-restriction.cpp
@@ -320,7 +320,7 @@ int ElemRestriction::ceedCreate(CeedMemType memType, CeedCopyMode copyMode, cons
   elemRestriction->setup(memType, copyMode, indicesInput);
 
   CeedInt defaultLayout[3] = {1, elemRestriction->ceedElementSize, elemRestriction->ceedElementSize * elemRestriction->ceedComponentCount};
-  CeedChkBackend(CeedElemRestrictionSetELayout(r, defaultLayout));
+  CeedCallBackend(CeedElemRestrictionSetELayout(r, defaultLayout));
 
   CeedOccaRegisterFunction(r, "Apply", ElemRestriction::ceedApply);
   CeedOccaRegisterFunction(r, "ApplyUnsigned", ElemRestriction::ceedApply);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -216,10 +216,6 @@ CEED_INTERN int CeedFree(void *p);
     if (!(cond)) return CeedError(ceed, ecode, __VA_ARGS__); \
   } while (0)
 
-/* Note - these are legacy macros that should be removed eventually */
-#define CeedChk(...) CeedCall(__VA_ARGS__)
-#define CeedChkBackend(...) CeedCallBackend(__VA_ARGS__)
-
 /* Note that CeedMalloc and CeedCalloc will, generally, return pointers with different memory alignments:
    CeedMalloc returns pointers aligned at CEED_ALIGN bytes, while CeedCalloc uses the alignment of calloc. */
 #define CeedMalloc(n, p) CeedMallocArray((n), sizeof(**(p)), p)

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -106,8 +106,8 @@ CEED_EXTERN int CeedIsDeterministic(Ceed ceed, bool *is_deterministic);
 CEED_EXTERN int CeedAddJitSourceRoot(Ceed ceed, const char *jit_source_root);
 CEED_EXTERN int CeedView(Ceed ceed, FILE *stream);
 CEED_EXTERN int CeedDestroy(Ceed *ceed);
+CEED_EXTERN int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func, int ecode, const char *format, ...);
 
-CEED_EXTERN int CeedErrorImpl(Ceed, const char *, int, const char *, int, const char *, ...);
 /// Raise an error on ceed object
 ///
 /// @param ceed Ceed library context or NULL
@@ -119,14 +119,14 @@ CEED_EXTERN int CeedErrorImpl(Ceed, const char *, int, const char *, int, const 
 #define CeedError(ceed, ecode, ...) (CeedErrorImpl((ceed), __FILE__, __LINE__, __func__, (ecode), __VA_ARGS__), (ecode))
 
 /// Ceed error handlers
-CEED_EXTERN int CeedErrorReturn(Ceed, const char *, int, const char *, int, const char *, va_list *);
-CEED_EXTERN int CeedErrorStore(Ceed, const char *, int, const char *, int, const char *, va_list *);
-CEED_EXTERN int CeedErrorAbort(Ceed, const char *, int, const char *, int, const char *, va_list *);
-CEED_EXTERN int CeedErrorExit(Ceed, const char *, int, const char *, int, const char *, va_list *);
 typedef int (*CeedErrorHandler)(Ceed, const char *, int, const char *, int, const char *, va_list *);
-CEED_EXTERN int CeedSetErrorHandler(Ceed ceed, CeedErrorHandler eh);
-CEED_EXTERN int CeedGetErrorMessage(Ceed, const char **err_msg);
-CEED_EXTERN int CeedResetErrorMessage(Ceed, const char **err_msg);
+CEED_EXTERN int CeedSetErrorHandler(Ceed ceed, CeedErrorHandler handler);
+CEED_EXTERN int CeedGetErrorMessage(Ceed ceed, const char **err_msg);
+CEED_EXTERN int CeedResetErrorMessage(Ceed ceed, const char **err_msg);
+CEED_EXTERN int CeedErrorReturn(Ceed ceed, const char *filename, int line_no, const char *func, int err_code, const char *format, va_list *args);
+CEED_EXTERN int CeedErrorStore(Ceed ceed, const char *filename, int line_no, const char *func, int err_code, const char *format, va_list *args);
+CEED_EXTERN int CeedErrorAbort(Ceed ceed, const char *filename, int line_no, const char *func, int err_code, const char *format, va_list *args);
+CEED_EXTERN int CeedErrorExit(Ceed ceed, const char *filename, int line_no, const char *func, int err_code, const char *format, va_list *args);
 
 /// libCEED library version numbering
 /// @ingroup Ceed

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -726,7 +726,7 @@ static int CeedQFunctionFortranStub(void *ctx, int nq, const CeedScalar *const *
   //         use this Fortran stub.
   if (inner_ctx) {
     ierr = CeedQFunctionContextGetData(inner_ctx, CEED_MEM_HOST, &ctx_);
-    CeedChk(ierr);
+    CeedCall(ierr);
   }
 
   fctx->f((void *)ctx_, &nq, u[0], u[1], u[2], u[3], u[4], u[5], u[6], u[7], u[8], u[9], u[10], u[11], u[12], u[13], u[14], u[15], v[0], v[1], v[2],
@@ -734,7 +734,7 @@ static int CeedQFunctionFortranStub(void *ctx, int nq, const CeedScalar *const *
 
   if (inner_ctx) {
     ierr = CeedQFunctionContextRestoreData(inner_ctx, (void *)&ctx_);
-    CeedChk(ierr);
+    CeedCall(ierr);
   }
 
   return ierr;


### PR DESCRIPTION
Address this comment in `backend.h`:

```
/* Note - these are legacy macros that should be removed eventually */
#define CeedChk(...) CeedCall(__VA_ARGS__)
#define CeedChkBackend(...) CeedCallBackend(__VA_ARGS__)
```

This isn't super important but I figured was worth addressing after the previous release.