### PR TITLE
Change order of ElemRestriction/Basis AtPoints

### DIFF
--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -373,11 +373,11 @@ static inline int CeedElemRestrictionApplyAtPointsInElement_Ref_Core(CeedElemRes
     CeedCallBackend(CeedElemRestrictionGetNumPointsInElement(rstr, e, &num_points));
     if (t_mode == CEED_NOTRANSPOSE) {
       for (CeedInt i = 0; i < num_points; i++) {
-        for (CeedInt j = 0; j < num_comp; j++) vv[i * num_comp + j + e_vec_offset] = uu[impl->offsets[i + l_vec_offset] * num_comp + j];
+        for (CeedInt j = 0; j < num_comp; j++) vv[j * num_points + i + e_vec_offset] = uu[impl->offsets[i + l_vec_offset] * num_comp + j];
       }
     } else {
       for (CeedInt i = 0; i < num_points; i++) {
-        for (CeedInt j = 0; j < num_comp; j++) vv[impl->offsets[i + l_vec_offset] * num_comp + j] = uu[i * num_comp + j + e_vec_offset];
+        for (CeedInt j = 0; j < num_comp; j++) vv[impl->offsets[i + l_vec_offset] * num_comp + j] = uu[j * num_points + i + e_vec_offset];
       }
     }
     e_vec_offset += num_points * num_comp;

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -1609,7 +1609,7 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
 
             for (CeedInt d = 0; d < dim; d++) {
               // ------ Tensor contract with current Chebyshev polynomial values
-              CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
+              CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[d * num_points + p], Q_1d, chebyshev_x));
               CeedCall(CeedTensorContractApply(basis->contract, pre, Q_1d, post, 1, chebyshev_x, t_mode, false,
                                                d == 0 ? chebyshev_coeffs : tmp[d % 2], tmp[(d + 1) % 2]));
               pre /= Q_1d;
@@ -1630,8 +1630,8 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
 
               for (CeedInt d = 0; d < dim; d++) {
                 // ------ Tensor contract with current Chebyshev polynomial values
-                if (pass == d) CeedCall(CeedChebyshevDerivativeAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
-                else CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
+                if (pass == d) CeedCall(CeedChebyshevDerivativeAtPoint(x_array_read[d * num_points + p], Q_1d, chebyshev_x));
+                else CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[d * num_points + p], Q_1d, chebyshev_x));
                 CeedCall(CeedTensorContractApply(basis->contract, pre, Q_1d, post, 1, chebyshev_x, t_mode, false,
                                                  d == 0 ? chebyshev_coeffs : tmp[d % 2], tmp[(d + 1) % 2]));
                 pre /= Q_1d;
@@ -1673,7 +1673,7 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
             for (CeedInt c = 0; c < num_comp; c++) tmp[0][c] = u_array[c * num_points + p];
             for (CeedInt d = 0; d < dim; d++) {
               // ------ Tensor contract with current Chebyshev polynomial values
-              CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
+              CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[d * num_points + p], Q_1d, chebyshev_x));
               CeedCall(CeedTensorContractApply(basis->contract, pre, 1, post, Q_1d, chebyshev_x, t_mode, p > 0 && d == (dim - 1), tmp[d % 2],
                                                d == (dim - 1) ? chebyshev_coeffs : tmp[(d + 1) % 2]));
               pre /= 1;
@@ -1694,8 +1694,8 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
               for (CeedInt c = 0; c < num_comp; c++) tmp[0][c] = u_array[(pass * num_comp + c) * num_points + p];
               for (CeedInt d = 0; d < dim; d++) {
                 // ------ Tensor contract with current Chebyshev polynomial values
-                if (pass == d) CeedCall(CeedChebyshevDerivativeAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
-                else CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
+                if (pass == d) CeedCall(CeedChebyshevDerivativeAtPoint(x_array_read[d * num_points + p], Q_1d, chebyshev_x));
+                else CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[d * num_points + p], Q_1d, chebyshev_x));
                 CeedCall(CeedTensorContractApply(basis->contract, pre, 1, post, Q_1d, chebyshev_x, t_mode,
                                                  (p > 0 || (p == 0 && pass > 0)) && d == (dim - 1), tmp[d % 2],
                                                  d == (dim - 1) ? chebyshev_coeffs : tmp[(d + 1) % 2]));

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -1611,10 +1611,11 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
               // ------ Tensor contract with current Chebyshev polynomial values
               CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
               CeedCall(CeedTensorContractApply(basis->contract, pre, Q_1d, post, 1, chebyshev_x, t_mode, false,
-                                               d == 0 ? chebyshev_coeffs : tmp[d % 2], d == (dim - 1) ? &v_array[p * num_comp] : tmp[(d + 1) % 2]));
+                                               d == 0 ? chebyshev_coeffs : tmp[d % 2], tmp[(d + 1) % 2]));
               pre /= Q_1d;
               post *= 1;
             }
+            for (CeedInt c = 0; c < num_comp; c++) v_array[c * num_points + p] = tmp[dim % 2][c];
           }
           break;
         }
@@ -1632,11 +1633,11 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
                 if (pass == d) CeedCall(CeedChebyshevDerivativeAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
                 else CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
                 CeedCall(CeedTensorContractApply(basis->contract, pre, Q_1d, post, 1, chebyshev_x, t_mode, false,
-                                                 d == 0 ? chebyshev_coeffs : tmp[d % 2],
-                                                 d == (dim - 1) ? &v_array[p * num_comp * dim + pass] : tmp[(d + 1) % 2]));
+                                                 d == 0 ? chebyshev_coeffs : tmp[d % 2], tmp[(d + 1) % 2]));
                 pre /= Q_1d;
                 post *= 1;
               }
+              for (CeedInt c = 0; c < num_comp; c++) v_array[(pass * num_comp + c) * num_points + p] = tmp[dim % 2][c];
             }
           }
           break;
@@ -1669,11 +1670,12 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
           for (CeedInt p = 0; p < num_points; p++) {
             CeedInt pre = num_comp * 1, post = 1;
 
+            for (CeedInt c = 0; c < num_comp; c++) tmp[0][c] = u_array[c * num_points + p];
             for (CeedInt d = 0; d < dim; d++) {
               // ------ Tensor contract with current Chebyshev polynomial values
               CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
-              CeedCall(CeedTensorContractApply(basis->contract, pre, 1, post, Q_1d, chebyshev_x, t_mode, p > 0 && d == (dim - 1),
-                                               d == 0 ? &u_array[p * num_comp] : tmp[d % 2], d == (dim - 1) ? chebyshev_coeffs : tmp[(d + 1) % 2]));
+              CeedCall(CeedTensorContractApply(basis->contract, pre, 1, post, Q_1d, chebyshev_x, t_mode, p > 0 && d == (dim - 1), tmp[d % 2],
+                                               d == (dim - 1) ? chebyshev_coeffs : tmp[(d + 1) % 2]));
               pre /= 1;
               post *= Q_1d;
             }
@@ -1689,13 +1691,14 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
             for (CeedInt pass = 0; pass < dim; pass++) {
               CeedInt pre = num_comp * 1, post = 1;
 
+              for (CeedInt c = 0; c < num_comp; c++) tmp[0][c] = u_array[(pass * num_comp + c) * num_points + p];
               for (CeedInt d = 0; d < dim; d++) {
                 // ------ Tensor contract with current Chebyshev polynomial values
                 if (pass == d) CeedCall(CeedChebyshevDerivativeAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
                 else CeedCall(CeedChebyshevPolynomialsAtPoint(x_array_read[p * dim + d], Q_1d, chebyshev_x));
-                CeedCall(CeedTensorContractApply(
-                    basis->contract, pre, 1, post, Q_1d, chebyshev_x, t_mode, (p > 0 || (p == 0 && pass > 0)) && d == (dim - 1),
-                    d == 0 ? &u_array[p * num_comp * dim + pass] : tmp[d % 2], d == (dim - 1) ? chebyshev_coeffs : tmp[(d + 1) % 2]));
+                CeedCall(CeedTensorContractApply(basis->contract, pre, 1, post, Q_1d, chebyshev_x, t_mode,
+                                                 (p > 0 || (p == 0 && pass > 0)) && d == (dim - 1), tmp[d % 2],
+                                                 d == (dim - 1) ? chebyshev_coeffs : tmp[(d + 1) % 2]));
                 pre /= 1;
                 post *= Q_1d;
               }

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -1131,7 +1131,7 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode t_mode,
   @param[in]  elem    Element number in range 0..@a num_elem
   @param[in]  t_mode  Apply restriction or transpose
   @param[in]  u       Input vector (of size @a l_size when t_mode=@ref CEED_NOTRANSPOSE)
-  @param[out] ru      Output vector (of shape [@a num_elem * @a elem_size] when t_mode=@ref CEED_NOTRANSPOSE).
+  @param[out] ru      Output vector (of shape [@a num_points * @a num_comp] when t_mode=@ref CEED_NOTRANSPOSE).
                         Ordering of the e-vector is decided by the backend.
   @param[in]  request Request or @ref CEED_REQUEST_IMMEDIATE
 

--- a/tests/t351-basis.c
+++ b/tests/t351-basis.c
@@ -75,13 +75,13 @@ int main(int argc, char **argv) {
       for (CeedInt i = 0; i < num_points; i++) {
         CeedScalar coord[dim];
 
-        for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d + i * dim];
+        for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d * num_points + i];
         const CeedScalar fx = Eval(dim, coord);
         if (fabs(v_array[i] - fx) > 1E-4) {
           // LCOV_EXCL_START
           printf("[%" CeedInt_FMT "] %f != %f = f(%f", dim, v_array[i], fx, coord[0]);
           for (CeedInt d = 1; d < dim; d++) printf(", %f", coord[d]);
-          puts(")");
+          printf(")\n");
           // LCOV_EXCL_STOP
         }
       }

--- a/tests/t352-basis.c
+++ b/tests/t352-basis.c
@@ -75,14 +75,14 @@ int main(int argc, char **argv) {
       for (CeedInt i = 0; i < num_points; i++) {
         CeedScalar coord[dim];
 
-        for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d + i * dim];
+        for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d * num_points + i];
         for (CeedInt c = 0; c < num_comp; c++) {
           CeedScalar fx = Eval(dim, c, coord);
           if (fabs(v_array[c * num_points + i] - fx) > 1E-4) {
             // LCOV_EXCL_START
             printf("[%" CeedInt_FMT ", %" CeedInt_FMT "] %f != %f = f(%f", dim, c, v_array[c + i * num_comp], fx, coord[0]);
             for (CeedInt d = 1; d < dim; d++) printf(", %f", coord[d]);
-            puts(")");
+            printf(")\n");
             // LCOV_EXCL_STOP
           }
         }

--- a/tests/t352-basis.c
+++ b/tests/t352-basis.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
         for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d + i * dim];
         for (CeedInt c = 0; c < num_comp; c++) {
           CeedScalar fx = Eval(dim, c, coord);
-          if (fabs(v_array[c + i * num_comp] - fx) > 1E-4) {
+          if (fabs(v_array[c * num_points + i] - fx) > 1E-4) {
             // LCOV_EXCL_START
             printf("[%" CeedInt_FMT ", %" CeedInt_FMT "] %f != %f = f(%f", dim, c, v_array[c + i * num_comp], fx, coord[0]);
             for (CeedInt d = 1; d < dim; d++) printf(", %f", coord[d]);

--- a/tests/t354-basis.c
+++ b/tests/t354-basis.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
       CeedVectorGetArrayRead(x_points, CEED_MEM_HOST, &x_array);
       CeedVectorGetArrayRead(u, CEED_MEM_HOST, &u_array);
       CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
-      for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d + i * dim];
+      for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d * num_points + i];
       CeedVectorSetArray(x_point, CEED_MEM_HOST, CEED_COPY_VALUES, coord);
       CeedBasisApplyAtPoints(basis_u, 1, CEED_TRANSPOSE, CEED_EVAL_INTERP, x_point, v_point, u_point);
       CeedVectorGetArrayRead(u_point, CEED_MEM_HOST, &u_point_array);
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         // LCOV_EXCL_START
         printf("[%" CeedInt_FMT "] %f != %f = f(%f", dim, v_array[i], fx, coord[0]);
         for (CeedInt d = 1; d < dim; d++) printf(", %f", coord[d]);
-        puts(")");
+        printf(")\n");
         // LCOV_EXCL_STOP
       }
       CeedVectorRestoreArrayRead(u_point, &u_point_array);

--- a/tests/t356-basis.c
+++ b/tests/t356-basis.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d + i * dim];
         for (CeedInt d = 0; d < dim; d++) {
           const CeedScalar dfx = EvalGrad(dim, coord, d);
-          if (fabs(v_array[i * dim + d] - dfx) > 1E-3) {
+          if (fabs(v_array[d * num_points + i] - dfx) > 1E-3) {
             // LCOV_EXCL_START
             printf("[%" CeedInt_FMT "] %f != %f = df(%f", dim, v_array[i * dim + d], dfx, coord[0]);
             for (CeedInt d = 1; d < dim; d++) printf(", %f", coord[d]);

--- a/tests/t356-basis.c
+++ b/tests/t356-basis.c
@@ -85,14 +85,15 @@ int main(int argc, char **argv) {
       for (CeedInt i = 0; i < num_points; i++) {
         CeedScalar coord[dim];
 
-        for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d + i * dim];
+        for (CeedInt d = 0; d < dim; d++) coord[d] = x_array[d * num_points + i];
         for (CeedInt d = 0; d < dim; d++) {
           const CeedScalar dfx = EvalGrad(dim, coord, d);
+
           if (fabs(v_array[d * num_points + i] - dfx) > 1E-3) {
             // LCOV_EXCL_START
-            printf("[%" CeedInt_FMT "] %f != %f = df(%f", dim, v_array[i * dim + d], dfx, coord[0]);
+            printf("[%" CeedInt_FMT "] %f != %f = df(%f", dim, v_array[d * num_points + i], dfx, coord[0]);
             for (CeedInt d = 1; d < dim; d++) printf(", %f", coord[d]);
-            puts(")");
+            printf(")\n");
             // LCOV_EXCL_STOP
           }
         }


### PR DESCRIPTION
This PR swaps to "contiguous by qpt" ordering for the output of AtPoints operations so we can reuse our QFunctions.

~~Something is wrong with my TensorContract in 2d/3d~~