### PR TITLE
Docstring consistency

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ AlignEscapedNewlines:         true
 AlignOperands:                Align
 AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 ColumnLimit:                  150
+ReflowComments:               false
 CommentPragmas:               'TESTARGS'
 DerivePointerAlignment:       false
 IncludeBlocks:                Preserve

--- a/gallery/ceed-gallery-list.h
+++ b/gallery/ceed-gallery-list.h
@@ -8,11 +8,9 @@
 // This header does not have guards because it is included multiple times.
 
 // List each gallery registration function once here.
-// This will be expanded inside CeedQFunctionRegisterAll() to call each registration function in the order listed, and also to define weak symbol
-// aliases for QFunctions that are not configured.
+// This will be expanded inside @ref CeedQFunctionRegisterAll() to call each registration function in the order listed, and also to define weak symbol aliases for @ref CeedQFunction that are not configured.
 //
-// At the time of this writing, all the gallery functions are defined, but we're adopting the same strategy here as for the backends because future
-// gallery QFunctions might depend on external libraries.
+// At the time of this writing, all the gallery functions are defined, but we're adopting the same strategy here as for the backends because future gallery @ref CeedQFunction might depend on external libraries.
 
 CEED_GALLERY_QFUNCTION(CeedQFunctionRegister_Identity)
 CEED_GALLERY_QFUNCTION(CeedQFunctionRegister_Mass1DBuild)

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -12,7 +12,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields identity @ref CeedQFunction that copies inputs directly into outputs
+  @brief Set fields identity `CeedQFunction` that copies inputs directly into outputs
 **/
 static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -36,7 +36,7 @@ static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested, CeedQFun
 }
 
 /**
-  @brief Register identity @ref CeedQFunction that copies inputs directly into outputs
+  @brief Register identity `CeedQFunction` that copies inputs directly into outputs
 **/
 CEED_INTERN int CeedQFunctionRegister_Identity(void) {
   return CeedQFunctionRegister("Identity", Identity_loc, 1, Identity, CeedQFunctionInit_Identity);

--- a/gallery/identity/ceed-identity.c
+++ b/gallery/identity/ceed-identity.c
@@ -12,7 +12,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields identity QFunction that copies inputs directly into outputs
+  @brief Set fields identity @ref CeedQFunction that copies inputs directly into outputs
 **/
 static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -36,7 +36,7 @@ static int CeedQFunctionInit_Identity(Ceed ceed, const char *requested, CeedQFun
 }
 
 /**
-  @brief Register identity QFunction that copies inputs directly into outputs
+  @brief Register identity @ref CeedQFunction that copies inputs directly into outputs
 **/
 CEED_INTERN int CeedQFunctionRegister_Identity(void) {
   return CeedQFunctionRegister("Identity", Identity_loc, 1, Identity, CeedQFunctionInit_Identity);

--- a/gallery/mass-vector/ceed-vectormassapply.c
+++ b/gallery/mass-vector/ceed-vectormassapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction for applying the mass matrix on a vector system with three components
+  @brief Set fields for `CeedQFunction` for applying the mass matrix on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3MassApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3MassApply(Ceed ceed, const char *requested, 
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the mass matrix on a vector system with three components
+  @brief Register `CeedQFunction` for applying the mass matrix on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3MassApply(void) {
   return CeedQFunctionRegister("Vector3MassApply", Vector3MassApply_loc, 1, Vector3MassApply, CeedQFunctionInit_Vector3MassApply);

--- a/gallery/mass-vector/ceed-vectormassapply.c
+++ b/gallery/mass-vector/ceed-vectormassapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction for applying the mass matrix on a vector system with three components
+  @brief Set fields for @ref CeedQFunction for applying the mass matrix on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3MassApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3MassApply(Ceed ceed, const char *requested, 
 }
 
 /**
-  @brief Register Ceed QFunction for applying the mass matrix on a vector system with three components
+  @brief Register @ref CeedQFunction for applying the mass matrix on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3MassApply(void) {
   return CeedQFunctionRegister("Vector3MassApply", Vector3MassApply_loc, 1, Vector3MassApply, CeedQFunctionInit_Vector3MassApply);

--- a/gallery/mass/ceed-mass1dbuild.c
+++ b/gallery/mass/ceed-mass1dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction building the geometric data for the 1D mass matrix
+  @brief Set fields for @ref CeedQFunction building the geometric data for the 1D mass matrix
 **/
 static int CeedQFunctionInit_Mass1DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Mass1DBuild(Ceed ceed, const char *requested, CeedQ
 }
 
 /**
-  @brief Register Ceed QFunction for building the geometric data for the 1D mass matrix
+  @brief Register @ref CeedQFunction for building the geometric data for the 1D mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_Mass1DBuild(void) {
   return CeedQFunctionRegister("Mass1DBuild", Mass1DBuild_loc, 1, Mass1DBuild, CeedQFunctionInit_Mass1DBuild);

--- a/gallery/mass/ceed-mass1dbuild.c
+++ b/gallery/mass/ceed-mass1dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction building the geometric data for the 1D mass matrix
+  @brief Set fields for `CeedQFunction` building the geometric data for the 1D mass matrix
 **/
 static int CeedQFunctionInit_Mass1DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Mass1DBuild(Ceed ceed, const char *requested, CeedQ
 }
 
 /**
-  @brief Register @ref CeedQFunction for building the geometric data for the 1D mass matrix
+  @brief Register `CeedQFunction` for building the geometric data for the 1D mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_Mass1DBuild(void) {
   return CeedQFunctionRegister("Mass1DBuild", Mass1DBuild_loc, 1, Mass1DBuild, CeedQFunctionInit_Mass1DBuild);

--- a/gallery/mass/ceed-mass2dbuild.c
+++ b/gallery/mass/ceed-mass2dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction building the geometric data for the 2D mass matrix
+  @brief Set fields for `CeedQFunction` building the geometric data for the 2D mass matrix
 **/
 static int CeedQFunctionInit_Mass2DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Mass2DBuild(Ceed ceed, const char *requested, CeedQ
 }
 
 /**
-  @brief Register @ref CeedQFunction for building the geometric data for the 2D mass matrix
+  @brief Register `CeedQFunction` for building the geometric data for the 2D mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_Mass2DBuild(void) {
   return CeedQFunctionRegister("Mass2DBuild", Mass2DBuild_loc, 1, Mass2DBuild, CeedQFunctionInit_Mass2DBuild);

--- a/gallery/mass/ceed-mass2dbuild.c
+++ b/gallery/mass/ceed-mass2dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction building the geometric data for the 2D mass matrix
+  @brief Set fields for @ref CeedQFunction building the geometric data for the 2D mass matrix
 **/
 static int CeedQFunctionInit_Mass2DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Mass2DBuild(Ceed ceed, const char *requested, CeedQ
 }
 
 /**
-  @brief Register Ceed QFunction for building the geometric data for the 2D mass matrix
+  @brief Register @ref CeedQFunction for building the geometric data for the 2D mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_Mass2DBuild(void) {
   return CeedQFunctionRegister("Mass2DBuild", Mass2DBuild_loc, 1, Mass2DBuild, CeedQFunctionInit_Mass2DBuild);

--- a/gallery/mass/ceed-mass3dbuild.c
+++ b/gallery/mass/ceed-mass3dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction building the geometric data for the 3D mass matrix
+  @brief Set fields for @ref CeedQFunction building the geometric data for the 3D mass matrix
 **/
 static int CeedQFunctionInit_Mass3DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Mass3DBuild(Ceed ceed, const char *requested, CeedQ
 }
 
 /**
-  @brief Register Ceed QFunction for building the geometric data for the 3D mass matrix
+  @brief Register @ref CeedQFunction for building the geometric data for the 3D mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_Mass3DBuild(void) {
   return CeedQFunctionRegister("Mass3DBuild", Mass3DBuild_loc, 1, Mass3DBuild, CeedQFunctionInit_Mass3DBuild);

--- a/gallery/mass/ceed-mass3dbuild.c
+++ b/gallery/mass/ceed-mass3dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction building the geometric data for the 3D mass matrix
+  @brief Set fields for `CeedQFunction` building the geometric data for the 3D mass matrix
 **/
 static int CeedQFunctionInit_Mass3DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Mass3DBuild(Ceed ceed, const char *requested, CeedQ
 }
 
 /**
-  @brief Register @ref CeedQFunction for building the geometric data for the 3D mass matrix
+  @brief Register `CeedQFunction` for building the geometric data for the 3D mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_Mass3DBuild(void) {
   return CeedQFunctionRegister("Mass3DBuild", Mass3DBuild_loc, 1, Mass3DBuild, CeedQFunctionInit_Mass3DBuild);

--- a/gallery/mass/ceed-massapply.c
+++ b/gallery/mass/ceed-massapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction for applying the mass matrix
+  @brief Set fields for `CeedQFunction` for applying the mass matrix
 **/
 static int CeedQFunctionInit_MassApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -29,7 +29,7 @@ static int CeedQFunctionInit_MassApply(Ceed ceed, const char *requested, CeedQFu
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the mass matrix
+  @brief Register `CeedQFunction` for applying the mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_MassApply(void) {
   return CeedQFunctionRegister("MassApply", MassApply_loc, 1, MassApply, CeedQFunctionInit_MassApply);

--- a/gallery/mass/ceed-massapply.c
+++ b/gallery/mass/ceed-massapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction for applying the mass matrix
+  @brief Set fields for @ref CeedQFunction for applying the mass matrix
 **/
 static int CeedQFunctionInit_MassApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -29,7 +29,7 @@ static int CeedQFunctionInit_MassApply(Ceed ceed, const char *requested, CeedQFu
 }
 
 /**
-  @brief Register Ceed QFunction for applying the mass matrix
+  @brief Register @ref CeedQFunction for applying the mass matrix
 **/
 CEED_INTERN int CeedQFunctionRegister_MassApply(void) {
   return CeedQFunctionRegister("MassApply", MassApply_loc, 1, MassApply, CeedQFunctionInit_MassApply);

--- a/gallery/poisson-vector/ceed-vectorpoisson1dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson1dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction applying the 1D Poisson operator on a vector system with three components
+  @brief Set fields for @ref CeedQFunction applying the 1D Poisson operator on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3Poisson1DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3Poisson1DApply(Ceed ceed, const char *reques
 }
 
 /**
-  @brief Register Ceed QFunction for applying the 1D Poisson operator on a vector system with three components
+  @brief Register @ref CeedQFunction for applying the 1D Poisson operator on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3Poisson1DApply(void) {
   return CeedQFunctionRegister("Vector3Poisson1DApply", Vector3Poisson1DApply_loc, 1, Vector3Poisson1DApply, CeedQFunctionInit_Vector3Poisson1DApply);

--- a/gallery/poisson-vector/ceed-vectorpoisson1dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson1dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction applying the 1D Poisson operator on a vector system with three components
+  @brief Set fields for `CeedQFunction` applying the 1D Poisson operator on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3Poisson1DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3Poisson1DApply(Ceed ceed, const char *reques
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the 1D Poisson operator on a vector system with three components
+  @brief Register `CeedQFunction` for applying the 1D Poisson operator on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3Poisson1DApply(void) {
   return CeedQFunctionRegister("Vector3Poisson1DApply", Vector3Poisson1DApply_loc, 1, Vector3Poisson1DApply, CeedQFunctionInit_Vector3Poisson1DApply);

--- a/gallery/poisson-vector/ceed-vectorpoisson2dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson2dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction applying the 2D Poisson operator on a vector system with three components
+  @brief Set fields for @ref CeedQFunction applying the 2D Poisson operator on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3Poisson2DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3Poisson2DApply(Ceed ceed, const char *reques
 }
 
 /**
-  @brief Register Ceed QFunction for applying the 2D Poisson operator on a vector system with three components
+  @brief Register @ref CeedQFunction for applying the 2D Poisson operator on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3Poisson2DApply(void) {
   return CeedQFunctionRegister("Vector3Poisson2DApply", Vector3Poisson2DApply_loc, 1, Vector3Poisson2DApply, CeedQFunctionInit_Vector3Poisson2DApply);

--- a/gallery/poisson-vector/ceed-vectorpoisson2dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson2dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction applying the 2D Poisson operator on a vector system with three components
+  @brief Set fields for `CeedQFunction` applying the 2D Poisson operator on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3Poisson2DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3Poisson2DApply(Ceed ceed, const char *reques
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the 2D Poisson operator on a vector system with three components
+  @brief Register `CeedQFunction` for applying the 2D Poisson operator on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3Poisson2DApply(void) {
   return CeedQFunctionRegister("Vector3Poisson2DApply", Vector3Poisson2DApply_loc, 1, Vector3Poisson2DApply, CeedQFunctionInit_Vector3Poisson2DApply);

--- a/gallery/poisson-vector/ceed-vectorpoisson3dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson3dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction applying the 3D Poisson operator on a vector system with three components
+  @brief Set fields for @ref CeedQFunction applying the 3D Poisson operator on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3Poisson3DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3Poisson3DApply(Ceed ceed, const char *reques
 }
 
 /**
-  @brief Register Ceed QFunction for applying the 3D Poisson operator on a vector system with three components
+  @brief Register @ref CeedQFunction for applying the 3D Poisson operator on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3Poisson3DApply(void) {
   return CeedQFunctionRegister("Vector3Poisson3DApply", Vector3Poisson3DApply_loc, 1, Vector3Poisson3DApply, CeedQFunctionInit_Vector3Poisson3DApply);

--- a/gallery/poisson-vector/ceed-vectorpoisson3dapply.c
+++ b/gallery/poisson-vector/ceed-vectorpoisson3dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction applying the 3D Poisson operator on a vector system with three components
+  @brief Set fields for `CeedQFunction` applying the 3D Poisson operator on a vector system with three components
 **/
 static int CeedQFunctionInit_Vector3Poisson3DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Vector3Poisson3DApply(Ceed ceed, const char *reques
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the 3D Poisson operator on a vector system with three components
+  @brief Register `CeedQFunction` for applying the 3D Poisson operator on a vector system with three components
 **/
 CEED_INTERN int CeedQFunctionRegister_Vector3Poisson3DApply(void) {
   return CeedQFunctionRegister("Vector3Poisson3DApply", Vector3Poisson3DApply_loc, 1, Vector3Poisson3DApply, CeedQFunctionInit_Vector3Poisson3DApply);

--- a/gallery/poisson/ceed-poisson1dapply.c
+++ b/gallery/poisson/ceed-poisson1dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction applying the 1D Poisson operator
+  @brief Set fields for `CeedQFunction` applying the 1D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson1DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson1DApply(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the 1D Poisson operator
+  @brief Register `CeedQFunction` for applying the 1D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson1DApply(void) {
   return CeedQFunctionRegister("Poisson1DApply", Poisson1DApply_loc, 1, Poisson1DApply, CeedQFunctionInit_Poisson1DApply);

--- a/gallery/poisson/ceed-poisson1dapply.c
+++ b/gallery/poisson/ceed-poisson1dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction applying the 1D Poisson operator
+  @brief Set fields for @ref CeedQFunction applying the 1D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson1DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson1DApply(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register Ceed QFunction for applying the 1D Poisson operator
+  @brief Register @ref CeedQFunction for applying the 1D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson1DApply(void) {
   return CeedQFunctionRegister("Poisson1DApply", Poisson1DApply_loc, 1, Poisson1DApply, CeedQFunctionInit_Poisson1DApply);

--- a/gallery/poisson/ceed-poisson1dbuild.c
+++ b/gallery/poisson/ceed-poisson1dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction building the geometric data for the 1D Poisson operator
+  @brief Set fields for @ref CeedQFunction building the geometric data for the 1D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson1DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson1DBuild(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register Ceed QFunction for building the geometric data for the 1D Poisson operator
+  @brief Register @ref CeedQFunction for building the geometric data for the 1D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson1DBuild(void) {
   return CeedQFunctionRegister("Poisson1DBuild", Poisson1DBuild_loc, 1, Poisson1DBuild, CeedQFunctionInit_Poisson1DBuild);

--- a/gallery/poisson/ceed-poisson1dbuild.c
+++ b/gallery/poisson/ceed-poisson1dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction building the geometric data for the 1D Poisson operator
+  @brief Set fields for `CeedQFunction` building the geometric data for the 1D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson1DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson1DBuild(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register @ref CeedQFunction for building the geometric data for the 1D Poisson operator
+  @brief Register `CeedQFunction` for building the geometric data for the 1D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson1DBuild(void) {
   return CeedQFunctionRegister("Poisson1DBuild", Poisson1DBuild_loc, 1, Poisson1DBuild, CeedQFunctionInit_Poisson1DBuild);

--- a/gallery/poisson/ceed-poisson2dapply.c
+++ b/gallery/poisson/ceed-poisson2dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction applying the 2D Poisson operator
+  @brief Set fields for `CeedQFunction` applying the 2D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson2DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson2DApply(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the 2D Poisson operator
+  @brief Register `CeedQFunction` for applying the 2D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson2DApply(void) {
   return CeedQFunctionRegister("Poisson2DApply", Poisson2DApply_loc, 1, Poisson2DApply, CeedQFunctionInit_Poisson2DApply);

--- a/gallery/poisson/ceed-poisson2dapply.c
+++ b/gallery/poisson/ceed-poisson2dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction applying the 2D Poisson operator
+  @brief Set fields for @ref CeedQFunction applying the 2D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson2DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson2DApply(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register Ceed QFunction for applying the 2D Poisson operator
+  @brief Register @ref CeedQFunction for applying the 2D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson2DApply(void) {
   return CeedQFunctionRegister("Poisson2DApply", Poisson2DApply_loc, 1, Poisson2DApply, CeedQFunctionInit_Poisson2DApply);

--- a/gallery/poisson/ceed-poisson2dbuild.c
+++ b/gallery/poisson/ceed-poisson2dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction building the geometric data for the 2D Poisson operator
+  @brief Set fields for `CeedQFunction` building the geometric data for the 2D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson2DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson2DBuild(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register @ref CeedQFunction for building the geometric data for the 2D Poisson operator
+  @brief Register `CeedQFunction` for building the geometric data for the 2D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson2DBuild(void) {
   return CeedQFunctionRegister("Poisson2DBuild", Poisson2DBuild_loc, 1, Poisson2DBuild, CeedQFunctionInit_Poisson2DBuild);

--- a/gallery/poisson/ceed-poisson2dbuild.c
+++ b/gallery/poisson/ceed-poisson2dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction building the geometric data for the 2D Poisson operator
+  @brief Set fields for @ref CeedQFunction building the geometric data for the 2D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson2DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson2DBuild(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register Ceed QFunction for building the geometric data for the 2D Poisson operator
+  @brief Register @ref CeedQFunction for building the geometric data for the 2D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson2DBuild(void) {
   return CeedQFunctionRegister("Poisson2DBuild", Poisson2DBuild_loc, 1, Poisson2DBuild, CeedQFunctionInit_Poisson2DBuild);

--- a/gallery/poisson/ceed-poisson3dapply.c
+++ b/gallery/poisson/ceed-poisson3dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction applying the 3D Poisson operator
+  @brief Set fields for `CeedQFunction` applying the 3D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson3DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson3DApply(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register @ref CeedQFunction for applying the 3D Poisson operator
+  @brief Register `CeedQFunction` for applying the 3D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson3DApply(void) {
   return CeedQFunctionRegister("Poisson3DApply", Poisson3DApply_loc, 1, Poisson3DApply, CeedQFunctionInit_Poisson3DApply);

--- a/gallery/poisson/ceed-poisson3dapply.c
+++ b/gallery/poisson/ceed-poisson3dapply.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction applying the 3D Poisson operator
+  @brief Set fields for @ref CeedQFunction applying the 3D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson3DApply(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson3DApply(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register Ceed QFunction for applying the 3D Poisson operator
+  @brief Register @ref CeedQFunction for applying the 3D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson3DApply(void) {
   return CeedQFunctionRegister("Poisson3DApply", Poisson3DApply_loc, 1, Poisson3DApply, CeedQFunctionInit_Poisson3DApply);

--- a/gallery/poisson/ceed-poisson3dbuild.c
+++ b/gallery/poisson/ceed-poisson3dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for Ceed QFunction building the geometric data for the 3D Poisson operator
+  @brief Set fields for @ref CeedQFunction building the geometric data for the 3D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson3DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson3DBuild(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register Ceed QFunction for building the geometric data for the 3D Poisson operator
+  @brief Register @ref CeedQFunction for building the geometric data for the 3D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson3DBuild(void) {
   return CeedQFunctionRegister("Poisson3DBuild", Poisson3DBuild_loc, 1, Poisson3DBuild, CeedQFunctionInit_Poisson3DBuild);

--- a/gallery/poisson/ceed-poisson3dbuild.c
+++ b/gallery/poisson/ceed-poisson3dbuild.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief Set fields for @ref CeedQFunction building the geometric data for the 3D Poisson operator
+  @brief Set fields for `CeedQFunction` building the geometric data for the 3D Poisson operator
 **/
 static int CeedQFunctionInit_Poisson3DBuild(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -30,7 +30,7 @@ static int CeedQFunctionInit_Poisson3DBuild(Ceed ceed, const char *requested, Ce
 }
 
 /**
-  @brief Register @ref CeedQFunction for building the geometric data for the 3D Poisson operator
+  @brief Register `CeedQFunction` for building the geometric data for the 3D Poisson operator
 **/
 CEED_INTERN int CeedQFunctionRegister_Poisson3DBuild(void) {
   return CeedQFunctionRegister("Poisson3DBuild", Poisson3DBuild_loc, 1, Poisson3DBuild, CeedQFunctionInit_Poisson3DBuild);

--- a/gallery/scale/ceed-scale.c
+++ b/gallery/scale/ceed-scale.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief  Set fields for vector scaling QFunction that scales inputs
+  @brief  Set fields for vector scaling @ref CeedQFunction that scales inputs
 **/
 static int CeedQFunctionInit_Scale(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -24,6 +24,6 @@ static int CeedQFunctionInit_Scale(Ceed ceed, const char *requested, CeedQFuncti
 }
 
 /**
-  @brief Register scaling QFunction
+  @brief Register scaling @ref CeedQFunction
 **/
 CEED_INTERN int CeedQFunctionRegister_Scale(void) { return CeedQFunctionRegister("Scale", Scale_loc, 1, Scale, CeedQFunctionInit_Scale); }

--- a/gallery/scale/ceed-scale.c
+++ b/gallery/scale/ceed-scale.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /**
-  @brief  Set fields for vector scaling @ref CeedQFunction that scales inputs
+  @brief  Set fields for vector scaling `CeedQFunction` that scales inputs
 **/
 static int CeedQFunctionInit_Scale(Ceed ceed, const char *requested, CeedQFunction qf) {
   // Check QFunction name
@@ -24,6 +24,6 @@ static int CeedQFunctionInit_Scale(Ceed ceed, const char *requested, CeedQFuncti
 }
 
 /**
-  @brief Register scaling @ref CeedQFunction
+  @brief Register scaling `CeedQFunction`
 **/
 CEED_INTERN int CeedQFunctionRegister_Scale(void) { return CeedQFunctionRegister("Scale", Scale_loc, 1, Scale, CeedQFunctionInit_Scale); }

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -206,9 +206,9 @@ struct CeedBasis_private {
   CeedScalar *div; /* row-major matrix of shape [Q, P] expressing the divergence of basis functions at quadrature points for H(div) discretizations */
   CeedScalar *curl; /* row-major matrix of shape [curl_dim * Q, P], curl_dim = 1 if dim < 3 else dim, expressing the curl of basis functions at
                        quadrature points for H(curl) discretizations */
-  CeedVector vec_chebyshev;
-  CeedBasis  basis_chebyshev; /* basis interpolating from nodes to Chebyshev polynomial coefficients */
-  void      *data;            /* place for the backend to store any data */
+  CeedVector  vec_chebyshev;
+  CeedBasis   basis_chebyshev; /* basis interpolating from nodes to Chebyshev polynomial coefficients */
+  void       *data;            /* place for the backend to store any data */
 };
 
 struct CeedTensorContract_private {

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -37,11 +37,11 @@
 #define CEED_VISIBILITY(mode)
 #endif
 
-/**
+/*
   CEED_EXTERN is used in this header to denote all publicly visible symbols.
 
   No other file should declare publicly visible symbols, thus it should never be used outside `"ceed.h"`.
- */
+*/
 #if defined(__clang_analyzer__)
 #define CEED_EXTERN extern
 #elif defined(__cplusplus)
@@ -54,9 +54,14 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-/// Typedefs and macros used in public interfaces and user @ref CeedQFunction source
+/*
+  Typedefs and macros used in public interfaces and user `CeedQFunction` source
+*/
 #include "types.h"  // IWYU pragma: export
-/// This line prevents IWYU from suggesting "ceed.h"
+
+/*
+  This line prevents IWYU from suggesting "ceed.h"
+*/
 // IWYU pragma: private, include <ceed.h>
 
 /// Library context created by CeedInit()
@@ -92,7 +97,7 @@ typedef struct CeedQFunctionContext_private *CeedQFunctionContext;
 typedef struct CeedContextFieldLabel_private *CeedContextFieldLabel;
 /// Handle for object describing FE-type operators acting on vectors
 ///
-/// Given an element restriction \f$E\f$, basis evaluator \f$B\f$, and quadrature function\f$f\f$, a @ref CeedOperator expresses operations of the form \f$E^T B^T f(B E u)\f$ acting on the vector \f$u\f$.
+/// Given an element restriction \f$E\f$, basis evaluator \f$B\f$, and quadrature function\f$f\f$, a `CeedOperator` expresses operations of the form \f$E^T B^T f(B E u)\f$ acting on the vector \f$u\f$.
 /// @ingroup CeedOperatorUser
 typedef struct CeedOperator_private *CeedOperator;
 
@@ -107,9 +112,9 @@ CEED_EXTERN int CeedView(Ceed ceed, FILE *stream);
 CEED_EXTERN int CeedDestroy(Ceed *ceed);
 CEED_EXTERN int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func, int ecode, const char *format, ...);
 
-/// Raise an error on @ref Ceed object
+/// Raise an error on `Ceed` object
 ///
-/// @param ceed Ceed library context or NULL
+/// @param ceed `Ceed` library context or `NULL`
 /// @param ecode Error code (int)
 /// @param ... printf-style format string followed by arguments as needed
 ///
@@ -205,7 +210,7 @@ CEED_EXTERN int                CeedRequestWait(CeedRequest *req);
 /// @ingroup CeedVector
 CEED_EXTERN const CeedVector CEED_VECTOR_ACTIVE;
 
-/// Argument for @ref CeedOperatorSetField() to use no vector.
+/// Argument for @ref CeedOperatorSetField() to use no `CeedVector`.
 /// Only use this option with @ref CeedEvalMode @ref CEED_EVAL_WEIGHT.
 /// @ingroup CeedVector
 CEED_EXTERN const CeedVector CEED_VECTOR_NONE;
@@ -217,18 +222,18 @@ CEED_EXTERN const CeedBasis CEED_BASIS_NONE;
 
 CEED_EXTERN const CeedBasis CEED_BASIS_COLLOCATED;
 
-/// Argument for @ref CeedOperatorSetField() to use no @ref CeedElemRestriction.
+/// Argument for @ref CeedOperatorSetField() to use no `CeedElemRestriction`.
 /// Only use this option with @ref CeedEvalMode @ref CEED_EVAL_WEIGHT.
 /// @ingroup CeedElemRestriction
 CEED_EXTERN const CeedElemRestriction CEED_ELEMRESTRICTION_NONE;
 
-/// Argument for @ref CeedOperatorCreate() that @ref CeedQFunction is not created by user.
-/// Only used for @ref CeedQFunction `dqf` and `dqfT`.
-/// If implemented, a backend may attempt to provide the action of these @ref CeedQFunction.
+/// Argument for @ref CeedOperatorCreate() that `CeedQFunction` is not created by user.
+/// Only used for `CeedQFunction` `dqf` and `dqfT`.
+/// If implemented, a backend may attempt to provide the action of these `CeedQFunction`.
 /// @ingroup CeedQFunction
 CEED_EXTERN const CeedQFunction CEED_QFUNCTION_NONE;
 
-/// Argument for @ref CeedElemRestrictionCreateStrided that L-vector is in the Ceed backend's preferred layout.
+/// Argument for @ref CeedElemRestrictionCreateStrided() that L-vector is in the Ceed backend's preferred layout.
 /// This argument should only be used with vectors created by a Ceed backend.
 /// @ingroup CeedElemRestriction
 CEED_EXTERN const CeedInt CEED_STRIDES_BACKEND[3];
@@ -321,7 +326,7 @@ CEED_EXTERN int CeedBasisDestroy(CeedBasis *basis);
 CEED_EXTERN int CeedGaussQuadrature(CeedInt Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d);
 CEED_EXTERN int CeedLobattoQuadrature(CeedInt Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d);
 
-/** Handle for the user provided @ref CeedQFunction callback function
+/** Handle for the user provided `CeedQFunction` callback function
 
  @param[in,out] ctx User-defined context set using @ref CeedQFunctionSetContext() or `NULL`
  @param[in] Q       Number of quadrature points at which to evaluate
@@ -359,7 +364,7 @@ CEED_EXTERN int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedE
 
 /** Handle for the user provided @ref CeedQFunctionContextDestroy() callback function
 
- @param[in,out] data  User @ref CeedQFunctionContext data
+ @param[in,out] data  User `CeedQFunctionContext` data
 
  @return An error code: 0 - success, otherwise - failure
 

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -21,15 +21,15 @@
 /// requires.
 /// @section Utility Utility Functions
 ///    These functions are intended general utilities that may be useful to libCEED developers and users.
-///    These functions can generally be found in "ceed.h".
+///    These functions can generally be found in `"ceed.h"`.
 /// @section User User Functions
-///    These functions are intended to be used by general users of libCEED and can generally be found in "ceed.h".
+///    These functions are intended to be used by general users of libCEED and can generally be found in `"ceed.h"`.
 /// @section Advanced Advanced Functions
-///    These functions are intended to be used by advanced users of libCEED and can generally be found in "ceed.h".
+///    These functions are intended to be used by advanced users of libCEED and can generally be found in `"ceed.h"`.
 /// @section Backend Backend Developer Functions
-///    These functions are intended to be used by backend developers of libCEED and can generally be found in "ceed-backend.h".
+///    These functions are intended to be used by backend developers of libCEED and can generally be found in `"ceed-backend.h"`.
 /// @section Developer Library Developer Functions
-///    These functions are intended to be used by library developers of libCEED and can generally be found in "ceed-impl.h".
+///    These functions are intended to be used by library developers of libCEED and can generally be found in `"ceed-impl.h"`.
 
 #if !defined(CEED_SKIP_VISIBILITY)
 #define CEED_VISIBILITY(mode) __attribute__((visibility(#mode)))
@@ -40,7 +40,7 @@
 /**
   CEED_EXTERN is used in this header to denote all publicly visible symbols.
 
-  No other file should declare publicly visible symbols, thus it should never be used outside ceed.h.
+  No other file should declare publicly visible symbols, thus it should never be used outside `"ceed.h"`.
  */
 #if defined(__clang_analyzer__)
 #define CEED_EXTERN extern
@@ -54,7 +54,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-/// Typedefs and macros used in public interfaces and user QFunction source
+/// Typedefs and macros used in public interfaces and user @ref CeedQFunction source
 #include "types.h"  // IWYU pragma: export
 /// This line prevents IWYU from suggesting "ceed.h"
 // IWYU pragma: private, include <ceed.h>
@@ -63,10 +63,10 @@
 /// @ingroup CeedUser
 typedef struct Ceed_private *Ceed;
 /// Non-blocking Ceed interfaces return a CeedRequest.
-/// To perform an operation immediately, pass \ref CEED_REQUEST_IMMEDIATE instead.
+/// To perform an operation immediately, pass @ref CEED_REQUEST_IMMEDIATE instead.
 /// @ingroup CeedUser
 typedef struct CeedRequest_private *CeedRequest;
-/// Handle for vectors over the field \ref CeedScalar
+/// Handle for vectors over the field @ref CeedScalar
 /// @ingroup CeedVectorUser
 typedef struct CeedVector_private *CeedVector;
 /// Handle for object describing restriction to elements
@@ -92,8 +92,7 @@ typedef struct CeedQFunctionContext_private *CeedQFunctionContext;
 typedef struct CeedContextFieldLabel_private *CeedContextFieldLabel;
 /// Handle for object describing FE-type operators acting on vectors
 ///
-/// Given an element restriction \f$E\f$, basis evaluator \f$B\f$, and quadrature function\f$f\f$, a CeedOperator expresses operations of the form
-/// \f$E^T B^T f(B E u)\f$ acting on the vector \f$u\f$.
+/// Given an element restriction \f$E\f$, basis evaluator \f$B\f$, and quadrature function\f$f\f$, a @ref CeedOperator expresses operations of the form \f$E^T B^T f(B E u)\f$ acting on the vector \f$u\f$.
 /// @ingroup CeedOperatorUser
 typedef struct CeedOperator_private *CeedOperator;
 
@@ -108,7 +107,7 @@ CEED_EXTERN int CeedView(Ceed ceed, FILE *stream);
 CEED_EXTERN int CeedDestroy(Ceed *ceed);
 CEED_EXTERN int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func, int ecode, const char *format, ...);
 
-/// Raise an error on ceed object
+/// Raise an error on @ref Ceed object
 ///
 /// @param ceed Ceed library context or NULL
 /// @param ecode Error code (int)
@@ -202,34 +201,34 @@ CEED_EXTERN CeedRequest *const CEED_REQUEST_IMMEDIATE;
 CEED_EXTERN CeedRequest *const CEED_REQUEST_ORDERED;
 CEED_EXTERN int                CeedRequestWait(CeedRequest *req);
 
-/// Argument for CeedOperatorSetField to use active input or output.
+/// Argument for @ref CeedOperatorSetField() to use active input or output.
 /// @ingroup CeedVector
 CEED_EXTERN const CeedVector CEED_VECTOR_ACTIVE;
 
-/// Argument for CeedOperatorSetField to use no vector.
-/// Only use this option with CeedEvalMode CEED_EVAL_WEIGHT.
+/// Argument for @ref CeedOperatorSetField() to use no vector.
+/// Only use this option with @ref CeedEvalMode @ref CEED_EVAL_WEIGHT.
 /// @ingroup CeedVector
 CEED_EXTERN const CeedVector CEED_VECTOR_NONE;
 
-/// Argument for CeedOperatorSetField that no basis operation is needed to translate between the E-vector and the Q-vector.
-/// Only use this option with CeedEvalMode CEED_EVAL_NONE.
+/// Argument for @ref CeedOperatorSetField() that no basis operation is needed to translate between the E-vector and the Q-vector.
+/// Only use this option with @ref CeedEvalMode @ref CEED_EVAL_NONE.
 /// @ingroup CeedBasis
 CEED_EXTERN const CeedBasis CEED_BASIS_NONE;
 
 CEED_EXTERN const CeedBasis CEED_BASIS_COLLOCATED;
 
-/// Argument for CeedOperatorSetField to use no ElemRestriction.
-/// Only use this option with CeedEvalMode CEED_EVAL_WEIGHT.
+/// Argument for @ref CeedOperatorSetField() to use no @ref CeedElemRestriction.
+/// Only use this option with @ref CeedEvalMode @ref CEED_EVAL_WEIGHT.
 /// @ingroup CeedElemRestriction
 CEED_EXTERN const CeedElemRestriction CEED_ELEMRESTRICTION_NONE;
 
-/// Argument for CeedOperatorCreate that QFunction is not created by user.
-/// Only used for QFunctions dqf and dqfT.
-/// If implemented, a backend may attempt to provide the action of these QFunctions.
+/// Argument for @ref CeedOperatorCreate() that @ref CeedQFunction is not created by user.
+/// Only used for @ref CeedQFunction `dqf` and `dqfT`.
+/// If implemented, a backend may attempt to provide the action of these @ref CeedQFunction.
 /// @ingroup CeedQFunction
 CEED_EXTERN const CeedQFunction CEED_QFUNCTION_NONE;
 
-/// Argument for CeedElemRestrictionCreateStrided that L-vector is in the Ceed backend's preferred layout.
+/// Argument for @ref CeedElemRestrictionCreateStrided that L-vector is in the Ceed backend's preferred layout.
 /// This argument should only be used with vectors created by a Ceed backend.
 /// @ingroup CeedElemRestriction
 CEED_EXTERN const CeedInt CEED_STRIDES_BACKEND[3];
@@ -322,16 +321,15 @@ CEED_EXTERN int CeedBasisDestroy(CeedBasis *basis);
 CEED_EXTERN int CeedGaussQuadrature(CeedInt Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d);
 CEED_EXTERN int CeedLobattoQuadrature(CeedInt Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d);
 
-/** Handle for the user provided CeedQFunction callback function
+/** Handle for the user provided @ref CeedQFunction callback function
 
- @param[in,out] ctx  User-defined context set using CeedQFunctionSetContext() or NULL
- @param[in] Q        Number of quadrature points at which to evaluate
- @param[in] in       Array of pointers to each input argument in the order provided by the user in CeedQFunctionAddInput().
-                       Each array has shape `[dim, num_comp, Q]` where `dim` is the geometric dimension for \ref CEED_EVAL_GRAD (`dim=1` for \ref
-CEED_EVAL_INTERP) and `num_comp` is the number of field components (`num_comp=1` for scalar fields). This results in indexing the `i`th input at
-quadrature point `j` as `in[i][(d*num_comp + c)*Q + j]`.
- @param[out]   out   Array of pointers to each output array in the order provided using CeedQFunctionAddOutput().
-                       The shapes are as above for \a in.
+ @param[in,out] ctx User-defined context set using @ref CeedQFunctionSetContext() or `NULL`
+ @param[in] Q       Number of quadrature points at which to evaluate
+ @param[in] in      Array of pointers to each input argument in the order provided by the user in @ref CeedQFunctionAddInput().
+                      Each array has shape `[dim, num_comp, Q]` where `dim` is the geometric dimension for @ref CEED_EVAL_GRAD (`dim=1` for @ref CEED_EVAL_INTERP) and `num_comp` is the number of field components (`num_comp=1` for scalar fields).
+                      This results in indexing the `i`th input at quadrature point `j` as `in[i][(d*num_comp + c)*Q + j]`.
+ @param[out]   out  Array of pointers to each output array in the order provided using @ref CeedQFunctionAddOutput().
+                      The shapes are as above for `in`.
 
  @return An error code: 0 - success, otherwise - failure
 
@@ -359,9 +357,9 @@ CEED_EXTERN int CeedQFunctionFieldGetName(CeedQFunctionField qf_field, char **fi
 CEED_EXTERN int CeedQFunctionFieldGetSize(CeedQFunctionField qf_field, CeedInt *size);
 CEED_EXTERN int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedEvalMode *eval_mode);
 
-/** Handle for the user provided CeedQFunctionContextDataDestroy callback function
+/** Handle for the user provided @ref CeedQFunctionContextDestroy() callback function
 
- @param[in,out] data  User-CeedQFunctionContext data
+ @param[in,out] data  User @ref CeedQFunctionContext data
 
  @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -23,10 +23,10 @@ static struct CeedBasis_private ceed_basis_none;
 /// @addtogroup CeedBasisUser
 /// @{
 
-/// Argument for CeedOperatorSetField indicating that the field does not require a CeedBasis
+/// Argument for @ref CeedOperatorSetField() indicating that the field does not require a @ref CeedBasis
 const CeedBasis CEED_BASIS_NONE = &ceed_basis_none;
 
-/// This feature will be removed. Use CEED_BASIS_NONE.
+/// This feature will be removed. Use @ref CEED_BASIS_NONE.
 const CeedBasis CEED_BASIS_COLLOCATED = &ceed_basis_none;
 
 /// @}
@@ -41,7 +41,7 @@ const CeedBasis CEED_BASIS_COLLOCATED = &ceed_basis_none;
   @brief Compute Chebyshev polynomial values at a point
 
   @param[in]  x           Coordinate to evaluate Chebyshev polynomials at
-  @param[in]  n           Number of Chebyshev polynomials to evaluate, n >= 2
+  @param[in]  n           Number of Chebyshev polynomials to evaluate, `n >= 2`
   @param[out] chebyshev_x Array of Chebyshev polynomial values
 
   @return An error code: 0 - success, otherwise - failure
@@ -59,7 +59,7 @@ static int CeedChebyshevPolynomialsAtPoint(CeedScalar x, CeedInt n, CeedScalar *
   @brief Compute values of the derivative of Chebyshev polynomials at a point
 
   @param[in]  x            Coordinate to evaluate derivative of Chebyshev polynomials at
-  @param[in]  n            Number of Chebyshev polynomials to evaluate, n >= 2
+  @param[in]  n            Number of Chebyshev polynomials to evaluate, `n >= 2`
   @param[out] chebyshev_dx Array of Chebyshev polynomial derivative values
 
   @return An error code: 0 - success, otherwise - failure
@@ -83,15 +83,15 @@ static int CeedChebyshevDerivativeAtPoint(CeedScalar x, CeedInt n, CeedScalar *c
 }
 
 /**
-  @brief Compute Householder reflection
+  @brief Compute Householder reflection.
 
-  Computes A = (I - b v v^T) A, where A is an mxn matrix indexed as A[i*row + j*col]
+  Computes \f$A = (I - b v v^T) A\f$, where \f$A\f$ is an \f$m \times n\f$ matrix indexed as `A[i*row + j*col]`.
 
   @param[in,out] A   Matrix to apply Householder reflection to, in place
   @param[in]     v   Householder vector
   @param[in]     b   Scaling factor
-  @param[in]     m   Number of rows in A
-  @param[in]     n   Number of columns in A
+  @param[in]     m   Number of rows in `A`
+  @param[in]     n   Number of columns in `A`
   @param[in]     row Row stride
   @param[in]     col Col stride
 
@@ -113,17 +113,17 @@ static int CeedHouseholderReflect(CeedScalar *A, const CeedScalar *v, CeedScalar
 /**
   @brief Compute Givens rotation
 
-  Computes A = G A (or G^T A in transpose mode), where A is an mxn matrix indexed as A[i*n + j*m]
+  Computes \f$A = G A\f$ (or \f$G^T A\f$ in transpose mode), where \f$A\f$ is an \f$m \times n\f$ matrix indexed as `A[i*n + j*m]`.
 
   @param[in,out] A      Row major matrix to apply Givens rotation to, in place
   @param[in]     c      Cosine factor
   @param[in]     s      Sine factor
-  @param[in]     t_mode @ref CEED_NOTRANSPOSE to rotate the basis counter-clockwise, which has the effect of rotating columns of A clockwise;
+  @param[in]     t_mode @ref CEED_NOTRANSPOSE to rotate the basis counter-clockwise, which has the effect of rotating columns of `A` clockwise;
                           @ref CEED_TRANSPOSE for the opposite rotation
   @param[in]     i      First row/column to apply rotation
   @param[in]     k      Second row/column to apply rotation
-  @param[in]     m      Number of rows in A
-  @param[in]     n      Number of columns in A
+  @param[in]     m      Number of rows in `A`
+  @param[in]     n      Number of columns in `A`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -149,14 +149,14 @@ static int CeedGivensRotation(CeedScalar *A, CeedScalar c, CeedScalar s, CeedTra
 }
 
 /**
-  @brief View an array stored in a CeedBasis
+  @brief View an array stored in a @ref CeedBasis
 
   @param[in] name   Name of array
   @param[in] fp_fmt Printing format
   @param[in] m      Number of rows in array
   @param[in] n      Number of columns in array
   @param[in] a      Array to be viewed
-  @param[in] stream Stream to view to, e.g., stdout
+  @param[in] stream Stream to view to, e.g., `stdout`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -183,14 +183,14 @@ static int CeedScalarView(const char *name, const char *fp_fmt, CeedInt m, CeedI
   @brief Create the interpolation and gradient matrices for projection from the nodes of `basis_from` to the nodes of `basis_to`.
 
   The interpolation is given by `interp_project = interp_to^+ * interp_from`, where the pseudoinverse `interp_to^+` is given by QR factorization.
-  The gradient is given by `grad_project = interp_to^+ * grad_from`, and is only computed for H^1 spaces otherwise it should not be used.
+  The gradient is given by `grad_project = interp_to^+ * grad_from`, and is only computed for \f$H^1\f$ spaces otherwise it should not be used.
 
   Note: `basis_from` and `basis_to` must have compatible quadrature spaces.
 
-  @param[in]  basis_from     CeedBasis to project from
-  @param[in]  basis_to       CeedBasis to project to
-  @param[out] interp_project Address of the variable where the newly created interpolation matrix will be stored.
-  @param[out] grad_project   Address of the variable where the newly created gradient matrix will be stored.
+  @param[in]  basis_from     @ref CeedBasis to project from
+  @param[in]  basis_to       @ref CeedBasis to project to
+  @param[out] interp_project Address of the variable where the newly created interpolation matrix will be stored
+  @param[out] grad_project   Address of the variable where the newly created gradient matrix will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -307,10 +307,10 @@ static int CeedBasisCreateProjectionMatrices(CeedBasis basis_from, CeedBasis bas
 /// @{
 
 /**
-  @brief Return collocated grad matrix
+  @brief Return collocated gradient matrix
 
-  @param[in]  basis         CeedBasis
-  @param[out] collo_grad_1d Row-major (Q_1d * Q_1d) matrix expressing derivatives of basis functions at quadrature points
+  @param[in]  basis         @ref CeedBasis
+  @param[out] collo_grad_1d Row-major (`Q_1d * Q_1d`) matrix expressing derivatives of basis functions at quadrature points
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -353,9 +353,9 @@ int CeedBasisGetCollocatedGrad(CeedBasis basis, CeedScalar *collo_grad_1d) {
 }
 
 /**
-  @brief Get tensor status for given CeedBasis
+  @brief Get tensor status for given @ref CeedBasis
 
-  @param[in]  basis     CeedBasis
+  @param[in]  basis     @ref CeedBasis
   @param[out] is_tensor Variable to store tensor status
 
   @return An error code: 0 - success, otherwise - failure
@@ -368,9 +368,9 @@ int CeedBasisIsTensor(CeedBasis basis, bool *is_tensor) {
 }
 
 /**
-  @brief Get backend data of a CeedBasis
+  @brief Get backend data of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] data  Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -383,9 +383,9 @@ int CeedBasisGetData(CeedBasis basis, void *data) {
 }
 
 /**
-  @brief Set backend data of a CeedBasis
+  @brief Set backend data of a @ref CeedBasis
 
-  @param[in,out] basis  CeedBasis
+  @param[in,out] basis  @ref CeedBasis
   @param[in]     data   Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -398,9 +398,9 @@ int CeedBasisSetData(CeedBasis basis, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a CeedBasis
+  @brief Increment the reference counter for a @ref CeedBasis
 
-  @param[in,out] basis Basis to increment the reference counter
+  @param[in,out] basis @ref CeedBasis to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -412,14 +412,14 @@ int CeedBasisReference(CeedBasis basis) {
 }
 
 /**
-  @brief Get number of Q-vector components for given CeedBasis
+  @brief Get number of Q-vector components for given @ref CeedBasis
 
-  @param[in]  basis  CeedBasis
-  @param[in]  eval_mode \ref CEED_EVAL_INTERP to use interpolated values,
-                          \ref CEED_EVAL_GRAD to use gradients,
-                          \ref CEED_EVAL_DIV to use divergence,
-                          \ref CEED_EVAL_CURL to use curl.
-  @param[out] q_comp Variable to store number of Q-vector components of basis
+  @param[in]  basis     @ref CeedBasis
+  @param[in]  eval_mode @ref CEED_EVAL_INTERP to use interpolated values,
+                          @ref CEED_EVAL_GRAD to use gradients,
+                          @ref CEED_EVAL_DIV to use divergence,
+                          @ref CEED_EVAL_CURL to use curl
+  @param[out] q_comp    Variable to store number of Q-vector components of basis
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -448,11 +448,11 @@ int CeedBasisGetNumQuadratureComponents(CeedBasis basis, CeedEvalMode eval_mode,
 }
 
 /**
-  @brief Estimate number of FLOPs required to apply CeedBasis in t_mode and eval_mode
+  @brief Estimate number of FLOPs required to apply @ref CeedBasis in `t_mode` and `eval_mode`
 
-  @param[in]  basis     Basis to estimate FLOPs for
+  @param[in]  basis     @ref CeedBasis to estimate FLOPs for
   @param[in]  t_mode    Apply basis or transpose
-  @param[in]  eval_mode Basis evaluation mode
+  @param[in]  eval_mode @ref CeedEvalMode
   @param[out] flops     Address of variable to hold FLOPs estimate
 
   @ref Backend
@@ -525,10 +525,10 @@ int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEva
 }
 
 /**
-  @brief Get CeedFESpace for a CeedBasis
+  @brief Get @ref CeedFESpace for a @ref CeedBasis
 
-  @param[in]  basis     CeedBasis
-  @param[out] fe_space  Variable to store CeedFESpace
+  @param[in]  basis    @ref CeedBasis
+  @param[out] fe_space Variable to store @ref CeedFESpace
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -540,9 +540,9 @@ int CeedBasisGetFESpace(CeedBasis basis, CeedFESpace *fe_space) {
 }
 
 /**
-  @brief Get dimension for given CeedElemTopology
+  @brief Get dimension for given @ref CeedElemTopology
 
-  @param[in]  topo CeedElemTopology
+  @param[in]  topo @ref CeedElemTopology
   @param[out] dim  Variable to store dimension of topology
 
   @return An error code: 0 - success, otherwise - failure
@@ -555,10 +555,10 @@ int CeedBasisGetTopologyDimension(CeedElemTopology topo, CeedInt *dim) {
 }
 
 /**
-  @brief Get CeedTensorContract of a CeedBasis
+  @brief Get @ref CeedTensorContract of a @ref CeedBasis
 
-  @param[in]  basis     CeedBasis
-  @param[out] contract  Variable to store CeedTensorContract
+  @param[in]  basis     @ref CeedBasis
+  @param[out] contract  Variable to store @ref CeedTensorContract
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -570,10 +570,10 @@ int CeedBasisGetTensorContract(CeedBasis basis, CeedTensorContract *contract) {
 }
 
 /**
-  @brief Set CeedTensorContract of a CeedBasis
+  @brief Set @ref CeedTensorContract of a @ref CeedBasis
 
-  @param[in,out] basis    CeedBasis
-  @param[in]     contract CeedTensorContract to set
+  @param[in,out] basis    @ref CeedBasis
+  @param[in]     contract @ref CeedTensorContract to set
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -586,17 +586,17 @@ int CeedBasisSetTensorContract(CeedBasis basis, CeedTensorContract contract) {
 }
 
 /**
-  @brief Return a reference implementation of matrix multiplication C = A B.
+  @brief Return a reference implementation of matrix multiplication \f$C = A B\f$.
 
-  Note: This is a reference implementation for CPU CeedScalar pointers that is not intended for high performance.
+  Note: This is a reference implementation for CPU @ref CeedScalar pointers that is not intended for high performance.
 
-  @param[in]  ceed  Ceed context for error handling
-  @param[in]  mat_A Row-major matrix A
-  @param[in]  mat_B Row-major matrix B
-  @param[out] mat_C Row-major output matrix C
-  @param[in]  m     Number of rows of C
-  @param[in]  n     Number of columns of C
-  @param[in]  kk    Number of columns of A/rows of B
+  @param[in]  ceed  @ref Ceed context for error handling
+  @param[in]  mat_A Row-major matrix `A`
+  @param[in]  mat_B Row-major matrix `B`
+  @param[out] mat_C Row-major output matrix `C`
+  @param[in]  m     Number of rows of `C`
+  @param[in]  n     Number of columns of `C`
+  @param[in]  kk    Number of columns of `A`/rows of `B`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -617,9 +617,9 @@ int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A, const CeedScala
 /**
   @brief Return QR Factorization of a matrix
 
-  @param[in]     ceed Ceed context for error handling
+  @param[in]     ceed @ref Ceed context for error handling
   @param[in,out] mat  Row-major matrix to be factorized in place
-  @param[in,out] tau  Vector of length m of scaling factors
+  @param[in,out] tau  Vector of length `m` of scaling factors
   @param[in]     m    Number of rows
   @param[in]     n    Number of columns
 
@@ -668,17 +668,17 @@ int CeedQRFactorization(Ceed ceed, CeedScalar *mat, CeedScalar *tau, CeedInt m, 
 /**
   @brief Apply Householder Q matrix
 
-  Compute mat_A = mat_Q mat_A, where mat_Q is mxm and mat_A is mxn.
+  Compute `mat_A = mat_Q mat_A`, where `mat_Q` is \f$m \times m\f$ and `mat_A` is \f$m \times n\f$.
 
   @param[in,out] mat_A  Matrix to apply Householder Q to, in place
   @param[in]     mat_Q  Householder Q matrix
   @param[in]     tau    Householder scaling factors
   @param[in]     t_mode Transpose mode for application
-  @param[in]     m      Number of rows in A
-  @param[in]     n      Number of columns in A
-  @param[in]     k      Number of elementary reflectors in Q, k<m
-  @param[in]     row    Row stride in A
-  @param[in]     col    Col stride in A
+  @param[in]     m      Number of rows in `A`
+  @param[in]     n      Number of columns in `A`
+  @param[in]     k      Number of elementary reflectors in Q, `k < m`
+  @param[in]     row    Row stride in `A`
+  @param[in]     col    Col stride in `A`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -702,7 +702,7 @@ int CeedHouseholderApplyQ(CeedScalar *mat_A, const CeedScalar *mat_Q, const Ceed
 /**
   @brief Return symmetric Schur decomposition of the symmetric matrix mat via symmetric QR factorization
 
-  @param[in]     ceed   Ceed context for error handling
+  @param[in]     ceed   @ref Ceed context for error handling
   @param[in,out] mat    Row-major matrix to be factorized in place
   @param[out]    lambda Vector of length n of eigenvalues
   @param[in]     n      Number of rows/columns
@@ -843,15 +843,15 @@ CeedPragmaOptimizeOn
 /**
   @brief Return Simultaneous Diagonalization of two matrices.
 
-  This solves the generalized eigenvalue problem A x = lambda B x, where A and B are symmetric and B is positive definite.
-  We generate the matrix X and vector Lambda such that X^T A X = Lambda and X^T B X = I.
-  This is equivalent to the LAPACK routine 'sygv' with TYPE = 1.
+  This solves the generalized eigenvalue problem `A x = lambda B x`, where `A` and `B` are symmetric and `B` is positive definite.
+  We generate the matrix `X` and vector `Lambda` such that `X^T A X = Lambda` and `X^T B X = I`.
+  This is equivalent to the LAPACK routine 'sygv' with `TYPE = 1`.
 
-  @param[in]  ceed   Ceed context for error handling
+  @param[in]  ceed   @ref Ceed context for error handling
   @param[in]  mat_A  Row-major matrix to be factorized with eigenvalues
   @param[in]  mat_B  Row-major matrix to be factorized to identity
   @param[out] mat_X  Row-major orthogonal matrix
-  @param[out] lambda Vector of length n of generalized eigenvalues
+  @param[out] lambda Vector of length `n` of generalized eigenvalues
   @param[in]  n      Number of rows/columns
 
   @return An error code: 0 - success, otherwise - failure
@@ -931,18 +931,18 @@ CeedPragmaOptimizeOn
 /// @{
 
 /**
-  @brief Create a tensor-product basis for H^1 discretizations
+  @brief Create a tensor-product basis for \f$H^1\f$ discretizations
 
-  @param[in]  ceed        Ceed object where the CeedBasis will be created
+  @param[in]  ceed        @ref Ceed object used to create the @ref CeedBasis
   @param[in]  dim         Topological dimension
   @param[in]  num_comp    Number of field components (1 for scalar fields)
   @param[in]  P_1d        Number of nodes in one dimension
   @param[in]  Q_1d        Number of quadrature points in one dimension
-  @param[in]  interp_1d   Row-major (Q_1d * P_1d) matrix expressing the values of nodal basis functions at quadrature points
-  @param[in]  grad_1d     Row-major (Q_1d * P_1d) matrix expressing derivatives of nodal basis functions at quadrature points
-  @param[in]  q_ref_1d    Array of length Q_1d holding the locations of quadrature points on the 1D reference element [-1, 1]
-  @param[in]  q_weight_1d Array of length Q_1d holding the quadrature weights on the reference element
-  @param[out] basis       Address of the variable where the newly created CeedBasis will be stored.
+  @param[in]  interp_1d   Row-major (`Q_1d * P_1d`) matrix expressing the values of nodal basis functions at quadrature points
+  @param[in]  grad_1d     Row-major (`Q_1d * P_1d`) matrix expressing derivatives of nodal basis functions at quadrature points
+  @param[in]  q_ref_1d    Array of length `Q_1d` holding the locations of quadrature points on the 1D reference element `[-1, 1]`
+  @param[in]  q_weight_1d Array of length `Q_1d` holding the quadrature weights on the reference element
+  @param[out] basis       Address of the variable where the newly created @ref CeedBasis will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -959,10 +959,10 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt num_comp, CeedInt P_
     return CEED_ERROR_SUCCESS;
   }
 
-  CeedCheck(dim > 0, ceed, CEED_ERROR_DIMENSION, "Basis dimension must be a positive value");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 component");
-  CeedCheck(P_1d > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
-  CeedCheck(Q_1d > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
+  CeedCheck(dim > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis dimension must be a positive value");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 component");
+  CeedCheck(P_1d > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 node");
+  CeedCheck(Q_1d > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 quadrature point");
 
   CeedElemTopology topo = dim == 1 ? CEED_TOPOLOGY_LINE : dim == 2 ? CEED_TOPOLOGY_QUAD : CEED_TOPOLOGY_HEX;
 
@@ -991,16 +991,16 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt num_comp, CeedInt P_
 }
 
 /**
-  @brief Create a tensor-product Lagrange basis
+  @brief Create a tensor-product \f$H^1\f$ Lagrange basis
 
-  @param[in]  ceed      Ceed object where the CeedBasis will be created
+  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
   @param[in]  dim       Topological dimension of element
   @param[in]  num_comp  Number of field components (1 for scalar fields)
   @param[in]  P         Number of Gauss-Lobatto nodes in one dimension.
-                          The polynomial degree of the resulting Q_k element is k=P-1.
+                          The polynomial degree of the resulting `Q_k` element is `k = P - 1`.
   @param[in]  Q         Number of quadrature points in one dimension.
-  @param[in]  quad_mode Distribution of the Q quadrature points (affects order of accuracy for the quadrature)
-  @param[out] basis     Address of the variable where the newly created CeedBasis will be stored.
+  @param[in]  quad_mode Distribution of the `Q` quadrature points (affects order of accuracy for the quadrature)
+  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1011,10 +1011,10 @@ int CeedBasisCreateTensorH1Lagrange(Ceed ceed, CeedInt dim, CeedInt num_comp, Ce
   int        ierr = CEED_ERROR_SUCCESS;
   CeedScalar c1, c2, c3, c4, dx, *nodes, *interp_1d, *grad_1d, *q_ref_1d, *q_weight_1d;
 
-  CeedCheck(dim > 0, ceed, CEED_ERROR_DIMENSION, "Basis dimension must be a positive value");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 component");
-  CeedCheck(P > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
-  CeedCheck(Q > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
+  CeedCheck(dim > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis dimension must be a positive value");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 component");
+  CeedCheck(P > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 node");
+  CeedCheck(Q > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 quadrature point");
 
   // Get Nodes and Weights
   CeedCall(CeedCalloc(P * Q, &interp_1d));
@@ -1068,18 +1068,18 @@ cleanup:
 }
 
 /**
-  @brief Create a non tensor-product basis for H^1 discretizations
+  @brief Create a non tensor-product basis for \f$H^1\f$ discretizations
 
-  @param[in]  ceed      Ceed object where the CeedBasis will be created
+  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
   @param[in]  topo      Topology of element, e.g. hypercube, simplex, ect
   @param[in]  num_comp  Number of field components (1 for scalar fields)
   @param[in]  num_nodes Total number of nodes
   @param[in]  num_qpts  Total number of quadrature points
-  @param[in]  interp    Row-major (num_qpts * num_nodes) matrix expressing the values of nodal basis functions at quadrature points
-  @param[in]  grad      Row-major (dim * num_qpts * num_nodes) matrix expressing derivatives of nodal basis functions at quadrature points
-  @param[in]  q_ref     Array of length num_qpts * dim holding the locations of quadrature points on the reference element
-  @param[in]  q_weight  Array of length num_qpts holding the quadrature weights on the reference element
-  @param[out] basis     Address of the variable where the newly created CeedBasis will be stored.
+  @param[in]  interp    Row-major (`num_qpts * num_nodes`) matrix expressing the values of nodal basis functions at quadrature points
+  @param[in]  grad      Row-major (`dim * num_qpts * num_nodes`) matrix expressing derivatives of nodal basis functions at quadrature points
+  @param[in]  q_ref     Array of length `num_qpts` * dim holding the locations of quadrature points on the reference element
+  @param[in]  q_weight  Array of length `num_qpts` holding the quadrature weights on the reference element
+  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1098,9 +1098,9 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, CeedIn
     return CEED_ERROR_SUCCESS;
   }
 
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 component");
-  CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
-  CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 component");
+  CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 node");
+  CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 quadrature point");
 
   CeedCall(CeedBasisGetTopologyDimension(topo, &dim));
 
@@ -1129,16 +1129,16 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, CeedIn
 /**
   @brief Create a non tensor-product basis for \f$H(\mathrm{div})\f$ discretizations
 
-  @param[in]  ceed      Ceed object where the CeedBasis will be created
+  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
   @param[in]  topo      Topology of element (`CEED_TOPOLOGY_QUAD`, `CEED_TOPOLOGY_PRISM`, etc.), dimension of which is used in some array sizes below
   @param[in]  num_comp  Number of components (usually 1 for vectors in H(div) bases)
-  @param[in]  num_nodes Total number of nodes (dofs per element)
+  @param[in]  num_nodes Total number of nodes (DoFs per element)
   @param[in]  num_qpts  Total number of quadrature points
-  @param[in]  interp    Row-major (dim * num_qpts * num_nodes) matrix expressing the values of basis functions at quadrature points
-  @param[in]  div       Row-major (num_qpts * num_nodes) matrix expressing divergence of basis functions at quadrature points
-  @param[in]  q_ref     Array of length num_qpts * dim holding the locations of quadrature points on the reference element
-  @param[in]  q_weight  Array of length num_qpts holding the quadrature weights on the reference element
-  @param[out] basis     Address of the variable where the newly created CeedBasis will be stored.
+  @param[in]  interp    Row-major (`dim * num_qpts * num_nodes`) matrix expressing the values of basis functions at quadrature points
+  @param[in]  div       Row-major (`num_qpts * num_nodes`) matrix expressing divergence of basis functions at quadrature points
+  @param[in]  q_ref     Array of length `num_qpts` * dim holding the locations of quadrature points on the reference element
+  @param[in]  q_weight  Array of length `num_qpts` holding the quadrature weights on the reference element
+  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1157,9 +1157,9 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Ceed
     return CEED_ERROR_SUCCESS;
   }
 
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 component");
-  CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
-  CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 component");
+  CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 node");
+  CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 quadrature point");
 
   CeedCall(CeedBasisGetTopologyDimension(topo, &dim));
 
@@ -1188,17 +1188,16 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Ceed
 /**
   @brief Create a non tensor-product basis for \f$H(\mathrm{curl})\f$ discretizations
 
-  @param[in]  ceed      Ceed object where the CeedBasis will be created
+  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
   @param[in]  topo      Topology of element (`CEED_TOPOLOGY_QUAD`, `CEED_TOPOLOGY_PRISM`, etc.), dimension of which is used in some array sizes below
-  @param[in]  num_comp  Number of components (usually 1 for vectors in H(curl) bases)
-  @param[in]  num_nodes Total number of nodes (dofs per element)
+  @param[in]  num_comp  Number of components (usually 1 for vectors in \f$H(\mathrm{curl})\f$ bases)
+  @param[in]  num_nodes Total number of nodes (DoFs per element)
   @param[in]  num_qpts  Total number of quadrature points
-  @param[in]  interp    Row-major (dim * num_qpts * num_nodes) matrix expressing the values of basis functions at quadrature points
-  @param[in]  curl      Row-major (curl_comp * num_qpts * num_nodes, curl_comp = 1 if dim < 3 else dim) matrix expressing curl of basis functions at
-quadrature points
-  @param[in]  q_ref     Array of length num_qpts * dim holding the locations of quadrature points on the reference element
-  @param[in]  q_weight  Array of length num_qpts holding the quadrature weights on the reference element
-  @param[out] basis     Address of the variable where the newly created CeedBasis will be stored.
+  @param[in]  interp    Row-major (`dim * num_qpts * num_nodes`) matrix expressing the values of basis functions at quadrature points
+  @param[in]  curl      Row-major (`curl_comp * num_qpts * num_nodes`, `curl_comp = 1` if `dim < 3` otherwise `curl_comp = dim`) matrix expressing curl of basis functions at quadrature points
+  @param[in]  q_ref     Array of length `num_qpts * dim` holding the locations of quadrature points on the reference element
+  @param[in]  q_weight  Array of length `num_qpts` holding the quadrature weights on the reference element
+  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1217,9 +1216,9 @@ int CeedBasisCreateHcurl(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Cee
     return CEED_ERROR_SUCCESS;
   }
 
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 component");
-  CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 node");
-  CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "Basis must have at least 1 quadrature point");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 component");
+  CeedCheck(num_nodes > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 node");
+  CeedCheck(num_qpts > 0, ceed, CEED_ERROR_DIMENSION, "CeedBasis must have at least 1 quadrature point");
 
   CeedCall(CeedBasisGetTopologyDimension(topo, &dim));
   curl_comp = (dim < 3) ? 1 : dim;
@@ -1247,22 +1246,21 @@ int CeedBasisCreateHcurl(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Cee
 }
 
 /**
-  @brief Create a CeedBasis for projection from the nodes of `basis_from` to the nodes of `basis_to`.
+  @brief Create a @ref CeedBasis for projection from the nodes of `basis_from` to the nodes of `basis_to`.
 
-  Only `CEED_EVAL_INTERP` will be valid for the new basis, `basis_project`.
-  For H^1 spaces, `CEED_EVAL_GRAD` will also be valid.
-  The interpolation is given by `interp_project = interp_to^+ * interp_from`, where the pseudoinverse `interp_to^+` is given by QR
-factorization.
-  The gradient (for the H^1 case) is given by `grad_project = interp_to^+ * grad_from`.
+  Only @ref CEED_EVAL_INTERP will be valid for the new basis, `basis_project`.
+  For \f$H^1\f$ spaces, @ref CEED_EVAL_GRAD will also be valid.
+  The interpolation is given by `interp_project = interp_to^+ * interp_from`, where the pseudoinverse `interp_to^+` is given by QR factorization.
+  The gradient (for the \f$H^1\f$ case) is given by `grad_project = interp_to^+ * grad_from`.
 
   Note: `basis_from` and `basis_to` must have compatible quadrature spaces.
 
   Note: `basis_project` will have the same number of components as `basis_from`, regardless of the number of components that `basis_to` has.
         If `basis_from` has 3 components and `basis_to` has 5 components, then `basis_project` will have 3 components.
 
-  @param[in]  basis_from    CeedBasis to prolong from
-  @param[in]  basis_to      CeedBasis to prolong to
-  @param[out] basis_project Address of the variable where the newly created CeedBasis will be stored.
+  @param[in]  basis_from    @ref CeedBasis to prolong from
+  @param[in]  basis_to      @ref CeedBasis to prolong to
+  @param[out] basis_project Address of the variable where the newly created @ref CeedBasis will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1313,12 +1311,12 @@ int CeedBasisCreateProjection(CeedBasis basis_from, CeedBasis basis_to, CeedBasi
 }
 
 /**
-  @brief Copy the pointer to a CeedBasis.
+  @brief Copy the pointer to a @ref CeedBasis.
 
-  Note: If the value of `basis_copy` passed into this function is non-NULL, then it is assumed that `basis_copy` is a pointer to a CeedBasis.
-        This CeedBasis will be destroyed if `basis_copy` is the only reference to this CeedBasis.
+  Note: If the value of `*basis_copy` passed into this function is non-`NULL`, then it is assumed that `*basis_copy` is a pointer to a @ref CeedBasis.
+        This @ref CeedBasis will be destroyed if `*basis_copy` is the only reference to this @ref CeedBasis.
 
-  @param[in]     basis      CeedBasis to copy reference to
+  @param[in]     basis      @ref CeedBasis to copy reference to
   @param[in,out] basis_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -1333,10 +1331,10 @@ int CeedBasisReferenceCopy(CeedBasis basis, CeedBasis *basis_copy) {
 }
 
 /**
-  @brief View a CeedBasis
+  @brief View a @ref CeedBasis
 
-  @param[in] basis  CeedBasis to view
-  @param[in] stream Stream to view to, e.g., stdout
+  @param[in] basis  @ref CeedBasis to view
+  @param[in] stream Stream to view to, e.g., `stdout`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1385,19 +1383,19 @@ int CeedBasisView(CeedBasis basis, FILE *stream) {
 /**
   @brief Apply basis evaluation from nodes to quadrature points or vice versa
 
-  @param[in]  basis      CeedBasis to evaluate
-  @param[in]  num_elem   The number of elements to apply the basis evaluation to;
-                           the backend will specify the ordering in CeedElemRestrictionCreateBlocked()
-  @param[in]  t_mode    \ref CEED_NOTRANSPOSE to evaluate from nodes to quadrature points;
-                          \ref CEED_TRANSPOSE to apply the transpose, mapping from quadrature points to nodes
-  @param[in]  eval_mode \ref CEED_EVAL_NONE to use values directly,
-                          \ref CEED_EVAL_INTERP to use interpolated values,
-                          \ref CEED_EVAL_GRAD to use gradients,
-                          \ref CEED_EVAL_DIV to use divergence,
-                          \ref CEED_EVAL_CURL to use curl,
-                          \ref CEED_EVAL_WEIGHT to use quadrature weights.
-  @param[in]  u        Input CeedVector
-  @param[out] v        Output CeedVector
+  @param[in]  basis     @ref CeedBasis to evaluate
+  @param[in]  num_elem  The number of elements to apply the basis evaluation to;
+                          the backend will specify the ordering in @ref CeedElemRestrictionCreate()
+  @param[in]  t_mode    @ref CEED_NOTRANSPOSE to evaluate from nodes to quadrature points;
+                          @ref CEED_TRANSPOSE to apply the transpose, mapping from quadrature points to nodes
+  @param[in]  eval_mode @ref CEED_EVAL_NONE to use values directly,
+                          @ref CEED_EVAL_INTERP to use interpolated values,
+                          @ref CEED_EVAL_GRAD to use gradients,
+                          @ref CEED_EVAL_DIV to use divergence,
+                          @ref CEED_EVAL_CURL to use curl,
+                          @ref CEED_EVAL_WEIGHT to use quadrature weights
+  @param[in]  u         Input @ref CeedVector
+  @param[out] v         Output @ref CeedVector
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1415,7 +1413,7 @@ int CeedBasisApply(CeedBasis basis, CeedInt num_elem, CeedTransposeMode t_mode, 
   CeedCall(CeedVectorGetLength(v, &v_length));
   if (u) CeedCall(CeedVectorGetLength(u, &u_length));
 
-  CeedCheck(basis->Apply, basis->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support BasisApply");
+  CeedCheck(basis->Apply, basis->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedBasisApply");
 
   // Check compatibility of topological and geometrical dimensions
   CeedCheck((t_mode == CEED_TRANSPOSE && v_length % num_nodes == 0 && u_length % num_qpts == 0) ||
@@ -1447,15 +1445,16 @@ int CeedBasisApply(CeedBasis basis, CeedInt num_elem, CeedTransposeMode t_mode, 
 /**
   @brief Apply basis evaluation from nodes to arbitrary points
 
-  @param[in]  basis      CeedBasis to evaluate
+  @param[in]  basis      @ref CeedBasis to evaluate
   @param[in]  num_points The number of points to apply the basis evaluation to
-  @param[in]  t_mode    \ref CEED_NOTRANSPOSE to evaluate from nodes to points;
-                          \ref CEED_TRANSPOSE to apply the transpose, mapping from points to nodes
-  @param[in]  eval_mode \ref CEED_EVAL_INTERP to use interpolated values,
-                          \ref CEED_EVAL_GRAD to use gradients
-  @param[in]  x_ref    CeedVector holding reference coordinates of each point
-  @param[in]  u        Input CeedVector, of length `num_nodes * num_comp` for `CEED_NOTRANSPOSE`
-  @param[out] v        Output CeedVector, of length `num_points * num_q_comp` for `CEED_NOTRANSPOSE` with `CEED_EVAL_INTERP`
+  @param[in]  t_mode     @ref CEED_NOTRANSPOSE to evaluate from nodes to points;
+                           @ref CEED_TRANSPOSE to apply the transpose, mapping from points to nodes
+  @param[in]  eval_mode  @ref CEED_EVAL_INTERP to use interpolated values,
+                           @ref CEED_EVAL_GRAD to use gradients,
+                           @ref CEED_EVAL_WEIGHT to use quadrature weights
+  @param[in]  x_ref      @ref CeedVector holding reference coordinates of each point
+  @param[in]  u          Input @ref CeedVector, of length `num_nodes * num_comp` for @ref CEED_NOTRANSPOSE
+  @param[out] v          Output @ref CeedVector, of length `num_points * num_q_comp` for @ref CEED_NOTRANSPOSE with @ref CEED_EVAL_INTERP
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1531,7 +1530,7 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
 
     // Build coefficient matrix
     // -- Note: Clang-tidy needs this check because it does not understand the is_tensor_basis check above
-    CeedCheck(P_1d > 0 && Q_1d > 0, basis->ceed, CEED_ERROR_INCOMPATIBLE, "Basis dimensions are malformed");
+    CeedCheck(P_1d > 0 && Q_1d > 0, basis->ceed, CEED_ERROR_INCOMPATIBLE, "CeedBasis dimensions are malformed");
     CeedCall(CeedCalloc(Q_1d * Q_1d, &C));
     CeedCall(CeedBasisGetQRef(basis, &q_ref_1d));
     for (CeedInt i = 0; i < Q_1d; i++) CeedCall(CeedChebyshevPolynomialsAtPoint(q_ref_1d[i], Q_1d, &C[i * Q_1d]));
@@ -1734,10 +1733,10 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
 }
 
 /**
-  @brief Get Ceed associated with a CeedBasis
+  @brief Get @ref Ceed associated with a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
-  @param[out] ceed  Variable to store Ceed
+  @param[in]  basis @ref CeedBasis
+  @param[out] ceed  Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1749,9 +1748,9 @@ int CeedBasisGetCeed(CeedBasis basis, Ceed *ceed) {
 }
 
 /**
-  @brief Get dimension for given CeedBasis
+  @brief Get dimension for given @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] dim   Variable to store dimension of basis
 
   @return An error code: 0 - success, otherwise - failure
@@ -1764,9 +1763,9 @@ int CeedBasisGetDimension(CeedBasis basis, CeedInt *dim) {
 }
 
 /**
-  @brief Get topology for given CeedBasis
+  @brief Get topology for given @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] topo  Variable to store topology of basis
 
   @return An error code: 0 - success, otherwise - failure
@@ -1779,10 +1778,10 @@ int CeedBasisGetTopology(CeedBasis basis, CeedElemTopology *topo) {
 }
 
 /**
-  @brief Get number of components for given CeedBasis
+  @brief Get number of components for given @ref CeedBasis
 
-  @param[in]  basis    CeedBasis
-  @param[out] num_comp Variable to store number of components of basis
+  @param[in]  basis    @ref CeedBasis
+  @param[out] num_comp Variable to store number of components
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1794,9 +1793,9 @@ int CeedBasisGetNumComponents(CeedBasis basis, CeedInt *num_comp) {
 }
 
 /**
-  @brief Get total number of nodes (in dim dimensions) of a CeedBasis
+  @brief Get total number of nodes (in `dim` dimensions) of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] P     Variable to store number of nodes
 
   @return An error code: 0 - success, otherwise - failure
@@ -1809,9 +1808,9 @@ int CeedBasisGetNumNodes(CeedBasis basis, CeedInt *P) {
 }
 
 /**
-  @brief Get total number of nodes (in 1 dimension) of a CeedBasis
+  @brief Get total number of nodes (in 1 dimension) of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] P_1d  Variable to store number of nodes
 
   @return An error code: 0 - success, otherwise - failure
@@ -1819,15 +1818,15 @@ int CeedBasisGetNumNodes(CeedBasis basis, CeedInt *P) {
   @ref Advanced
 **/
 int CeedBasisGetNumNodes1D(CeedBasis basis, CeedInt *P_1d) {
-  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "Cannot supply P_1d for non-tensor basis");
+  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "Cannot supply P_1d for non-tensor CeedBasis");
   *P_1d = basis->P_1d;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get total number of quadrature points (in dim dimensions) of a CeedBasis
+  @brief Get total number of quadrature points (in `dim` dimensions) of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] Q     Variable to store number of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1840,9 +1839,9 @@ int CeedBasisGetNumQuadraturePoints(CeedBasis basis, CeedInt *Q) {
 }
 
 /**
-  @brief Get total number of quadrature points (in 1 dimension) of a CeedBasis
+  @brief Get total number of quadrature points (in 1 dimension) of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] Q_1d  Variable to store number of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1850,15 +1849,15 @@ int CeedBasisGetNumQuadraturePoints(CeedBasis basis, CeedInt *Q) {
   @ref Advanced
 **/
 int CeedBasisGetNumQuadraturePoints1D(CeedBasis basis, CeedInt *Q_1d) {
-  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "Cannot supply Q_1d for non-tensor basis");
+  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "Cannot supply Q_1d for non-tensor CeedBasis");
   *Q_1d = basis->Q_1d;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get reference coordinates of quadrature points (in dim dimensions) of a CeedBasis
+  @brief Get reference coordinates of quadrature points (in `dim` dimensions) of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] q_ref Variable to store reference coordinates of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1871,9 +1870,9 @@ int CeedBasisGetQRef(CeedBasis basis, const CeedScalar **q_ref) {
 }
 
 /**
-  @brief Get quadrature weights of quadrature points (in dim dimensions) of a CeedBasis
+  @brief Get quadrature weights of quadrature points (in `dim` dimensions) of a @ref CeedBasis
 
-  @param[in]  basis    CeedBasis
+  @param[in]  basis    @ref CeedBasis
   @param[out] q_weight Variable to store quadrature weights
 
   @return An error code: 0 - success, otherwise - failure
@@ -1886,9 +1885,9 @@ int CeedBasisGetQWeights(CeedBasis basis, const CeedScalar **q_weight) {
 }
 
 /**
-  @brief Get interpolation matrix of a CeedBasis
+  @brief Get interpolation matrix of a @ref CeedBasis
 
-  @param[in]  basis  CeedBasis
+  @param[in]  basis  @ref CeedBasis
   @param[out] interp Variable to store interpolation matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1920,9 +1919,9 @@ int CeedBasisGetInterp(CeedBasis basis, const CeedScalar **interp) {
 }
 
 /**
-  @brief Get 1D interpolation matrix of a tensor product CeedBasis
+  @brief Get 1D interpolation matrix of a tensor product @ref CeedBasis
 
-  @param[in]  basis     CeedBasis
+  @param[in]  basis     @ref CeedBasis
   @param[out] interp_1d Variable to store interpolation matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1930,15 +1929,15 @@ int CeedBasisGetInterp(CeedBasis basis, const CeedScalar **interp) {
   @ref Backend
 **/
 int CeedBasisGetInterp1D(CeedBasis basis, const CeedScalar **interp_1d) {
-  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "CeedBasis is not a tensor product basis.");
+  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "CeedBasis is not a tensor product CeedBasis");
   *interp_1d = basis->interp_1d;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get gradient matrix of a CeedBasis
+  @brief Get gradient matrix of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] grad  Variable to store gradient matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1973,9 +1972,9 @@ int CeedBasisGetGrad(CeedBasis basis, const CeedScalar **grad) {
 }
 
 /**
-  @brief Get 1D gradient matrix of a tensor product CeedBasis
+  @brief Get 1D gradient matrix of a tensor product @ref CeedBasis
 
-  @param[in]  basis   CeedBasis
+  @param[in]  basis   @ref CeedBasis
   @param[out] grad_1d Variable to store gradient matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1983,15 +1982,15 @@ int CeedBasisGetGrad(CeedBasis basis, const CeedScalar **grad) {
   @ref Advanced
 **/
 int CeedBasisGetGrad1D(CeedBasis basis, const CeedScalar **grad_1d) {
-  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "CeedBasis is not a tensor product basis.");
+  CeedCheck(basis->is_tensor_basis, basis->ceed, CEED_ERROR_MINOR, "CeedBasis is not a tensor product CeedBasis");
   *grad_1d = basis->grad_1d;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get divergence matrix of a CeedBasis
+  @brief Get divergence matrix of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] div   Variable to store divergence matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1999,15 +1998,15 @@ int CeedBasisGetGrad1D(CeedBasis basis, const CeedScalar **grad_1d) {
   @ref Advanced
 **/
 int CeedBasisGetDiv(CeedBasis basis, const CeedScalar **div) {
-  CeedCheck(basis->div, basis->ceed, CEED_ERROR_MINOR, "CeedBasis does not have divergence matrix.");
+  CeedCheck(basis->div, basis->ceed, CEED_ERROR_MINOR, "CeedBasis does not have divergence matrix");
   *div = basis->div;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get curl matrix of a CeedBasis
+  @brief Get curl matrix of a @ref CeedBasis
 
-  @param[in]  basis CeedBasis
+  @param[in]  basis @ref CeedBasis
   @param[out] curl  Variable to store curl matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -2015,15 +2014,15 @@ int CeedBasisGetDiv(CeedBasis basis, const CeedScalar **div) {
   @ref Advanced
 **/
 int CeedBasisGetCurl(CeedBasis basis, const CeedScalar **curl) {
-  CeedCheck(basis->curl, basis->ceed, CEED_ERROR_MINOR, "CeedBasis does not have curl matrix.");
+  CeedCheck(basis->curl, basis->ceed, CEED_ERROR_MINOR, "CeedBasis does not have curl matrix");
   *curl = basis->curl;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Destroy a CeedBasis
+  @brief Destroy a @ref  CeedBasis
 
-  @param[in,out] basis CeedBasis to destroy
+  @param[in,out] basis @ref CeedBasis to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2054,9 +2053,9 @@ int CeedBasisDestroy(CeedBasis *basis) {
 /**
   @brief Construct a Gauss-Legendre quadrature
 
-  @param[in]  Q           Number of quadrature points (integrates polynomials of degree 2*Q-1 exactly)
-  @param[out] q_ref_1d    Array of length Q to hold the abscissa on [-1, 1]
-  @param[out] q_weight_1d Array of length Q to hold the weights
+  @param[in]  Q           Number of quadrature points (integrates polynomials of degree `2*Q-1` exactly)
+  @param[out] q_ref_1d    Array of length `Q` to hold the abscissa on `[-1, 1]`
+  @param[out] q_weight_1d Array of length `Q` to hold the weights
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2106,9 +2105,9 @@ int CeedGaussQuadrature(CeedInt Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d
 /**
   @brief Construct a Gauss-Legendre-Lobatto quadrature
 
-  @param[in]  Q           Number of quadrature points (integrates polynomials of degree 2*Q-3 exactly)
-  @param[out] q_ref_1d    Array of length Q to hold the abscissa on [-1, 1]
-  @param[out] q_weight_1d Array of length Q to hold the weights
+  @param[in]  Q           Number of quadrature points (integrates polynomials of degree `2*Q-3` exactly)
+  @param[out] q_ref_1d    Array of length `Q` to hold the abscissa on `[-1, 1]`
+  @param[out] q_weight_1d Array of length `Q` to hold the weights
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -23,7 +23,7 @@ static struct CeedBasis_private ceed_basis_none;
 /// @addtogroup CeedBasisUser
 /// @{
 
-/// Argument for @ref CeedOperatorSetField() indicating that the field does not require a @ref CeedBasis
+/// Argument for @ref CeedOperatorSetField() indicating that the field does not require a `CeedBasis`
 const CeedBasis CEED_BASIS_NONE = &ceed_basis_none;
 
 /// This feature will be removed. Use @ref CEED_BASIS_NONE.
@@ -149,7 +149,7 @@ static int CeedGivensRotation(CeedScalar *A, CeedScalar c, CeedScalar s, CeedTra
 }
 
 /**
-  @brief View an array stored in a @ref CeedBasis
+  @brief View an array stored in a `CeedBasis`
 
   @param[in] name   Name of array
   @param[in] fp_fmt Printing format
@@ -187,8 +187,8 @@ static int CeedScalarView(const char *name, const char *fp_fmt, CeedInt m, CeedI
 
   Note: `basis_from` and `basis_to` must have compatible quadrature spaces.
 
-  @param[in]  basis_from     @ref CeedBasis to project from
-  @param[in]  basis_to       @ref CeedBasis to project to
+  @param[in]  basis_from     `CeedBasis` to project from
+  @param[in]  basis_to       `CeedBasis` to project to
   @param[out] interp_project Address of the variable where the newly created interpolation matrix will be stored
   @param[out] grad_project   Address of the variable where the newly created gradient matrix will be stored
 
@@ -309,7 +309,7 @@ static int CeedBasisCreateProjectionMatrices(CeedBasis basis_from, CeedBasis bas
 /**
   @brief Return collocated gradient matrix
 
-  @param[in]  basis         @ref CeedBasis
+  @param[in]  basis         `CeedBasis`
   @param[out] collo_grad_1d Row-major (`Q_1d * Q_1d`) matrix expressing derivatives of basis functions at quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -353,9 +353,9 @@ int CeedBasisGetCollocatedGrad(CeedBasis basis, CeedScalar *collo_grad_1d) {
 }
 
 /**
-  @brief Get tensor status for given @ref CeedBasis
+  @brief Get tensor status for given `CeedBasis`
 
-  @param[in]  basis     @ref CeedBasis
+  @param[in]  basis     `CeedBasis`
   @param[out] is_tensor Variable to store tensor status
 
   @return An error code: 0 - success, otherwise - failure
@@ -368,9 +368,9 @@ int CeedBasisIsTensor(CeedBasis basis, bool *is_tensor) {
 }
 
 /**
-  @brief Get backend data of a @ref CeedBasis
+  @brief Get backend data of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] data  Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -383,9 +383,9 @@ int CeedBasisGetData(CeedBasis basis, void *data) {
 }
 
 /**
-  @brief Set backend data of a @ref CeedBasis
+  @brief Set backend data of a `CeedBasis`
 
-  @param[in,out] basis  @ref CeedBasis
+  @param[in,out] basis  `CeedBasis`
   @param[in]     data   Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -398,9 +398,9 @@ int CeedBasisSetData(CeedBasis basis, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedBasis
+  @brief Increment the reference counter for a `CeedBasis`
 
-  @param[in,out] basis @ref CeedBasis to increment the reference counter
+  @param[in,out] basis `CeedBasis` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -412,9 +412,9 @@ int CeedBasisReference(CeedBasis basis) {
 }
 
 /**
-  @brief Get number of Q-vector components for given @ref CeedBasis
+  @brief Get number of Q-vector components for given `CeedBasis`
 
-  @param[in]  basis     @ref CeedBasis
+  @param[in]  basis     `CeedBasis`
   @param[in]  eval_mode @ref CEED_EVAL_INTERP to use interpolated values,
                           @ref CEED_EVAL_GRAD to use gradients,
                           @ref CEED_EVAL_DIV to use divergence,
@@ -448,9 +448,9 @@ int CeedBasisGetNumQuadratureComponents(CeedBasis basis, CeedEvalMode eval_mode,
 }
 
 /**
-  @brief Estimate number of FLOPs required to apply @ref CeedBasis in `t_mode` and `eval_mode`
+  @brief Estimate number of FLOPs required to apply `CeedBasis` in `t_mode` and `eval_mode`
 
-  @param[in]  basis     @ref CeedBasis to estimate FLOPs for
+  @param[in]  basis     `CeedBasis` to estimate FLOPs for
   @param[in]  t_mode    Apply basis or transpose
   @param[in]  eval_mode @ref CeedEvalMode
   @param[out] flops     Address of variable to hold FLOPs estimate
@@ -525,10 +525,10 @@ int CeedBasisGetFlopsEstimate(CeedBasis basis, CeedTransposeMode t_mode, CeedEva
 }
 
 /**
-  @brief Get @ref CeedFESpace for a @ref CeedBasis
+  @brief Get `CeedFESpace` for a `CeedBasis`
 
-  @param[in]  basis    @ref CeedBasis
-  @param[out] fe_space Variable to store @ref CeedFESpace
+  @param[in]  basis    `CeedBasis`
+  @param[out] fe_space Variable to store `CeedFESpace`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -540,9 +540,9 @@ int CeedBasisGetFESpace(CeedBasis basis, CeedFESpace *fe_space) {
 }
 
 /**
-  @brief Get dimension for given @ref CeedElemTopology
+  @brief Get dimension for given `CeedElemTopology`
 
-  @param[in]  topo @ref CeedElemTopology
+  @param[in]  topo `CeedElemTopology`
   @param[out] dim  Variable to store dimension of topology
 
   @return An error code: 0 - success, otherwise - failure
@@ -555,10 +555,10 @@ int CeedBasisGetTopologyDimension(CeedElemTopology topo, CeedInt *dim) {
 }
 
 /**
-  @brief Get @ref CeedTensorContract of a @ref CeedBasis
+  @brief Get `CeedTensorContract` of a `CeedBasis`
 
-  @param[in]  basis     @ref CeedBasis
-  @param[out] contract  Variable to store @ref CeedTensorContract
+  @param[in]  basis     `CeedBasis`
+  @param[out] contract  Variable to store `CeedTensorContract`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -570,10 +570,10 @@ int CeedBasisGetTensorContract(CeedBasis basis, CeedTensorContract *contract) {
 }
 
 /**
-  @brief Set @ref CeedTensorContract of a @ref CeedBasis
+  @brief Set `CeedTensorContract` of a `CeedBasis`
 
-  @param[in,out] basis    @ref CeedBasis
-  @param[in]     contract @ref CeedTensorContract to set
+  @param[in,out] basis    `CeedBasis`
+  @param[in]     contract `CeedTensorContract` to set
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -588,9 +588,9 @@ int CeedBasisSetTensorContract(CeedBasis basis, CeedTensorContract contract) {
 /**
   @brief Return a reference implementation of matrix multiplication \f$C = A B\f$.
 
-  Note: This is a reference implementation for CPU @ref CeedScalar pointers that is not intended for high performance.
+  Note: This is a reference implementation for CPU `CeedScalar` pointers that is not intended for high performance.
 
-  @param[in]  ceed  @ref Ceed context for error handling
+  @param[in]  ceed  `Ceed` context for error handling
   @param[in]  mat_A Row-major matrix `A`
   @param[in]  mat_B Row-major matrix `B`
   @param[out] mat_C Row-major output matrix `C`
@@ -617,7 +617,7 @@ int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A, const CeedScala
 /**
   @brief Return QR Factorization of a matrix
 
-  @param[in]     ceed @ref Ceed context for error handling
+  @param[in]     ceed `Ceed` context for error handling
   @param[in,out] mat  Row-major matrix to be factorized in place
   @param[in,out] tau  Vector of length `m` of scaling factors
   @param[in]     m    Number of rows
@@ -702,7 +702,7 @@ int CeedHouseholderApplyQ(CeedScalar *mat_A, const CeedScalar *mat_Q, const Ceed
 /**
   @brief Return symmetric Schur decomposition of the symmetric matrix mat via symmetric QR factorization
 
-  @param[in]     ceed   @ref Ceed context for error handling
+  @param[in]     ceed   `Ceed` context for error handling
   @param[in,out] mat    Row-major matrix to be factorized in place
   @param[out]    lambda Vector of length n of eigenvalues
   @param[in]     n      Number of rows/columns
@@ -847,7 +847,7 @@ CeedPragmaOptimizeOn
   We generate the matrix `X` and vector `Lambda` such that `X^T A X = Lambda` and `X^T B X = I`.
   This is equivalent to the LAPACK routine 'sygv' with `TYPE = 1`.
 
-  @param[in]  ceed   @ref Ceed context for error handling
+  @param[in]  ceed   `Ceed` context for error handling
   @param[in]  mat_A  Row-major matrix to be factorized with eigenvalues
   @param[in]  mat_B  Row-major matrix to be factorized to identity
   @param[out] mat_X  Row-major orthogonal matrix
@@ -933,7 +933,7 @@ CeedPragmaOptimizeOn
 /**
   @brief Create a tensor-product basis for \f$H^1\f$ discretizations
 
-  @param[in]  ceed        @ref Ceed object used to create the @ref CeedBasis
+  @param[in]  ceed        `Ceed` object used to create the `CeedBasis`
   @param[in]  dim         Topological dimension
   @param[in]  num_comp    Number of field components (1 for scalar fields)
   @param[in]  P_1d        Number of nodes in one dimension
@@ -942,7 +942,7 @@ CeedPragmaOptimizeOn
   @param[in]  grad_1d     Row-major (`Q_1d * P_1d`) matrix expressing derivatives of nodal basis functions at quadrature points
   @param[in]  q_ref_1d    Array of length `Q_1d` holding the locations of quadrature points on the 1D reference element `[-1, 1]`
   @param[in]  q_weight_1d Array of length `Q_1d` holding the quadrature weights on the reference element
-  @param[out] basis       Address of the variable where the newly created @ref CeedBasis will be stored
+  @param[out] basis       Address of the variable where the newly created `CeedBasis` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -993,14 +993,14 @@ int CeedBasisCreateTensorH1(Ceed ceed, CeedInt dim, CeedInt num_comp, CeedInt P_
 /**
   @brief Create a tensor-product \f$H^1\f$ Lagrange basis
 
-  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
+  @param[in]  ceed      `Ceed` object used to create the `CeedBasis`
   @param[in]  dim       Topological dimension of element
   @param[in]  num_comp  Number of field components (1 for scalar fields)
   @param[in]  P         Number of Gauss-Lobatto nodes in one dimension.
                           The polynomial degree of the resulting `Q_k` element is `k = P - 1`.
   @param[in]  Q         Number of quadrature points in one dimension.
   @param[in]  quad_mode Distribution of the `Q` quadrature points (affects order of accuracy for the quadrature)
-  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
+  @param[out] basis     Address of the variable where the newly created `CeedBasis` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1070,7 +1070,7 @@ cleanup:
 /**
   @brief Create a non tensor-product basis for \f$H^1\f$ discretizations
 
-  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
+  @param[in]  ceed      `Ceed` object used to create the `CeedBasis`
   @param[in]  topo      Topology of element, e.g. hypercube, simplex, ect
   @param[in]  num_comp  Number of field components (1 for scalar fields)
   @param[in]  num_nodes Total number of nodes
@@ -1079,7 +1079,7 @@ cleanup:
   @param[in]  grad      Row-major (`dim * num_qpts * num_nodes`) matrix expressing derivatives of nodal basis functions at quadrature points
   @param[in]  q_ref     Array of length `num_qpts` * dim holding the locations of quadrature points on the reference element
   @param[in]  q_weight  Array of length `num_qpts` holding the quadrature weights on the reference element
-  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
+  @param[out] basis     Address of the variable where the newly created `CeedBasis` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1129,7 +1129,7 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, CeedIn
 /**
   @brief Create a non tensor-product basis for \f$H(\mathrm{div})\f$ discretizations
 
-  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
+  @param[in]  ceed      `Ceed` object used to create the `CeedBasis`
   @param[in]  topo      Topology of element (`CEED_TOPOLOGY_QUAD`, `CEED_TOPOLOGY_PRISM`, etc.), dimension of which is used in some array sizes below
   @param[in]  num_comp  Number of components (usually 1 for vectors in H(div) bases)
   @param[in]  num_nodes Total number of nodes (DoFs per element)
@@ -1138,7 +1138,7 @@ int CeedBasisCreateH1(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, CeedIn
   @param[in]  div       Row-major (`num_qpts * num_nodes`) matrix expressing divergence of basis functions at quadrature points
   @param[in]  q_ref     Array of length `num_qpts` * dim holding the locations of quadrature points on the reference element
   @param[in]  q_weight  Array of length `num_qpts` holding the quadrature weights on the reference element
-  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
+  @param[out] basis     Address of the variable where the newly created `CeedBasis` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1188,7 +1188,7 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Ceed
 /**
   @brief Create a non tensor-product basis for \f$H(\mathrm{curl})\f$ discretizations
 
-  @param[in]  ceed      @ref Ceed object used to create the @ref CeedBasis
+  @param[in]  ceed      `Ceed` object used to create the `CeedBasis`
   @param[in]  topo      Topology of element (`CEED_TOPOLOGY_QUAD`, `CEED_TOPOLOGY_PRISM`, etc.), dimension of which is used in some array sizes below
   @param[in]  num_comp  Number of components (usually 1 for vectors in \f$H(\mathrm{curl})\f$ bases)
   @param[in]  num_nodes Total number of nodes (DoFs per element)
@@ -1197,7 +1197,7 @@ int CeedBasisCreateHdiv(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Ceed
   @param[in]  curl      Row-major (`curl_comp * num_qpts * num_nodes`, `curl_comp = 1` if `dim < 3` otherwise `curl_comp = dim`) matrix expressing curl of basis functions at quadrature points
   @param[in]  q_ref     Array of length `num_qpts * dim` holding the locations of quadrature points on the reference element
   @param[in]  q_weight  Array of length `num_qpts` holding the quadrature weights on the reference element
-  @param[out] basis     Address of the variable where the newly created @ref CeedBasis will be stored
+  @param[out] basis     Address of the variable where the newly created `CeedBasis` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1246,7 +1246,7 @@ int CeedBasisCreateHcurl(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Cee
 }
 
 /**
-  @brief Create a @ref CeedBasis for projection from the nodes of `basis_from` to the nodes of `basis_to`.
+  @brief Create a `CeedBasis` for projection from the nodes of `basis_from` to the nodes of `basis_to`.
 
   Only @ref CEED_EVAL_INTERP will be valid for the new basis, `basis_project`.
   For \f$H^1\f$ spaces, @ref CEED_EVAL_GRAD will also be valid.
@@ -1258,9 +1258,9 @@ int CeedBasisCreateHcurl(Ceed ceed, CeedElemTopology topo, CeedInt num_comp, Cee
   Note: `basis_project` will have the same number of components as `basis_from`, regardless of the number of components that `basis_to` has.
         If `basis_from` has 3 components and `basis_to` has 5 components, then `basis_project` will have 3 components.
 
-  @param[in]  basis_from    @ref CeedBasis to prolong from
-  @param[in]  basis_to      @ref CeedBasis to prolong to
-  @param[out] basis_project Address of the variable where the newly created @ref CeedBasis will be stored
+  @param[in]  basis_from    `CeedBasis` to prolong from
+  @param[in]  basis_to      `CeedBasis` to prolong to
+  @param[out] basis_project Address of the variable where the newly created `CeedBasis` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1311,12 +1311,12 @@ int CeedBasisCreateProjection(CeedBasis basis_from, CeedBasis basis_to, CeedBasi
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedBasis.
+  @brief Copy the pointer to a `CeedBasis`.
 
-  Note: If the value of `*basis_copy` passed into this function is non-`NULL`, then it is assumed that `*basis_copy` is a pointer to a @ref CeedBasis.
-        This @ref CeedBasis will be destroyed if `*basis_copy` is the only reference to this @ref CeedBasis.
+  Note: If the value of `*basis_copy` passed into this function is non-`NULL`, then it is assumed that `*basis_copy` is a pointer to a `CeedBasis`.
+        This `CeedBasis` will be destroyed if `*basis_copy` is the only reference to this `CeedBasis`.
 
-  @param[in]     basis      @ref CeedBasis to copy reference to
+  @param[in]     basis      `CeedBasis` to copy reference to
   @param[in,out] basis_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -1331,9 +1331,9 @@ int CeedBasisReferenceCopy(CeedBasis basis, CeedBasis *basis_copy) {
 }
 
 /**
-  @brief View a @ref CeedBasis
+  @brief View a `CeedBasis`
 
-  @param[in] basis  @ref CeedBasis to view
+  @param[in] basis  `CeedBasis` to view
   @param[in] stream Stream to view to, e.g., `stdout`
 
   @return An error code: 0 - success, otherwise - failure
@@ -1383,7 +1383,7 @@ int CeedBasisView(CeedBasis basis, FILE *stream) {
 /**
   @brief Apply basis evaluation from nodes to quadrature points or vice versa
 
-  @param[in]  basis     @ref CeedBasis to evaluate
+  @param[in]  basis     `CeedBasis` to evaluate
   @param[in]  num_elem  The number of elements to apply the basis evaluation to;
                           the backend will specify the ordering in @ref CeedElemRestrictionCreate()
   @param[in]  t_mode    @ref CEED_NOTRANSPOSE to evaluate from nodes to quadrature points;
@@ -1394,8 +1394,8 @@ int CeedBasisView(CeedBasis basis, FILE *stream) {
                           @ref CEED_EVAL_DIV to use divergence,
                           @ref CEED_EVAL_CURL to use curl,
                           @ref CEED_EVAL_WEIGHT to use quadrature weights
-  @param[in]  u         Input @ref CeedVector
-  @param[out] v         Output @ref CeedVector
+  @param[in]  u         Input `CeedVector`
+  @param[out] v         Output `CeedVector`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1445,16 +1445,16 @@ int CeedBasisApply(CeedBasis basis, CeedInt num_elem, CeedTransposeMode t_mode, 
 /**
   @brief Apply basis evaluation from nodes to arbitrary points
 
-  @param[in]  basis      @ref CeedBasis to evaluate
+  @param[in]  basis      `CeedBasis` to evaluate
   @param[in]  num_points The number of points to apply the basis evaluation to
   @param[in]  t_mode     @ref CEED_NOTRANSPOSE to evaluate from nodes to points;
                            @ref CEED_TRANSPOSE to apply the transpose, mapping from points to nodes
   @param[in]  eval_mode  @ref CEED_EVAL_INTERP to use interpolated values,
                            @ref CEED_EVAL_GRAD to use gradients,
                            @ref CEED_EVAL_WEIGHT to use quadrature weights
-  @param[in]  x_ref      @ref CeedVector holding reference coordinates of each point
-  @param[in]  u          Input @ref CeedVector, of length `num_nodes * num_comp` for @ref CEED_NOTRANSPOSE
-  @param[out] v          Output @ref CeedVector, of length `num_points * num_q_comp` for @ref CEED_NOTRANSPOSE with @ref CEED_EVAL_INTERP
+  @param[in]  x_ref      `CeedVector` holding reference coordinates of each point
+  @param[in]  u          Input `CeedVector`, of length `num_nodes * num_comp` for @ref CEED_NOTRANSPOSE
+  @param[out] v          Output `CeedVector`, of length `num_points * num_q_comp` for @ref CEED_NOTRANSPOSE with @ref CEED_EVAL_INTERP
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1733,10 +1733,10 @@ int CeedBasisApplyAtPoints(CeedBasis basis, CeedInt num_points, CeedTransposeMod
 }
 
 /**
-  @brief Get @ref Ceed associated with a @ref CeedBasis
+  @brief Get `Ceed` associated with a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
-  @param[out] ceed  Variable to store @ref Ceed
+  @param[in]  basis `CeedBasis`
+  @param[out] ceed  Variable to store `Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1748,9 +1748,9 @@ int CeedBasisGetCeed(CeedBasis basis, Ceed *ceed) {
 }
 
 /**
-  @brief Get dimension for given @ref CeedBasis
+  @brief Get dimension for given `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] dim   Variable to store dimension of basis
 
   @return An error code: 0 - success, otherwise - failure
@@ -1763,9 +1763,9 @@ int CeedBasisGetDimension(CeedBasis basis, CeedInt *dim) {
 }
 
 /**
-  @brief Get topology for given @ref CeedBasis
+  @brief Get topology for given `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] topo  Variable to store topology of basis
 
   @return An error code: 0 - success, otherwise - failure
@@ -1778,9 +1778,9 @@ int CeedBasisGetTopology(CeedBasis basis, CeedElemTopology *topo) {
 }
 
 /**
-  @brief Get number of components for given @ref CeedBasis
+  @brief Get number of components for given `CeedBasis`
 
-  @param[in]  basis    @ref CeedBasis
+  @param[in]  basis    `CeedBasis`
   @param[out] num_comp Variable to store number of components
 
   @return An error code: 0 - success, otherwise - failure
@@ -1793,9 +1793,9 @@ int CeedBasisGetNumComponents(CeedBasis basis, CeedInt *num_comp) {
 }
 
 /**
-  @brief Get total number of nodes (in `dim` dimensions) of a @ref CeedBasis
+  @brief Get total number of nodes (in `dim` dimensions) of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] P     Variable to store number of nodes
 
   @return An error code: 0 - success, otherwise - failure
@@ -1808,9 +1808,9 @@ int CeedBasisGetNumNodes(CeedBasis basis, CeedInt *P) {
 }
 
 /**
-  @brief Get total number of nodes (in 1 dimension) of a @ref CeedBasis
+  @brief Get total number of nodes (in 1 dimension) of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] P_1d  Variable to store number of nodes
 
   @return An error code: 0 - success, otherwise - failure
@@ -1824,9 +1824,9 @@ int CeedBasisGetNumNodes1D(CeedBasis basis, CeedInt *P_1d) {
 }
 
 /**
-  @brief Get total number of quadrature points (in `dim` dimensions) of a @ref CeedBasis
+  @brief Get total number of quadrature points (in `dim` dimensions) of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] Q     Variable to store number of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1839,9 +1839,9 @@ int CeedBasisGetNumQuadraturePoints(CeedBasis basis, CeedInt *Q) {
 }
 
 /**
-  @brief Get total number of quadrature points (in 1 dimension) of a @ref CeedBasis
+  @brief Get total number of quadrature points (in 1 dimension) of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] Q_1d  Variable to store number of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1855,9 +1855,9 @@ int CeedBasisGetNumQuadraturePoints1D(CeedBasis basis, CeedInt *Q_1d) {
 }
 
 /**
-  @brief Get reference coordinates of quadrature points (in `dim` dimensions) of a @ref CeedBasis
+  @brief Get reference coordinates of quadrature points (in `dim` dimensions) of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] q_ref Variable to store reference coordinates of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1870,9 +1870,9 @@ int CeedBasisGetQRef(CeedBasis basis, const CeedScalar **q_ref) {
 }
 
 /**
-  @brief Get quadrature weights of quadrature points (in `dim` dimensions) of a @ref CeedBasis
+  @brief Get quadrature weights of quadrature points (in `dim` dimensions) of a `CeedBasis`
 
-  @param[in]  basis    @ref CeedBasis
+  @param[in]  basis    `CeedBasis`
   @param[out] q_weight Variable to store quadrature weights
 
   @return An error code: 0 - success, otherwise - failure
@@ -1885,9 +1885,9 @@ int CeedBasisGetQWeights(CeedBasis basis, const CeedScalar **q_weight) {
 }
 
 /**
-  @brief Get interpolation matrix of a @ref CeedBasis
+  @brief Get interpolation matrix of a `CeedBasis`
 
-  @param[in]  basis  @ref CeedBasis
+  @param[in]  basis  `CeedBasis`
   @param[out] interp Variable to store interpolation matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1919,9 +1919,9 @@ int CeedBasisGetInterp(CeedBasis basis, const CeedScalar **interp) {
 }
 
 /**
-  @brief Get 1D interpolation matrix of a tensor product @ref CeedBasis
+  @brief Get 1D interpolation matrix of a tensor product `CeedBasis`
 
-  @param[in]  basis     @ref CeedBasis
+  @param[in]  basis     `CeedBasis`
   @param[out] interp_1d Variable to store interpolation matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1935,9 +1935,9 @@ int CeedBasisGetInterp1D(CeedBasis basis, const CeedScalar **interp_1d) {
 }
 
 /**
-  @brief Get gradient matrix of a @ref CeedBasis
+  @brief Get gradient matrix of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] grad  Variable to store gradient matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1972,9 +1972,9 @@ int CeedBasisGetGrad(CeedBasis basis, const CeedScalar **grad) {
 }
 
 /**
-  @brief Get 1D gradient matrix of a tensor product @ref CeedBasis
+  @brief Get 1D gradient matrix of a tensor product `CeedBasis`
 
-  @param[in]  basis   @ref CeedBasis
+  @param[in]  basis   `CeedBasis`
   @param[out] grad_1d Variable to store gradient matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -1988,9 +1988,9 @@ int CeedBasisGetGrad1D(CeedBasis basis, const CeedScalar **grad_1d) {
 }
 
 /**
-  @brief Get divergence matrix of a @ref CeedBasis
+  @brief Get divergence matrix of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] div   Variable to store divergence matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -2004,9 +2004,9 @@ int CeedBasisGetDiv(CeedBasis basis, const CeedScalar **div) {
 }
 
 /**
-  @brief Get curl matrix of a @ref CeedBasis
+  @brief Get curl matrix of a `CeedBasis`
 
-  @param[in]  basis @ref CeedBasis
+  @param[in]  basis `CeedBasis`
   @param[out] curl  Variable to store curl matrix
 
   @return An error code: 0 - success, otherwise - failure
@@ -2022,7 +2022,7 @@ int CeedBasisGetCurl(CeedBasis basis, const CeedScalar **curl) {
 /**
   @brief Destroy a @ref  CeedBasis
 
-  @param[in,out] basis @ref CeedBasis to destroy
+  @param[in,out] basis `CeedBasis` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-cuda.c
+++ b/interface/ceed-cuda.c
@@ -14,7 +14,7 @@
 /**
   @brief Set CUDA function pointer to evaluate action at quadrature points
 
-  @param[in,out] qf CeedQFunction to set device pointer
+  @param[in,out] qf @ref CeedQFunction to set device pointer
   @param[in]     f  Device function pointer to evaluate action at quadrature points
 
   @return An error code: 0 - success, otherwise - failure

--- a/interface/ceed-cuda.c
+++ b/interface/ceed-cuda.c
@@ -14,7 +14,7 @@
 /**
   @brief Set CUDA function pointer to evaluate action at quadrature points
 
-  @param[in,out] qf @ref CeedQFunction to set device pointer
+  @param[in,out] qf `CeedQFunction` to set device pointer
   @param[in]     f  Device function pointer to evaluate action at quadrature points
 
   @return An error code: 0 - success, otherwise - failure

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -22,7 +22,7 @@
 /// @{
 
 /**
-  @brief Permute and pad offsets for a blocked @ref CeedElemRestriction
+  @brief Permute and pad offsets for a blocked `CeedElemRestriction`
 
   @param[in]  offsets       Array of shape `[num_elem, elem_size]`
   @param[out] block_offsets Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
@@ -48,7 +48,7 @@ int CeedPermutePadOffsets(const CeedInt *offsets, CeedInt *block_offsets, CeedIn
 }
 
 /**
-  @brief Permute and pad orientations for a blocked @ref CeedElemRestriction
+  @brief Permute and pad orientations for a blocked `CeedElemRestriction`
 
   @param[in]  orients       Array of shape `[num_elem, elem_size]`
   @param[out] block_orients Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
@@ -73,7 +73,7 @@ int CeedPermutePadOrients(const bool *orients, bool *block_orients, CeedInt num_
 }
 
 /**
-  @brief Permute and pad curl-conforming orientations for a blocked @ref CeedElemRestriction
+  @brief Permute and pad curl-conforming orientations for a blocked `CeedElemRestriction`
 
   @param[in]  curl_orients       Array of shape `[num_elem, 3 * elem_size]`
   @param[out] block_curl_orients Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
@@ -107,9 +107,9 @@ int CeedPermutePadCurlOrients(const CeedInt8 *curl_orients, CeedInt8 *block_curl
 /// @{
 
 /**
-  @brief Get the type of a @ref CeedElemRestriction
+  @brief Get the type of a `CeedElemRestriction`
 
-  @param[in]  rstr      @ref CeedElemRestriction
+  @param[in]  rstr      `CeedElemRestriction`
   @param[out] rstr_type Variable to store restriction type
 
   @return An error code: 0 - success, otherwise - failure
@@ -122,9 +122,9 @@ int CeedElemRestrictionGetType(CeedElemRestriction rstr, CeedRestrictionType *rs
 }
 
 /**
-  @brief Get the strided status of a @ref CeedElemRestriction
+  @brief Get the strided status of a `CeedElemRestriction`
 
-  @param[in]  rstr       @ref CeedElemRestriction
+  @param[in]  rstr       `CeedElemRestriction`
   @param[out] is_strided Variable to store strided status
 
   @return An error code: 0 - success, otherwise - failure
@@ -137,9 +137,9 @@ int CeedElemRestrictionIsStrided(CeedElemRestriction rstr, bool *is_strided) {
 }
 
 /**
-  @brief Get the points status of a @ref CeedElemRestriction
+  @brief Get the points status of a `CeedElemRestriction`
 
-  @param[in]  rstr      @ref CeedElemRestriction
+  @param[in]  rstr      `CeedElemRestriction`
   @param[out] is_points Variable to store points status
 
   @return An error code: 0 - success, otherwise - failure
@@ -152,10 +152,10 @@ int CeedElemRestrictionIsPoints(CeedElemRestriction rstr, bool *is_points) {
 }
 
 /**
-  @brief Check if two @ref CeedElemRestriction created with @ref CeedElemRestrictionCreateAtPoints() and use the same points per element
+  @brief Check if two `CeedElemRestriction` created with @ref CeedElemRestrictionCreateAtPoints() and use the same points per element
 
-  @param[in]  rstr_a         First @ref CeedElemRestriction
-  @param[in]  rstr_b         Second @ref CeedElemRestriction
+  @param[in]  rstr_a         First `CeedElemRestriction`
+  @param[in]  rstr_b         Second `CeedElemRestriction`
   @param[out] are_compatible Variable to store compatibility status
 
   @return An error code: 0 - success, otherwise - failure
@@ -191,9 +191,9 @@ int CeedElemRestrictionAtPointsAreCompatible(CeedElemRestriction rstr_a, CeedEle
 }
 
 /**
-  @brief Get the strides of a strided @ref CeedElemRestriction
+  @brief Get the strides of a strided `CeedElemRestriction`
 
-  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  rstr    `CeedElemRestriction`
   @param[out] strides Variable to store strides array
 
   @return An error code: 0 - success, otherwise - failure
@@ -207,9 +207,9 @@ int CeedElemRestrictionGetStrides(CeedElemRestriction rstr, CeedInt (*strides)[3
 }
 
 /**
-  @brief Get the backend stride status of a @ref CeedElemRestriction
+  @brief Get the backend stride status of a `CeedElemRestriction`
 
-  @param[in]  rstr                 @ref CeedElemRestriction
+  @param[in]  rstr                 `CeedElemRestriction`
   @param[out] has_backend_strides  Variable to store stride status
 
   @return An error code: 0 - success, otherwise - failure
@@ -224,9 +224,9 @@ int CeedElemRestrictionHasBackendStrides(CeedElemRestriction rstr, bool *has_bac
 }
 
 /**
-  @brief Get read-only access to a @ref CeedElemRestriction offsets array by @ref CeedMemType
+  @brief Get read-only access to a `CeedElemRestriction` offsets array by @ref CeedMemType
 
-  @param[in]  rstr     @ref CeedElemRestriction to retrieve offsets
+  @param[in]  rstr     `CeedElemRestriction` to retrieve offsets
   @param[in]  mem_type Memory type on which to access the array.
                          If the backend uses a different memory type, this will perform a copy (possibly cached).
   @param[out] offsets  Array on memory type `mem_type`
@@ -249,7 +249,7 @@ int CeedElemRestrictionGetOffsets(CeedElemRestriction rstr, CeedMemType mem_type
 /**
   @brief Restore an offsets array obtained using @ref CeedElemRestrictionGetOffsets()
 
-  @param[in] rstr    @ref CeedElemRestriction to restore
+  @param[in] rstr    `CeedElemRestriction` to restore
   @param[in] offsets Array of offset data
 
   @return An error code: 0 - success, otherwise - failure
@@ -267,9 +267,9 @@ int CeedElemRestrictionRestoreOffsets(CeedElemRestriction rstr, const CeedInt **
 }
 
 /**
-  @brief Get read-only access to a @ref CeedElemRestriction orientations array by @ref CeedMemType
+  @brief Get read-only access to a `CeedElemRestriction` orientations array by @ref CeedMemType
 
-  @param[in]  rstr     @ref CeedElemRestriction to retrieve orientations
+  @param[in]  rstr     `CeedElemRestriction` to retrieve orientations
   @param[in]  mem_type Memory type on which to access the array.
                          If the backend uses a different memory type, this will perform a copy (possibly cached).
   @param[out] orients  Array on memory type `mem_type`
@@ -288,7 +288,7 @@ int CeedElemRestrictionGetOrientations(CeedElemRestriction rstr, CeedMemType mem
 /**
   @brief Restore an orientations array obtained using @ref CeedElemRestrictionGetOrientations()
 
-  @param[in] rstr    @ref CeedElemRestriction to restore
+  @param[in] rstr    `CeedElemRestriction` to restore
   @param[in] orients Array of orientation data
 
   @return An error code: 0 - success, otherwise - failure
@@ -302,9 +302,9 @@ int CeedElemRestrictionRestoreOrientations(CeedElemRestriction rstr, const bool 
 }
 
 /**
-  @brief Get read-only access to a @ref CeedElemRestriction curl-conforming orientations array by @ref CeedMemType
+  @brief Get read-only access to a `CeedElemRestriction` curl-conforming orientations array by @ref CeedMemType
 
-  @param[in]  rstr         @ref CeedElemRestriction to retrieve curl-conforming orientations
+  @param[in]  rstr         `CeedElemRestriction` to retrieve curl-conforming orientations
   @param[in]  mem_type     Memory type on which to access the array.
                              If the backend uses a different memory type, this will perform a copy (possibly cached).
   @param[out] curl_orients Array on memory type `mem_type`
@@ -323,7 +323,7 @@ int CeedElemRestrictionGetCurlOrientations(CeedElemRestriction rstr, CeedMemType
 /**
   @brief Restore an orientations array obtained using @ref CeedElemRestrictionGetCurlOrientations()
 
-  @param[in] rstr         @ref CeedElemRestriction to restore
+  @param[in] rstr         `CeedElemRestriction` to restore
   @param[in] curl_orients Array of orientation data
 
   @return An error code: 0 - success, otherwise - failure
@@ -338,9 +338,9 @@ int CeedElemRestrictionRestoreCurlOrientations(CeedElemRestriction rstr, const C
 
 /**
 
-  @brief Get the E-vector layout of a @ref CeedElemRestriction
+  @brief Get the E-vector layout of a `CeedElemRestriction`
 
-  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  rstr    `CeedElemRestriction`
   @param[out] layout  Variable to store layout array, stored as `[nodes, components, elements]`.
                         The data for node `i`, component `j`, element `k` in the E-vector is given by `i*layout[0] + j*layout[1] + k*layout[2]`.
 
@@ -356,9 +356,9 @@ int CeedElemRestrictionGetELayout(CeedElemRestriction rstr, CeedInt (*layout)[3]
 
 /**
 
-  @brief Set the E-vector layout of a @ref CeedElemRestriction
+  @brief Set the E-vector layout of a `CeedElemRestriction`
 
-  @param[in] rstr   @ref CeedElemRestriction
+  @param[in] rstr   `CeedElemRestriction`
   @param[in] layout Variable to containing layout array, stored as `[nodes, components, elements]`.
                       The data for node `i`, component `j`, element `k` in the E-vector is given by `i*layout[0] + j*layout[1] + k*layout[2]`.
 
@@ -372,9 +372,9 @@ int CeedElemRestrictionSetELayout(CeedElemRestriction rstr, CeedInt layout[3]) {
 }
 
 /**
-  @brief Get the backend data of a @ref CeedElemRestriction
+  @brief Get the backend data of a `CeedElemRestriction`
 
-  @param[in]  rstr @ref CeedElemRestriction
+  @param[in]  rstr `CeedElemRestriction`
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -387,9 +387,9 @@ int CeedElemRestrictionGetData(CeedElemRestriction rstr, void *data) {
 }
 
 /**
-  @brief Set the backend data of a @ref CeedElemRestriction
+  @brief Set the backend data of a `CeedElemRestriction`
 
-  @param[in,out] rstr @ref CeedElemRestriction
+  @param[in,out] rstr `CeedElemRestriction`
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -402,9 +402,9 @@ int CeedElemRestrictionSetData(CeedElemRestriction rstr, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedElemRestriction
+  @brief Increment the reference counter for a `CeedElemRestriction`
 
-  @param[in,out] rstr @ref CeedElemRestriction to increment the reference counter
+  @param[in,out] rstr `CeedElemRestriction` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -416,9 +416,9 @@ int CeedElemRestrictionReference(CeedElemRestriction rstr) {
 }
 
 /**
-  @brief Estimate number of FLOPs required to apply @ref CeedElemRestriction in `t_mode`
+  @brief Estimate number of FLOPs required to apply `CeedElemRestriction` in `t_mode`
 
-  @param[in]  rstr   @ref CeedElemRestriction to estimate FLOPs for
+  @param[in]  rstr   `CeedElemRestriction` to estimate FLOPs for
   @param[in]  t_mode Apply restriction or transpose
   @param[out] flops  Address of variable to hold FLOPs estimate
 
@@ -480,13 +480,13 @@ static struct CeedElemRestriction_private ceed_elemrestriction_none;
 /// Indicate that the stride is determined by the backend
 const CeedInt CEED_STRIDES_BACKEND[3] = {0};
 
-/// Argument for @ref CeedOperatorSetField() indicating that the field does not require a @ref CeedElemRestriction
+/// Argument for @ref CeedOperatorSetField() indicating that the field does not require a `CeedElemRestriction`
 const CeedElemRestriction CEED_ELEMRESTRICTION_NONE = &ceed_elemrestriction_none;
 
 /**
-  @brief Create a @ref CeedElemRestriction
+  @brief Create a `CeedElemRestriction`
 
-  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed        `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem    Number of elements described in the `offsets` array
   @param[in]  elem_size   Size (number of "nodes") per element
   @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
@@ -497,9 +497,9 @@ const CeedElemRestriction CEED_ELEMRESTRICTION_NONE = &ceed_elemrestriction_none
   @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
   @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
   @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
-                            Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where 0 <= i < @a num_elem.
+                            Row `i` holds the ordered list of the offsets (into the input `CeedVector`) for the unknowns corresponding to element `i`, where 0 <= i < @a num_elem.
                             All offsets must be in the range `[0, l_size - 1]`.
-  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr        Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -538,9 +538,9 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size, Ce
 }
 
 /**
-  @brief Create a @ref CeedElemRestriction with orientation signs
+  @brief Create a `CeedElemRestriction` with orientation signs
 
-  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed        `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem    Number of elements described in the `offsets` array
   @param[in]  elem_size   Size (number of "nodes") per element
   @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
@@ -551,10 +551,10 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size, Ce
   @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
   @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
   @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
-                            Row i holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                            Row i holds the ordered list of the offsets (into the input `CeedVector`) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
                             All offsets must be in the range `[0, l_size - 1]`.
   @param[in]  orients     Boolean array of shape `[num_elem, elem_size]` with `false` for positively oriented and `true` to flip the orientation
-  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr        Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -595,9 +595,9 @@ int CeedElemRestrictionCreateOriented(Ceed ceed, CeedInt num_elem, CeedInt elem_
 }
 
 /**
-  @brief Create a @ref CeedElemRestriction with a general tridiagonal transformation matrix for curl-conforming elements
+  @brief Create a `CeedElemRestriction` with a general tridiagonal transformation matrix for curl-conforming elements
 
-  @param[in]  ceed         @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed         `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem     Number of elements described in the `offsets` array
   @param[in]  elem_size    Size (number of "nodes") per element
   @param[in]  num_comp     Number of field components per interpolation node (1 for scalar fields)
@@ -608,11 +608,11 @@ int CeedElemRestrictionCreateOriented(Ceed ceed, CeedInt num_elem, CeedInt elem_
   @param[in]  mem_type     Memory type of the `offsets` array, see @ref CeedMemType
   @param[in]  copy_mode    Copy mode for the `offsets` array, see @ref CeedCopyMode
   @param[in]  offsets      Array of shape `[num_elem, elem_size]`.
-                             Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                             Row `i` holds the ordered list of the offsets (into the input `CeedVector`) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
                              All offsets must be in the range `[0, l_size - 1]`.
   @param[in]  curl_orients Array of shape `[num_elem, 3 * elem_size]` representing a row-major tridiagonal matrix (`curl_orients[i * 3 * elem_size] = curl_orients[(i + 1) * 3 * elem_size - 1] = 0`, where `0 <= i < num_elem`) which is applied to the element unknowns upon restriction.
                              This orientation matrix allows for pairs of face degrees of freedom on elements for \f$H(\mathrm{curl})\f$ spaces to be coupled in the element restriction operation, which is a way to resolve face orientation issues for 3D meshes (https://dl.acm.org/doi/pdf/10.1145/3524456).
-  @param[out] rstr         Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr         Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -653,9 +653,9 @@ int CeedElemRestrictionCreateCurlOriented(Ceed ceed, CeedInt num_elem, CeedInt e
 }
 
 /**
-  @brief Create a strided @ref CeedElemRestriction
+  @brief Create a strided `CeedElemRestriction`
 
-  @param[in]  ceed      @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed      `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem  Number of elements described by the restriction
   @param[in]  elem_size Size (number of "nodes") per element
   @param[in]  num_comp  Number of field components per interpolation "node" (1 for scalar fields)
@@ -663,8 +663,8 @@ int CeedElemRestrictionCreateCurlOriented(Ceed ceed, CeedInt num_elem, CeedInt e
                           This vector may be larger than the elements and fields given by this restriction.
   @param[in]  strides   Array for strides between `[nodes, components, elements]`.
                           Data for node `i`, component `j`, element `k` can be found in the L-vector at index `i*strides[0] + j*strides[1] + k*strides[2]`.
-                          @ref CEED_STRIDES_BACKEND may be used for @ref CeedVector ordered by the same @ref Ceed backend.
-  @param[out] rstr      Address of the variable where the newly created @ref CeedElemRestriction will be stored
+                          @ref CEED_STRIDES_BACKEND may be used for `CeedVector` ordered by the same `Ceed` backend.
+  @param[out] rstr      Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -704,7 +704,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
 }
 
 /**
-  @brief Create a points @ref CeedElemRestriction, for restricting for restricting from a all local points to the current element in which they are located.
+  @brief Create a points `CeedElemRestriction`, for restricting for restricting from a all local points to the current element in which they are located.
 
   The offsets array is arranged as
 
@@ -717,7 +717,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   element_0_point_1
   ...
 
-  @param[in]  ceed       @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed       `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem   Number of elements described in the `offsets` array
   @param[in]  num_points Number of points described in the `offsets` array
   @param[in]  num_comp   Number of field components per interpolation node (1 for scalar fields).
@@ -729,7 +729,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   @param[in]  offsets    Array of size `num_elem + 1 + num_points`.
                            The first portion of the offsets array holds the ranges of indices corresponding to each element.
                            The second portion holds the indices for each element.
-  @param[out] rstr       Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr       Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -767,9 +767,9 @@ int CeedElemRestrictionCreateAtPoints(Ceed ceed, CeedInt num_elem, CeedInt num_p
 }
 
 /**
-  @brief Create a blocked @ref CeedElemRestriction, typically only used by backends
+  @brief Create a blocked `CeedElemRestriction`, typically only used by backends
 
-  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed        `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem    Number of elements described in the `offsets` array
   @param[in]  elem_size   Size (number of unknowns) per element
   @param[in]  block_size  Number of elements in a block
@@ -781,11 +781,11 @@ int CeedElemRestrictionCreateAtPoints(Ceed ceed, CeedInt num_elem, CeedInt num_p
   @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
   @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
   @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
-                            Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                            Row `i` holds the ordered list of the offsets (into the input `CeedVector`) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
                             All offsets must be in the range `[0, l_size - 1]`.
                             The backend will permute and pad this array to the desired ordering for the blocksize, which is typically given by the backend.
                             The default reordering is to interlace elements.
-  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr        Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -833,9 +833,9 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem, CeedInt elem_s
 }
 
 /**
-  @brief Create a blocked oriented @ref CeedElemRestriction, typically only used by backends
+  @brief Create a blocked oriented `CeedElemRestriction`, typically only used by backends
 
-  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed        `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem    Number of elements described in the `offsets` array.
   @param[in]  elem_size   Size (number of unknowns) per element
   @param[in]  block_size  Number of elements in a block
@@ -847,13 +847,13 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
   @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
   @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
-                            Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                            Row `i` holds the ordered list of the offsets (into the input `CeedVector`) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
                             All offsets must be in the range `[0, l_size - 1]`.
                             The backend will permute and pad this array to the desired ordering for the blocksize, which is typically given by the backend.
                             The default reordering is to interlace elements.
   @param[in]  orients     Boolean array of shape `[num_elem, elem_size]` with `false` for positively oriented and `true` to flip the orientation.
                             Will also be permuted and padded similarly to `offsets`.
-  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr        Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -904,9 +904,9 @@ int CeedElemRestrictionCreateBlockedOriented(Ceed ceed, CeedInt num_elem, CeedIn
 }
 
 /**
-  @brief Create a blocked curl-oriented @ref CeedElemRestriction, typically only used by backends
+  @brief Create a blocked curl-oriented `CeedElemRestriction`, typically only used by backends
 
-  @param[in]  ceed         @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed         `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem     Number of elements described in the `offsets` array.
   @param[in]  elem_size    Size (number of unknowns) per element
   @param[in]  block_size   Number of elements in a block
@@ -918,14 +918,14 @@ int CeedElemRestrictionCreateBlockedOriented(Ceed ceed, CeedInt num_elem, CeedIn
   @param[in]  mem_type     Memory type of the `offsets` array, see @ref CeedMemType
   @param[in]  copy_mode    Copy mode for the `offsets` array, see @ref CeedCopyMode
   @param[in]  offsets      Array of shape `[num_elem, elem_size]`.
-                             Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                             Row `i` holds the ordered list of the offsets (into the input `CeedVector`) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
                              All offsets must be in the range `[0, l_size - 1]`.
                              The backend will permute and pad this array to the desired  ordering for the blocksize, which is typically given by the backend.
                              The default reordering is to interlace elements.
   @param[in]  curl_orients Array of shape `[num_elem, 3 * elem_size]` representing a row-major tridiagonal matrix (`curl_orients[i * 3 * elem_size] = curl_orients[(i + 1) * 3 * elem_size - 1] = 0`, where `0 <= i < num_elem`) which is applied to the element unknowns upon restriction.
                              This orientation matrix allows for pairs of face degrees of freedom on elements for \f$H(\mathrm{curl})\f$ spaces to be coupled in the element restriction  operation, which is a way to resolve face orientation issues for 3D meshes (https://dl.acm.org/doi/pdf/10.1145/3524456).
                              Will also be permuted and padded similarly to offsets.
-  @param[out] rstr         Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[out] rstr         Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -977,9 +977,9 @@ int CeedElemRestrictionCreateBlockedCurlOriented(Ceed ceed, CeedInt num_elem, Ce
 }
 
 /**
-  @brief Create a blocked strided @ref CeedElemRestriction, typically only used by backends
+  @brief Create a blocked strided `CeedElemRestriction`, typically only used by backends
 
-  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  ceed        `Ceed` context used to create the `CeedElemRestriction`
   @param[in]  num_elem    Number of elements described by the restriction
   @param[in]  elem_size   Size (number of "nodes") per element
   @param[in]  block_size  Number of elements in a block
@@ -988,8 +988,8 @@ int CeedElemRestrictionCreateBlockedCurlOriented(Ceed ceed, CeedInt num_elem, Ce
                             This vector may be larger than the elements and fields given by this restriction.
   @param[in]  strides     Array for strides between `[nodes, components, elements]`.
                             Data for node `i`, component `j`, element `k` can be found in the L-vector at index `i*strides[0] + j*strides[1] +k*strides[2]`.
-                            @ref CEED_STRIDES_BACKEND may be used for @ref CeedVector ordered by the same @ref Ceed backend.
-  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
+                            @ref CEED_STRIDES_BACKEND may be used for `CeedVector` ordered by the same `Ceed` backend.
+  @param[out] rstr        Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1032,12 +1032,12 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem, CeedInt
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedElemRestriction and set @ref CeedElemRestrictionApply() implementation to use the unsigned version.
+  @brief Copy the pointer to a `CeedElemRestriction` and set @ref CeedElemRestrictionApply() implementation to use the unsigned version.
 
   Both pointers should be destroyed with @ref CeedElemRestrictionDestroy().
 
-  @param[in]     rstr          @ref CeedElemRestriction to create unsigned reference to
-  @param[in,out] rstr_unsigned Variable to store unsigned @ref CeedElemRestriction
+  @param[in]     rstr          `CeedElemRestriction` to create unsigned reference to
+  @param[in,out] rstr_unsigned Variable to store unsigned `CeedElemRestriction`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1064,12 +1064,12 @@ int CeedElemRestrictionCreateUnsignedCopy(CeedElemRestriction rstr, CeedElemRest
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedElemRestriction and set @ref CeedElemRestrictionApply() implementation to use the unoriented version.
+  @brief Copy the pointer to a `CeedElemRestriction` and set @ref CeedElemRestrictionApply() implementation to use the unoriented version.
 
   Both pointers should be destroyed with @ref CeedElemRestrictionDestroy().
 
-  @param[in]     rstr            @ref CeedElemRestriction to create unoriented reference to
-  @param[in,out] rstr_unoriented Variable to store unoriented @ref CeedElemRestriction
+  @param[in]     rstr            `CeedElemRestriction` to create unoriented reference to
+  @param[in,out] rstr_unoriented Variable to store unoriented `CeedElemRestriction`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1096,14 +1096,14 @@ int CeedElemRestrictionCreateUnorientedCopy(CeedElemRestriction rstr, CeedElemRe
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedElemRestriction.
+  @brief Copy the pointer to a `CeedElemRestriction`.
 
   Both pointers should be destroyed with @ref CeedElemRestrictionDestroy().
 
-  Note: If the value of `*rstr_copy` passed into this function is non-`NULL`, then it is assumed that `*rstr_copy` is a pointer to a @ref CeedElemRestriction.
-        This @ref CeedElemRestriction will be destroyed if `*rstr_copy` is the only reference to this @ref CeedElemRestriction.
+  Note: If the value of `*rstr_copy` passed into this function is non-`NULL`, then it is assumed that `*rstr_copy` is a pointer to a `CeedElemRestriction`.
+        This `CeedElemRestriction` will be destroyed if `*rstr_copy` is the only reference to this `CeedElemRestriction`.
 
-  @param[in]     rstr      @ref CeedElemRestriction to copy reference to
+  @param[in]     rstr      `CeedElemRestriction` to copy reference to
   @param[in,out] rstr_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -1118,9 +1118,9 @@ int CeedElemRestrictionReferenceCopy(CeedElemRestriction rstr, CeedElemRestricti
 }
 
 /**
-  @brief Create @ref CeedVector associated with a @ref CeedElemRestriction
+  @brief Create `CeedVector` associated with a `CeedElemRestriction`
 
-  @param[in]  rstr  @ref CeedElemRestriction
+  @param[in]  rstr  `CeedElemRestriction`
   @param[out] l_vec The address of the L-vector to be created, or `NULL`
   @param[out] e_vec The address of the E-vector to be created, or `NULL`
 
@@ -1145,7 +1145,7 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *l_vec,
 /**
   @brief Restrict an L-vector to an E-vector or apply its transpose
 
-  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  rstr    `CeedElemRestriction`
   @param[in]  t_mode  Apply restriction or transpose
   @param[in]  u       Input vector (of size `l_size` when `t_mode` = @ref CEED_NOTRANSPOSE)
   @param[out] ru      Output vector (of shape `[num_elem * elem_size]` when `t_mode` = @ref CEED_NOTRANSPOSE).
@@ -1177,7 +1177,7 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode t_mode,
 /**
   @brief Restrict an L-vector of points to a single element or apply its transpose
 
-  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  rstr    `CeedElemRestriction`
   @param[in]  elem    Element number in range `[0, num_elem)`
   @param[in]  t_mode  Apply restriction or transpose
   @param[in]  u       Input vector (of size `l_size` when `t_mode` = @ref CEED_NOTRANSPOSE)
@@ -1217,7 +1217,7 @@ int CeedElemRestrictionApplyAtPointsInElement(CeedElemRestriction rstr, CeedInt 
 /**
   @brief Restrict an L-vector to a block of an E-vector or apply its transpose
 
-  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  rstr    `CeedElemRestriction`
   @param[in]  block   Block number to restrict to/from, i.e. `block = 0` will handle elements `[0 : block_size]` and `block = 3` will handle elements `[3*block_size : 4*block_size]`
   @param[in]  t_mode  Apply restriction or transpose
   @param[in]  u       Input vector (of size `l_size` when `t_mode` = @ref CEED_NOTRANSPOSE)
@@ -1254,10 +1254,10 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block, CeedT
 }
 
 /**
-  @brief Get the @ref Ceed associated with a @ref CeedElemRestriction
+  @brief Get the `Ceed` associated with a `CeedElemRestriction`
 
-  @param[in]  rstr @ref CeedElemRestriction
-  @param[out] ceed Variable to store @ref Ceed
+  @param[in]  rstr `CeedElemRestriction`
+  @param[out] ceed Variable to store `Ceed` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1271,7 +1271,7 @@ int CeedElemRestrictionGetCeed(CeedElemRestriction rstr, Ceed *ceed) {
 /**
   @brief Get the L-vector component stride
 
-  @param[in]  rstr        @ref CeedElemRestriction
+  @param[in]  rstr        `CeedElemRestriction`
   @param[out] comp_stride Variable to store component stride
 
   @return An error code: 0 - success, otherwise - failure
@@ -1284,9 +1284,9 @@ int CeedElemRestrictionGetCompStride(CeedElemRestriction rstr, CeedInt *comp_str
 }
 
 /**
-  @brief Get the total number of elements in the range of a @ref CeedElemRestriction
+  @brief Get the total number of elements in the range of a `CeedElemRestriction`
 
-  @param[in] rstr      @ref CeedElemRestriction
+  @param[in] rstr      `CeedElemRestriction`
   @param[out] num_elem Variable to store number of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1299,9 +1299,9 @@ int CeedElemRestrictionGetNumElements(CeedElemRestriction rstr, CeedInt *num_ele
 }
 
 /**
-  @brief Get the size of elements in the @ref CeedElemRestriction
+  @brief Get the size of elements in the `CeedElemRestriction`
 
-  @param[in]  rstr      @ref CeedElemRestriction
+  @param[in]  rstr      `CeedElemRestriction`
   @param[out] elem_size Variable to store size of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1315,9 +1315,9 @@ int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr, CeedInt *elem_si
 
 /**
 
-  @brief Get the number of points in the l-vector for a points @ref CeedElemRestriction
+  @brief Get the number of points in the l-vector for a points `CeedElemRestriction`
 
-  @param[in]  rstr       @ref CeedElemRestriction
+  @param[in]  rstr       `CeedElemRestriction`
   @param[out] num_points The number of points in the l-vector
 
   @return An error code: 0 - success, otherwise - failure
@@ -1337,9 +1337,9 @@ int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_point
 
 /**
 
-  @brief Get the number of points in an element of a @ref CeedElemRestriction at points
+  @brief Get the number of points in an element of a `CeedElemRestriction` at points
 
-  @param[in]  rstr       @ref CeedElemRestriction
+  @param[in]  rstr       `CeedElemRestriction`
   @param[in]  elem       Index number of element to retrieve the number of points for
   @param[out] num_points The number of points in the element at index elem
 
@@ -1362,9 +1362,9 @@ int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt e
 }
 
 /**
-  @brief Get the maximum number of points in an element for a @ref CeedElemRestriction at points
+  @brief Get the maximum number of points in an element for a `CeedElemRestriction` at points
 
-  @param[in]  rstr       @ref CeedElemRestriction
+  @param[in]  rstr       `CeedElemRestriction`
   @param[out] max_points Variable to store size of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1393,9 +1393,9 @@ int CeedElemRestrictionGetMaxPointsInElement(CeedElemRestriction rstr, CeedInt *
 }
 
 /**
-  @brief Get the size of the l-vector for a @ref CeedElemRestriction
+  @brief Get the size of the l-vector for a `CeedElemRestriction`
 
-  @param[in]  rstr   @ref CeedElemRestriction
+  @param[in]  rstr   `CeedElemRestriction`
   @param[out] l_size Variable to store number of nodes
 
   @return An error code: 0 - success, otherwise - failure
@@ -1408,9 +1408,9 @@ int CeedElemRestrictionGetLVectorSize(CeedElemRestriction rstr, CeedSize *l_size
 }
 
 /**
-  @brief Get the number of components in the elements of a @ref CeedElemRestriction
+  @brief Get the number of components in the elements of a `CeedElemRestriction`
 
-  @param[in]  rstr     @ref CeedElemRestriction
+  @param[in]  rstr     `CeedElemRestriction`
   @param[out] num_comp Variable to store number of components
 
   @return An error code: 0 - success, otherwise - failure
@@ -1423,9 +1423,9 @@ int CeedElemRestrictionGetNumComponents(CeedElemRestriction rstr, CeedInt *num_c
 }
 
 /**
-  @brief Get the number of blocks in a @ref CeedElemRestriction
+  @brief Get the number of blocks in a `CeedElemRestriction`
 
-  @param[in]  rstr      @ref CeedElemRestriction
+  @param[in]  rstr      `CeedElemRestriction`
   @param[out] num_block Variable to store number of blocks
 
   @return An error code: 0 - success, otherwise - failure
@@ -1438,9 +1438,9 @@ int CeedElemRestrictionGetNumBlocks(CeedElemRestriction rstr, CeedInt *num_block
 }
 
 /**
-  @brief Get the size of blocks in the @ref CeedElemRestriction
+  @brief Get the size of blocks in the `CeedElemRestriction`
 
-  @param[in]  rstr       @ref CeedElemRestriction
+  @param[in]  rstr       `CeedElemRestriction`
   @param[out] block_size Variable to store size of blocks
 
   @return An error code: 0 - success, otherwise - failure
@@ -1453,9 +1453,9 @@ int CeedElemRestrictionGetBlockSize(CeedElemRestriction rstr, CeedInt *block_siz
 }
 
 /**
-  @brief Get the multiplicity of nodes in a @ref CeedElemRestriction
+  @brief Get the multiplicity of nodes in a `CeedElemRestriction`
 
-  @param[in]  rstr @ref CeedElemRestriction
+  @param[in]  rstr `CeedElemRestriction`
   @param[out] mult Vector to store multiplicity (of size `l_size`)
 
   @return An error code: 0 - success, otherwise - failure
@@ -1480,9 +1480,9 @@ int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr, CeedVector mult
 }
 
 /**
-  @brief View a @ref CeedElemRestriction
+  @brief View a `CeedElemRestriction`
 
-  @param[in] rstr   @ref CeedElemRestriction to view
+  @param[in] rstr   `CeedElemRestriction` to view
   @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
@@ -1518,9 +1518,9 @@ int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream) {
 }
 
 /**
-  @brief Destroy a @ref CeedElemRestriction
+  @brief Destroy a `CeedElemRestriction`
 
-  @param[in,out] rstr @ref CeedElemRestriction to destroy
+  @param[in,out] rstr `CeedElemRestriction` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -22,14 +22,14 @@
 /// @{
 
 /**
-  @brief Permute and pad offsets for a blocked restriction
+  @brief Permute and pad offsets for a blocked @ref CeedElemRestriction
 
-  @param[in]  offsets        Array of shape [@a num_elem, @a elem_size].
-  @param[out] block_offsets  Array of permuted and padded array values of shape [@a num_block, @a elem_size, @a block_size].
-  @param[in]  num_block      Number of blocks
-  @param[in]  num_elem       Number of elements
-  @param[in]  block_size     Number of elements in a block
-  @param[in]  elem_size      Size of each element
+  @param[in]  offsets       Array of shape `[num_elem, elem_size]`
+  @param[out] block_offsets Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
+  @param[in]  num_block     Number of blocks
+  @param[in]  num_elem      Number of elements
+  @param[in]  block_size    Number of elements in a block
+  @param[in]  elem_size     Size of each element
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -48,10 +48,10 @@ int CeedPermutePadOffsets(const CeedInt *offsets, CeedInt *block_offsets, CeedIn
 }
 
 /**
-  @brief Permute and pad orientations for a blocked restriction
+  @brief Permute and pad orientations for a blocked @ref CeedElemRestriction
 
-  @param[in]  orients       Array of shape [@a num_elem, @a elem_size].
-  @param[out] block_orients Array of permuted and padded array values of shape [@a num_block, @a elem_size, @a block_size].
+  @param[in]  orients       Array of shape `[num_elem, elem_size]`
+  @param[out] block_orients Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
   @param[in]  num_block     Number of blocks
   @param[in]  num_elem      Number of elements
   @param[in]  block_size    Number of elements in a block
@@ -73,10 +73,10 @@ int CeedPermutePadOrients(const bool *orients, bool *block_orients, CeedInt num_
 }
 
 /**
-  @brief Permute and pad curl-conforming orientations for a blocked restriction
+  @brief Permute and pad curl-conforming orientations for a blocked @ref CeedElemRestriction
 
-  @param[in]  curl_orients       Array of shape [@a num_elem, @a 3 * elem_size].
-  @param[out] block_curl_orients Array of permuted and padded array values of shape [@a num_block, @a elem_size, @a block_size].
+  @param[in]  curl_orients       Array of shape `[num_elem, 3 * elem_size]`
+  @param[out] block_curl_orients Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
   @param[in]  num_block          Number of blocks
   @param[in]  num_elem           Number of elements
   @param[in]  block_size         Number of elements in a block
@@ -107,9 +107,9 @@ int CeedPermutePadCurlOrients(const CeedInt8 *curl_orients, CeedInt8 *block_curl
 /// @{
 
 /**
-  @brief Get the type of a CeedElemRestriction
+  @brief Get the type of a @ref CeedElemRestriction
 
-  @param[in]  rstr      CeedElemRestriction
+  @param[in]  rstr      @ref CeedElemRestriction
   @param[out] rstr_type Variable to store restriction type
 
   @return An error code: 0 - success, otherwise - failure
@@ -122,10 +122,14 @@ int CeedElemRestrictionGetType(CeedElemRestriction rstr, CeedRestrictionType *rs
 }
 
 /**
-  @brief Get the strided status of a CeedElemRestriction
+  @brief Get the strided status of a @ref CeedElemRestriction
 
-  @param[in]  rstr       CeedElemRestriction
-  @param[out] is_strided Variable to store strided status, 1 if strided else 0
+  @param[in]  rstr       @ref CeedElemRestriction
+  @param[out] is_strided Variable to store strided status
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
 **/
 int CeedElemRestrictionIsStrided(CeedElemRestriction rstr, bool *is_strided) {
   *is_strided = (rstr->rstr_type == CEED_RESTRICTION_STRIDED);
@@ -133,10 +137,14 @@ int CeedElemRestrictionIsStrided(CeedElemRestriction rstr, bool *is_strided) {
 }
 
 /**
-  @brief Get the points status of a CeedElemRestriction
+  @brief Get the points status of a @ref CeedElemRestriction
 
-  @param[in]  rstr      CeedElemRestriction
-  @param[out] is_points Variable to store points status, 1 if points else 0
+  @param[in]  rstr      @ref CeedElemRestriction
+  @param[out] is_points Variable to store points status
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
 **/
 int CeedElemRestrictionIsPoints(CeedElemRestriction rstr, bool *is_points) {
   *is_points = (rstr->rstr_type == CEED_RESTRICTION_POINTS);
@@ -144,18 +152,22 @@ int CeedElemRestrictionIsPoints(CeedElemRestriction rstr, bool *is_points) {
 }
 
 /**
-  @brief Check if two CeedElemRestrictionAtPoints use the same points per element
+  @brief Check if two @ref CeedElemRestriction created with @ref CeedElemRestrictionCreateAtPoints() and use the same points per element
 
-  @param[in]  rstr_a         First CeedElemRestriction
-  @param[in]  rstr_b         Second CeedElemRestriction
+  @param[in]  rstr_a         First @ref CeedElemRestriction
+  @param[in]  rstr_b         Second @ref CeedElemRestriction
   @param[out] are_compatible Variable to store compatibility status
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
 **/
 int CeedElemRestrictionAtPointsAreCompatible(CeedElemRestriction rstr_a, CeedElemRestriction rstr_b, bool *are_compatible) {
   CeedInt num_elem_a, num_elem_b, num_points_a, num_points_b;
 
   // Cannot compare non-points restrictions
-  CeedCheck(rstr_a->rstr_type == CEED_RESTRICTION_POINTS, rstr_a->ceed, CEED_ERROR_UNSUPPORTED, "First ElemRestriction must be AtPoints");
-  CeedCheck(rstr_b->rstr_type == CEED_RESTRICTION_POINTS, rstr_b->ceed, CEED_ERROR_UNSUPPORTED, "Second ElemRestriction must be AtPoints");
+  CeedCheck(rstr_a->rstr_type == CEED_RESTRICTION_POINTS, rstr_a->ceed, CEED_ERROR_UNSUPPORTED, "First CeedElemRestriction must be AtPoints");
+  CeedCheck(rstr_b->rstr_type == CEED_RESTRICTION_POINTS, rstr_b->ceed, CEED_ERROR_UNSUPPORTED, "Second CeedElemRestriction must be AtPoints");
 
   CeedCall(CeedElemRestrictionGetNumElements(rstr_a, &num_elem_a));
   CeedCall(CeedElemRestrictionGetNumElements(rstr_b, &num_elem_b));
@@ -179,9 +191,9 @@ int CeedElemRestrictionAtPointsAreCompatible(CeedElemRestriction rstr_a, CeedEle
 }
 
 /**
-  @brief Get the strides of a strided CeedElemRestriction
+  @brief Get the strides of a strided @ref CeedElemRestriction
 
-  @param[in]  rstr    CeedElemRestriction
+  @param[in]  rstr    @ref CeedElemRestriction
   @param[out] strides Variable to store strides array
 
   @return An error code: 0 - success, otherwise - failure
@@ -189,15 +201,15 @@ int CeedElemRestrictionAtPointsAreCompatible(CeedElemRestriction rstr_a, CeedEle
   @ref Backend
 **/
 int CeedElemRestrictionGetStrides(CeedElemRestriction rstr, CeedInt (*strides)[3]) {
-  CeedCheck(rstr->strides, rstr->ceed, CEED_ERROR_MINOR, "ElemRestriction has no stride data");
+  CeedCheck(rstr->strides, rstr->ceed, CEED_ERROR_MINOR, "CeedElemRestriction has no stride data");
   for (CeedInt i = 0; i < 3; i++) (*strides)[i] = rstr->strides[i];
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get the backend stride status of a CeedElemRestriction
+  @brief Get the backend stride status of a @ref CeedElemRestriction
 
-  @param[in]  rstr                 CeedElemRestriction
+  @param[in]  rstr                 @ref CeedElemRestriction
   @param[out] has_backend_strides  Variable to store stride status
 
   @return An error code: 0 - success, otherwise - failure
@@ -205,19 +217,19 @@ int CeedElemRestrictionGetStrides(CeedElemRestriction rstr, CeedInt (*strides)[3
   @ref Backend
 **/
 int CeedElemRestrictionHasBackendStrides(CeedElemRestriction rstr, bool *has_backend_strides) {
-  CeedCheck(rstr->strides, rstr->ceed, CEED_ERROR_MINOR, "ElemRestriction has no stride data");
+  CeedCheck(rstr->strides, rstr->ceed, CEED_ERROR_MINOR, "CeedElemRestriction has no stride data");
   *has_backend_strides = ((rstr->strides[0] == CEED_STRIDES_BACKEND[0]) && (rstr->strides[1] == CEED_STRIDES_BACKEND[1]) &&
                           (rstr->strides[2] == CEED_STRIDES_BACKEND[2]));
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get read-only access to a CeedElemRestriction offsets array by memtype
+  @brief Get read-only access to a @ref CeedElemRestriction offsets array by @ref CeedMemType
 
-  @param[in]  rstr     CeedElemRestriction to retrieve offsets
+  @param[in]  rstr     @ref CeedElemRestriction to retrieve offsets
   @param[in]  mem_type Memory type on which to access the array.
                          If the backend uses a different memory type, this will perform a copy (possibly cached).
-  @param[out] offsets  Array on memory type mem_type
+  @param[out] offsets  Array on memory type `mem_type`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -227,7 +239,7 @@ int CeedElemRestrictionGetOffsets(CeedElemRestriction rstr, CeedMemType mem_type
   if (rstr->rstr_base) {
     CeedCall(CeedElemRestrictionGetOffsets(rstr->rstr_base, mem_type, offsets));
   } else {
-    CeedCheck(rstr->GetOffsets, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetOffsets");
+    CeedCheck(rstr->GetOffsets, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedElemRestrictionGetOffsets");
     CeedCall(rstr->GetOffsets(rstr, mem_type, offsets));
     rstr->num_readers++;
   }
@@ -235,9 +247,9 @@ int CeedElemRestrictionGetOffsets(CeedElemRestriction rstr, CeedMemType mem_type
 }
 
 /**
-  @brief Restore an offsets array obtained using CeedElemRestrictionGetOffsets()
+  @brief Restore an offsets array obtained using @ref CeedElemRestrictionGetOffsets()
 
-  @param[in] rstr    CeedElemRestriction to restore
+  @param[in] rstr    @ref CeedElemRestriction to restore
   @param[in] offsets Array of offset data
 
   @return An error code: 0 - success, otherwise - failure
@@ -255,28 +267,28 @@ int CeedElemRestrictionRestoreOffsets(CeedElemRestriction rstr, const CeedInt **
 }
 
 /**
-  @brief Get read-only access to a CeedElemRestriction orientations array by memtype
+  @brief Get read-only access to a @ref CeedElemRestriction orientations array by @ref CeedMemType
 
-  @param[in]  rstr     CeedElemRestriction to retrieve orientations
+  @param[in]  rstr     @ref CeedElemRestriction to retrieve orientations
   @param[in]  mem_type Memory type on which to access the array.
                          If the backend uses a different memory type, this will perform a copy (possibly cached).
-  @param[out] orients  Array on memory type mem_type
+  @param[out] orients  Array on memory type `mem_type`
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedElemRestrictionGetOrientations(CeedElemRestriction rstr, CeedMemType mem_type, const bool **orients) {
-  CeedCheck(rstr->GetOrientations, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetOrientations");
+  CeedCheck(rstr->GetOrientations, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedElemRestrictionGetOrientations");
   CeedCall(rstr->GetOrientations(rstr, mem_type, orients));
   rstr->num_readers++;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Restore an orientations array obtained using CeedElemRestrictionGetOrientations()
+  @brief Restore an orientations array obtained using @ref CeedElemRestrictionGetOrientations()
 
-  @param[in] rstr    CeedElemRestriction to restore
+  @param[in] rstr    @ref CeedElemRestriction to restore
   @param[in] orients Array of orientation data
 
   @return An error code: 0 - success, otherwise - failure
@@ -290,28 +302,28 @@ int CeedElemRestrictionRestoreOrientations(CeedElemRestriction rstr, const bool 
 }
 
 /**
-  @brief Get read-only access to a CeedElemRestriction curl-conforming orientations array by memtype
+  @brief Get read-only access to a @ref CeedElemRestriction curl-conforming orientations array by @ref CeedMemType
 
-  @param[in]  rstr         CeedElemRestriction to retrieve curl-conforming orientations
+  @param[in]  rstr         @ref CeedElemRestriction to retrieve curl-conforming orientations
   @param[in]  mem_type     Memory type on which to access the array.
                              If the backend uses a different memory type, this will perform a copy (possibly cached).
-  @param[out] curl_orients Array on memory type mem_type
+  @param[out] curl_orients Array on memory type `mem_type`
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedElemRestrictionGetCurlOrientations(CeedElemRestriction rstr, CeedMemType mem_type, const CeedInt8 **curl_orients) {
-  CeedCheck(rstr->GetCurlOrientations, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetCurlOrientations");
+  CeedCheck(rstr->GetCurlOrientations, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedElemRestrictionGetCurlOrientations");
   CeedCall(rstr->GetCurlOrientations(rstr, mem_type, curl_orients));
   rstr->num_readers++;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Restore an orientations array obtained using CeedElemRestrictionGetCurlOrientations()
+  @brief Restore an orientations array obtained using @ref CeedElemRestrictionGetCurlOrientations()
 
-  @param[in] rstr         CeedElemRestriction to restore
+  @param[in] rstr         @ref CeedElemRestriction to restore
   @param[in] curl_orients Array of orientation data
 
   @return An error code: 0 - success, otherwise - failure
@@ -326,29 +338,29 @@ int CeedElemRestrictionRestoreCurlOrientations(CeedElemRestriction rstr, const C
 
 /**
 
-  @brief Get the E-vector layout of a CeedElemRestriction
+  @brief Get the E-vector layout of a @ref CeedElemRestriction
 
-  @param[in]  rstr    CeedElemRestriction
-  @param[out] layout  Variable to store layout array, stored as [nodes, components, elements].
-                        The data for node i, component j, element k in the E-vector is given by i*layout[0] + j*layout[1] + k*layout[2]
+  @param[in]  rstr    @ref CeedElemRestriction
+  @param[out] layout  Variable to store layout array, stored as `[nodes, components, elements]`.
+                        The data for node `i`, component `j`, element `k` in the E-vector is given by `i*layout[0] + j*layout[1] + k*layout[2]`.
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Backend
 **/
 int CeedElemRestrictionGetELayout(CeedElemRestriction rstr, CeedInt (*layout)[3]) {
-  CeedCheck(rstr->layout[0], rstr->ceed, CEED_ERROR_MINOR, "ElemRestriction has no layout data");
+  CeedCheck(rstr->layout[0], rstr->ceed, CEED_ERROR_MINOR, "CeedElemRestriction has no layout data");
   for (CeedInt i = 0; i < 3; i++) (*layout)[i] = rstr->layout[i];
   return CEED_ERROR_SUCCESS;
 }
 
 /**
 
-  @brief Set the E-vector layout of a CeedElemRestriction
+  @brief Set the E-vector layout of a @ref CeedElemRestriction
 
-  @param[in] rstr   CeedElemRestriction
-  @param[in] layout Variable to containing layout array, stored as [nodes, components, elements].
-                      The data for node i, component j, element k in the E-vector is given by i*layout[0] + j*layout[1] + k*layout[2]
+  @param[in] rstr   @ref CeedElemRestriction
+  @param[in] layout Variable to containing layout array, stored as `[nodes, components, elements]`.
+                      The data for node `i`, component `j`, element `k` in the E-vector is given by `i*layout[0] + j*layout[1] + k*layout[2]`.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -360,9 +372,9 @@ int CeedElemRestrictionSetELayout(CeedElemRestriction rstr, CeedInt layout[3]) {
 }
 
 /**
-  @brief Get the backend data of a CeedElemRestriction
+  @brief Get the backend data of a @ref CeedElemRestriction
 
-  @param[in]  rstr CeedElemRestriction
+  @param[in]  rstr @ref CeedElemRestriction
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -375,9 +387,9 @@ int CeedElemRestrictionGetData(CeedElemRestriction rstr, void *data) {
 }
 
 /**
-  @brief Set the backend data of a CeedElemRestriction
+  @brief Set the backend data of a @ref CeedElemRestriction
 
-  @param[in,out] rstr CeedElemRestriction
+  @param[in,out] rstr @ref CeedElemRestriction
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -390,9 +402,9 @@ int CeedElemRestrictionSetData(CeedElemRestriction rstr, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a CeedElemRestriction
+  @brief Increment the reference counter for a @ref CeedElemRestriction
 
-  @param[in,out] rstr ElemRestriction to increment the reference counter
+  @param[in,out] rstr @ref CeedElemRestriction to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -404,9 +416,9 @@ int CeedElemRestrictionReference(CeedElemRestriction rstr) {
 }
 
 /**
-  @brief Estimate number of FLOPs required to apply CeedElemRestriction in t_mode
+  @brief Estimate number of FLOPs required to apply @ref CeedElemRestriction in `t_mode`
 
-  @param[in]  rstr   ElemRestriction to estimate FLOPs for
+  @param[in]  rstr   @ref CeedElemRestriction to estimate FLOPs for
   @param[in]  t_mode Apply restriction or transpose
   @param[out] flops  Address of variable to hold FLOPs estimate
 
@@ -468,26 +480,26 @@ static struct CeedElemRestriction_private ceed_elemrestriction_none;
 /// Indicate that the stride is determined by the backend
 const CeedInt CEED_STRIDES_BACKEND[3] = {0};
 
-/// Argument for CeedOperatorSetField indicating that the field does not requre a CeedElemRestriction
+/// Argument for @ref CeedOperatorSetField() indicating that the field does not require a @ref CeedElemRestriction
 const CeedElemRestriction CEED_ELEMRESTRICTION_NONE = &ceed_elemrestriction_none;
 
 /**
-  @brief Create a CeedElemRestriction
+  @brief Create a @ref CeedElemRestriction
 
-  @param[in]  ceed        Ceed object where the CeedElemRestriction will be created
-  @param[in]  num_elem    Number of elements described in the @a offsets array
+  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem    Number of elements described in the `offsets` array
   @param[in]  elem_size   Size (number of "nodes") per element
   @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
   @param[in]  comp_stride Stride between components for the same L-vector "node".
-                            Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
+                            Data for node `i`, component `j`, element `k` can be found in the L-vector at index `offsets[i + k*elem_size] + j*comp_stride`.
   @param[in]  l_size      The size of the L-vector.
                             This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type    Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode   Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets     Array of shape [@a num_elem, @a elem_size].
-                            Row i holds the ordered list of the offsets (into the input CeedVector) for the unknowns corresponding to element i, where
-0 <= i < @a num_elem. All offsets must be in the range [0, @a l_size - 1].
-  @param[out] rstr        Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
+                            Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where 0 <= i < @a num_elem.
+                            All offsets must be in the range `[0, l_size - 1]`.
+  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -499,15 +511,15 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size, Ce
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreate");
     CeedCall(CeedElemRestrictionCreate(delegate, num_elem, elem_size, num_comp, comp_stride, l_size, mem_type, copy_mode, offsets, rstr));
     return CEED_ERROR_SUCCESS;
   }
 
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
-  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
+  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(1, rstr));
   CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
@@ -526,23 +538,23 @@ int CeedElemRestrictionCreate(Ceed ceed, CeedInt num_elem, CeedInt elem_size, Ce
 }
 
 /**
-  @brief Create a CeedElemRestriction with orientation signs
+  @brief Create a @ref CeedElemRestriction with orientation signs
 
-  @param[in]  ceed        Ceed object where the CeedElemRestriction will be created
-  @param[in]  num_elem    Number of elements described in the @a offsets array
+  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem    Number of elements described in the `offsets` array
   @param[in]  elem_size   Size (number of "nodes") per element
   @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
   @param[in]  comp_stride Stride between components for the same L-vector "node".
-                            Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
+                            Data for node `i`, component `j`, element `k` can be found in the L-vector at index `offsets[i + k*elem_size] + j*comp_stride`.
   @param[in]  l_size      The size of the L-vector.
                             This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type    Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode   Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets     Array of shape [@a num_elem, @a elem_size].
-                            Row i holds the ordered list of the offsets (into the input CeedVector) for the unknowns corresponding to element i, where
-0 <= i < @a num_elem. All offsets must be in the range [0, @a l_size - 1].
-  @param[in]  orients     Array of shape [@a num_elem, @a elem_size] with bool false for positively oriented and true to flip the orientation.
-  @param[out] rstr        Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
+                            Row i holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                            All offsets must be in the range `[0, l_size - 1]`.
+  @param[in]  orients     Boolean array of shape `[num_elem, elem_size]` with `false` for positively oriented and `true` to flip the orientation
+  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -555,7 +567,7 @@ int CeedElemRestrictionCreateOriented(Ceed ceed, CeedInt num_elem, CeedInt elem_
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateOriented");
     CeedCall(
         CeedElemRestrictionCreateOriented(delegate, num_elem, elem_size, num_comp, comp_stride, l_size, mem_type, copy_mode, offsets, orients, rstr));
     return CEED_ERROR_SUCCESS;
@@ -563,8 +575,8 @@ int CeedElemRestrictionCreateOriented(Ceed ceed, CeedInt num_elem, CeedInt elem_
 
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
-  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
+  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(1, rstr));
   CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
@@ -583,26 +595,24 @@ int CeedElemRestrictionCreateOriented(Ceed ceed, CeedInt num_elem, CeedInt elem_
 }
 
 /**
-  @brief Create a CeedElemRestriction with a general tridiagonal transformation matrix for curl-conforming elements
+  @brief Create a @ref CeedElemRestriction with a general tridiagonal transformation matrix for curl-conforming elements
 
-  @param[in]  ceed         Ceed object where the CeedElemRestriction will be created
-  @param[in]  num_elem     Number of elements described in the @a offsets array
+  @param[in]  ceed         @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem     Number of elements described in the `offsets` array
   @param[in]  elem_size    Size (number of "nodes") per element
   @param[in]  num_comp     Number of field components per interpolation node (1 for scalar fields)
   @param[in]  comp_stride  Stride between components for the same L-vector "node".
-                             Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
+                             Data for node `i`, component `j`, element `k` can be found in the L-vector at index `offsets[i + k*elem_size] + j*comp_stride`.
   @param[in]  l_size       The size of the L-vector.
                              This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type     Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode    Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets      Array of shape [@a num_elem, @a elem_size].
-                             Row i holds the ordered list of the offsets (into the input CeedVector) for the unknowns corresponding to element i,
-where 0 <= i < @a num_elem. All offsets must be in the range [0, @a l_size - 1].
-  @param[in]  curl_orients Array of shape [@a num_elem, @a 3 * elem_size] representing a row-major tridiagonal matrix (curl_orients[i * 3 * elem_size]
-= curl_orients[(i + 1) * 3 * elem_size - 1] = 0, where 0 <= i < @a num_elem) which is applied to the element unknowns upon restriction. This
-orientation matrix allows for pairs of face degrees of freedom on elements for H(curl) spaces to be coupled in the element restriction operation,
-which is a way to resolve face orientation issues for 3D meshes (https://dl.acm.org/doi/pdf/10.1145/3524456).
-  @param[out] rstr         Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  mem_type     Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode    Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets      Array of shape `[num_elem, elem_size]`.
+                             Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                             All offsets must be in the range `[0, l_size - 1]`.
+  @param[in]  curl_orients Array of shape `[num_elem, 3 * elem_size]` representing a row-major tridiagonal matrix (`curl_orients[i * 3 * elem_size] = curl_orients[(i + 1) * 3 * elem_size - 1] = 0`, where `0 <= i < num_elem`) which is applied to the element unknowns upon restriction.
+                             This orientation matrix allows for pairs of face degrees of freedom on elements for \f$H(\mathrm{curl})\f$ spaces to be coupled in the element restriction operation, which is a way to resolve face orientation issues for 3D meshes (https://dl.acm.org/doi/pdf/10.1145/3524456).
+  @param[out] rstr         Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -615,7 +625,7 @@ int CeedElemRestrictionCreateCurlOriented(Ceed ceed, CeedInt num_elem, CeedInt e
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateCurlOriented");
     CeedCall(CeedElemRestrictionCreateCurlOriented(delegate, num_elem, elem_size, num_comp, comp_stride, l_size, mem_type, copy_mode, offsets,
                                                    curl_orients, rstr));
     return CEED_ERROR_SUCCESS;
@@ -623,8 +633,8 @@ int CeedElemRestrictionCreateCurlOriented(Ceed ceed, CeedInt num_elem, CeedInt e
 
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
-  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
+  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(1, rstr));
   CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
@@ -643,18 +653,18 @@ int CeedElemRestrictionCreateCurlOriented(Ceed ceed, CeedInt num_elem, CeedInt e
 }
 
 /**
-  @brief Create a strided CeedElemRestriction
+  @brief Create a strided @ref CeedElemRestriction
 
-  @param[in]  ceed      Ceed object where the CeedElemRestriction will be created
+  @param[in]  ceed      @ref Ceed context used to create the @ref CeedElemRestriction
   @param[in]  num_elem  Number of elements described by the restriction
   @param[in]  elem_size Size (number of "nodes") per element
   @param[in]  num_comp  Number of field components per interpolation "node" (1 for scalar fields)
   @param[in]  l_size    The size of the L-vector.
                           This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  strides   Array for strides between [nodes, components, elements].
-                          Data for node i, component j, element k can be found in the L-vector at index i*strides[0] + j*strides[1] + k*strides[2].
-                          @a CEED_STRIDES_BACKEND may be used with vectors created by a Ceed backend.
-  @param[out] rstr      Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  strides   Array for strides between `[nodes, components, elements]`.
+                          Data for node `i`, component `j`, element `k` can be found in the L-vector at index `i*strides[0] + j*strides[1] + k*strides[2]`.
+                          @ref CEED_STRIDES_BACKEND may be used for @ref CeedVector ordered by the same @ref Ceed backend.
+  @param[out] rstr      Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -666,14 +676,14 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateStrided");
     CeedCall(CeedElemRestrictionCreateStrided(delegate, num_elem, elem_size, num_comp, l_size, strides, rstr));
     return CEED_ERROR_SUCCESS;
   }
 
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
   CeedCheck(l_size >= num_elem * elem_size * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector size must be at least num_elem * elem_size * num_comp");
 
   CeedCall(CeedCalloc(1, rstr));
@@ -694,8 +704,7 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
 }
 
 /**
-  @brief Create a points CeedElemRestriction, for restricting for restricting from a all local points to the current element in which they are
- located.
+  @brief Create a points @ref CeedElemRestriction, for restricting for restricting from a all local points to the current element in which they are located.
 
   The offsets array is arranged as
 
@@ -708,19 +717,19 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   element_0_point_1
   ...
 
-  @param[in]  ceed          Ceed object where the CeedElemRestriction will be created
-  @param[in]  num_elem      Number of elements described in the @a offsets array
-  @param[in]  num_points    Number of points described in the @a offsets array
-  @param[in]  num_comp      Number of field components per interpolation node (1 for scalar fields).
-                              Components are assumed to be contiguous by point.
-  @param[in]  l_size        The size of the L-vector.
-                              This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type      Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode     Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets       Array of size num_elem + 1 + num_points.
-                              The first portion of the offsets array holds the ranges of indices corresponding to each element.
-                              The second portion holds the indices for each element.
-  @param[out] rstr          Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  ceed       @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem   Number of elements described in the `offsets` array
+  @param[in]  num_points Number of points described in the `offsets` array
+  @param[in]  num_comp   Number of field components per interpolation node (1 for scalar fields).
+                           Components are assumed to be contiguous by point.
+  @param[in]  l_size     The size of the L-vector.
+                           This vector may be larger than the elements and fields given by this restriction.
+  @param[in]  mem_type   Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode  Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets    Array of size `num_elem + 1 + num_points`.
+                           The first portion of the offsets array holds the ranges of indices corresponding to each element.
+                           The second portion holds the indices for each element.
+  @param[out] rstr       Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -732,14 +741,14 @@ int CeedElemRestrictionCreateAtPoints(Ceed ceed, CeedInt num_elem, CeedInt num_p
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreateAtPoints");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateAtPoints");
     CeedCall(CeedElemRestrictionCreateAtPoints(delegate, num_elem, num_points, num_comp, l_size, mem_type, copy_mode, offsets, rstr));
     return CEED_ERROR_SUCCESS;
   }
 
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(num_points >= 0, ceed, CEED_ERROR_DIMENSION, "Number of points must be non-negative");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
   CeedCheck(l_size >= num_points * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector must be at least num_points * num_comp");
 
   CeedCall(CeedCalloc(1, rstr));
@@ -758,24 +767,25 @@ int CeedElemRestrictionCreateAtPoints(Ceed ceed, CeedInt num_elem, CeedInt num_p
 }
 
 /**
-  @brief Create a blocked CeedElemRestriction, typically only called by backends
+  @brief Create a blocked @ref CeedElemRestriction, typically only used by backends
 
-  @param[in]  ceed          Ceed object where the CeedElemRestriction will be created
-  @param[in]  num_elem      Number of elements described in the @a offsets array
-  @param[in]  elem_size     Size (number of unknowns) per element
-  @param[in]  block_size    Number of elements in a block
-  @param[in]  num_comp      Number of field components per interpolation node (1 for scalar fields)
-  @param[in]  comp_stride   Stride between components for the same L-vector "node".
-                              Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
-  @param[in]  l_size        The size of the L-vector.
-                              This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type      Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode     Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets       Array of shape [@a num_elem, @a elem_size].
-                              Row i holds the ordered list of the offsets (into the input CeedVector) for the unknowns corresponding to element i,
- where 0 <= i < @a num_elem. All offsets must be in the range [0, @a l_size - 1]. The backend will permute and pad this array to the desired ordering
- for the blocksize, which is typically given by the backend. The default reordering is to interlace elements.
-  @param[out] rstr          Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem    Number of elements described in the `offsets` array
+  @param[in]  elem_size   Size (number of unknowns) per element
+  @param[in]  block_size  Number of elements in a block
+  @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
+  @param[in]  comp_stride Stride between components for the same L-vector "node".
+                            Data for node `i`, component `j`, element `k` can be found in the L-vector at index `offsets[i + k*elem_size] + j*comp_stride`.
+  @param[in]  l_size      The size of the L-vector.
+                            This vector may be larger than the elements and fields given by this restriction.
+  @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
+                            Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                            All offsets must be in the range `[0, l_size - 1]`.
+                            The backend will permute and pad this array to the desired ordering for the blocksize, which is typically given by the backend.
+                            The default reordering is to interlace elements.
+  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -790,7 +800,7 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem, CeedInt elem_s
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreateBlocked");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateBlocked");
     CeedCall(CeedElemRestrictionCreateBlocked(delegate, num_elem, elem_size, block_size, num_comp, comp_stride, l_size, mem_type, copy_mode, offsets,
                                               rstr));
     return CEED_ERROR_SUCCESS;
@@ -799,8 +809,8 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
   CeedCheck(block_size > 0, ceed, CEED_ERROR_DIMENSION, "Block size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
-  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
+  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(num_block * block_size * elem_size, &block_offsets));
   CeedCall(CeedPermutePadOffsets(offsets, block_offsets, num_block, num_elem, block_size, elem_size));
@@ -823,26 +833,27 @@ int CeedElemRestrictionCreateBlocked(Ceed ceed, CeedInt num_elem, CeedInt elem_s
 }
 
 /**
-  @brief Create a blocked oriented CeedElemRestriction, typically only called by backends
+  @brief Create a blocked oriented @ref CeedElemRestriction, typically only used by backends
 
-  @param[in]  ceed          Ceed object where the CeedElemRestriction will be created.
-  @param[in]  num_elem      Number of elements described in the @a offsets array.
-  @param[in]  elem_size     Size (number of unknowns) per element
-  @param[in]  block_size    Number of elements in a block
-  @param[in]  num_comp      Number of field components per interpolation node (1 for scalar fields)
-  @param[in]  comp_stride   Stride between components for the same L-vector "node".
-                              Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
-  @param[in]  l_size        The size of the L-vector.
-                              This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type      Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode     Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets       Array of shape [@a num_elem, @a elem_size].
-                            Row i holds the ordered list of the offsets (into the input CeedVector) for the unknowns corresponding to element i, where
- 0 <= i < @a num_elem. All offsets must be in the range [0, @a l_size - 1]. The backend will permute and pad this array to the desired ordering for
- the blocksize, which is typically given by the backend. The default reordering is to interlace elements.
-  @param[in]  orients       Array of shape [@a num_elem, @a elem_size] with bool false for positively oriented and true to flip the orientation.
-                              Will also be permuted and padded similarly to @a offsets.
-  @param[out] rstr          Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem    Number of elements described in the `offsets` array.
+  @param[in]  elem_size   Size (number of unknowns) per element
+  @param[in]  block_size  Number of elements in a block
+  @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
+  @param[in]  comp_stride Stride between components for the same L-vector "node".
+                            Data for node `i`, component `j`, element `k` can be found in the L-vector at index `offsets[i + k*elem_size] + j*comp_stride`.
+  @param[in]  l_size      The size of the L-vector.
+                            This vector may be larger than the elements and fields given by this restriction.
+  @param[in]  mem_type    Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode   Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets     Array of shape `[num_elem, elem_size]`.
+                            Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                            All offsets must be in the range `[0, l_size - 1]`.
+                            The backend will permute and pad this array to the desired ordering for the blocksize, which is typically given by the backend.
+                            The default reordering is to interlace elements.
+  @param[in]  orients     Boolean array of shape `[num_elem, elem_size]` with `false` for positively oriented and `true` to flip the orientation.
+                            Will also be permuted and padded similarly to `offsets`.
+  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -858,7 +869,7 @@ int CeedElemRestrictionCreateBlockedOriented(Ceed ceed, CeedInt num_elem, CeedIn
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreateBlocked");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateBlockedOriented");
     CeedCall(CeedElemRestrictionCreateBlockedOriented(delegate, num_elem, elem_size, block_size, num_comp, comp_stride, l_size, mem_type, copy_mode,
                                                       offsets, orients, rstr));
     return CEED_ERROR_SUCCESS;
@@ -866,8 +877,8 @@ int CeedElemRestrictionCreateBlockedOriented(Ceed ceed, CeedInt num_elem, CeedIn
 
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
   CeedCheck(block_size > 0, ceed, CEED_ERROR_DIMENSION, "Block size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
-  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
+  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(num_block * block_size * elem_size, &block_offsets));
   CeedCall(CeedCalloc(num_block * block_size * elem_size, &block_orients));
@@ -893,29 +904,28 @@ int CeedElemRestrictionCreateBlockedOriented(Ceed ceed, CeedInt num_elem, CeedIn
 }
 
 /**
-  @brief Create a blocked curl-oriented CeedElemRestriction, typically only called by backends
+  @brief Create a blocked curl-oriented @ref CeedElemRestriction, typically only used by backends
 
-  @param[in]  ceed           Ceed object where the CeedElemRestriction will be created.
-  @param[in]  num_elem       Number of elements described in the @a offsets array.
-  @param[in]  elem_size      Size (number of unknowns) per element
-  @param[in]  block_size     Number of elements in a block
-  @param[in]  num_comp       Number of field components per interpolation node (1 for scalar fields)
-  @param[in]  comp_stride    Stride between components for the same L-vector "node".
-                               Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
-  @param[in]  l_size         The size of the L-vector.
-                               This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  mem_type       Memory type of the @a offsets array, see CeedMemType
-  @param[in]  copy_mode      Copy mode for the @a offsets array, see CeedCopyMode
-  @param[in]  offsets        Array of shape [@a num_elem, @a elem_size].
-                             Row i holds the ordered list of the offsets (into the input CeedVector) for the unknowns corresponding to element i,
-where 0 <= i < @a num_elem. All offsets must be in the range [0, @a l_size - 1]. The backend will permute and pad this array to the desired ordering
-for the blocksize, which is typically given by the backend. The default reordering is to interlace elements.
-  @param[in]  curl_orients Array of shape [@a num_elem, @a 3 * elem_size] representing a row-major tridiagonal matrix (curl_orients[i * 3 * elem_size]
-= curl_orients[(i + 1) * 3 * elem_size - 1] = 0, where 0 <= i < @a num_elem) which is applied to the element unknowns upon restriction. This
-orientation matrix allows for pairs of face degrees of freedom on elements for H(curl) spaces to be coupled in the element restriction operation,
-which is a way to resolve face orientation issues for 3D meshes (https://dl.acm.org/doi/pdf/10.1145/3524456). Will also be permuted and padded
-similarly to @a offsets.
-  @param[out] rstr           Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  ceed         @ref Ceed context used to create the @ref CeedElemRestriction
+  @param[in]  num_elem     Number of elements described in the `offsets` array.
+  @param[in]  elem_size    Size (number of unknowns) per element
+  @param[in]  block_size   Number of elements in a block
+  @param[in]  num_comp     Number of field components per interpolation node (1 for scalar fields)
+  @param[in]  comp_stride  Stride between components for the same L-vector "node".
+                             Data for node `i`, component `j`, element `k` can be found in the L-vector at index `offsets[i + k*elem_size] + j*comp_stride`.
+  @param[in]  l_size       The size of the L-vector.
+                             This vector may be larger than the elements and fields given by this restriction.
+  @param[in]  mem_type     Memory type of the `offsets` array, see @ref CeedMemType
+  @param[in]  copy_mode    Copy mode for the `offsets` array, see @ref CeedCopyMode
+  @param[in]  offsets      Array of shape `[num_elem, elem_size]`.
+                             Row `i` holds the ordered list of the offsets (into the input @ref CeedVector) for the unknowns corresponding to element `i`, where `0 <= i < num_elem`.
+                             All offsets must be in the range `[0, l_size - 1]`.
+                             The backend will permute and pad this array to the desired  ordering for the blocksize, which is typically given by the backend.
+                             The default reordering is to interlace elements.
+  @param[in]  curl_orients Array of shape `[num_elem, 3 * elem_size]` representing a row-major tridiagonal matrix (`curl_orients[i * 3 * elem_size] = curl_orients[(i + 1) * 3 * elem_size - 1] = 0`, where `0 <= i < num_elem`) which is applied to the element unknowns upon restriction.
+                             This orientation matrix allows for pairs of face degrees of freedom on elements for \f$H(\mathrm{curl})\f$ spaces to be coupled in the element restriction  operation, which is a way to resolve face orientation issues for 3D meshes (https://dl.acm.org/doi/pdf/10.1145/3524456).
+                             Will also be permuted and padded similarly to offsets.
+  @param[out] rstr         Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -931,7 +941,7 @@ int CeedElemRestrictionCreateBlockedCurlOriented(Ceed ceed, CeedInt num_elem, Ce
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreateBlocked");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateBlockedCurlOriented");
     CeedCall(CeedElemRestrictionCreateBlockedCurlOriented(delegate, num_elem, elem_size, block_size, num_comp, comp_stride, l_size, mem_type,
                                                           copy_mode, offsets, curl_orients, rstr));
     return CEED_ERROR_SUCCESS;
@@ -940,8 +950,8 @@ int CeedElemRestrictionCreateBlockedCurlOriented(Ceed ceed, CeedInt num_elem, Ce
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
   CeedCheck(block_size > 0, ceed, CEED_ERROR_DIMENSION, "Block size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
-  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction component stride must be at least 1");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
+  CeedCheck(num_comp == 1 || comp_stride > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction component stride must be at least 1");
 
   CeedCall(CeedCalloc(num_block * block_size * elem_size, &block_offsets));
   CeedCall(CeedCalloc(num_block * block_size * 3 * elem_size, &block_curl_orients));
@@ -967,19 +977,19 @@ int CeedElemRestrictionCreateBlockedCurlOriented(Ceed ceed, CeedInt num_elem, Ce
 }
 
 /**
-  @brief Create a blocked strided CeedElemRestriction, typically only called by backends
+  @brief Create a blocked strided @ref CeedElemRestriction, typically only used by backends
 
-  @param[in]  ceed        Ceed object where the CeedElemRestriction will be created
+  @param[in]  ceed        @ref Ceed context used to create the @ref CeedElemRestriction
   @param[in]  num_elem    Number of elements described by the restriction
   @param[in]  elem_size   Size (number of "nodes") per element
   @param[in]  block_size  Number of elements in a block
   @param[in]  num_comp    Number of field components per interpolation node (1 for scalar fields)
   @param[in]  l_size      The size of the L-vector.
                             This vector may be larger than the elements and fields given by this restriction.
-  @param[in]  strides     Array for strides between [nodes, components, elements].
-                            Data for node i, component j, element k can be found in the L-vector at index i*strides[0] + j*strides[1] + k*strides[2].
-                            @a CEED_STRIDES_BACKEND may be used with vectors created by a Ceed backend.
-  @param[out] rstr        Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  strides     Array for strides between `[nodes, components, elements]`.
+                            Data for node `i`, component `j`, element `k` can be found in the L-vector at index `i*strides[0] + j*strides[1] +k*strides[2]`.
+                            @ref CEED_STRIDES_BACKEND may be used for @ref CeedVector ordered by the same @ref Ceed backend.
+  @param[out] rstr        Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -993,7 +1003,7 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem, CeedInt
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "ElemRestriction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionCreateBlocked");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionCreateBlockedStrided");
     CeedCall(CeedElemRestrictionCreateBlockedStrided(delegate, num_elem, elem_size, block_size, num_comp, l_size, strides, rstr));
     return CEED_ERROR_SUCCESS;
   }
@@ -1001,7 +1011,7 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem, CeedInt
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
   CeedCheck(block_size > 0, ceed, CEED_ERROR_DIMENSION, "Block size must be at least 1");
-  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "ElemRestriction must have at least 1 component");
+  CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
   CeedCheck(l_size >= num_elem * elem_size * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector size must be at least num_elem * elem_size * num_comp");
 
   CeedCall(CeedCalloc(1, rstr));
@@ -1022,12 +1032,12 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem, CeedInt
 }
 
 /**
-  @brief Copy the pointer to a CeedElemRestriction and set `CeedElemRestrictionApply()` implementation to use the unsigned version.
+  @brief Copy the pointer to a @ref CeedElemRestriction and set @ref CeedElemRestrictionApply() implementation to use the unsigned version.
 
-  Both pointers should be destroyed with `CeedElemRestrictionDestroy()`.
+  Both pointers should be destroyed with @ref CeedElemRestrictionDestroy().
 
-  @param[in]     rstr          CeedElemRestriction to create unsigned reference to
-  @param[in,out] rstr_unsigned Variable to store unsigned CeedElemRestriction
+  @param[in]     rstr          @ref CeedElemRestriction to create unsigned reference to
+  @param[in,out] rstr_unsigned Variable to store unsigned @ref CeedElemRestriction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1054,12 +1064,12 @@ int CeedElemRestrictionCreateUnsignedCopy(CeedElemRestriction rstr, CeedElemRest
 }
 
 /**
-  @brief Copy the pointer to a CeedElemRestriction and set `CeedElemRestrictionApply()` implementation to use the unoriented version.
+  @brief Copy the pointer to a @ref CeedElemRestriction and set @ref CeedElemRestrictionApply() implementation to use the unoriented version.
 
-  Both pointers should be destroyed with `CeedElemRestrictionDestroy()`.
+  Both pointers should be destroyed with @ref CeedElemRestrictionDestroy().
 
-  @param[in]     rstr            CeedElemRestriction to create unoriented reference to
-  @param[in,out] rstr_unoriented Variable to store unoriented CeedElemRestriction
+  @param[in]     rstr            @ref CeedElemRestriction to create unoriented reference to
+  @param[in,out] rstr_unoriented Variable to store unoriented @ref CeedElemRestriction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1086,14 +1096,14 @@ int CeedElemRestrictionCreateUnorientedCopy(CeedElemRestriction rstr, CeedElemRe
 }
 
 /**
-  @brief Copy the pointer to a CeedElemRestriction.
+  @brief Copy the pointer to a @ref CeedElemRestriction.
 
-  Both pointers should be destroyed with `CeedElemRestrictionDestroy()`.
+  Both pointers should be destroyed with @ref CeedElemRestrictionDestroy().
 
-  Note: If the value of `rstr_copy` passed into this function is non-NULL, then it is assumed that `rstr_copy` is a pointer to a CeedElemRestriction.
-        This CeedElemRestriction will be destroyed if `rstr_copy` is the only reference to this CeedElemRestriction.
+  Note: If the value of `*rstr_copy` passed into this function is non-`NULL`, then it is assumed that `*rstr_copy` is a pointer to a @ref CeedElemRestriction.
+        This @ref CeedElemRestriction will be destroyed if `*rstr_copy` is the only reference to this @ref CeedElemRestriction.
 
-  @param[in]     rstr      CeedElemRestriction to copy reference to
+  @param[in]     rstr      @ref CeedElemRestriction to copy reference to
   @param[in,out] rstr_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -1108,11 +1118,11 @@ int CeedElemRestrictionReferenceCopy(CeedElemRestriction rstr, CeedElemRestricti
 }
 
 /**
-  @brief Create CeedVectors associated with a CeedElemRestriction
+  @brief Create @ref CeedVector associated with a @ref CeedElemRestriction
 
-  @param[in]  rstr  CeedElemRestriction
-  @param[out] l_vec The address of the L-vector to be created, or NULL
-  @param[out] e_vec The address of the E-vector to be created, or NULL
+  @param[in]  rstr  @ref CeedElemRestriction
+  @param[out] l_vec The address of the L-vector to be created, or `NULL`
+  @param[out] e_vec The address of the E-vector to be created, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1135,10 +1145,10 @@ int CeedElemRestrictionCreateVector(CeedElemRestriction rstr, CeedVector *l_vec,
 /**
   @brief Restrict an L-vector to an E-vector or apply its transpose
 
-  @param[in]  rstr    CeedElemRestriction
+  @param[in]  rstr    @ref CeedElemRestriction
   @param[in]  t_mode  Apply restriction or transpose
-  @param[in]  u       Input vector (of size @a l_size when t_mode=@ref CEED_NOTRANSPOSE)
-  @param[out] ru      Output vector (of shape [@a num_elem * @a elem_size] when t_mode=@ref CEED_NOTRANSPOSE).
+  @param[in]  u       Input vector (of size `l_size` when `t_mode` = @ref CEED_NOTRANSPOSE)
+  @param[out] ru      Output vector (of shape `[num_elem * elem_size]` when `t_mode` = @ref CEED_NOTRANSPOSE).
                         Ordering of the e-vector is decided by the backend.
   @param[in]  request Request or @ref CEED_REQUEST_IMMEDIATE
 
@@ -1167,11 +1177,11 @@ int CeedElemRestrictionApply(CeedElemRestriction rstr, CeedTransposeMode t_mode,
 /**
   @brief Restrict an L-vector of points to a single element or apply its transpose
 
-  @param[in]  rstr    CeedElemRestriction
-  @param[in]  elem    Element number in range 0..@a num_elem
+  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  elem    Element number in range `[0, num_elem)`
   @param[in]  t_mode  Apply restriction or transpose
-  @param[in]  u       Input vector (of size @a l_size when t_mode=@ref CEED_NOTRANSPOSE)
-  @param[out] ru      Output vector (of shape [@a num_points * @a num_comp] when t_mode=@ref CEED_NOTRANSPOSE).
+  @param[in]  u       Input vector (of size `l_size` when `t_mode` = @ref CEED_NOTRANSPOSE)
+  @param[out] ru      Output vector (of shape [`num_points * num_comp]` when `t_mode` = @ref CEED_NOTRANSPOSE).
                         Ordering of the e-vector is decided by the backend.
   @param[in]  request Request or @ref CEED_REQUEST_IMMEDIATE
 
@@ -1207,12 +1217,11 @@ int CeedElemRestrictionApplyAtPointsInElement(CeedElemRestriction rstr, CeedInt 
 /**
   @brief Restrict an L-vector to a block of an E-vector or apply its transpose
 
-  @param[in]  rstr    CeedElemRestriction
-  @param[in]  block   Block number to restrict to/from, i.e. block=0 will handle elements [0 : block_size] and block=3 will handle elements
-[3*block_size : 4*block_size]
+  @param[in]  rstr    @ref CeedElemRestriction
+  @param[in]  block   Block number to restrict to/from, i.e. `block = 0` will handle elements `[0 : block_size]` and `block = 3` will handle elements `[3*block_size : 4*block_size]`
   @param[in]  t_mode  Apply restriction or transpose
-  @param[in]  u       Input vector (of size @a l_size when t_mode=@ref CEED_NOTRANSPOSE)
-  @param[out] ru      Output vector (of shape [@a block_size * @a elem_size] when t_mode=@ref CEED_NOTRANSPOSE).
+  @param[in]  u       Input vector (of size `l_size` when `t_mode` = @ref CEED_NOTRANSPOSE)
+  @param[out] ru      Output vector (of shape `[block_size * elem_size]` when `t_mode` = @ref CEED_NOTRANSPOSE).
                         Ordering of the e-vector is decided by the backend.
   @param[in]  request Request or @ref CEED_REQUEST_IMMEDIATE
 
@@ -1224,7 +1233,7 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block, CeedT
                                   CeedRequest *request) {
   CeedInt m, n;
 
-  CeedCheck(rstr->ApplyBlock, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement ElemRestrictionApplyBlock");
+  CeedCheck(rstr->ApplyBlock, rstr->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not implement CeedElemRestrictionApplyBlock");
 
   if (t_mode == CEED_NOTRANSPOSE) {
     m = rstr->block_size * rstr->elem_size * rstr->num_comp;
@@ -1245,10 +1254,10 @@ int CeedElemRestrictionApplyBlock(CeedElemRestriction rstr, CeedInt block, CeedT
 }
 
 /**
-  @brief Get the Ceed associated with a CeedElemRestriction
+  @brief Get the @ref Ceed associated with a @ref CeedElemRestriction
 
-  @param[in]  rstr CeedElemRestriction
-  @param[out] ceed Variable to store Ceed
+  @param[in]  rstr @ref CeedElemRestriction
+  @param[out] ceed Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1262,7 +1271,7 @@ int CeedElemRestrictionGetCeed(CeedElemRestriction rstr, Ceed *ceed) {
 /**
   @brief Get the L-vector component stride
 
-  @param[in]  rstr        CeedElemRestriction
+  @param[in]  rstr        @ref CeedElemRestriction
   @param[out] comp_stride Variable to store component stride
 
   @return An error code: 0 - success, otherwise - failure
@@ -1275,9 +1284,9 @@ int CeedElemRestrictionGetCompStride(CeedElemRestriction rstr, CeedInt *comp_str
 }
 
 /**
-  @brief Get the total number of elements in the range of a CeedElemRestriction
+  @brief Get the total number of elements in the range of a @ref CeedElemRestriction
 
-  @param[in] rstr      CeedElemRestriction
+  @param[in] rstr      @ref CeedElemRestriction
   @param[out] num_elem Variable to store number of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1290,9 +1299,9 @@ int CeedElemRestrictionGetNumElements(CeedElemRestriction rstr, CeedInt *num_ele
 }
 
 /**
-  @brief Get the size of elements in the CeedElemRestriction
+  @brief Get the size of elements in the @ref CeedElemRestriction
 
-  @param[in]  rstr      CeedElemRestriction
+  @param[in]  rstr      @ref CeedElemRestriction
   @param[out] elem_size Variable to store size of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1306,9 +1315,9 @@ int CeedElemRestrictionGetElementSize(CeedElemRestriction rstr, CeedInt *elem_si
 
 /**
 
-  @brief Get the number of points in the l-vector for a points CeedElemRestriction
+  @brief Get the number of points in the l-vector for a points @ref CeedElemRestriction
 
-  @param[in]  rstr       CeedElemRestriction
+  @param[in]  rstr       @ref CeedElemRestriction
   @param[out] num_points The number of points in the l-vector
 
   @return An error code: 0 - success, otherwise - failure
@@ -1328,9 +1337,9 @@ int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_point
 
 /**
 
-  @brief Get the number of points in an element of a points CeedElemRestriction
+  @brief Get the number of points in an element of a @ref CeedElemRestriction at points
 
-  @param[in]  rstr       CeedElemRestriction
+  @param[in]  rstr       @ref CeedElemRestriction
   @param[in]  elem       Index number of element to retrieve the number of points for
   @param[out] num_points The number of points in the element at index elem
 
@@ -1353,9 +1362,9 @@ int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt e
 }
 
 /**
-  @brief Get the maximum number of points in an element for a CeedElemRestriction at points
+  @brief Get the maximum number of points in an element for a @ref CeedElemRestriction at points
 
-  @param[in]  rstr       CeedElemRestriction
+  @param[in]  rstr       @ref CeedElemRestriction
   @param[out] max_points Variable to store size of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1384,9 +1393,9 @@ int CeedElemRestrictionGetMaxPointsInElement(CeedElemRestriction rstr, CeedInt *
 }
 
 /**
-  @brief Get the size of the l-vector for a CeedElemRestriction
+  @brief Get the size of the l-vector for a @ref CeedElemRestriction
 
-  @param[in]  rstr   CeedElemRestriction
+  @param[in]  rstr   @ref CeedElemRestriction
   @param[out] l_size Variable to store number of nodes
 
   @return An error code: 0 - success, otherwise - failure
@@ -1399,9 +1408,9 @@ int CeedElemRestrictionGetLVectorSize(CeedElemRestriction rstr, CeedSize *l_size
 }
 
 /**
-  @brief Get the number of components in the elements of a CeedElemRestriction
+  @brief Get the number of components in the elements of a @ref CeedElemRestriction
 
-  @param[in]  rstr     CeedElemRestriction
+  @param[in]  rstr     @ref CeedElemRestriction
   @param[out] num_comp Variable to store number of components
 
   @return An error code: 0 - success, otherwise - failure
@@ -1414,9 +1423,9 @@ int CeedElemRestrictionGetNumComponents(CeedElemRestriction rstr, CeedInt *num_c
 }
 
 /**
-  @brief Get the number of blocks in a CeedElemRestriction
+  @brief Get the number of blocks in a @ref CeedElemRestriction
 
-  @param[in]  rstr      CeedElemRestriction
+  @param[in]  rstr      @ref CeedElemRestriction
   @param[out] num_block Variable to store number of blocks
 
   @return An error code: 0 - success, otherwise - failure
@@ -1429,9 +1438,9 @@ int CeedElemRestrictionGetNumBlocks(CeedElemRestriction rstr, CeedInt *num_block
 }
 
 /**
-  @brief Get the size of blocks in the CeedElemRestriction
+  @brief Get the size of blocks in the @ref CeedElemRestriction
 
-  @param[in]  rstr       CeedElemRestriction
+  @param[in]  rstr       @ref CeedElemRestriction
   @param[out] block_size Variable to store size of blocks
 
   @return An error code: 0 - success, otherwise - failure
@@ -1444,10 +1453,10 @@ int CeedElemRestrictionGetBlockSize(CeedElemRestriction rstr, CeedInt *block_siz
 }
 
 /**
-  @brief Get the multiplicity of nodes in a CeedElemRestriction
+  @brief Get the multiplicity of nodes in a @ref CeedElemRestriction
 
-  @param[in]  rstr CeedElemRestriction
-  @param[out] mult Vector to store multiplicity (of size l_size)
+  @param[in]  rstr @ref CeedElemRestriction
+  @param[out] mult Vector to store multiplicity (of size `l_size`)
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1471,10 +1480,10 @@ int CeedElemRestrictionGetMultiplicity(CeedElemRestriction rstr, CeedVector mult
 }
 
 /**
-  @brief View a CeedElemRestriction
+  @brief View a @ref CeedElemRestriction
 
-  @param[in] rstr   CeedElemRestriction to view
-  @param[in] stream Stream to write; typically stdout/stderr or a file
+  @param[in] rstr   @ref CeedElemRestriction to view
+  @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
 
@@ -1509,9 +1518,9 @@ int CeedElemRestrictionView(CeedElemRestriction rstr, FILE *stream) {
 }
 
 /**
-  @brief Destroy a CeedElemRestriction
+  @brief Destroy a @ref CeedElemRestriction
 
-  @param[in,out] rstr CeedElemRestriction to destroy
+  @param[in,out] rstr @ref CeedElemRestriction to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-hip.c
+++ b/interface/ceed-hip.c
@@ -14,7 +14,7 @@
 /**
   @brief Set HIP function pointer to evaluate action at quadrature points
 
-  @param[in,out] qf CeedQFunction to set device pointer
+  @param[in,out] qf @ref CeedQFunction to set device pointer
   @param[in]     f  Device function pointer to evaluate action at quadrature points
 
   @return An error code: 0 - success, otherwise - failure

--- a/interface/ceed-hip.c
+++ b/interface/ceed-hip.c
@@ -14,7 +14,7 @@
 /**
   @brief Set HIP function pointer to evaluate action at quadrature points
 
-  @param[in,out] qf @ref CeedQFunction to set device pointer
+  @param[in,out] qf `CeedQFunction` to set device pointer
   @param[in]     f  Device function pointer to evaluate action at quadrature points
 
   @return An error code: 0 - success, otherwise - failure

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -16,7 +16,7 @@
 /**
   @brief Check if valid file exists at path given
 
-  @param[in]  ceed             @ref Ceed object for error handling
+  @param[in]  ceed             `Ceed` object for error handling
   @param[in]  source_file_path Absolute path to source file
   @param[out] is_valid         Boolean flag indicating if file can be opened
 
@@ -63,7 +63,7 @@ int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid) {
 /**
   @brief Load source file into initialized string buffer, including full text of local files in place of `#include "local.h"`
 
-  @param[in]  ceed             @ref Ceed object for error handling
+  @param[in]  ceed             `Ceed` object for error handling
   @param[in]  source_file_path Absolute path to source file
   @param[out] buffer           String buffer for source file contents
 
@@ -195,7 +195,7 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, c
 
   Note: Caller is responsible for freeing the string buffer with @ref CeedFree().
 
-  @param[in]  ceed             @ref Ceed object for error handling
+  @param[in]  ceed             `Ceed` object for error handling
   @param[in]  source_file_path Absolute path to source file
   @param[out] buffer           String buffer for source file contents
 
@@ -219,7 +219,7 @@ int CeedLoadSourceToBuffer(Ceed ceed, const char *source_file_path, char **buffe
 
   Note: Caller is responsible for freeing the string buffer with @ref CeedFree().
 
-  @param[in]  ceed               @ref Ceed object for error handling
+  @param[in]  ceed               `Ceed` object for error handling
   @param[in]  base_file_path     Absolute path to current file
   @param[in]  relative_file_path Relative path to target file
   @param[out] new_file_path      String buffer for absolute path to target file
@@ -258,7 +258,7 @@ int CeedGetJitRelativePath(const char *absolute_file_path, const char **relative
 /**
   @brief Build an absolute filepath to a JiT file
 
-  @param[in]  ceed               @ref Ceed object for error handling
+  @param[in]  ceed               `Ceed` object for error handling
   @param[in]  relative_file_path Relative path to installed JiT file
   @param[out] absolute_file_path String buffer for absolute path to target file, to be freed by caller
 

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -16,7 +16,7 @@
 /**
   @brief Check if valid file exists at path given
 
-  @param[in]  ceed             Ceed object for error handling
+  @param[in]  ceed             @ref Ceed object for error handling
   @param[in]  source_file_path Absolute path to source file
   @param[out] is_valid         Boolean flag indicating if file can be opened
 
@@ -63,7 +63,7 @@ int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid) {
 /**
   @brief Load source file into initialized string buffer, including full text of local files in place of `#include "local.h"`
 
-  @param[in]  ceed             Ceed object for error handling
+  @param[in]  ceed             @ref Ceed object for error handling
   @param[in]  source_file_path Absolute path to source file
   @param[out] buffer           String buffer for source file contents
 
@@ -193,9 +193,9 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, c
 /**
   @brief Initialize and load source file into string buffer, including full text of local files in place of `#include "local.h"`.
 
-  Note: Caller is responsible for freeing the string buffer with `CeedFree()`.
+  Note: Caller is responsible for freeing the string buffer with @ref CeedFree().
 
-  @param[in]  ceed             Ceed object for error handling
+  @param[in]  ceed             @ref Ceed object for error handling
   @param[in]  source_file_path Absolute path to source file
   @param[out] buffer           String buffer for source file contents
 
@@ -215,11 +215,11 @@ int CeedLoadSourceToBuffer(Ceed ceed, const char *source_file_path, char **buffe
 /**
   @brief Build an absolute filepath from a base filepath and an absolute filepath.
 
-  This helps construct source file paths for `CeedLoadSourceToBuffer()`.
+  This helps construct source file paths for @ref CeedLoadSourceToBuffer().
 
-  Note: Caller is responsible for freeing the string buffer with `CeedFree()`.
+  Note: Caller is responsible for freeing the string buffer with @ref CeedFree().
 
-  @param[in]  ceed               Ceed object for error handling
+  @param[in]  ceed               @ref Ceed object for error handling
   @param[in]  base_file_path     Absolute path to current file
   @param[in]  relative_file_path Relative path to target file
   @param[out] new_file_path      String buffer for absolute path to target file
@@ -258,7 +258,7 @@ int CeedGetJitRelativePath(const char *absolute_file_path, const char **relative
 /**
   @brief Build an absolute filepath to a JiT file
 
-  @param[in]  ceed               Ceed object for error handling
+  @param[in]  ceed               @ref Ceed object for error handling
   @param[in]  relative_file_path Relative path to installed JiT file
   @param[out] absolute_file_path String buffer for absolute path to target file, to be freed by caller
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -22,12 +22,12 @@
 /// @{
 
 /**
-  @brief Check if a CeedOperator Field matches the QFunction Field
+  @brief Check if a @ref CeedOperatorField matches the @ref CeedQFunctionField
 
-  @param[in] ceed     Ceed object for error handling
-  @param[in] qf_field QFunction Field matching Operator Field
-  @param[in] r        Operator Field ElemRestriction
-  @param[in] b        Operator Field Basis
+  @param[in] ceed     @ref Ceed object for error handling
+  @param[in] qf_field @ref CeedQFunctionField matching @ref CeedOperatorField
+  @param[in] r        @ref CeedOperatorField @ref CeedElemRestriction
+  @param[in] b        @ref CeedOperatorField @ref CeedBasis
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -51,15 +51,15 @@ static int CeedOperatorCheckField(Ceed ceed, CeedQFunctionField qf_field, CeedEl
     CeedCall(CeedBasisGetNumComponents(b, &num_comp));
     CeedCall(CeedBasisGetNumQuadratureComponents(b, eval_mode, &q_comp));
     CeedCheck(r == CEED_ELEMRESTRICTION_NONE || rstr_num_comp == num_comp, ceed, CEED_ERROR_DIMENSION,
-              "Field '%s' of size %" CeedInt_FMT " and EvalMode %s: ElemRestriction has %" CeedInt_FMT " components, but Basis has %" CeedInt_FMT
-              " components",
+              "Field '%s' of size %" CeedInt_FMT " and EvalMode %s: CeedElemRestriction has %" CeedInt_FMT
+              " components, but CeedBasis has %" CeedInt_FMT " components",
               qf_field->field_name, qf_field->size, CeedEvalModes[qf_field->eval_mode], rstr_num_comp, num_comp);
   }
   // Field size
   switch (eval_mode) {
     case CEED_EVAL_NONE:
       CeedCheck(size == rstr_num_comp, ceed, CEED_ERROR_DIMENSION,
-                "Field '%s' of size %" CeedInt_FMT " and EvalMode %s: ElemRestriction has %" CeedInt_FMT " components", qf_field->field_name,
+                "Field '%s' of size %" CeedInt_FMT " and EvalMode %s: CeedElemRestriction has %" CeedInt_FMT " components", qf_field->field_name,
                 qf_field->size, CeedEvalModes[qf_field->eval_mode], rstr_num_comp);
       break;
     case CEED_EVAL_INTERP:
@@ -67,8 +67,8 @@ static int CeedOperatorCheckField(Ceed ceed, CeedQFunctionField qf_field, CeedEl
     case CEED_EVAL_DIV:
     case CEED_EVAL_CURL:
       CeedCheck(size == num_comp * q_comp, ceed, CEED_ERROR_DIMENSION,
-                "Field '%s' of size %" CeedInt_FMT " and EvalMode %s: ElemRestriction/Basis has %" CeedInt_FMT " components", qf_field->field_name,
-                qf_field->size, CeedEvalModes[qf_field->eval_mode], num_comp * q_comp);
+                "Field '%s' of size %" CeedInt_FMT " and EvalMode %s: CeedElemRestriction/Basis has %" CeedInt_FMT " components",
+                qf_field->field_name, qf_field->size, CeedEvalModes[qf_field->eval_mode], num_comp * q_comp);
       break;
     case CEED_EVAL_WEIGHT:
       // No additional checks required
@@ -78,14 +78,14 @@ static int CeedOperatorCheckField(Ceed ceed, CeedQFunctionField qf_field, CeedEl
 }
 
 /**
-  @brief View a field of a CeedOperator
+  @brief View a field of a @ref CeedOperator
 
-  @param[in] field        Operator field to view
-  @param[in] qf_field     QFunction field (carries field name)
+  @param[in] field        @ref CeedOperatorField to view
+  @param[in] qf_field     @ref CeedQFunctionField (carries field name)
   @param[in] field_number Number of field being viewed
   @param[in] sub          true indicates sub-operator, which increases indentation; false for top-level operator
   @param[in] input        true for an input field; false for output field
-  @param[in] stream       Stream to view to, e.g., stdout
+  @param[in] stream       Stream to view to, e.g., `stdout`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -109,11 +109,11 @@ static int CeedOperatorFieldView(CeedOperatorField field, CeedQFunctionField qf_
 }
 
 /**
-  @brief View a single CeedOperator
+  @brief View a single @ref CeedOperator
 
-  @param[in] op     CeedOperator to view
+  @param[in] op     @ref CeedOperator to view
   @param[in] sub    Boolean flag for sub-operator
-  @param[in] stream Stream to write; typically stdout/stderr or a file
+  @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
 
@@ -141,10 +141,10 @@ int CeedOperatorSingleView(CeedOperator op, bool sub, FILE *stream) {
 }
 
 /**
-  @brief Find the active vector basis for a non-composite CeedOperator
+  @brief Find the active input vector @ref CeedBasis for a non-composite @ref CeedOperator
 
-  @param[in] op            CeedOperator to find active basis for
-  @param[out] active_basis Basis for active input vector or NULL for composite operator
+  @param[in]  op           @ref CeedOperator to find active @ref CeedBasis for
+  @param[out] active_basis @ref CeedBasis for active input vector or `NULL` for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -156,11 +156,11 @@ int CeedOperatorGetActiveBasis(CeedOperator op, CeedBasis *active_basis) {
 }
 
 /**
-  @brief Find the active input and output vector bases for a non-composite CeedOperator
+  @brief Find the active input and output vector @ref CeedBasis for a non-composite @ref CeedOperator
 
-  @param[in] op                   CeedOperator to find active bases for
-  @param[out] active_input_basis  Basis for active input vector or NULL for composite operator
-  @param[out] active_output_basis Basis for active output vector or NULL for composite operator
+  @param[in]  op                  @ref CeedOperator to find active @ref CeedBasis for
+  @param[out] active_input_basis  @ref CeedBasis for active input vector or `NULL` for composite operator
+  @param[out] active_output_basis @ref CeedBasis for active output vector or `NULL` for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -200,10 +200,10 @@ int CeedOperatorGetActiveBases(CeedOperator op, CeedBasis *active_input_basis, C
 }
 
 /**
-  @brief Find the active vector ElemRestriction for a non-composite CeedOperator
+  @brief Find the active vector @ref CeedElemRestriction for a non-composite @ref CeedOperator
 
-  @param[in] op           CeedOperator to find active ElemRestriction for
-  @param[out] active_rstr ElemRestriction for active input vector or NULL for composite operator
+  @param[in]  op          @ref CeedOperator to find active @ref CeedElemRestriction for
+  @param[out] active_rstr @ref CeedElemRestriction for active input vector or NULL for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -215,11 +215,11 @@ int CeedOperatorGetActiveElemRestriction(CeedOperator op, CeedElemRestriction *a
 }
 
 /**
-  @brief Find the active input and output vector ElemRestrictions for a non-composite CeedOperator
+  @brief Find the active input and output vector @ref CeedElemRestriction for a non-composite @ref CeedOperator
 
-  @param[in] op                  CeedOperator to find active ElemRestrictions for
-  @param[out] active_input_rstr  ElemRestriction for active input vector or NULL for composite operator
-  @param[out] active_output_rstr ElemRestriction for active output vector or NULL for composite operator
+  @param[in]  op                 @ref CeedOperator to find active @ref CeedElemRestriction for
+  @param[out] active_input_rstr  @ref CeedElemRestriction for active input vector or NULL for composite operator
+  @param[out] active_output_rstr @ref CeedElemRestriction for active output vector or NULL for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -259,13 +259,12 @@ int CeedOperatorGetActiveElemRestrictions(CeedOperator op, CeedElemRestriction *
 }
 
 /**
-  @brief Set QFunctionContext field values of the specified type.
+  @brief Set @ref CeedQFunctionContext field values of the specified type.
 
-  For composite operators, the value is set in all sub-operator QFunctionContexts that have a matching `field_name`.
-  A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have
-any field of a matching type.
+  For composite operators, the value is set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have any field of a matching type.
 
-  @param[in,out] op          CeedOperator
+  @param[in,out] op          @ref CeedOperator
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[in]     values      Values to set
@@ -314,13 +313,12 @@ static int CeedOperatorContextSetGeneric(CeedOperator op, CeedContextFieldLabel 
 }
 
 /**
-  @brief Get QFunctionContext field values of the specified type, read-only.
+  @brief Get @ref CeedQFunctionContext field values of the specified type, read-only.
 
-  For composite operators, the values retrieved are for the first sub-operator QFunctionContext that have a matching `field_name`.
-  A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have
-any field of a matching type.
+  For composite operators, the values retrieved are for the first sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have any field of a matching type.
 
-  @param[in,out] op          CeedOperator
+  @param[in,out] op          @ref CeedOperator
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[out]    num_values  Number of values of type `field_type` in array `values`
@@ -374,13 +372,12 @@ static int CeedOperatorContextGetGenericRead(CeedOperator op, CeedContextFieldLa
 }
 
 /**
-  @brief Restore QFunctionContext field values of the specified type, read-only.
+  @brief Restore @ref CeedQFunctionContext field values of the specified type, read-only.
 
-  For composite operators, the values restored are for the first sub-operator QFunctionContext that have a matching `field_name`.
-  A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have
-any field of a matching type.
+  For composite operators, the values restored are for the first sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have any field of a matching type.
 
-  @param[in,out] op          CeedOperator
+  @param[in,out] op          @ref CeedOperator
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[in]     values      Values array to restore
@@ -437,9 +434,9 @@ static int CeedOperatorContextRestoreGenericRead(CeedOperator op, CeedContextFie
 /// @{
 
 /**
-  @brief Get the number of arguments associated with a CeedOperator
+  @brief Get the number of arguments associated with a @ref CeedOperator
 
-  @param[in]  op        CeedOperator
+  @param[in]  op        @ref CeedOperator
   @param[out] num_args  Variable to store vector number of arguments
 
   @return An error code: 0 - success, otherwise - failure
@@ -453,9 +450,9 @@ int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args) {
 }
 
 /**
-  @brief Get the setup status of a CeedOperator
+  @brief Get the setup status of a @ref CeedOperator
 
-  @param[in]  op            CeedOperator
+  @param[in]  op            @ref CeedOperator
   @param[out] is_setup_done Variable to store setup status
 
   @return An error code: 0 - success, otherwise - failure
@@ -468,10 +465,10 @@ int CeedOperatorIsSetupDone(CeedOperator op, bool *is_setup_done) {
 }
 
 /**
-  @brief Get the QFunction associated with a CeedOperator
+  @brief Get the @ref CeedQFunction associated with a @ref CeedOperator
 
-  @param[in]  op CeedOperator
-  @param[out] qf Variable to store QFunction
+  @param[in]  op @ref CeedOperator
+  @param[out] qf Variable to store @ref CeedQFunction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -484,9 +481,9 @@ int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf) {
 }
 
 /**
-  @brief Get a boolean value indicating if the CeedOperator is composite
+  @brief Get a boolean value indicating if the @ref CeedOperator is composite
 
-  @param[in]  op           CeedOperator
+  @param[in]  op           @ref CeedOperator
   @param[out] is_composite Variable to store composite status
 
   @return An error code: 0 - success, otherwise - failure
@@ -499,9 +496,9 @@ int CeedOperatorIsComposite(CeedOperator op, bool *is_composite) {
 }
 
 /**
-  @brief Get the backend data of a CeedOperator
+  @brief Get the backend data of a @ref CeedOperator
 
-  @param[in]  op   CeedOperator
+  @param[in]  op   @ref CeedOperator
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -514,9 +511,9 @@ int CeedOperatorGetData(CeedOperator op, void *data) {
 }
 
 /**
-  @brief Set the backend data of a CeedOperator
+  @brief Set the backend data of a @ref CeedOperator
 
-  @param[in,out] op   CeedOperator
+  @param[in,out] op   @ref CeedOperator
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -529,9 +526,9 @@ int CeedOperatorSetData(CeedOperator op, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a CeedOperator
+  @brief Increment the reference counter for a @ref CeedOperator
 
-  @param[in,out] op CeedOperator to increment the reference counter
+  @param[in,out] op @ref CeedOperator to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -543,9 +540,9 @@ int CeedOperatorReference(CeedOperator op) {
 }
 
 /**
-  @brief Set the setup flag of a CeedOperator to True
+  @brief Set the setup flag of a @ref CeedOperator to `true`
 
-  @param[in,out] op CeedOperator
+  @param[in,out] op @ref CeedOperator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -565,15 +562,15 @@ int CeedOperatorSetSetupDone(CeedOperator op) {
 /// @{
 
 /**
-  @brief Create a CeedOperator and associate a CeedQFunction.
+  @brief Create a @ref CeedOperator and associate a @ref CeedQFunction.
 
-  A CeedBasis and CeedElemRestriction can be associated with CeedQFunction fields with \ref CeedOperatorSetField.
+  A @ref CeedBasis and @ref CeedElemRestriction can be associated with @ref CeedQFunction fields with @ref CeedOperatorSetField().
 
-  @param[in]  ceed Ceed object where the CeedOperator will be created
-  @param[in]  qf   QFunction defining the action of the operator at quadrature points
-  @param[in]  dqf  QFunction defining the action of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
-  @param[in]  dqfT QFunction defining the action of the transpose of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
-  @param[out] op   Address of the variable where the newly created CeedOperator will be stored
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperator
+  @param[in]  qf   @ref CeedQFunction defining the action of the operator at quadrature points
+  @param[in]  dqf  @ref CeedQFunction defining the action of the Jacobian of `qf` (or @ref CEED_QFUNCTION_NONE)
+  @param[in]  dqfT @ref CeedQFunction defining the action of the transpose of the Jacobian of `qf` (or @ref CEED_QFUNCTION_NONE)
+  @param[out] op   Address of the variable where the newly created @ref CeedOperator will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -584,12 +581,12 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, CeedQFunc
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "Operator"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support OperatorCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedOperatorCreate");
     CeedCall(CeedOperatorCreate(delegate, qf, dqf, dqfT, op));
     return CEED_ERROR_SUCCESS;
   }
 
-  CeedCheck(qf && qf != CEED_QFUNCTION_NONE, ceed, CEED_ERROR_MINOR, "Operator must have a valid QFunction.");
+  CeedCheck(qf && qf != CEED_QFUNCTION_NONE, ceed, CEED_ERROR_MINOR, "Operator must have a valid CeedQFunction.");
 
   CeedCall(CeedCalloc(1, op));
   CeedCall(CeedReferenceCopy(ceed, &(*op)->ceed));
@@ -607,15 +604,15 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, CeedQFunc
 }
 
 /**
-  @brief Create a CeedOperator for evaluation at evaluation at arbitrary points in each element.
+  @brief Create a @ref CeedOperator for evaluation at evaluation at arbitrary points in each element.
 
-  A CeedBasis and CeedElemRestriction can be associated with CeedQFunction fields with \ref CeedOperatorSetField.
-  The locations of each point are set with \ref CeedOperatorAtPointsSetPoints.
+  A @ref CeedBasis and @ref CeedElemRestriction can be associated with @ref CeedQFunction fields with @ref CeedOperatorSetField.
+  The locations of each point are set with @ref CeedOperatorAtPointsSetPoints().
 
-  @param[in]  ceed Ceed object where the CeedOperator will be created
-  @param[in]  qf   QFunction defining the action of the operator at quadrature points
-  @param[in]  dqf  QFunction defining the action of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
-  @param[in]  dqfT QFunction defining the action of the transpose of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperator
+  @param[in]  qf   @ref CeedQFunction defining the action of the operator at quadrature points
+  @param[in]  dqf  @ref CeedQFunction defining the action of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
+  @param[in]  dqfT @ref CeedQFunction defining the action of the transpose of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
   @param[out] op   Address of the variable where the newly created CeedOperator will be stored
 
   @return An error code: 0 - success, otherwise - failure
@@ -627,12 +624,12 @@ int CeedOperatorCreateAtPoints(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, C
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "Operator"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support OperatorCreateAtPoints");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedOperatorCreateAtPoints");
     CeedCall(CeedOperatorCreateAtPoints(delegate, qf, dqf, dqfT, op));
     return CEED_ERROR_SUCCESS;
   }
 
-  CeedCheck(qf && qf != CEED_QFUNCTION_NONE, ceed, CEED_ERROR_MINOR, "Operator must have a valid QFunction.");
+  CeedCheck(qf && qf != CEED_QFUNCTION_NONE, ceed, CEED_ERROR_MINOR, "Operator must have a valid CeedQFunction.");
 
   CeedCall(CeedCalloc(1, op));
   CeedCall(CeedReferenceCopy(ceed, &(*op)->ceed));
@@ -651,10 +648,10 @@ int CeedOperatorCreateAtPoints(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, C
 }
 
 /**
-  @brief Create an operator that composes the action of several operators
+  @brief Create a composite @ref CeedOperator that composes the action of several @ref CeedOperator
 
-  @param[in]  ceed Ceed object where the CeedOperator will be created
-  @param[out] op   Address of the variable where the newly created Composite CeedOperator will be stored
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperator
+  @param[out] op   Address of the variable where the newly created composite @ref CeedOperator will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -684,14 +681,14 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
 }
 
 /**
-  @brief Copy the pointer to a CeedOperator.
+  @brief Copy the pointer to a @ref CeedOperator.
 
-  Both pointers should be destroyed with `CeedOperatorDestroy()`.
+  Both pointers should be destroyed with @ref CeedOperatorDestroy().
 
-  Note: If the value of `op_copy` passed to this function is non-NULL, then it is assumed that `op_copy` is a pointer to a CeedOperator.
-        This CeedOperator will be destroyed if `op_copy` is the only reference to this CeedOperator.
+  Note: If the value of `*op_copy` passed to this function is non-`NULL`, then it is assumed that `*op_copy` is a pointer to a @ref CeedOperator.
+        This @ref CeedOperator will be destroyed if `*op_copy` is the only reference to this @ref CeedOperator.
 
-  @param[in]  op         CeedOperator to copy reference to
+  @param[in]     op      @ref CeedOperator to copy reference to
   @param[in,out] op_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -706,24 +703,23 @@ int CeedOperatorReferenceCopy(CeedOperator op, CeedOperator *op_copy) {
 }
 
 /**
-  @brief Provide a field to a CeedOperator for use by its CeedQFunction.
+  @brief Provide a field to a @ref CeedOperator for use by its @ref CeedQFunction.
 
-  This function is used to specify both active and passive fields to a CeedOperator.
-  For passive fields, a vector @arg v must be provided.
+  This function is used to specify both active and passive fields to a @ref CeedOperator.
+  For passive fields, a @ref CeedVector `v` must be provided.
   Passive fields can inputs or outputs (updated in-place when operator is applied).
 
-  Active fields must be specified using this function, but their data (in a CeedVector) is passed in CeedOperatorApply().
-  There can be at most one active input CeedVector and at most one active output CeedVector passed to CeedOperatorApply().
+  Active fields must be specified using this function, but their data (in a @ref CeedVector) is passed in @ref CeedOperatorApply().
+  There can be at most one active input @ref CeedVector and at most one active output@ref  CeedVector passed to @ref CeedOperatorApply().
 
   The number of quadrature points must agree across all points.
-  When using @ref CEED_BASIS_NONE, the number of quadrature points is determined by the element size of r.
+  When using @ref CEED_BASIS_NONE, the number of quadrature points is determined by the element size of `r`.
 
-  @param[in,out] op         CeedOperator on which to provide the field
-  @param[in]     field_name Name of the field (to be matched with the name used by CeedQFunction)
-  @param[in]     r          CeedElemRestriction
-  @param[in]     b          CeedBasis in which the field resides or @ref CEED_BASIS_NONE if collocated with quadrature points
-  @param[in]     v          CeedVector to be used by CeedOperator or @ref CEED_VECTOR_ACTIVE if field is active or @ref CEED_VECTOR_NONE
-                              if using @ref CEED_EVAL_WEIGHT in the QFunction
+  @param[in,out] op         @ref CeedOperator on which to provide the field
+  @param[in]     field_name Name of the field (to be matched with the name used by @ref CeedQFunction)
+  @param[in]     r          @ref CeedElemRestriction
+  @param[in]     b          @ref CeedBasis in which the field resides or @ref CEED_BASIS_NONE if collocated with quadrature points
+  @param[in]     v          @ref CeedVector to be used by CeedOperator or @ref CEED_VECTOR_ACTIVE if field is active or @ref CEED_VECTOR_NONE if using @ref CEED_EVAL_WEIGHT in the @ref CeedQFunction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -737,20 +733,20 @@ int CeedOperatorSetField(CeedOperator op, const char *field_name, CeedElemRestri
 
   CeedCheck(!op->is_composite, op->ceed, CEED_ERROR_INCOMPATIBLE, "Cannot add field to composite operator.");
   CeedCheck(!op->is_immutable, op->ceed, CEED_ERROR_MAJOR, "Operator cannot be changed after set as immutable");
-  CeedCheck(r, op->ceed, CEED_ERROR_INCOMPATIBLE, "ElemRestriction r for field \"%s\" must be non-NULL.", field_name);
-  CeedCheck(b, op->ceed, CEED_ERROR_INCOMPATIBLE, "Basis b for field \"%s\" must be non-NULL.", field_name);
-  CeedCheck(v, op->ceed, CEED_ERROR_INCOMPATIBLE, "Vector v for field \"%s\" must be non-NULL.", field_name);
+  CeedCheck(r, op->ceed, CEED_ERROR_INCOMPATIBLE, "CeedElemRestriction r for field \"%s\" must be non-NULL.", field_name);
+  CeedCheck(b, op->ceed, CEED_ERROR_INCOMPATIBLE, "CeedBasis b for field \"%s\" must be non-NULL.", field_name);
+  CeedCheck(v, op->ceed, CEED_ERROR_INCOMPATIBLE, "CeedVector v for field \"%s\" must be non-NULL.", field_name);
 
   CeedCall(CeedElemRestrictionGetNumElements(r, &num_elem));
   CeedCheck(r == CEED_ELEMRESTRICTION_NONE || !op->has_restriction || op->num_elem == num_elem, op->ceed, CEED_ERROR_DIMENSION,
-            "ElemRestriction with %" CeedInt_FMT " elements incompatible with prior %" CeedInt_FMT " elements", num_elem, op->num_elem);
+            "CeedElemRestriction with %" CeedInt_FMT " elements incompatible with prior %" CeedInt_FMT " elements", num_elem, op->num_elem);
   {
     CeedRestrictionType rstr_type;
 
     CeedCall(CeedElemRestrictionGetType(r, &rstr_type));
     if (rstr_type == CEED_RESTRICTION_POINTS) {
-      CeedCheck(op->is_at_points, op->ceed, CEED_ERROR_UNSUPPORTED, "ElemRestrictionAtPoints not supported for standard operator fields");
-      CeedCheck(b == CEED_BASIS_NONE, op->ceed, CEED_ERROR_UNSUPPORTED, "ElemRestrictionAtPoints must be used with CEED_BASIS_NONE");
+      CeedCheck(op->is_at_points, op->ceed, CEED_ERROR_UNSUPPORTED, "CeedElemRestriction AtPoints not supported for standard operator fields");
+      CeedCheck(b == CEED_BASIS_NONE, op->ceed, CEED_ERROR_UNSUPPORTED, "CeedElemRestriction AtPoints must be used with CEED_BASIS_NONE");
       if (!op->first_points_rstr) {
         CeedCall(CeedElemRestrictionReferenceCopy(r, &op->first_points_rstr));
       } else {
@@ -758,7 +754,7 @@ int CeedOperatorSetField(CeedOperator op, const char *field_name, CeedElemRestri
 
         CeedCall(CeedElemRestrictionAtPointsAreCompatible(op->first_points_rstr, r, &are_compatible));
         CeedCheck(are_compatible, op->ceed, CEED_ERROR_INCOMPATIBLE,
-                  "ElemRestriction must have compatible offsets with previously set ElemRestriction");
+                  "CeedElemRestriction must have compatible offsets with previously set CeedElemRestriction");
       }
     }
   }
@@ -766,9 +762,9 @@ int CeedOperatorSetField(CeedOperator op, const char *field_name, CeedElemRestri
   if (b == CEED_BASIS_NONE) CeedCall(CeedElemRestrictionGetElementSize(r, &num_qpts));
   else CeedCall(CeedBasisGetNumQuadraturePoints(b, &num_qpts));
   CeedCheck(op->num_qpts == 0 || op->num_qpts == num_qpts, op->ceed, CEED_ERROR_DIMENSION,
-            "%s must correspond to the same number of quadrature points as previously added Bases. Found %" CeedInt_FMT
+            "%s must correspond to the same number of quadrature points as previously added CeedBases. Found %" CeedInt_FMT
             " quadrature points but expected %" CeedInt_FMT " quadrature points.",
-            b == CEED_BASIS_NONE ? "ElemRestriction" : "Basis", num_qpts, op->num_qpts);
+            b == CEED_BASIS_NONE ? "CeedElemRestriction" : "CeedBasis", num_qpts, op->num_qpts);
   for (CeedInt i = 0; i < op->qf->num_input_fields; i++) {
     if (!strcmp(field_name, (*op->qf->input_fields[i]).field_name)) {
       qf_field = op->qf->input_fields[i];
@@ -785,7 +781,7 @@ int CeedOperatorSetField(CeedOperator op, const char *field_name, CeedElemRestri
     }
   }
   // LCOV_EXCL_START
-  return CeedError(op->ceed, CEED_ERROR_INCOMPLETE, "QFunction has no knowledge of field '%s'", field_name);
+  return CeedError(op->ceed, CEED_ERROR_INCOMPLETE, "CeedQFunction has no knowledge of field '%s'", field_name);
   // LCOV_EXCL_STOP
 found:
   CeedCall(CeedOperatorCheckField(op->ceed, qf_field, r, b));
@@ -820,15 +816,15 @@ found:
 }
 
 /**
-  @brief Get the CeedOperatorFields of a CeedOperator.
+  @brief Get the @ref CeedOperatorField of a @ref CeedOperator.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op                CeedOperator
+  @param[in]  op                @ref CeedOperator
   @param[out] num_input_fields  Variable to store number of input fields
-  @param[out] input_fields      Variable to store input_fields
+  @param[out] input_fields      Variable to store input fields
   @param[out] num_output_fields Variable to store number of output fields
-  @param[out] output_fields     Variable to store output_fields
+  @param[out] output_fields     Variable to store output fields
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -847,13 +843,13 @@ int CeedOperatorGetFields(CeedOperator op, CeedInt *num_input_fields, CeedOperat
 }
 
 /**
-  @brief Set the arbitrary points in each element for a CeedOperatorAtPoints.
+  @brief Set the arbitrary points in each element for a @ref CeedOperator at points.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in,out] op           CeedOperatorAtPoints
-  @param[in]     rstr_points  CeedElemRestriction for the coordinates of each point by element
-  @param[in]     point_coords CeedVector holding coordinates of each point
+  @param[in,out] op           @ref CeedOperator at points
+  @param[in]     rstr_points  @ref CeedElemRestriction for the coordinates of each point by element
+  @param[in]     point_coords @ref CeedVector holding coordinates of each point
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -870,7 +866,7 @@ int CeedOperatorAtPointsSetPoints(CeedOperator op, CeedElemRestriction rstr_poin
 
     CeedCall(CeedElemRestrictionAtPointsAreCompatible(op->first_points_rstr, rstr_points, &are_compatible));
     CeedCheck(are_compatible, op->ceed, CEED_ERROR_INCOMPATIBLE,
-              "ElemRestriction must have compatible offsets with previously set field ElemRestrictions");
+              "CeedElemRestriction must have compatible offsets with previously set field CeedElemRestriction");
   }
 
   CeedCall(CeedElemRestrictionReferenceCopy(rstr_points, &op->rstr_points));
@@ -879,13 +875,13 @@ int CeedOperatorAtPointsSetPoints(CeedOperator op, CeedElemRestriction rstr_poin
 }
 
 /**
-  @brief Get the arbitrary points in each element for a CeedOperatorAtPoints.
+  @brief Get the arbitrary points in each element for a @ref CeedOperator at points.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op           CeedOperatorAtPoints
-  @param[out] rstr_points  Variable to hold CeedElemRestriction for the coordinates of each point by element
-  @param[out] point_coords Variable to hold CeedVector holding coordinates of each point
+  @param[in]  op           @ref CeedOperator at points
+  @param[out] rstr_points  Variable to hold @ref CeedElemRestriction for the coordinates of each point by element
+  @param[out] point_coords Variable to hold @ref CeedVector holding coordinates of each point
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -901,13 +897,13 @@ int CeedOperatorAtPointsGetPoints(CeedOperator op, CeedElemRestriction *rstr_poi
 }
 
 /**
-  @brief Get a CeedOperatorField of an CeedOperator from its name
+  @brief Get a @ref CeedOperatorField of a @ref CeedOperator from its name
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op         CeedOperator
-  @param[in]  field_name Name of desired CeedOperatorField
-  @param[out] op_field   CeedOperatorField corresponding to the name
+  @param[in]  op         @ref CeedOperator
+  @param[in]  field_name Name of desired @ref CeedOperatorField
+  @param[out] op_field   @ref CeedOperatorField corresponding to the name
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -942,9 +938,9 @@ int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOper
 }
 
 /**
-  @brief Get the name of a CeedOperatorField
+  @brief Get the name of a @ref CeedOperatorField
 
-  @param[in]  op_field    CeedOperatorField
+  @param[in]  op_field    @ref CeedOperatorField
   @param[out] field_name  Variable to store the field name
 
   @return An error code: 0 - success, otherwise - failure
@@ -957,10 +953,10 @@ int CeedOperatorFieldGetName(CeedOperatorField op_field, char **field_name) {
 }
 
 /**
-  @brief Get the CeedElemRestriction of a CeedOperatorField
+  @brief Get the @ref CeedElemRestriction of a @ref CeedOperatorField
 
-  @param[in]  op_field CeedOperatorField
-  @param[out] rstr     Variable to store CeedElemRestriction
+  @param[in]  op_field @ref CeedOperatorField
+  @param[out] rstr     Variable to store @ref CeedElemRestriction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -972,10 +968,10 @@ int CeedOperatorFieldGetElemRestriction(CeedOperatorField op_field, CeedElemRest
 }
 
 /**
-  @brief Get the CeedBasis of a CeedOperatorField
+  @brief Get the @ref CeedBasis of a @ref CeedOperatorField
 
-  @param[in]  op_field CeedOperatorField
-  @param[out] basis    Variable to store CeedBasis
+  @param[in]  op_field @ref CeedOperatorField
+  @param[out] basis    Variable to store @ref CeedBasis
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -987,10 +983,10 @@ int CeedOperatorFieldGetBasis(CeedOperatorField op_field, CeedBasis *basis) {
 }
 
 /**
-  @brief Get the CeedVector of a CeedOperatorField
+  @brief Get the @ref CeedVector of a @ref CeedOperatorField
 
-  @param[in]  op_field CeedOperatorField
-  @param[out] vec      Variable to store CeedVector
+  @param[in]  op_field @ref CeedOperatorField
+  @param[out] vec      Variable to store @ref CeedVector
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1002,10 +998,10 @@ int CeedOperatorFieldGetVector(CeedOperatorField op_field, CeedVector *vec) {
 }
 
 /**
-  @brief Add a sub-operator to a composite CeedOperator
+  @brief Add a sub-operator to a composite @ref CeedOperator
 
-  @param[in,out] composite_op Composite CeedOperator
-  @param[in]     sub_op       Sub-operator CeedOperator
+  @param[in,out] composite_op Composite @ref CeedOperator
+  @param[in]     sub_op       Sub-operator @ref CeedOperator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1037,10 +1033,10 @@ int CeedCompositeOperatorAddSub(CeedOperator composite_op, CeedOperator sub_op) 
 }
 
 /**
-  @brief Get the number of sub_operators associated with a CeedOperator
+  @brief Get the number of sub-operators associated with a @ref CeedOperator
 
-  @param[in]  op               CeedOperator
-  @param[out] num_suboperators Variable to store number of sub_operators
+  @param[in]  op               @ref CeedOperator
+  @param[out] num_suboperators Variable to store number of sub-operators
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1053,10 +1049,10 @@ int CeedCompositeOperatorGetNumSub(CeedOperator op, CeedInt *num_suboperators) {
 }
 
 /**
-  @brief Get the list of sub_operators associated with a CeedOperator
+  @brief Get the list of sub-operators associated with a @ref CeedOperator
 
-  @param op                  CeedOperator
-  @param[out] sub_operators  Variable to store list of sub_operators
+  @param[in]  op             @ref CeedOperator
+  @param[out] sub_operators  Variable to store list of sub-operators
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1069,9 +1065,9 @@ int CeedCompositeOperatorGetSubList(CeedOperator op, CeedOperator **sub_operator
 }
 
 /**
-  @brief Check if a CeedOperator is ready to be used.
+  @brief Check if a @ref CeedOperator is ready to be used.
 
-  @param[in] op CeedOperator to check
+  @param[in] op @ref CeedOperator to check
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1104,7 +1100,7 @@ int CeedOperatorCheckReady(CeedOperator op) {
     CeedCheck(op->num_fields == qf->num_input_fields + qf->num_output_fields, ceed, CEED_ERROR_INCOMPLETE, "Not all operator fields set");
     CeedCheck(op->has_restriction, ceed, CEED_ERROR_INCOMPLETE, "At least one restriction required");
     CeedCheck(op->num_qpts > 0 || op->is_at_points, ceed, CEED_ERROR_INCOMPLETE,
-              "At least one non-collocated basis is required or the number of quadrature points must be set");
+              "At least one non-collocated CeedBasis is required or the number of quadrature points must be set");
   }
 
   // Flag as immutable and ready
@@ -1116,13 +1112,13 @@ int CeedOperatorCheckReady(CeedOperator op) {
 }
 
 /**
-  @brief Get vector lengths for the active input and/or output vectors of a CeedOperator.
+  @brief Get vector lengths for the active input and/or output @ref CeedVector of a @ref CeedOperator.
 
-  Note: Lengths of -1 indicate that the CeedOperator does not have an active input and/or output.
+  Note: Lengths of `-1` indicate that the CeedOperator does not have an active input and/or output.
 
-  @param[in]  op          CeedOperator
-  @param[out] input_size  Variable to store active input vector length, or NULL
-  @param[out] output_size Variable to store active output vector length, or NULL
+  @param[in]  op          @ref CeedOperator
+  @param[out] input_size  Variable to store active input vector length, or `NULL`
+  @param[out] output_size Variable to store active output vector length, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1154,14 +1150,12 @@ int CeedOperatorGetActiveVectorLengths(CeedOperator op, CeedSize *input_size, Ce
 }
 
 /**
-  @brief Set reuse of CeedQFunction data in CeedOperatorLinearAssemble* functions.
+  @brief Set reuse of @ref CeedQFunction data in `CeedOperatorLinearAssemble*()` functions.
 
-  When `reuse_assembly_data = false` (default), the CeedQFunction associated with this CeedOperator is re-assembled every time a
-`CeedOperatorLinearAssemble*` function is called.
-  When `reuse_assembly_data = true`, the CeedQFunction associated with this CeedOperator is reused between calls to
-`CeedOperatorSetQFunctionAssemblyDataUpdated`.
+  When `reuse_assembly_data = false` (default), the @ref CeedQFunction associated with this @ref CeedOperator is re-assembled every time a `CeedOperatorLinearAssemble*()` function is called.
+  When `reuse_assembly_data = true`, the @ref CeedQFunction associated with this @ref CeedOperator is reused between calls to @ref CeedOperatorSetQFunctionAssemblyDataUpdateNeeded().
 
-  @param[in] op                  CeedOperator
+  @param[in] op                  @ref CeedOperator
   @param[in] reuse_assembly_data Boolean flag setting assembly data reuse
 
   @return An error code: 0 - success, otherwise - failure
@@ -1183,9 +1177,9 @@ int CeedOperatorSetQFunctionAssemblyReuse(CeedOperator op, bool reuse_assembly_d
 }
 
 /**
-  @brief Mark CeedQFunction data as updated and the CeedQFunction as requiring re-assembly.
+  @brief Mark @ref CeedQFunction data as updated and the @ref CeedQFunction as requiring re-assembly.
 
-  @param[in] op                CeedOperator
+  @param[in] op                @ref CeedOperator
   @param[in] needs_data_update Boolean flag setting assembly data reuse
 
   @return An error code: 0 - success, otherwise - failure
@@ -1207,9 +1201,9 @@ int CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(CeedOperator op, bool needs
 }
 
 /**
-  @brief Set name of CeedOperator for CeedOperatorView output
+  @brief Set name of @ref CeedOperator for @ref CeedOperatorView() output
 
-  @param[in,out] op   CeedOperator
+  @param[in,out] op   @ref CeedOperator
   @param[in]     name Name to set, or NULL to remove previously set name
 
   @return An error code: 0 - success, otherwise - failure
@@ -1230,10 +1224,10 @@ int CeedOperatorSetName(CeedOperator op, const char *name) {
 }
 
 /**
-  @brief View a CeedOperator
+  @brief View a @ref CeedOperator
 
-  @param[in] op     CeedOperator to view
-  @param[in] stream Stream to write; typically stdout/stderr or a file
+  @param[in] op     @ref CeedOperator to view
+  @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
 
@@ -1258,10 +1252,10 @@ int CeedOperatorView(CeedOperator op, FILE *stream) {
 }
 
 /**
-  @brief Get the Ceed associated with a CeedOperator
+  @brief Get the @ref Ceed associated with a @ref CeedOperator
 
-  @param[in]  op   CeedOperator
-  @param[out] ceed Variable to store Ceed
+  @param[in]  op   @ref CeedOperator
+  @param[out] ceed Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1273,9 +1267,9 @@ int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed) {
 }
 
 /**
-  @brief Get the number of elements associated with a CeedOperator
+  @brief Get the number of elements associated with a @ref CeedOperator
 
-  @param[in]  op       CeedOperator
+  @param[in]  op       @ref CeedOperator
   @param[out] num_elem Variable to store number of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1289,9 +1283,9 @@ int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem) {
 }
 
 /**
-  @brief Get the number of quadrature points associated with a CeedOperator
+  @brief Get the number of quadrature points associated with a @ref CeedOperator
 
-  @param[in]  op       CeedOperator
+  @param[in]  op       @ref CeedOperator
   @param[out] num_qpts Variable to store vector number of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1305,9 +1299,9 @@ int CeedOperatorGetNumQuadraturePoints(CeedOperator op, CeedInt *num_qpts) {
 }
 
 /**
-  @brief Estimate number of FLOPs required to apply CeedOperator on the active vector
+  @brief Estimate number of FLOPs required to apply @ref CeedOperator on the active @ref CeedVector
 
-  @param[in]  op    CeedOperator to estimate FLOPs for
+  @param[in]  op    @ref CeedOperator to estimate FLOPs for
   @param[out] flops Address of variable to hold FLOPs estimate
 
   @ref Backend
@@ -1377,33 +1371,33 @@ int CeedOperatorGetFlopsEstimate(CeedOperator op, CeedSize *flops) {
 }
 
 /**
-  @brief Get CeedQFunction global context for a CeedOperator.
+  @brief Get @ref CeedQFunction global context for a @ref CeedOperator.
 
-  The caller is responsible for destroying `ctx` returned from this function via `CeedQFunctionContextDestroy()`.
+  The caller is responsible for destroying `ctx` returned from this function via @ref CeedQFunctionContextDestroy().
 
-  Note: If the value of `ctx` passed into this function is non-NULL, then it is assumed that `ctx` is a pointer to a CeedQFunctionContext.
-        This CeedQFunctionContext will be destroyed if `ctx` is the only reference to this CeedQFunctionContext.
+  Note: If the value of `ctx` passed into this function is non-`NULL`, then it is assumed that `ctx` is a pointer to a @ref CeedQFunctionContext.
+        This @ref CeedQFunctionContext will be destroyed if `ctx` is the only reference to this @ref CeedQFunctionContext.
 
-  @param[in]  op  CeedOperator
-  @param[out] ctx Variable to store CeedQFunctionContext
+  @param[in]  op  @ref CeedOperator
+  @param[out] ctx Variable to store @ref CeedQFunctionContext
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref Advanced
 **/
 int CeedOperatorGetContext(CeedOperator op, CeedQFunctionContext *ctx) {
-  CeedCheck(!op->is_composite, op->ceed, CEED_ERROR_INCOMPATIBLE, "Cannot retrieve QFunctionContext for composite operator");
+  CeedCheck(!op->is_composite, op->ceed, CEED_ERROR_INCOMPATIBLE, "Cannot retrieve CeedQFunctionContext for composite operator");
   if (op->qf->ctx) CeedCall(CeedQFunctionContextReferenceCopy(op->qf->ctx, ctx));
   else *ctx = NULL;
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get label for a registered QFunctionContext field, or `NULL` if no field has been registered with this `field_name`.
+  @brief Get label for a registered @ref CeedQFunctionContext field, or `NULL` if no field has been registered with this `field_name`.
 
-  Fields are registered via `CeedQFunctionContextRegister*()` functions (eg. `CeedQFunctionContextRegisterDouble()`).
+  Fields are registered via `CeedQFunctionContextRegister*()` functions (eg. @ref CeedQFunctionContextRegisterDouble()).
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_name  Name of field to retrieve label
   @param[out] field_label Variable to field label
 
@@ -1506,11 +1500,11 @@ int CeedOperatorGetContextFieldLabel(CeedOperator op, const char *field_name, Ce
 }
 
 /**
-  @brief Set QFunctionContext field holding double precision values.
+  @brief Set @ref CeedQFunctionContext field holding double precision values.
 
-  For composite operators, the values are set in all sub-operator QFunctionContexts that have a matching `field_name`.
+  For composite operators, the values are set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
 
-  @param[in,out] op          CeedOperator
+  @param[in,out] op          @ref CeedOperator
   @param[in]     field_label Label of field to set
   @param[in]     values      Values to set
 
@@ -1523,11 +1517,11 @@ int CeedOperatorSetContextDouble(CeedOperator op, CeedContextFieldLabel field_la
 }
 
 /**
-  @brief Get QFunctionContext field holding double precision values, read-only.
+  @brief Get @ref CeedQFunctionContext field holding double precision values, read-only.
 
-  For composite operators, the values correspond to the first sub-operator QFunctionContexts that has a matching `field_name`.
+  For composite operators, the values correspond to the first sub-operator @ref CeedQFunctionContext that has a matching `field_name`.
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_label Label of field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -1541,9 +1535,9 @@ int CeedOperatorGetContextDoubleRead(CeedOperator op, CeedContextFieldLabel fiel
 }
 
 /**
-  @brief Restore QFunctionContext field holding double precision values, read-only.
+  @brief Restore @ref CeedQFunctionContext field holding double precision values, read-only.
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_label Label of field to restore
   @param[out] values      Pointer to context values
 
@@ -1556,11 +1550,11 @@ int CeedOperatorRestoreContextDoubleRead(CeedOperator op, CeedContextFieldLabel 
 }
 
 /**
-  @brief Set QFunctionContext field holding int32 values.
+  @brief Set @ref CeedQFunctionContext field holding `int32` values.
 
-  For composite operators, the values are set in all sub-operator QFunctionContexts that have a matching `field_name`.
+  For composite operators, the values are set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
 
-  @param[in,out] op          CeedOperator
+  @param[in,out] op          @ref CeedOperator
   @param[in]     field_label Label of field to set
   @param[in]     values      Values to set
 
@@ -1573,13 +1567,13 @@ int CeedOperatorSetContextInt32(CeedOperator op, CeedContextFieldLabel field_lab
 }
 
 /**
-  @brief Get QFunctionContext field holding int32 values, read-only.
+  @brief Get @ref CeedQFunctionContext field holding `int32` values, read-only.
 
-  For composite operators, the values correspond to the first sub-operator QFunctionContexts that has a matching `field_name`.
+  For composite operators, the values correspond to the first sub-operator @ref CeedQFunctionContext that has a matching `field_name`.
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_label Label of field to get
-  @param[out] num_values  Number of int32 values in `values`
+  @param[out] num_values  Number of `int32` values in `values`
   @param[out] values      Pointer to context values
 
   @return An error code: 0 - success, otherwise - failure
@@ -1591,9 +1585,9 @@ int CeedOperatorGetContextInt32Read(CeedOperator op, CeedContextFieldLabel field
 }
 
 /**
-  @brief Restore QFunctionContext field holding int32 values, read-only.
+  @brief Restore @ref CeedQFunctionContext field holding `int32` values, read-only.
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_label Label of field to get
   @param[out] values      Pointer to context values
 
@@ -1606,11 +1600,11 @@ int CeedOperatorRestoreContextInt32Read(CeedOperator op, CeedContextFieldLabel f
 }
 
 /**
-  @brief Set QFunctionContext field holding boolean values.
+  @brief Set @ref CeedQFunctionContext field holding boolean values.
 
-  For composite operators, the values are set in all sub-operator QFunctionContexts that have a matching `field_name`.
+  For composite operators, the values are set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
 
-  @param[in,out] op          CeedOperator
+  @param[in,out] op          @ref CeedOperator
   @param[in]     field_label Label of field to set
   @param[in]     values      Values to set
 
@@ -1623,13 +1617,13 @@ int CeedOperatorSetContextBoolean(CeedOperator op, CeedContextFieldLabel field_l
 }
 
 /**
-  @brief Get QFunctionContext field holding boolean values, read-only.
+  @brief Get @ref CeedQFunctionContext field holding boolean values, read-only.
 
-  For composite operators, the values correspond to the first sub-operator QFunctionContexts that has a matching `field_name`.
+  For composite operators, the values correspond to the first sub-operator @ref CeedQFunctionContext that has a matching `field_name`.
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_label Label of field to get
-  @param[out] num_values  Number of int32 values in `values`
+  @param[out] num_values  Number of boolean values in `values`
   @param[out] values      Pointer to context values
 
   @return An error code: 0 - success, otherwise - failure
@@ -1641,9 +1635,9 @@ int CeedOperatorGetContextBooleanRead(CeedOperator op, CeedContextFieldLabel fie
 }
 
 /**
-  @brief Restore QFunctionContext field holding boolean values, read-only.
+  @brief Restore @ref CeedQFunctionContext field holding boolean values, read-only.
 
-  @param[in]  op          CeedOperator
+  @param[in]  op          @ref CeedOperator
   @param[in]  field_label Label of field to get
   @param[out] values      Pointer to context values
 
@@ -1656,18 +1650,17 @@ int CeedOperatorRestoreContextBooleanRead(CeedOperator op, CeedContextFieldLabel
 }
 
 /**
-  @brief Apply CeedOperator to a vector
+  @brief Apply @ref CeedOperator to a @ref CeedVector.
 
   This computes the action of the operator on the specified (active) input, yielding its (active) output.
-  All inputs and outputs must be specified using CeedOperatorSetField().
+  All inputs and outputs must be specified using @ref CeedOperatorSetField().
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op      CeedOperator to apply
-  @param[in]  in      CeedVector containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
-  @param[out] out     CeedVector to store result of applying operator (must be distinct from @a in) or @ref CEED_VECTOR_NONE if there are no
-active outputs
-  @param[in]  request Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op      @ref CeedOperator to apply
+  @param[in]  in      @ref CeedVector containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
+  @param[out] out     @ref CeedVector to store result of applying operator (must be distinct from `in`) or @ref CEED_VECTOR_NONE if there are no active outputs
+  @param[in]  request Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1725,15 +1718,15 @@ int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out, CeedReques
 }
 
 /**
-  @brief Apply CeedOperator to a vector and add result to output vector
+  @brief Apply @ref CeedOperator to a @ref CeedVector and add result to output @ref CeedVector.
 
   This computes the action of the operator on the specified (active) input, yielding its (active) output.
-  All inputs and outputs must be specified using CeedOperatorSetField().
+  All inputs and outputs must be specified using @ref CeedOperatorSetField().
 
-  @param[in]  op      CeedOperator to apply
-  @param[in]  in      CeedVector containing input state or NULL if there are no active inputs
-  @param[out] out     CeedVector to sum in result of applying operator (must be distinct from @a in) or NULL if there are no active outputs
-  @param[in]  request Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op      @ref CeedOperator to apply
+  @param[in]  in      @ref CeedVector containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
+  @param[out] out     @ref CeedVector to sum in result of applying operator (must be distinct from `in`) or @ref CEED_VECTOR_NONE if there are no active outputs
+  @param[in]  request Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1764,9 +1757,9 @@ int CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedReq
 }
 
 /**
-  @brief Destroy a CeedOperator
+  @brief Destroy a @ref CeedOperator
 
-  @param[in,out] op CeedOperator to destroy
+  @param[in,out] op @ref CeedOperator to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -22,12 +22,12 @@
 /// @{
 
 /**
-  @brief Check if a @ref CeedOperatorField matches the @ref CeedQFunctionField
+  @brief Check if a `CeedOperator` Field matches the `CeedQFunction` Field
 
-  @param[in] ceed     @ref Ceed object for error handling
-  @param[in] qf_field @ref CeedQFunctionField matching @ref CeedOperatorField
-  @param[in] r        @ref CeedOperatorField @ref CeedElemRestriction
-  @param[in] b        @ref CeedOperatorField @ref CeedBasis
+  @param[in] ceed     `Ceed` object for error handling
+  @param[in] qf_field `CeedQFunction` Field matching `CeedOperator` Field
+  @param[in] r        `CeedOperator` Field `CeedElemRestriction` 
+  @param[in] b        `CeedOperator` Field `CeedBasis` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -78,10 +78,10 @@ static int CeedOperatorCheckField(Ceed ceed, CeedQFunctionField qf_field, CeedEl
 }
 
 /**
-  @brief View a field of a @ref CeedOperator
+  @brief View a field of a `CeedOperator` 
 
-  @param[in] field        @ref CeedOperatorField to view
-  @param[in] qf_field     @ref CeedQFunctionField (carries field name)
+  @param[in] field        `CeedOperator` Field to view
+  @param[in] qf_field     `CeedQFunction` Field (carries field name)
   @param[in] field_number Number of field being viewed
   @param[in] sub          true indicates sub-operator, which increases indentation; false for top-level operator
   @param[in] input        true for an input field; false for output field
@@ -109,9 +109,9 @@ static int CeedOperatorFieldView(CeedOperatorField field, CeedQFunctionField qf_
 }
 
 /**
-  @brief View a single @ref CeedOperator
+  @brief View a single `CeedOperator` 
 
-  @param[in] op     @ref CeedOperator to view
+  @param[in] op     `CeedOperator` to view
   @param[in] sub    Boolean flag for sub-operator
   @param[in] stream Stream to write; typically `stdout` or a file
 
@@ -141,10 +141,10 @@ int CeedOperatorSingleView(CeedOperator op, bool sub, FILE *stream) {
 }
 
 /**
-  @brief Find the active input vector @ref CeedBasis for a non-composite @ref CeedOperator
+  @brief Find the active input vector `CeedBasis` for a non-composite `CeedOperator` 
 
-  @param[in]  op           @ref CeedOperator to find active @ref CeedBasis for
-  @param[out] active_basis @ref CeedBasis for active input vector or `NULL` for composite operator
+  @param[in]  op           `CeedOperator` to find active `CeedBasis` for
+  @param[out] active_basis `CeedBasis` for active input vector or `NULL` for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -156,11 +156,11 @@ int CeedOperatorGetActiveBasis(CeedOperator op, CeedBasis *active_basis) {
 }
 
 /**
-  @brief Find the active input and output vector @ref CeedBasis for a non-composite @ref CeedOperator
+  @brief Find the active input and output vector `CeedBasis` for a non-composite `CeedOperator` 
 
-  @param[in]  op                  @ref CeedOperator to find active @ref CeedBasis for
-  @param[out] active_input_basis  @ref CeedBasis for active input vector or `NULL` for composite operator
-  @param[out] active_output_basis @ref CeedBasis for active output vector or `NULL` for composite operator
+  @param[in]  op                  `CeedOperator` to find active `CeedBasis` for
+  @param[out] active_input_basis  `CeedBasis` for active input vector or `NULL` for composite operator
+  @param[out] active_output_basis `CeedBasis` for active output vector or `NULL` for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -200,10 +200,10 @@ int CeedOperatorGetActiveBases(CeedOperator op, CeedBasis *active_input_basis, C
 }
 
 /**
-  @brief Find the active vector @ref CeedElemRestriction for a non-composite @ref CeedOperator
+  @brief Find the active vector `CeedElemRestriction` for a non-composite `CeedOperator` 
 
-  @param[in]  op          @ref CeedOperator to find active @ref CeedElemRestriction for
-  @param[out] active_rstr @ref CeedElemRestriction for active input vector or NULL for composite operator
+  @param[in]  op          `CeedOperator` to find active `CeedElemRestriction` for
+  @param[out] active_rstr `CeedElemRestriction` for active input vector or NULL for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -215,11 +215,11 @@ int CeedOperatorGetActiveElemRestriction(CeedOperator op, CeedElemRestriction *a
 }
 
 /**
-  @brief Find the active input and output vector @ref CeedElemRestriction for a non-composite @ref CeedOperator
+  @brief Find the active input and output vector `CeedElemRestriction` for a non-composite `CeedOperator` 
 
-  @param[in]  op                 @ref CeedOperator to find active @ref CeedElemRestriction for
-  @param[out] active_input_rstr  @ref CeedElemRestriction for active input vector or NULL for composite operator
-  @param[out] active_output_rstr @ref CeedElemRestriction for active output vector or NULL for composite operator
+  @param[in]  op                 `CeedOperator` to find active `CeedElemRestriction` for
+  @param[out] active_input_rstr  `CeedElemRestriction` for active input vector or NULL for composite operator
+  @param[out] active_output_rstr `CeedElemRestriction` for active output vector or NULL for composite operator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -259,12 +259,12 @@ int CeedOperatorGetActiveElemRestrictions(CeedOperator op, CeedElemRestriction *
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field values of the specified type.
+  @brief Set `CeedQFunctionContext` field values of the specified type.
 
-  For composite operators, the value is set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  For composite operators, the value is set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
   A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have any field of a matching type.
 
-  @param[in,out] op          @ref CeedOperator
+  @param[in,out] op          `CeedOperator` 
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[in]     values      Values to set
@@ -313,12 +313,12 @@ static int CeedOperatorContextSetGeneric(CeedOperator op, CeedContextFieldLabel 
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field values of the specified type, read-only.
+  @brief Get `CeedQFunctionContext` field values of the specified type, read-only.
 
-  For composite operators, the values retrieved are for the first sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  For composite operators, the values retrieved are for the first sub-operator `CeedQFunctionContext` that have a matching `field_name`.
   A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have any field of a matching type.
 
-  @param[in,out] op          @ref CeedOperator
+  @param[in,out] op          `CeedOperator` 
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[out]    num_values  Number of values of type `field_type` in array `values`
@@ -372,12 +372,12 @@ static int CeedOperatorContextGetGenericRead(CeedOperator op, CeedContextFieldLa
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field values of the specified type, read-only.
+  @brief Restore `CeedQFunctionContext` field values of the specified type, read-only.
 
-  For composite operators, the values restored are for the first sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  For composite operators, the values restored are for the first sub-operator `CeedQFunctionContext` that have a matching `field_name`.
   A non-zero error code is returned for single operators that do not have a matching field of the same type or composite operators that do not have any field of a matching type.
 
-  @param[in,out] op          @ref CeedOperator
+  @param[in,out] op          `CeedOperator` 
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[in]     values      Values array to restore
@@ -434,9 +434,9 @@ static int CeedOperatorContextRestoreGenericRead(CeedOperator op, CeedContextFie
 /// @{
 
 /**
-  @brief Get the number of arguments associated with a @ref CeedOperator
+  @brief Get the number of arguments associated with a `CeedOperator` 
 
-  @param[in]  op        @ref CeedOperator
+  @param[in]  op        `CeedOperator` 
   @param[out] num_args  Variable to store vector number of arguments
 
   @return An error code: 0 - success, otherwise - failure
@@ -450,9 +450,9 @@ int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args) {
 }
 
 /**
-  @brief Get the setup status of a @ref CeedOperator
+  @brief Get the setup status of a `CeedOperator` 
 
-  @param[in]  op            @ref CeedOperator
+  @param[in]  op            `CeedOperator` 
   @param[out] is_setup_done Variable to store setup status
 
   @return An error code: 0 - success, otherwise - failure
@@ -465,10 +465,10 @@ int CeedOperatorIsSetupDone(CeedOperator op, bool *is_setup_done) {
 }
 
 /**
-  @brief Get the @ref CeedQFunction associated with a @ref CeedOperator
+  @brief Get the `CeedQFunction` associated with a `CeedOperator` 
 
-  @param[in]  op @ref CeedOperator
-  @param[out] qf Variable to store @ref CeedQFunction
+  @param[in]  op `CeedOperator` 
+  @param[out] qf Variable to store `CeedQFunction` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -481,9 +481,9 @@ int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf) {
 }
 
 /**
-  @brief Get a boolean value indicating if the @ref CeedOperator is composite
+  @brief Get a boolean value indicating if the `CeedOperator` is composite
 
-  @param[in]  op           @ref CeedOperator
+  @param[in]  op           `CeedOperator` 
   @param[out] is_composite Variable to store composite status
 
   @return An error code: 0 - success, otherwise - failure
@@ -496,9 +496,9 @@ int CeedOperatorIsComposite(CeedOperator op, bool *is_composite) {
 }
 
 /**
-  @brief Get the backend data of a @ref CeedOperator
+  @brief Get the backend data of a `CeedOperator` 
 
-  @param[in]  op   @ref CeedOperator
+  @param[in]  op   `CeedOperator` 
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -511,9 +511,9 @@ int CeedOperatorGetData(CeedOperator op, void *data) {
 }
 
 /**
-  @brief Set the backend data of a @ref CeedOperator
+  @brief Set the backend data of a `CeedOperator` 
 
-  @param[in,out] op   @ref CeedOperator
+  @param[in,out] op   `CeedOperator` 
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -526,9 +526,9 @@ int CeedOperatorSetData(CeedOperator op, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedOperator
+  @brief Increment the reference counter for a `CeedOperator` 
 
-  @param[in,out] op @ref CeedOperator to increment the reference counter
+  @param[in,out] op `CeedOperator` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -540,9 +540,9 @@ int CeedOperatorReference(CeedOperator op) {
 }
 
 /**
-  @brief Set the setup flag of a @ref CeedOperator to `true`
+  @brief Set the setup flag of a `CeedOperator` to `true`
 
-  @param[in,out] op @ref CeedOperator
+  @param[in,out] op `CeedOperator` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -562,15 +562,15 @@ int CeedOperatorSetSetupDone(CeedOperator op) {
 /// @{
 
 /**
-  @brief Create a @ref CeedOperator and associate a @ref CeedQFunction.
+  @brief Create a `CeedOperator` and associate a `CeedQFunction`.
 
-  A @ref CeedBasis and @ref CeedElemRestriction can be associated with @ref CeedQFunction fields with @ref CeedOperatorSetField().
+  A `CeedBasis` and `CeedElemRestriction` can be associated with `CeedQFunction` fields with @ref CeedOperatorSetField().
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperator
-  @param[in]  qf   @ref CeedQFunction defining the action of the operator at quadrature points
-  @param[in]  dqf  @ref CeedQFunction defining the action of the Jacobian of `qf` (or @ref CEED_QFUNCTION_NONE)
-  @param[in]  dqfT @ref CeedQFunction defining the action of the transpose of the Jacobian of `qf` (or @ref CEED_QFUNCTION_NONE)
-  @param[out] op   Address of the variable where the newly created @ref CeedOperator will be stored
+  @param[in]  ceed `Ceed` object used to create the `CeedOperator` 
+  @param[in]  qf   `CeedQFunction` defining the action of the operator at quadrature points
+  @param[in]  dqf  `CeedQFunction` defining the action of the Jacobian of `qf` (or @ref CEED_QFUNCTION_NONE)
+  @param[in]  dqfT `CeedQFunction` defining the action of the transpose of the Jacobian of `qf` (or @ref CEED_QFUNCTION_NONE)
+  @param[out] op   Address of the variable where the newly created `CeedOperator` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -604,15 +604,15 @@ int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, CeedQFunc
 }
 
 /**
-  @brief Create a @ref CeedOperator for evaluation at evaluation at arbitrary points in each element.
+  @brief Create a `CeedOperator` for evaluation at evaluation at arbitrary points in each element.
 
-  A @ref CeedBasis and @ref CeedElemRestriction can be associated with @ref CeedQFunction fields with @ref CeedOperatorSetField.
+  A `CeedBasis` and `CeedElemRestriction` can be associated with `CeedQFunction` fields with `CeedOperator` SetField.
   The locations of each point are set with @ref CeedOperatorAtPointsSetPoints().
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperator
-  @param[in]  qf   @ref CeedQFunction defining the action of the operator at quadrature points
-  @param[in]  dqf  @ref CeedQFunction defining the action of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
-  @param[in]  dqfT @ref CeedQFunction defining the action of the transpose of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
+  @param[in]  ceed `Ceed` object used to create the `CeedOperator` 
+  @param[in]  qf   `CeedQFunction` defining the action of the operator at quadrature points
+  @param[in]  dqf  `CeedQFunction` defining the action of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
+  @param[in]  dqfT `CeedQFunction` defining the action of the transpose of the Jacobian of @a qf (or @ref CEED_QFUNCTION_NONE)
   @param[out] op   Address of the variable where the newly created CeedOperator will be stored
 
   @return An error code: 0 - success, otherwise - failure
@@ -648,10 +648,10 @@ int CeedOperatorCreateAtPoints(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, C
 }
 
 /**
-  @brief Create a composite @ref CeedOperator that composes the action of several @ref CeedOperator
+  @brief Create a composite `CeedOperator` that composes the action of several `CeedOperator` 
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperator
-  @param[out] op   Address of the variable where the newly created composite @ref CeedOperator will be stored
+  @param[in]  ceed `Ceed` object used to create the `CeedOperator` 
+  @param[out] op   Address of the variable where the newly created composite `CeedOperator` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -681,14 +681,14 @@ int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedOperator.
+  @brief Copy the pointer to a `CeedOperator`.
 
   Both pointers should be destroyed with @ref CeedOperatorDestroy().
 
-  Note: If the value of `*op_copy` passed to this function is non-`NULL`, then it is assumed that `*op_copy` is a pointer to a @ref CeedOperator.
-        This @ref CeedOperator will be destroyed if `*op_copy` is the only reference to this @ref CeedOperator.
+  Note: If the value of `*op_copy` passed to this function is non-`NULL`, then it is assumed that `*op_copy` is a pointer to a `CeedOperator`.
+        This `CeedOperator` will be destroyed if `*op_copy` is the only reference to this `CeedOperator`.
 
-  @param[in]     op      @ref CeedOperator to copy reference to
+  @param[in]     op      `CeedOperator` to copy reference to
   @param[in,out] op_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -703,23 +703,23 @@ int CeedOperatorReferenceCopy(CeedOperator op, CeedOperator *op_copy) {
 }
 
 /**
-  @brief Provide a field to a @ref CeedOperator for use by its @ref CeedQFunction.
+  @brief Provide a field to a `CeedOperator` for use by its `CeedQFunction`.
 
-  This function is used to specify both active and passive fields to a @ref CeedOperator.
-  For passive fields, a @ref CeedVector `v` must be provided.
+  This function is used to specify both active and passive fields to a `CeedOperator`.
+  For passive fields, a `CeedVector` `v` must be provided.
   Passive fields can inputs or outputs (updated in-place when operator is applied).
 
-  Active fields must be specified using this function, but their data (in a @ref CeedVector) is passed in @ref CeedOperatorApply().
-  There can be at most one active input @ref CeedVector and at most one active output@ref  CeedVector passed to @ref CeedOperatorApply().
+  Active fields must be specified using this function, but their data (in a `CeedVector`) is passed in @ref CeedOperatorApply().
+  There can be at most one active input `CeedVector` and at most one active output@ref  CeedVector passed to @ref CeedOperatorApply().
 
   The number of quadrature points must agree across all points.
   When using @ref CEED_BASIS_NONE, the number of quadrature points is determined by the element size of `r`.
 
-  @param[in,out] op         @ref CeedOperator on which to provide the field
-  @param[in]     field_name Name of the field (to be matched with the name used by @ref CeedQFunction)
-  @param[in]     r          @ref CeedElemRestriction
-  @param[in]     b          @ref CeedBasis in which the field resides or @ref CEED_BASIS_NONE if collocated with quadrature points
-  @param[in]     v          @ref CeedVector to be used by CeedOperator or @ref CEED_VECTOR_ACTIVE if field is active or @ref CEED_VECTOR_NONE if using @ref CEED_EVAL_WEIGHT in the @ref CeedQFunction
+  @param[in,out] op         `CeedOperator` on which to provide the field
+  @param[in]     field_name Name of the field (to be matched with the name used by `CeedQFunction`)
+  @param[in]     r          `CeedElemRestriction` 
+  @param[in]     b          `CeedBasis` in which the field resides or @ref CEED_BASIS_NONE if collocated with quadrature points
+  @param[in]     v          `CeedVector` to be used by CeedOperator or @ref CEED_VECTOR_ACTIVE if field is active or @ref CEED_VECTOR_NONE if using @ref CEED_EVAL_WEIGHT in the `CeedQFunction` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -816,11 +816,11 @@ found:
 }
 
 /**
-  @brief Get the @ref CeedOperatorField of a @ref CeedOperator.
+  @brief Get the `CeedOperator` Field of a `CeedOperator`.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op                @ref CeedOperator
+  @param[in]  op                `CeedOperator` 
   @param[out] num_input_fields  Variable to store number of input fields
   @param[out] input_fields      Variable to store input fields
   @param[out] num_output_fields Variable to store number of output fields
@@ -843,13 +843,13 @@ int CeedOperatorGetFields(CeedOperator op, CeedInt *num_input_fields, CeedOperat
 }
 
 /**
-  @brief Set the arbitrary points in each element for a @ref CeedOperator at points.
+  @brief Set the arbitrary points in each element for a `CeedOperator` at points.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in,out] op           @ref CeedOperator at points
-  @param[in]     rstr_points  @ref CeedElemRestriction for the coordinates of each point by element
-  @param[in]     point_coords @ref CeedVector holding coordinates of each point
+  @param[in,out] op           `CeedOperator` at points
+  @param[in]     rstr_points  `CeedElemRestriction` for the coordinates of each point by element
+  @param[in]     point_coords `CeedVector` holding coordinates of each point
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -875,13 +875,13 @@ int CeedOperatorAtPointsSetPoints(CeedOperator op, CeedElemRestriction rstr_poin
 }
 
 /**
-  @brief Get the arbitrary points in each element for a @ref CeedOperator at points.
+  @brief Get the arbitrary points in each element for a `CeedOperator` at points.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op           @ref CeedOperator at points
-  @param[out] rstr_points  Variable to hold @ref CeedElemRestriction for the coordinates of each point by element
-  @param[out] point_coords Variable to hold @ref CeedVector holding coordinates of each point
+  @param[in]  op           `CeedOperator` at points
+  @param[out] rstr_points  Variable to hold `CeedElemRestriction` for the coordinates of each point by element
+  @param[out] point_coords Variable to hold `CeedVector` holding coordinates of each point
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -897,13 +897,13 @@ int CeedOperatorAtPointsGetPoints(CeedOperator op, CeedElemRestriction *rstr_poi
 }
 
 /**
-  @brief Get a @ref CeedOperatorField of a @ref CeedOperator from its name
+  @brief Get a `CeedOperator` Field of a `CeedOperator` from its name
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op         @ref CeedOperator
-  @param[in]  field_name Name of desired @ref CeedOperatorField
-  @param[out] op_field   @ref CeedOperatorField corresponding to the name
+  @param[in]  op         `CeedOperator` 
+  @param[in]  field_name Name of desired `CeedOperator` Field
+  @param[out] op_field   `CeedOperator` Field corresponding to the name
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -938,9 +938,9 @@ int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOper
 }
 
 /**
-  @brief Get the name of a @ref CeedOperatorField
+  @brief Get the name of a `CeedOperator` Field
 
-  @param[in]  op_field    @ref CeedOperatorField
+  @param[in]  op_field    `CeedOperator` Field
   @param[out] field_name  Variable to store the field name
 
   @return An error code: 0 - success, otherwise - failure
@@ -953,10 +953,10 @@ int CeedOperatorFieldGetName(CeedOperatorField op_field, char **field_name) {
 }
 
 /**
-  @brief Get the @ref CeedElemRestriction of a @ref CeedOperatorField
+  @brief Get the `CeedElemRestriction` of a `CeedOperator` Field
 
-  @param[in]  op_field @ref CeedOperatorField
-  @param[out] rstr     Variable to store @ref CeedElemRestriction
+  @param[in]  op_field `CeedOperator` Field
+  @param[out] rstr     Variable to store `CeedElemRestriction` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -968,10 +968,10 @@ int CeedOperatorFieldGetElemRestriction(CeedOperatorField op_field, CeedElemRest
 }
 
 /**
-  @brief Get the @ref CeedBasis of a @ref CeedOperatorField
+  @brief Get the `CeedBasis` of a `CeedOperator` Field
 
-  @param[in]  op_field @ref CeedOperatorField
-  @param[out] basis    Variable to store @ref CeedBasis
+  @param[in]  op_field `CeedOperator` Field
+  @param[out] basis    Variable to store `CeedBasis` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -983,10 +983,10 @@ int CeedOperatorFieldGetBasis(CeedOperatorField op_field, CeedBasis *basis) {
 }
 
 /**
-  @brief Get the @ref CeedVector of a @ref CeedOperatorField
+  @brief Get the `CeedVector` of a `CeedOperator` Field
 
-  @param[in]  op_field @ref CeedOperatorField
-  @param[out] vec      Variable to store @ref CeedVector
+  @param[in]  op_field `CeedOperator` Field
+  @param[out] vec      Variable to store `CeedVector` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -998,10 +998,10 @@ int CeedOperatorFieldGetVector(CeedOperatorField op_field, CeedVector *vec) {
 }
 
 /**
-  @brief Add a sub-operator to a composite @ref CeedOperator
+  @brief Add a sub-operator to a composite `CeedOperator` 
 
-  @param[in,out] composite_op Composite @ref CeedOperator
-  @param[in]     sub_op       Sub-operator @ref CeedOperator
+  @param[in,out] composite_op Composite `CeedOperator` 
+  @param[in]     sub_op       Sub-operator `CeedOperator` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1033,9 +1033,9 @@ int CeedCompositeOperatorAddSub(CeedOperator composite_op, CeedOperator sub_op) 
 }
 
 /**
-  @brief Get the number of sub-operators associated with a @ref CeedOperator
+  @brief Get the number of sub-operators associated with a `CeedOperator` 
 
-  @param[in]  op               @ref CeedOperator
+  @param[in]  op               `CeedOperator` 
   @param[out] num_suboperators Variable to store number of sub-operators
 
   @return An error code: 0 - success, otherwise - failure
@@ -1049,9 +1049,9 @@ int CeedCompositeOperatorGetNumSub(CeedOperator op, CeedInt *num_suboperators) {
 }
 
 /**
-  @brief Get the list of sub-operators associated with a @ref CeedOperator
+  @brief Get the list of sub-operators associated with a `CeedOperator` 
 
-  @param[in]  op             @ref CeedOperator
+  @param[in]  op             `CeedOperator` 
   @param[out] sub_operators  Variable to store list of sub-operators
 
   @return An error code: 0 - success, otherwise - failure
@@ -1065,9 +1065,9 @@ int CeedCompositeOperatorGetSubList(CeedOperator op, CeedOperator **sub_operator
 }
 
 /**
-  @brief Check if a @ref CeedOperator is ready to be used.
+  @brief Check if a `CeedOperator` is ready to be used.
 
-  @param[in] op @ref CeedOperator to check
+  @param[in] op `CeedOperator` to check
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1112,11 +1112,11 @@ int CeedOperatorCheckReady(CeedOperator op) {
 }
 
 /**
-  @brief Get vector lengths for the active input and/or output @ref CeedVector of a @ref CeedOperator.
+  @brief Get vector lengths for the active input and/or output `CeedVector` of a `CeedOperator`.
 
   Note: Lengths of `-1` indicate that the CeedOperator does not have an active input and/or output.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[out] input_size  Variable to store active input vector length, or `NULL`
   @param[out] output_size Variable to store active output vector length, or `NULL`
 
@@ -1150,12 +1150,12 @@ int CeedOperatorGetActiveVectorLengths(CeedOperator op, CeedSize *input_size, Ce
 }
 
 /**
-  @brief Set reuse of @ref CeedQFunction data in `CeedOperatorLinearAssemble*()` functions.
+  @brief Set reuse of `CeedQFunction` data in `CeedOperatorLinearAssemble*()` functions.
 
-  When `reuse_assembly_data = false` (default), the @ref CeedQFunction associated with this @ref CeedOperator is re-assembled every time a `CeedOperatorLinearAssemble*()` function is called.
-  When `reuse_assembly_data = true`, the @ref CeedQFunction associated with this @ref CeedOperator is reused between calls to @ref CeedOperatorSetQFunctionAssemblyDataUpdateNeeded().
+  When `reuse_assembly_data = false` (default), the `CeedQFunction` associated with this `CeedOperator` is re-assembled every time a `CeedOperatorLinearAssemble*()` function is called.
+  When `reuse_assembly_data = true`, the `CeedQFunction` associated with this `CeedOperator` is reused between calls to @ref CeedOperatorSetQFunctionAssemblyDataUpdateNeeded().
 
-  @param[in] op                  @ref CeedOperator
+  @param[in] op                  `CeedOperator` 
   @param[in] reuse_assembly_data Boolean flag setting assembly data reuse
 
   @return An error code: 0 - success, otherwise - failure
@@ -1177,9 +1177,9 @@ int CeedOperatorSetQFunctionAssemblyReuse(CeedOperator op, bool reuse_assembly_d
 }
 
 /**
-  @brief Mark @ref CeedQFunction data as updated and the @ref CeedQFunction as requiring re-assembly.
+  @brief Mark `CeedQFunction` data as updated and the `CeedQFunction` as requiring re-assembly.
 
-  @param[in] op                @ref CeedOperator
+  @param[in] op                `CeedOperator` 
   @param[in] needs_data_update Boolean flag setting assembly data reuse
 
   @return An error code: 0 - success, otherwise - failure
@@ -1201,9 +1201,9 @@ int CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(CeedOperator op, bool needs
 }
 
 /**
-  @brief Set name of @ref CeedOperator for @ref CeedOperatorView() output
+  @brief Set name of `CeedOperator` for @ref CeedOperatorView() output
 
-  @param[in,out] op   @ref CeedOperator
+  @param[in,out] op   `CeedOperator` 
   @param[in]     name Name to set, or NULL to remove previously set name
 
   @return An error code: 0 - success, otherwise - failure
@@ -1224,9 +1224,9 @@ int CeedOperatorSetName(CeedOperator op, const char *name) {
 }
 
 /**
-  @brief View a @ref CeedOperator
+  @brief View a `CeedOperator` 
 
-  @param[in] op     @ref CeedOperator to view
+  @param[in] op     `CeedOperator` to view
   @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
@@ -1252,10 +1252,10 @@ int CeedOperatorView(CeedOperator op, FILE *stream) {
 }
 
 /**
-  @brief Get the @ref Ceed associated with a @ref CeedOperator
+  @brief Get the `Ceed` associated with a `CeedOperator` 
 
-  @param[in]  op   @ref CeedOperator
-  @param[out] ceed Variable to store @ref Ceed
+  @param[in]  op   `CeedOperator` 
+  @param[out] ceed Variable to store `Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1267,9 +1267,9 @@ int CeedOperatorGetCeed(CeedOperator op, Ceed *ceed) {
 }
 
 /**
-  @brief Get the number of elements associated with a @ref CeedOperator
+  @brief Get the number of elements associated with a `CeedOperator` 
 
-  @param[in]  op       @ref CeedOperator
+  @param[in]  op       `CeedOperator` 
   @param[out] num_elem Variable to store number of elements
 
   @return An error code: 0 - success, otherwise - failure
@@ -1283,9 +1283,9 @@ int CeedOperatorGetNumElements(CeedOperator op, CeedInt *num_elem) {
 }
 
 /**
-  @brief Get the number of quadrature points associated with a @ref CeedOperator
+  @brief Get the number of quadrature points associated with a `CeedOperator` 
 
-  @param[in]  op       @ref CeedOperator
+  @param[in]  op       `CeedOperator` 
   @param[out] num_qpts Variable to store vector number of quadrature points
 
   @return An error code: 0 - success, otherwise - failure
@@ -1299,9 +1299,9 @@ int CeedOperatorGetNumQuadraturePoints(CeedOperator op, CeedInt *num_qpts) {
 }
 
 /**
-  @brief Estimate number of FLOPs required to apply @ref CeedOperator on the active @ref CeedVector
+  @brief Estimate number of FLOPs required to apply `CeedOperator` on the active `CeedVector` 
 
-  @param[in]  op    @ref CeedOperator to estimate FLOPs for
+  @param[in]  op    `CeedOperator` to estimate FLOPs for
   @param[out] flops Address of variable to hold FLOPs estimate
 
   @ref Backend
@@ -1371,15 +1371,15 @@ int CeedOperatorGetFlopsEstimate(CeedOperator op, CeedSize *flops) {
 }
 
 /**
-  @brief Get @ref CeedQFunction global context for a @ref CeedOperator.
+  @brief Get `CeedQFunction` global context for a `CeedOperator`.
 
   The caller is responsible for destroying `ctx` returned from this function via @ref CeedQFunctionContextDestroy().
 
-  Note: If the value of `ctx` passed into this function is non-`NULL`, then it is assumed that `ctx` is a pointer to a @ref CeedQFunctionContext.
-        This @ref CeedQFunctionContext will be destroyed if `ctx` is the only reference to this @ref CeedQFunctionContext.
+  Note: If the value of `ctx` passed into this function is non-`NULL`, then it is assumed that `ctx` is a pointer to a `CeedQFunctionContext`.
+        This `CeedQFunctionContext` will be destroyed if `ctx` is the only reference to this `CeedQFunctionContext`.
 
-  @param[in]  op  @ref CeedOperator
-  @param[out] ctx Variable to store @ref CeedQFunctionContext
+  @param[in]  op  `CeedOperator` 
+  @param[out] ctx Variable to store `CeedQFunctionContext` 
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1393,11 +1393,11 @@ int CeedOperatorGetContext(CeedOperator op, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Get label for a registered @ref CeedQFunctionContext field, or `NULL` if no field has been registered with this `field_name`.
+  @brief Get label for a registered `CeedQFunctionContext` field, or `NULL` if no field has been registered with this `field_name`.
 
   Fields are registered via `CeedQFunctionContextRegister*()` functions (eg. @ref CeedQFunctionContextRegisterDouble()).
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_name  Name of field to retrieve label
   @param[out] field_label Variable to field label
 
@@ -1500,11 +1500,11 @@ int CeedOperatorGetContextFieldLabel(CeedOperator op, const char *field_name, Ce
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field holding double precision values.
+  @brief Set `CeedQFunctionContext` field holding double precision values.
 
-  For composite operators, the values are set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
 
-  @param[in,out] op          @ref CeedOperator
+  @param[in,out] op          `CeedOperator` 
   @param[in]     field_label Label of field to set
   @param[in]     values      Values to set
 
@@ -1517,11 +1517,11 @@ int CeedOperatorSetContextDouble(CeedOperator op, CeedContextFieldLabel field_la
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field holding double precision values, read-only.
+  @brief Get `CeedQFunctionContext` field holding double precision values, read-only.
 
-  For composite operators, the values correspond to the first sub-operator @ref CeedQFunctionContext that has a matching `field_name`.
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_label Label of field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -1535,9 +1535,9 @@ int CeedOperatorGetContextDoubleRead(CeedOperator op, CeedContextFieldLabel fiel
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field holding double precision values, read-only.
+  @brief Restore `CeedQFunctionContext` field holding double precision values, read-only.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_label Label of field to restore
   @param[out] values      Pointer to context values
 
@@ -1550,11 +1550,11 @@ int CeedOperatorRestoreContextDoubleRead(CeedOperator op, CeedContextFieldLabel 
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field holding `int32` values.
+  @brief Set `CeedQFunctionContext` field holding `int32` values.
 
-  For composite operators, the values are set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
 
-  @param[in,out] op          @ref CeedOperator
+  @param[in,out] op          `CeedOperator` 
   @param[in]     field_label Label of field to set
   @param[in]     values      Values to set
 
@@ -1567,11 +1567,11 @@ int CeedOperatorSetContextInt32(CeedOperator op, CeedContextFieldLabel field_lab
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field holding `int32` values, read-only.
+  @brief Get `CeedQFunctionContext` field holding `int32` values, read-only.
 
-  For composite operators, the values correspond to the first sub-operator @ref CeedQFunctionContext that has a matching `field_name`.
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_label Label of field to get
   @param[out] num_values  Number of `int32` values in `values`
   @param[out] values      Pointer to context values
@@ -1585,9 +1585,9 @@ int CeedOperatorGetContextInt32Read(CeedOperator op, CeedContextFieldLabel field
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field holding `int32` values, read-only.
+  @brief Restore `CeedQFunctionContext` field holding `int32` values, read-only.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_label Label of field to get
   @param[out] values      Pointer to context values
 
@@ -1600,11 +1600,11 @@ int CeedOperatorRestoreContextInt32Read(CeedOperator op, CeedContextFieldLabel f
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field holding boolean values.
+  @brief Set `CeedQFunctionContext` field holding boolean values.
 
-  For composite operators, the values are set in all sub-operator @ref CeedQFunctionContext that have a matching `field_name`.
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
 
-  @param[in,out] op          @ref CeedOperator
+  @param[in,out] op          `CeedOperator` 
   @param[in]     field_label Label of field to set
   @param[in]     values      Values to set
 
@@ -1617,11 +1617,11 @@ int CeedOperatorSetContextBoolean(CeedOperator op, CeedContextFieldLabel field_l
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field holding boolean values, read-only.
+  @brief Get `CeedQFunctionContext` field holding boolean values, read-only.
 
-  For composite operators, the values correspond to the first sub-operator @ref CeedQFunctionContext that has a matching `field_name`.
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_label Label of field to get
   @param[out] num_values  Number of boolean values in `values`
   @param[out] values      Pointer to context values
@@ -1635,9 +1635,9 @@ int CeedOperatorGetContextBooleanRead(CeedOperator op, CeedContextFieldLabel fie
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field holding boolean values, read-only.
+  @brief Restore `CeedQFunctionContext` field holding boolean values, read-only.
 
-  @param[in]  op          @ref CeedOperator
+  @param[in]  op          `CeedOperator` 
   @param[in]  field_label Label of field to get
   @param[out] values      Pointer to context values
 
@@ -1650,16 +1650,16 @@ int CeedOperatorRestoreContextBooleanRead(CeedOperator op, CeedContextFieldLabel
 }
 
 /**
-  @brief Apply @ref CeedOperator to a @ref CeedVector.
+  @brief Apply `CeedOperator` to a `CeedVector`.
 
   This computes the action of the operator on the specified (active) input, yielding its (active) output.
   All inputs and outputs must be specified using @ref CeedOperatorSetField().
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op      @ref CeedOperator to apply
-  @param[in]  in      @ref CeedVector containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
-  @param[out] out     @ref CeedVector to store result of applying operator (must be distinct from `in`) or @ref CEED_VECTOR_NONE if there are no active outputs
+  @param[in]  op      `CeedOperator` to apply
+  @param[in]  in      `CeedVector` containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
+  @param[out] out     `CeedVector` to store result of applying operator (must be distinct from `in`) or @ref CEED_VECTOR_NONE if there are no active outputs
   @param[in]  request Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
@@ -1718,14 +1718,14 @@ int CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out, CeedReques
 }
 
 /**
-  @brief Apply @ref CeedOperator to a @ref CeedVector and add result to output @ref CeedVector.
+  @brief Apply `CeedOperator` to a `CeedVector` and add result to output `CeedVector`.
 
   This computes the action of the operator on the specified (active) input, yielding its (active) output.
   All inputs and outputs must be specified using @ref CeedOperatorSetField().
 
-  @param[in]  op      @ref CeedOperator to apply
-  @param[in]  in      @ref CeedVector containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
-  @param[out] out     @ref CeedVector to sum in result of applying operator (must be distinct from `in`) or @ref CEED_VECTOR_NONE if there are no active outputs
+  @param[in]  op      `CeedOperator` to apply
+  @param[in]  in      `CeedVector` containing input state or @ref CEED_VECTOR_NONE if there are no active inputs
+  @param[out] out     `CeedVector` to sum in result of applying operator (must be distinct from `in`) or @ref CEED_VECTOR_NONE if there are no active outputs
   @param[in]  request Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
@@ -1757,9 +1757,9 @@ int CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedReq
 }
 
 /**
-  @brief Destroy a @ref CeedOperator
+  @brief Destroy a `CeedOperator` 
 
-  @param[in,out] op @ref CeedOperator to destroy
+  @param[in,out] op `CeedOperator` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -24,11 +24,11 @@
 /// @{
 
 /**
-  @brief Duplicate a CeedQFunction with a reference Ceed to fallback for advanced CeedOperator functionality
+  @brief Duplicate a @ref CeedQFunction with a reference @ref Ceed to fallback for advanced @ref CeedOperator functionality
 
-  @param[in]  fallback_ceed Ceed on which to create fallback CeedQFunction
-  @param[in]  qf            CeedQFunction to create fallback for
-  @param[out] qf_fallback   fallback CeedQFunction
+  @param[in]  fallback_ceed @ref Ceed on which to create fallback @ref CeedQFunction
+  @param[in]  qf            @ref CeedQFunction to create fallback for
+  @param[out] qf_fallback   Fallback @ref CeedQFunction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -71,9 +71,9 @@ static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, Cee
 }
 
 /**
-  @brief Duplicate a CeedOperator with a reference Ceed to fallback for advanced CeedOperator functionality
+  @brief Duplicate a @ref CeedOperator with a reference @ref Ceed to fallback for advanced @ref CeedOperator functionality
 
-  @param[in,out] op CeedOperator to create fallback for
+  @param[in,out] op @ref CeedOperator to create fallback for
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -140,12 +140,12 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
 }
 
 /**
-  @brief Select correct basis matrix pointer based on CeedEvalMode
+  @brief Select correct basis matrix pointer based on @ref CeedEvalMode
 
-  @param[in]  basis     CeedBasis from which to get the basis matrix
+  @param[in]  basis     @ref CeedBasis from which to get the basis matrix
   @param[in]  eval_mode Current basis evaluation mode
   @param[in]  identity  Pointer to identity matrix
-  @param[out] basis_ptr Basis pointer to set
+  @param[out] basis_ptr @ref CeedBasis pointer to set
 
   @ref Developer
 **/
@@ -176,10 +176,10 @@ static inline int CeedOperatorGetBasisPointer(CeedBasis basis, CeedEvalMode eval
 /**
   @brief Core logic for assembling operator diagonal or point block diagonal
 
-  @param[in]  op             CeedOperator to assemble point block diagonal
-  @param[in]  request        Address of CeedRequest for non-blocking completion, else CEED_REQUEST_IMMEDIATE
+  @param[in]  op             @ref CeedOperator to assemble point block diagonal
+  @param[in]  request        Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
   @param[in]  is_point_block Boolean flag to assemble diagonal or point block diagonal
-  @param[out] assembled      CeedVector to store assembled diagonal
+  @param[out] assembled      @ref CeedVector to store assembled diagonal
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -362,10 +362,10 @@ static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, Ce
 /**
   @brief Core logic for assembling composite operator diagonal
 
-  @param[in]  op             CeedOperator to assemble point block diagonal
-  @param[in]  request        Address of CeedRequest for non-blocking completion, else CEED_REQUEST_IMMEDIATE
+  @param[in]  op             @ref CeedOperator to assemble point block diagonal
+  @param[in]  request        Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
   @param[in]  is_point_block Boolean flag to assemble diagonal or point block diagonal
-  @param[out] assembled      CeedVector to store assembled diagonal
+  @param[out] assembled      @ref CeedVector to store assembled diagonal
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -389,11 +389,11 @@ static inline int CeedCompositeOperatorLinearAssembleAddDiagonal(CeedOperator op
 }
 
 /**
-  @brief Build nonzero pattern for non-composite operator
+  @brief Build nonzero pattern for non-composite @ref CeedOperator.
 
-  Users should generally use CeedOperatorLinearAssembleSymbolic()
+  Users should generally use @ref CeedOperatorLinearAssembleSymbolic().
 
-  @param[in]  op     CeedOperator to assemble nonzero pattern
+  @param[in]  op     @ref CeedOperator to assemble nonzero pattern
   @param[in]  offset Offset for number of entries
   @param[out] rows   Row number for each entry
   @param[out] cols   Column number for each entry
@@ -498,11 +498,11 @@ static int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset, C
 }
 
 /**
-  @brief Assemble nonzero entries for non-composite operator
+  @brief Assemble nonzero entries for non-composite @ref CeedOperator.
 
-  Users should generally use CeedOperatorLinearAssemble()
+  Users should generally use @ref CeedOperatorLinearAssemble().
 
-  @param[in]  op     CeedOperator to assemble
+  @param[in]  op     @ref CeedOperator to assemble
   @param[in]  offset Offset for number of entries
   @param[out] values Values to assemble into matrix
 
@@ -744,9 +744,9 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset, CeedVecto
 }
 
 /**
-  @brief Count number of entries for assembled CeedOperator
+  @brief Count number of entries for assembled @ref CeedOperator
 
-  @param[in]  op          CeedOperator to assemble
+  @param[in]  op          @ref CeedOperator to assemble
   @param[out] num_entries Number of entries in assembled representation
 
   @return An error code: 0 - success, otherwise - failure
@@ -781,16 +781,16 @@ static int CeedSingleOperatorAssemblyCountEntries(CeedOperator op, CeedSize *num
 }
 
 /**
-  @brief Common code for creating a multigrid coarse operator and level transfer operators for a CeedOperator
+  @brief Common code for creating a multigrid coarse operator and level transfer operators for a @ref CeedOperator
 
-  @param[in]  op_fine      Fine grid operator
-  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or NULL if not creating prolongation/restriction operators
-  @param[in]  rstr_coarse  Coarse grid restriction
-  @param[in]  basis_coarse Coarse grid active vector basis
-  @param[in]  basis_c_to_f Basis for coarse to fine interpolation, or NULL if not creating prolongation/restriction operators
-  @param[out] op_coarse    Coarse grid operator
-  @param[out] op_prolong   Coarse to fine operator, or NULL
-  @param[out] op_restrict  Fine to coarse operator, or NULL
+  @param[in]  op_fine      Fine grid @ref CeedOperator
+  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
+  @param[in]  rstr_coarse  Coarse grid @ref CeedElemRestriction
+  @param[in]  basis_coarse Coarse grid active vector @ref CeedBasis
+  @param[in]  basis_c_to_f @ref CeedBasis for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction operators
+  @param[out] op_coarse    Coarse grid @ref CeedOperator
+  @param[out] op_prolong   Coarse to fine @ref CeedOperator, or `NULL`
+  @param[out] op_restrict  Fine to coarse @ref CeedOperator, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1001,10 +1001,10 @@ CeedPragmaOptimizeOn
 /// @{
 
 /**
-  @brief Create point block restriction for active operator field
+  @brief Create point block restriction for active @ref CeedOperatorField
 
-  @param[in]  rstr             Original CeedElemRestriction for active field
-  @param[out] point_block_rstr Address of the variable where the newly created CeedElemRestriction will be stored
+  @param[in]  rstr             Original @ref CeedElemRestriction for active field
+  @param[out] point_block_rstr Address of the variable where the newly created @ref CeedElemRestriction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1042,10 +1042,10 @@ int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rstr, Ceed
 }
 
 /**
-  @brief Create object holding CeedQFunction assembly data for CeedOperator
+  @brief Create object holding @ref CeedQFunction assembly data for @ref CeedOperator
 
-  @param[in]  ceed A Ceed object where the CeedQFunctionAssemblyData will be created
-  @param[out] data Address of the variable where the newly created CeedQFunctionAssemblyData will be stored
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedQFunctionAssemblyData
+  @param[out] data Address of the variable where the newly created @ref CeedQFunctionAssemblyData will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1060,9 +1060,9 @@ int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data) 
 }
 
 /**
-  @brief Increment the reference counter for a CeedQFunctionAssemblyData
+  @brief Increment the reference counter for a @ref CeedQFunctionAssemblyData
 
-  @param[in,out] data CeedQFunctionAssemblyData to increment the reference counter
+  @param[in,out] data @ref CeedQFunctionAssemblyData to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1074,9 +1074,9 @@ int CeedQFunctionAssemblyDataReference(CeedQFunctionAssemblyData data) {
 }
 
 /**
-  @brief Set re-use of CeedQFunctionAssemblyData
+  @brief Set re-use of @ref CeedQFunctionAssemblyData
 
-  @param[in,out] data       CeedQFunctionAssemblyData to mark for reuse
+  @param[in,out] data       @ref CeedQFunctionAssemblyData to mark for reuse
   @param[in]     reuse_data Boolean flag indicating data re-use
 
   @return An error code: 0 - success, otherwise - failure
@@ -1090,9 +1090,9 @@ int CeedQFunctionAssemblyDataSetReuse(CeedQFunctionAssemblyData data, bool reuse
 }
 
 /**
-  @brief Mark QFunctionAssemblyData as stale
+  @brief Mark @ref CeedQFunctionAssemblyData as stale
 
-  @param[in,out] data              CeedQFunctionAssemblyData to mark as stale
+  @param[in,out] data              @ref CeedQFunctionAssemblyData to mark as stale
   @param[in]     needs_data_update Boolean flag indicating if update is needed or completed
 
   @return An error code: 0 - success, otherwise - failure
@@ -1105,9 +1105,9 @@ int CeedQFunctionAssemblyDataSetUpdateNeeded(CeedQFunctionAssemblyData data, boo
 }
 
 /**
-  @brief Determine if QFunctionAssemblyData needs update
+  @brief Determine if @ref CeedQFunctionAssemblyData needs update
 
-  @param[in]  data             CeedQFunctionAssemblyData to mark as stale
+  @param[in]  data             @ref CeedQFunctionAssemblyData to mark as stale
   @param[out] is_update_needed Boolean flag indicating if re-assembly is required
 
   @return An error code: 0 - success, otherwise - failure
@@ -1120,15 +1120,14 @@ int CeedQFunctionAssemblyDataIsUpdateNeeded(CeedQFunctionAssemblyData data, bool
 }
 
 /**
-  @brief Copy the pointer to a CeedQFunctionAssemblyData.
+  @brief Copy the pointer to a @ref CeedQFunctionAssemblyData.
 
-  Both pointers should be destroyed with `CeedCeedQFunctionAssemblyDataDestroy()`.
+  Both pointers should be destroyed with @ref CeedQFunctionAssemblyDataDestroy().
 
-  Note: If the value of `data_copy` passed to this function is non-NULL, then it is assumed that `*data_copy` is a pointer to a
-        CeedQFunctionAssemblyData. This CeedQFunctionAssemblyData will be destroyed if `data_copy` is the only reference to this
-        CeedQFunctionAssemblyData.
+  Note: If the value of `*data_copy` passed to this function is non-`NULL`, then it is assumed that `*data_copy` is a pointer to a @ref CeedQFunctionAssemblyData.
+        This @ref CeedQFunctionAssemblyData will be destroyed if `*data_copy` is the only reference to this @ref CeedQFunctionAssemblyData.
 
-  @param[in]     data      CeedQFunctionAssemblyData to copy reference to
+  @param[in]     data      @ref CeedQFunctionAssemblyData to copy reference to
   @param[in,out] data_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -1143,9 +1142,9 @@ int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQ
 }
 
 /**
-  @brief Get setup status for internal objects for CeedQFunctionAssemblyData
+  @brief Get setup status for internal objects for @ref CeedQFunctionAssemblyData
 
-  @param[in]  data     CeedQFunctionAssemblyData to retrieve status
+  @param[in]  data     @ref CeedQFunctionAssemblyData to retrieve status
   @param[out] is_setup Boolean flag for setup status
 
   @return An error code: 0 - success, otherwise - failure
@@ -1158,11 +1157,11 @@ int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_se
 }
 
 /**
-  @brief Set internal objects for CeedQFunctionAssemblyData
+  @brief Set internal objects for @ref CeedQFunctionAssemblyData
 
-  @param[in,out] data CeedQFunctionAssemblyData to set objects
-  @param[in]     vec  CeedVector to store assembled CeedQFunction at quadrature points
-  @param[in]     rstr CeedElemRestriction for CeedVector containing assembled CeedQFunction
+  @param[in,out] data @ref CeedQFunctionAssemblyData to set objects
+  @param[in]     vec  @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
+  @param[in]     rstr @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1177,11 +1176,11 @@ int CeedQFunctionAssemblyDataSetObjects(CeedQFunctionAssemblyData data, CeedVect
 }
 
 /**
-  @brief Get internal objects for CeedQFunctionAssemblyData
+  @brief Get internal objects for @ref CeedQFunctionAssemblyData
 
-  @param[in,out] data CeedQFunctionAssemblyData to set objects
-  @param[out]    vec  CeedVector to store assembled CeedQFunction at quadrature points
-  @param[out]    rstr CeedElemRestriction for CeedVector containing assembled CeedQFunction
+  @param[in,out] data @ref CeedQFunctionAssemblyData to set objects
+  @param[out]    vec  @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
+  @param[out]    rstr @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1196,9 +1195,9 @@ int CeedQFunctionAssemblyDataGetObjects(CeedQFunctionAssemblyData data, CeedVect
 }
 
 /**
-  @brief Destroy CeedQFunctionAssemblyData
+  @brief Destroy @ref CeedQFunctionAssemblyData
 
-  @param[in,out] data  CeedQFunctionAssemblyData to destroy
+  @param[in,out] data  @ref CeedQFunctionAssemblyData to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1218,10 +1217,10 @@ int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data) {
 }
 
 /**
-  @brief Get CeedOperatorAssemblyData
+  @brief Get @ref CeedOperatorAssemblyData
 
-  @param[in]  op   CeedOperator to assemble
-  @param[out] data CeedQFunctionAssemblyData
+  @param[in]  op   @ref CeedOperator to assemble
+  @param[out] data @ref CeedQFunctionAssemblyData
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1239,19 +1238,18 @@ int CeedOperatorGetOperatorAssemblyData(CeedOperator op, CeedOperatorAssemblyDat
 }
 
 /**
-  @brief Create object holding CeedOperator assembly data.
+  @brief Create object holding @ref CeedOperator assembly data.
 
-  The CeedOperatorAssemblyData holds an array with references to every active CeedBasis used in the CeedOperator.
-  An array with references to the corresponding active CeedElemRestrictions is also stored.
-  For each active CeedBasis, the CeedOperatorAssemblyData holds an array of all input and output CeedEvalModes for this CeedBasis.
-  The CeedOperatorAssemblyData holds an array of offsets for indexing into the assembled CeedQFunction arrays to the row representing each
-CeedEvalMode.
-  The number of input columns across all active bases for the assembled CeedQFunction is also stored.
-  Lastly, the CeedOperatorAssembly data holds assembled matrices representing the full action of the CeedBasis for all CeedEvalModes.
+  The @ref CeedOperatorAssemblyData holds an array with references to every active @ref CeedBasis used in the @ref CeedOperator.
+  An array with references to the corresponding active @ref CeedElemRestriction is also stored.
+  For each active @ref CeedBasis, the @ref CeedOperatorAssemblyData holds an array of all input and output @ref CeedEvalMode for this @ref CeedBasis.
+  The @ref CeedOperatorAssemblyData holds an array of offsets for indexing into the assembled @ref CeedQFunction arrays to the row representing each @ref CeedEvalMode.
+  The number of input columns across all active bases for the assembled @ref CeedQFunction is also stored.
+  Lastly, the CeedOperatorAssembly data holds assembled matrices representing the full action of the @ref CeedBasis for all @ref CeedEvalMode.
 
-  @param[in]  ceed Ceed object where the CeedOperatorAssemblyData will be created
-  @param[in]  op   CeedOperator to be assembled
-  @param[out] data Address of the variable where the newly created CeedOperatorAssemblyData will be stored
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperatorAssemblyData 
+  @param[in]  op   @ref CeedOperator to be assembled
+  @param[out] data Address of the variable where the newly created @ref CeedOperatorAssemblyData will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1399,22 +1397,21 @@ int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op, CeedOperatorAssem
 }
 
 /**
-  @brief Get CeedOperator CeedEvalModes for assembly.
+  @brief Get @ref CeedOperator @ref CeedEvalMode for assembly.
 
-  Note: See CeedOperatorAssemblyDataCreate for a full description of the data stored in this object.
+  Note: See @ref CeedOperatorAssemblyDataCreate() for a full description of the data stored in this object.
 
-  @param[in]  data                  CeedOperatorAssemblyData
+  @param[in]  data                  @ref CeedOperatorAssemblyData
   @param[out] num_active_bases_in   Total number of active bases for input
-  @param[out] num_eval_modes_in     Pointer to hold array of numbers of input CeedEvalModes, or NULL.
-                                      `eval_modes_in[0]` holds an array of eval modes for the first active basis.
-  @param[out] eval_modes_in         Pointer to hold arrays of input CeedEvalModes, or NULL.
-  @param[out] eval_mode_offsets_in  Pointer to hold arrays of input offsets at each quadrature point.
+  @param[out] num_eval_modes_in     Pointer to hold array of numbers of input @ref CeedEvalMode, or `NULL`.
+                                      `eval_modes_in[0]` holds an array of eval modes for the first active @ref CeedBasis.
+  @param[out] eval_modes_in         Pointer to hold arrays of input @ref CeedEvalMode, or `NULL`
+  @param[out] eval_mode_offsets_in  Pointer to hold arrays of input offsets at each quadrature point
   @param[out] num_active_bases_out  Total number of active bases for output
-  @param[out] num_eval_modes_out    Pointer to hold array of numbers of output CeedEvalModes, or NULL
-  @param[out] eval_modes_out        Pointer to hold arrays of output CeedEvalModes, or NULL.
+  @param[out] num_eval_modes_out    Pointer to hold array of numbers of output @ref CeedEvalModes, or `NULL`
+  @param[out] eval_modes_out        Pointer to hold arrays of output @ref CeedEvalMode, or `NULL`
   @param[out] eval_mode_offsets_out Pointer to hold arrays of output offsets at each quadrature point
-  @param[out] num_output_components The number of columns in the assembled CeedQFunction matrix for each quadrature point,
-                                      including contributions of all active bases
+  @param[out] num_output_components The number of columns in the assembled @ref CeedQFunction matrix for each quadrature point, including contributions of all active bases
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1437,17 +1434,17 @@ int CeedOperatorAssemblyDataGetEvalModes(CeedOperatorAssemblyData data, CeedInt 
 }
 
 /**
-  @brief Get CeedOperator CeedBasis data for assembly.
+  @brief Get @ref CeedOperator @ref CeedBasis data for assembly.
 
-  Note: See CeedOperatorAssemblyDataCreate for a full description of the data stored in this object.
+  Note: See @ref CeedOperatorAssemblyDataCreate() for a full description of the data stored in this object.
 
-  @param[in]  data                 CeedOperatorAssemblyData
-  @param[out] num_active_bases_in  Number of active input bases, or NULL
-  @param[out] active_bases_in      Pointer to hold active input CeedBasis, or NULL
-  @param[out] assembled_bases_in   Pointer to hold assembled active input B, or NULL
-  @param[out] num_active_bases_out Number of active output bases, or NULL
-  @param[out] active_bases_out     Pointer to hold active output CeedBasis, or NULL
-  @param[out] assembled_bases_out  Pointer to hold assembled active output B, or NULL
+  @param[in]  data                 @ref CeedOperatorAssemblyData
+  @param[out] num_active_bases_in  Number of active input bases, or `NULL`
+  @param[out] active_bases_in      Pointer to hold active input @ref CeedBasis, or `NULL`
+  @param[out] assembled_bases_in   Pointer to hold assembled active input `B`, or `NULL`
+  @param[out] num_active_bases_out Number of active output bases, or `NULL`
+  @param[out] active_bases_out     Pointer to hold active output @ref CeedBasis, or `NULL`
+  @param[out] assembled_bases_out  Pointer to hold assembled active output `B`, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1564,15 +1561,15 @@ int CeedOperatorAssemblyDataGetBases(CeedOperatorAssemblyData data, CeedInt *num
 }
 
 /**
-  @brief Get CeedOperator CeedBasis data for assembly.
+  @brief Get @ref CeedOperator @ref CeedBasis data for assembly.
 
-  Note: See CeedOperatorAssemblyDataCreate for a full description of the data stored in this object.
+  Note: See @ref CeedOperatorAssemblyDataCreate() for a full description of the data stored in this object.
 
-  @param[in]  data                      CeedOperatorAssemblyData
-  @param[out] num_active_elem_rstrs_in  Number of active input element restrictions, or NULL
-  @param[out] active_elem_rstrs_in      Pointer to hold active input CeedElemRestrictions, or NULL
-  @param[out] num_active_elem_rstrs_out Number of active output element restrictions, or NULL
-  @param[out] active_elem_rstrs_out     Pointer to hold active output CeedElemRestrictions, or NULL
+  @param[in]  data                      @ref CeedOperatorAssemblyData
+  @param[out] num_active_elem_rstrs_in  Number of active input element restrictions, or `NULL`
+  @param[out] active_elem_rstrs_in      Pointer to hold active input @ref CeedElemRestriction, or `NULL`
+  @param[out] num_active_elem_rstrs_out Number of active output element restrictions, or `NULL`
+  @param[out] active_elem_rstrs_out     Pointer to hold active output @ref CeedElemRestriction, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1589,9 +1586,9 @@ int CeedOperatorAssemblyDataGetElemRestrictions(CeedOperatorAssemblyData data, C
 }
 
 /**
-  @brief Destroy CeedOperatorAssemblyData
+  @brief Destroy @ref CeedOperatorAssemblyData
 
-  @param[in,out] data CeedOperatorAssemblyData to destroy
+  @param[in,out] data @ref CeedOperatorAssemblyData to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1635,10 +1632,10 @@ int CeedOperatorAssemblyDataDestroy(CeedOperatorAssemblyData *data) {
 }
 
 /**
-  @brief Retrieve fallback CeedOperator with a reference Ceed for advanced CeedOperator functionality
+  @brief Retrieve fallback @ref CeedOperator with a reference @ref Ceed for advanced @ref CeedOperator functionality
 
-  @param[in]  op          CeedOperator to retrieve fallback for
-  @param[out] op_fallback Fallback CeedOperator
+  @param[in]  op          @ref CeedOperator to retrieve fallback for
+  @param[out] op_fallback Fallback @ref CeedOperator
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1670,10 +1667,10 @@ int CeedOperatorGetFallback(CeedOperator op, CeedOperator *op_fallback) {
 }
 
 /**
-  @brief Get the parent CeedOperator for a fallback CeedOperator
+  @brief Get the parent @ref CeedOperator for a fallback @ref CeedOperator
 
-  @param[in]  op     CeedOperator context
-  @param[out] parent Variable to store parent CeedOperator context
+  @param[in]  op     @ref CeedOperator context
+  @param[out] parent Variable to store parent @ref CeedOperator context
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1685,10 +1682,10 @@ int CeedOperatorGetFallbackParent(CeedOperator op, CeedOperator *parent) {
 }
 
 /**
-  @brief Get the Ceed context of the parent CeedOperator for a fallback CeedOperator
+  @brief Get the @ref Ceed context of the parent @ref CeedOperator for a fallback @ref CeedOperator
 
-  @param[in]  op     CeedOperator context
-  @param[out] parent Variable to store parent Ceed context
+  @param[in]  op     @ref CeedOperator context
+  @param[out] parent Variable to store parent @ref Ceed context
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1708,22 +1705,20 @@ int CeedOperatorGetFallbackParentCeed(CeedOperator op, Ceed *parent) {
 /// @{
 
 /**
-  @brief Assemble a linear CeedQFunction associated with a CeedOperator
+  @brief Assemble a linear @ref CeedQFunction associated with a @ref CeedOperator.
 
-  This returns a CeedVector containing a matrix at each quadrature point providing the action of the CeedQFunction associated with the CeedOperator.
-  The vector `assembled` is of shape `[num_elements, num_input_fields, num_output_fields, num_quad_points]` and contains column-major matrices
-representing the action of the CeedQFunction for a corresponding quadrature point on an element.
+  This returns a @ref CeedVector containing a matrix at each quadrature point providing the action of the @ref CeedQFunction associated with the @ref CeedOperator.
+  The vector `assembled` is of shape `[num_elements, num_input_fields, num_output_fields, num_quad_points]` and contains column-major matrices representing the action of the @ref CeedQFunction for a corresponding quadrature point on an element.
 
-  Inputs and outputs are in the order provided by the user when adding CeedOperator fields.
-  For example, a CeedQFunction with inputs 'u' and 'gradu' and outputs 'gradv' and 'v', provided in that order, would result in an assembled QFunction
-that consists of (1 + dim) x (dim + 1) matrices at each quadrature point acting on the input [u, du_0, du_1] and producing the output [dv_0, dv_1, v].
+  Inputs and outputs are in the order provided by the user when adding @ref CeedOperator fields.
+  For example, a @ref CeedQFunction with inputs `u` and `gradu` and outputs `gradv` and `v`, provided in that order, would result in an assembled @ref CeedQFunction that consists of `(1 + dim) x (dim + 1)` matrices at each quadrature point acting on the input `[u, du_0, du_1]` and producing the output `[dv_0, dv_1, v]`.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op        CeedOperator to assemble CeedQFunction
-  @param[out] assembled CeedVector to store assembled CeedQFunction at quadrature points
-  @param[out] rstr      CeedElemRestriction for CeedVector containing assembled CeedQFunction
-  @param[in]  request   Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
+  @param[out] assembled @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
+  @param[out] rstr      @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
+  @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1747,19 +1742,19 @@ int CeedOperatorLinearAssembleQFunction(CeedOperator op, CeedVector *assembled, 
 }
 
 /**
-  @brief Assemble CeedQFunction and store result internally.
+  @brief Assemble @ref CeedQFunction and store result internally.
 
   Return copied references of stored data to the caller.
   Caller is responsible for ownership and destruction of the copied references.
-  See also @ref CeedOperatorLinearAssembleQFunction
+  See also @ref CeedOperatorLinearAssembleQFunction().
 
-  Note: If the value of `assembled` or `rstr` passed to this function are non-NULL, then it is assumed that they hold valid pointers.
+  Note: If the value of `assembled` or `rstr` passed to this function are non-`NULL`, then it is assumed that they hold valid pointers.
         These objects will be destroyed if `*assembled` or `*rstr` is the only reference to the object.
 
-  @param[in]  op        CeedOperator to assemble CeedQFunction
-  @param[out] assembled CeedVector to store assembled CeedQFunction at quadrature points
-  @param[out] rstr      CeedElemRestriction for CeedVector containing assembledCeedQFunction
-  @param[in]  request   Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
+  @param[out] assembled @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
+  @param[out] rstr      @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
+  @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1821,17 +1816,17 @@ int CeedOperatorLinearAssembleQFunctionBuildOrUpdate(CeedOperator op, CeedVector
 }
 
 /**
-  @brief Assemble the diagonal of a square linear CeedOperator
+  @brief Assemble the diagonal of a square linear @ref CeedOperator
 
-  This overwrites a CeedVector with the diagonal of a linear CeedOperator.
+  This overwrites a @ref CeedVector with the diagonal of a linear @ref CeedOperator.
 
-  Note: Currently only non-composite CeedOperators with a single field and composite CeedOperators with single field sub-operators are supported.
+  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op        CeedOperator to assemble CeedQFunction
-  @param[out] assembled CeedVector to store assembled CeedOperator diagonal
-  @param[in]  request   Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
+  @param[out] assembled @ref CeedVector to store assembled @ref CeedOperator diagonal
+  @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1881,17 +1876,17 @@ int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled, Ce
 }
 
 /**
-  @brief Assemble the diagonal of a square linear CeedOperator
+  @brief Assemble the diagonal of a square linear @ref CeedOperator
 
-  This sums into a CeedVector the diagonal of a linear CeedOperator.
+  This sums into a @ref CeedVector the diagonal of a linear @ref CeedOperator.
 
-  Note: Currently only non-composite CeedOperators with a single field and composite CeedOperators with single field sub-operators are supported.
+  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
 
   Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
 
-  @param[in]  op        CeedOperator to assemble CeedQFunction
-  @param[out] assembled CeedVector to store assembled CeedOperator diagonal
-  @param[in]  request   Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
+  @param[out] assembled @ref CeedVector to store assembled @ref CeedOperator diagonal
+  @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1939,21 +1934,19 @@ int CeedOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedVector assembled,
 }
 
 /**
-   @brief Fully assemble the point-block diagonal pattern of a linear operator.
+   @brief Fully assemble the point-block diagonal pattern of a linear @ref CeedOperator.
 
-   Expected to be used in conjunction with CeedOperatorLinearAssemblePointBlockDiagonal().
+   Expected to be used in conjunction with @ref CeedOperatorLinearAssemblePointBlockDiagonal().
 
-   The assembly routines use coordinate format, with `num_entries` tuples of the form (i, j, value) which indicate that value should be added to the
-matrix in entry (i, j).
-  Note that the (i, j) pairs are unique.
-  This function returns the number of entries and their (i, j) locations, while CeedOperatorLinearAssemblePointBlockDiagonal() provides the values in
-the same ordering.
+   The assembly routines use coordinate format, with `num_entries` tuples of the form `(i, j, value)` which indicate that value should be added to the matrix in entry `(i, j)`.
+   Note that the `(i, j)` pairs are unique.
+   This function returns the number of entries and their `(i, j)` locations, while @ref CeedOperatorLinearAssemblePointBlockDiagonal() provides the values in the same ordering.
 
    This will generally be slow unless your operator is low-order.
 
-   Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+   Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-   @param[in]  op          CeedOperator to assemble
+   @param[in]  op          @ref CeedOperator to assemble
    @param[out] num_entries Number of entries in coordinate nonzero pattern
    @param[out] rows        Row number for each entry
    @param[out] cols        Column number for each entry
@@ -2044,19 +2037,19 @@ int CeedOperatorLinearAssemblePointBlockDiagonalSymbolic(CeedOperator op, CeedSi
 }
 
 /**
-  @brief Assemble the point block diagonal of a square linear CeedOperator
+  @brief Assemble the point block diagonal of a square linear @ref CeedOperator
 
-  This overwrites a CeedVector with the point block diagonal of a linear CeedOperator.
+  This overwrites a @ref CeedVector with the point block diagonal of a linear @ref CeedOperator.
 
-  Note: Currently only non-composite CeedOperators with a single field and composite CeedOperators with single field sub-operators are supported.
+  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op        CeedOperator to assemble CeedQFunction
-  @param[out] assembled CeedVector to store assembled CeedOperator point block diagonal, provided in row-major form with an @a num_comp * @a num_comp
-block at each node. The dimensions of this vector are derived from the active vector for the CeedOperator. The array has shape [nodes, component out,
-component in].
-  @param[in]  request   Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
+  @param[out] assembled @ref CeedVector to store assembled @ref CeedOperator point block diagonal, provided in row-major form with an `num_comp * num_comp` block at each node.
+                          The dimensions of this vector are derived from the active vector for the @ref CeedOperator.
+                          The array has shape `[nodes, component out, component in]`.
+  @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2106,19 +2099,19 @@ int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op, CeedVector ass
 }
 
 /**
-  @brief Assemble the point block diagonal of a square linear CeedOperator
+  @brief Assemble the point block diagonal of a square linear @ref CeedOperator
 
-  This sums into a CeedVector with the point block diagonal of a linear CeedOperator.
+  This sums into a @ref CeedVector with the point block diagonal of a linear @ref CeedOperator.
 
-  Note: Currently only non-composite CeedOperators with a single field and composite CeedOperators with single field sub-operators are supported.
+  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op        CeedOperator to assemble CeedQFunction
-  @param[out] assembled CeedVector to store assembled CeedOperator point block diagonal, provided in row-major form with an @a num_comp * @a num_comp
-block at each node. The dimensions of this vector are derived from the active vector for the CeedOperator. The array has shape [nodes, component out,
-component in].
-  @param[in]  request Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
+  @param[out] assembled @ref CeedVector to store assembled CeedOperator point block diagonal, provided in row-major form with an `num_comp * num_comp` block at each node.
+                          The dimensions of this vector are derived from the active vector for the @ref CeedOperator.
+                          The array has shape `[nodes, component out, component in]`.
+  @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2166,20 +2159,19 @@ int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op, CeedVector 
 }
 
 /**
-   @brief Fully assemble the nonzero pattern of a linear operator.
+   @brief Fully assemble the nonzero pattern of a linear @ref CeedOperator.
 
-   Expected to be used in conjunction with CeedOperatorLinearAssemble().
+   Expected to be used in conjunction with @ref CeedOperatorLinearAssemble().
 
-   The assembly routines use coordinate format, with num_entries tuples of the form (i, j, value) which indicate that value should be added to the
-matrix in entry (i, j).
-  Note that the (i, j) pairs are not unique and may repeat.
-  This function returns the number of entries and their (i, j) locations, while CeedOperatorLinearAssemble() provides the values in the same ordering.
+   The assembly routines use coordinate format, with `num_entries` tuples of the form `(i, j, value)` which indicate that value should be added to the matrix in entry `(i, j)`.
+   Note that the `(i, j)` pairs are not unique and may repeat.
+   This function returns the number of entries and their `(i, j)` locations, while @ref CeedOperatorLinearAssemble() provides the values in the same ordering.
 
    This will generally be slow unless your operator is low-order.
 
-   Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+   Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-   @param[in]  op          CeedOperator to assemble
+   @param[in]  op          @ref CeedOperator to assemble
    @param[out] num_entries Number of entries in coordinate nonzero pattern
    @param[out] rows        Row number for each entry
    @param[out] cols        Column number for each entry
@@ -2246,18 +2238,17 @@ int CeedOperatorLinearAssembleSymbolic(CeedOperator op, CeedSize *num_entries, C
 /**
    @brief Fully assemble the nonzero entries of a linear operator.
 
-   Expected to be used in conjunction with CeedOperatorLinearAssembleSymbolic().
+   Expected to be used in conjunction with @ref CeedOperatorLinearAssembleSymbolic().
 
-   The assembly routines use coordinate format, with num_entries tuples of the form (i, j, value) which indicate that value should be added to the
-matrix in entry (i, j).
-  Note that the (i, j) pairs are not unique and may repeat.
-  This function returns the values of the nonzero entries to be added, their (i, j) locations are provided by CeedOperatorLinearAssembleSymbolic()
+   The assembly routines use coordinate format, with `num_entries` tuples of the form `(i, j, value)` which indicate that value should be added to the matrix in entry `(i, j)`.
+   Note that the `(i, j)` pairs are not unique and may repeat.
+   This function returns the values of the nonzero entries to be added, their `(i, j)` locations are provided by @ref CeedOperatorLinearAssembleSymbolic().
 
    This will generally be slow unless your operator is low-order.
 
-   Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+   Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-   @param[in]  op     CeedOperator to assemble
+   @param[in]  op     @ref CeedOperator to assemble
    @param[out] values Values to assemble into matrix
 
    @ref User
@@ -2311,14 +2302,14 @@ int CeedOperatorLinearAssemble(CeedOperator op, CeedVector values) {
 }
 
 /**
-  @brief Get the multiplicity of nodes across suboperators in a composite CeedOperator
+  @brief Get the multiplicity of nodes across sub-operators in a composite @ref CeedOperator
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op               Composite CeedOperator
-  @param[in]  num_skip_indices Number of suboperators to skip
-  @param[in]  skip_indices     Array of indices of suboperators to skip
-  @param[out] mult             Vector to store multiplicity (of size l_size)
+  @param[in]  op               Composite @ref CeedOperator
+  @param[in]  num_skip_indices Number of sub-operators to skip
+  @param[in]  skip_indices     Array of indices of sub-operators to skip
+  @param[out] mult             Vector to store multiplicity (of size `l_size`)
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2384,18 +2375,17 @@ int CeedCompositeOperatorGetMultiplicity(CeedOperator op, CeedInt num_skip_indic
 }
 
 /**
-  @brief Create a multigrid coarse operator and level transfer operators for a CeedOperator, creating the prolongation basis from the fine and coarse
-grid interpolation
+  @brief Create a multigrid coarse @ref CeedOperator and level transfer @ref CeedOperator for a @ref CeedOperator, creating the prolongation basis from the fine and coarse grid interpolation.
 
-  Note: Calling this function asserts that setup is complete and sets all four CeedOperators as immutable.
+  Note: Calling this function asserts that setup is complete and sets all four @ref CeedOperator as immutable.
 
-  @param[in]  op_fine      Fine grid operator
-  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or NULL if not creating prolongation/restriction operators
-  @param[in]  rstr_coarse  Coarse grid restriction
-  @param[in]  basis_coarse Coarse grid active vector basis
-  @param[out] op_coarse    Coarse grid operator
-  @param[out] op_prolong   Coarse to fine operator, or NULL
-  @param[out] op_restrict  Fine to coarse operator, or NULL
+  @param[in]  op_fine      Fine grid @ref CeedOperator
+  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
+  @param[in]  rstr_coarse  Coarse grid @ref CeedElemRestriction
+  @param[in]  basis_coarse Coarse grid active vector @ref CeedBasis
+  @param[out] op_coarse    Coarse grid @ref CeedOperator
+  @param[out] op_prolong   Coarse to fine @ref CeedOperator, or `NULL`
+  @param[out] op_restrict  Fine to coarse @ref CeedOperator, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2421,18 +2411,18 @@ int CeedOperatorMultigridLevelCreate(CeedOperator op_fine, CeedVector p_mult_fin
 }
 
 /**
-  @brief Create a multigrid coarse operator and level transfer operators for a CeedOperator with a tensor basis for the active basis
+  @brief Create a multigrid coarse @ref CeedOperator and level transfer @ref CeedOperator for a @ref CeedOperator with a tensor basis for the active basis.
 
-  Note: Calling this function asserts that setup is complete and sets all four CeedOperators as immutable.
+  Note: Calling this function asserts that setup is complete and sets all four @ref CeedOperator as immutable.
 
-  @param[in]  op_fine       Fine grid operator
-  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or NULL if not creating prolongation/restriction operators
-  @param[in]  rstr_coarse   Coarse grid restriction
-  @param[in]  basis_coarse  Coarse grid active vector basis
-  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or NULL if not creating prolongation/restriction operators
-  @param[out] op_coarse     Coarse grid operator
-  @param[out] op_prolong    Coarse to fine operator, or NULL
-  @param[out] op_restrict   Fine to coarse operator, or NULL
+  @param[in]  op_fine       Fine grid @ref CeedOperator
+  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
+  @param[in]  rstr_coarse   Coarse grid @ref CeedElemRestriction
+  @param[in]  basis_coarse  Coarse grid active vector @ref CeedBasis
+  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction @ref CeedOperator
+  @param[out] op_coarse     Coarse grid @ref CeedOperator
+  @param[out] op_prolong    Coarse to fine @ref CeedOperator, or `NULL`
+  @param[out] op_restrict   Fine to coarse @ref CeedOperator, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2482,18 +2472,18 @@ int CeedOperatorMultigridLevelCreateTensorH1(CeedOperator op_fine, CeedVector p_
 }
 
 /**
-  @brief Create a multigrid coarse operator and level transfer operators for a CeedOperator with a non-tensor basis for the active vector
+  @brief Create a multigrid coarse @ref CeedOperator and level transfer @ref CeedOperator for a @ref CeedOperator with a non-tensor basis for the active vector
 
-  Note: Calling this function asserts that setup is complete and sets all four CeedOperators as immutable.
+  Note: Calling this function asserts that setup is complete and sets all four @ref CeedOperator as immutable.
 
-  @param[in]  op_fine       Fine grid operator
-  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or NULL if not creating prolongation/restriction operators
-  @param[in]  rstr_coarse   Coarse grid restriction
-  @param[in]  basis_coarse  Coarse grid active vector basis
-  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or NULL if not creating prolongation/restriction operators
-  @param[out] op_coarse     Coarse grid operator
-  @param[out] op_prolong    Coarse to fine operator, or NULL
-  @param[out] op_restrict   Fine to coarse operator, or NULL
+  @param[in]  op_fine       Fine grid @ref CeedOperator
+  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
+  @param[in]  rstr_coarse   Coarse grid @ref CeedElemRestriction
+  @param[in]  basis_coarse  Coarse grid active vector @ref CeedBasis
+  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction @ref CeedOperator
+  @param[out] op_coarse     Coarse grid @ref CeedOperator
+  @param[out] op_prolong    Coarse to fine @ref CeedOperator, or `NULL`
+  @param[out] op_restrict   Fine to coarse @ref CeedOperator, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2544,20 +2534,19 @@ int CeedOperatorMultigridLevelCreateH1(CeedOperator op_fine, CeedVector p_mult_f
 }
 
 /**
-  @brief Build a FDM based approximate inverse for each element for a CeedOperator
+  @brief Build a FDM based approximate inverse for each element for a @ref CeedOperator
 
-  This returns a CeedOperator and CeedVector to apply a Fast Diagonalization Method based approximate inverse.
+  This returns a @ref CeedOperator and @ref CeedVector to apply a Fast Diagonalization Method based approximate inverse.
   This function obtains the simultaneous diagonalization for the 1D mass and Laplacian operators, \f$M = V^T V, K = V^T S V\f$.
-  The assembled QFunction is used to modify the eigenvalues from simultaneous diagonalization and obtain an approximate inverse of the form \f$V^T
-\hat S V\f$.
-  The CeedOperator must be linear and non-composite.
-  The associated CeedQFunction must therefore also be linear.
+  The assembled @ref CeedQFunction is used to modify the eigenvalues from simultaneous diagonalization and obtain an approximate inverse of the form \f$V^T \hat S V\f$.
+  The @ref CeedOperator must be linear and non-composite.
+  The associated @ref CeedQFunction must therefore also be linear.
 
-  Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
 
-  @param[in]  op      CeedOperator to create element inverses
-  @param[out] fdm_inv CeedOperator to apply the action of a FDM based inverse for each element
-  @param[in]  request Address of CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
+  @param[in]  op      @ref CeedOperator to create element inverses
+  @param[out] fdm_inv @ref CeedOperator to apply the action of a FDM based inverse for each element
+  @param[in]  request Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -24,11 +24,11 @@
 /// @{
 
 /**
-  @brief Duplicate a @ref CeedQFunction with a reference @ref Ceed to fallback for advanced @ref CeedOperator functionality
+  @brief Duplicate a `CeedQFunction` with a reference `Ceed` to fallback for advanced `CeedOperator` functionality
 
-  @param[in]  fallback_ceed @ref Ceed on which to create fallback @ref CeedQFunction
-  @param[in]  qf            @ref CeedQFunction to create fallback for
-  @param[out] qf_fallback   Fallback @ref CeedQFunction
+  @param[in]  fallback_ceed `Ceed` on which to create fallback `CeedQFunction`
+  @param[in]  qf            `CeedQFunction` to create fallback for
+  @param[out] qf_fallback   Fallback `CeedQFunction`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -71,9 +71,9 @@ static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, Cee
 }
 
 /**
-  @brief Duplicate a @ref CeedOperator with a reference @ref Ceed to fallback for advanced @ref CeedOperator functionality
+  @brief Duplicate a `CeedOperator` with a reference `Ceed` to fallback for advanced `CeedOperator` functionality
 
-  @param[in,out] op @ref CeedOperator to create fallback for
+  @param[in,out] op `CeedOperator` to create fallback for
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -142,10 +142,10 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
 /**
   @brief Select correct basis matrix pointer based on @ref CeedEvalMode
 
-  @param[in]  basis     @ref CeedBasis from which to get the basis matrix
+  @param[in]  basis     `CeedBasis` from which to get the basis matrix
   @param[in]  eval_mode Current basis evaluation mode
   @param[in]  identity  Pointer to identity matrix
-  @param[out] basis_ptr @ref CeedBasis pointer to set
+  @param[out] basis_ptr `CeedBasis` pointer to set
 
   @ref Developer
 **/
@@ -176,10 +176,10 @@ static inline int CeedOperatorGetBasisPointer(CeedBasis basis, CeedEvalMode eval
 /**
   @brief Core logic for assembling operator diagonal or point block diagonal
 
-  @param[in]  op             @ref CeedOperator to assemble point block diagonal
+  @param[in]  op             `CeedOperator` to assemble point block diagonal
   @param[in]  request        Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
   @param[in]  is_point_block Boolean flag to assemble diagonal or point block diagonal
-  @param[out] assembled      @ref CeedVector to store assembled diagonal
+  @param[out] assembled      `CeedVector` to store assembled diagonal
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -362,10 +362,10 @@ static inline int CeedSingleOperatorAssembleAddDiagonal_Core(CeedOperator op, Ce
 /**
   @brief Core logic for assembling composite operator diagonal
 
-  @param[in]  op             @ref CeedOperator to assemble point block diagonal
+  @param[in]  op             `CeedOperator` to assemble point block diagonal
   @param[in]  request        Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
   @param[in]  is_point_block Boolean flag to assemble diagonal or point block diagonal
-  @param[out] assembled      @ref CeedVector to store assembled diagonal
+  @param[out] assembled      `CeedVector` to store assembled diagonal
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -389,11 +389,11 @@ static inline int CeedCompositeOperatorLinearAssembleAddDiagonal(CeedOperator op
 }
 
 /**
-  @brief Build nonzero pattern for non-composite @ref CeedOperator.
+  @brief Build nonzero pattern for non-composite CeedOperator`.
 
   Users should generally use @ref CeedOperatorLinearAssembleSymbolic().
 
-  @param[in]  op     @ref CeedOperator to assemble nonzero pattern
+  @param[in]  op     `CeedOperator` to assemble nonzero pattern
   @param[in]  offset Offset for number of entries
   @param[out] rows   Row number for each entry
   @param[out] cols   Column number for each entry
@@ -498,11 +498,11 @@ static int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset, C
 }
 
 /**
-  @brief Assemble nonzero entries for non-composite @ref CeedOperator.
+  @brief Assemble nonzero entries for non-composite `CeedOperator`.
 
   Users should generally use @ref CeedOperatorLinearAssemble().
 
-  @param[in]  op     @ref CeedOperator to assemble
+  @param[in]  op     `CeedOperator` to assemble
   @param[in]  offset Offset for number of entries
   @param[out] values Values to assemble into matrix
 
@@ -744,9 +744,9 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset, CeedVecto
 }
 
 /**
-  @brief Count number of entries for assembled @ref CeedOperator
+  @brief Count number of entries for assembled `CeedOperator`
 
-  @param[in]  op          @ref CeedOperator to assemble
+  @param[in]  op          `CeedOperator` to assemble
   @param[out] num_entries Number of entries in assembled representation
 
   @return An error code: 0 - success, otherwise - failure
@@ -781,16 +781,16 @@ static int CeedSingleOperatorAssemblyCountEntries(CeedOperator op, CeedSize *num
 }
 
 /**
-  @brief Common code for creating a multigrid coarse operator and level transfer operators for a @ref CeedOperator
+  @brief Common code for creating a multigrid coarse `CeedOperator` and level transfer `CeedOperator` for a `CeedOperator`
 
-  @param[in]  op_fine      Fine grid @ref CeedOperator
-  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
-  @param[in]  rstr_coarse  Coarse grid @ref CeedElemRestriction
-  @param[in]  basis_coarse Coarse grid active vector @ref CeedBasis
-  @param[in]  basis_c_to_f @ref CeedBasis for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction operators
-  @param[out] op_coarse    Coarse grid @ref CeedOperator
-  @param[out] op_prolong   Coarse to fine @ref CeedOperator, or `NULL`
-  @param[out] op_restrict  Fine to coarse @ref CeedOperator, or `NULL`
+  @param[in]  op_fine      Fine grid `CeedOperator`
+  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction `CeedOperator`
+  @param[in]  rstr_coarse  Coarse grid `CeedElemRestriction`
+  @param[in]  basis_coarse Coarse grid active vector `CeedBasis`
+  @param[in]  basis_c_to_f `CeedBasis` for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction operators
+  @param[out] op_coarse    Coarse grid `CeedOperator`
+  @param[out] op_prolong   Coarse to fine `CeedOperator`, or `NULL`
+  @param[out] op_restrict  Fine to coarse `CeedOperator`, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1001,10 +1001,10 @@ CeedPragmaOptimizeOn
 /// @{
 
 /**
-  @brief Create point block restriction for active @ref CeedOperatorField
+  @brief Create point block restriction for active `CeedOperatorField`
 
-  @param[in]  rstr             Original @ref CeedElemRestriction for active field
-  @param[out] point_block_rstr Address of the variable where the newly created @ref CeedElemRestriction will be stored
+  @param[in]  rstr             Original `CeedElemRestriction` for active field
+  @param[out] point_block_rstr Address of the variable where the newly created `CeedElemRestriction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1042,10 +1042,10 @@ int CeedOperatorCreateActivePointBlockRestriction(CeedElemRestriction rstr, Ceed
 }
 
 /**
-  @brief Create object holding @ref CeedQFunction assembly data for @ref CeedOperator
+  @brief Create object holding `CeedQFunction` assembly data for `CeedOperator`
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedQFunctionAssemblyData
-  @param[out] data Address of the variable where the newly created @ref CeedQFunctionAssemblyData will be stored
+  @param[in]  ceed `Ceed` object used to create the `CeedQFunctionAssemblyData`
+  @param[out] data Address of the variable where the newly created `CeedQFunctionAssemblyData` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1060,9 +1060,9 @@ int CeedQFunctionAssemblyDataCreate(Ceed ceed, CeedQFunctionAssemblyData *data) 
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedQFunctionAssemblyData
+  @brief Increment the reference counter for a `CeedQFunctionAssemblyData`
 
-  @param[in,out] data @ref CeedQFunctionAssemblyData to increment the reference counter
+  @param[in,out] data `CeedQFunctionAssemblyData` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1074,9 +1074,9 @@ int CeedQFunctionAssemblyDataReference(CeedQFunctionAssemblyData data) {
 }
 
 /**
-  @brief Set re-use of @ref CeedQFunctionAssemblyData
+  @brief Set re-use of `CeedQFunctionAssemblyData`
 
-  @param[in,out] data       @ref CeedQFunctionAssemblyData to mark for reuse
+  @param[in,out] data       `CeedQFunctionAssemblyData` to mark for reuse
   @param[in]     reuse_data Boolean flag indicating data re-use
 
   @return An error code: 0 - success, otherwise - failure
@@ -1090,9 +1090,9 @@ int CeedQFunctionAssemblyDataSetReuse(CeedQFunctionAssemblyData data, bool reuse
 }
 
 /**
-  @brief Mark @ref CeedQFunctionAssemblyData as stale
+  @brief Mark `CeedQFunctionAssemblyData` as stale
 
-  @param[in,out] data              @ref CeedQFunctionAssemblyData to mark as stale
+  @param[in,out] data              `CeedQFunctionAssemblyData` to mark as stale
   @param[in]     needs_data_update Boolean flag indicating if update is needed or completed
 
   @return An error code: 0 - success, otherwise - failure
@@ -1105,9 +1105,9 @@ int CeedQFunctionAssemblyDataSetUpdateNeeded(CeedQFunctionAssemblyData data, boo
 }
 
 /**
-  @brief Determine if @ref CeedQFunctionAssemblyData needs update
+  @brief Determine if `CeedQFunctionAssemblyData` needs update
 
-  @param[in]  data             @ref CeedQFunctionAssemblyData to mark as stale
+  @param[in]  data             `CeedQFunctionAssemblyData` to mark as stale
   @param[out] is_update_needed Boolean flag indicating if re-assembly is required
 
   @return An error code: 0 - success, otherwise - failure
@@ -1120,14 +1120,14 @@ int CeedQFunctionAssemblyDataIsUpdateNeeded(CeedQFunctionAssemblyData data, bool
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedQFunctionAssemblyData.
+  @brief Copy the pointer to a `CeedQFunctionAssemblyData`.
 
   Both pointers should be destroyed with @ref CeedQFunctionAssemblyDataDestroy().
 
-  Note: If the value of `*data_copy` passed to this function is non-`NULL`, then it is assumed that `*data_copy` is a pointer to a @ref CeedQFunctionAssemblyData.
-        This @ref CeedQFunctionAssemblyData will be destroyed if `*data_copy` is the only reference to this @ref CeedQFunctionAssemblyData.
+  Note: If the value of ` *data_copy` passed to this function is non-`NULL` , then it is assumed that ` *data_copy` is a pointer to a `CeedQFunctionAssemblyData`.
+        This `CeedQFunctionAssemblyData` will be destroyed if ` *data_copy` is the only reference to this `CeedQFunctionAssemblyData`.
 
-  @param[in]     data      @ref CeedQFunctionAssemblyData to copy reference to
+  @param[in]     data      `CeedQFunctionAssemblyData` to copy reference to
   @param[in,out] data_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -1142,9 +1142,9 @@ int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQ
 }
 
 /**
-  @brief Get setup status for internal objects for @ref CeedQFunctionAssemblyData
+  @brief Get setup status for internal objects for `CeedQFunctionAssemblyData`
 
-  @param[in]  data     @ref CeedQFunctionAssemblyData to retrieve status
+  @param[in]  data     `CeedQFunctionAssemblyData` to retrieve status
   @param[out] is_setup Boolean flag for setup status
 
   @return An error code: 0 - success, otherwise - failure
@@ -1157,11 +1157,11 @@ int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_se
 }
 
 /**
-  @brief Set internal objects for @ref CeedQFunctionAssemblyData
+  @brief Set internal objects for `CeedQFunctionAssemblyData`
 
-  @param[in,out] data @ref CeedQFunctionAssemblyData to set objects
-  @param[in]     vec  @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
-  @param[in]     rstr @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
+  @param[in,out] data `CeedQFunctionAssemblyData` to set objects
+  @param[in]     vec  `CeedVector` to store assembled `CeedQFunction` at quadrature points
+  @param[in]     rstr `CeedElemRestriction` for `CeedVector` containing assembled `CeedQFunction`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1176,11 +1176,11 @@ int CeedQFunctionAssemblyDataSetObjects(CeedQFunctionAssemblyData data, CeedVect
 }
 
 /**
-  @brief Get internal objects for @ref CeedQFunctionAssemblyData
+  @brief Get internal objects for `CeedQFunctionAssemblyData`
 
-  @param[in,out] data @ref CeedQFunctionAssemblyData to set objects
-  @param[out]    vec  @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
-  @param[out]    rstr @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
+  @param[in,out] data `CeedQFunctionAssemblyData` to set objects
+  @param[out]    vec  `CeedVector` to store assembled `CeedQFunction` at quadrature points
+  @param[out]    rstr `CeedElemRestriction` for `CeedVector` containing assembled `CeedQFunction`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1195,9 +1195,9 @@ int CeedQFunctionAssemblyDataGetObjects(CeedQFunctionAssemblyData data, CeedVect
 }
 
 /**
-  @brief Destroy @ref CeedQFunctionAssemblyData
+  @brief Destroy `CeedQFunctionAssemblyData`
 
-  @param[in,out] data  @ref CeedQFunctionAssemblyData to destroy
+  @param[in,out] data  `CeedQFunctionAssemblyData` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1217,10 +1217,10 @@ int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data) {
 }
 
 /**
-  @brief Get @ref CeedOperatorAssemblyData
+  @brief Get `CeedOperatorAssemblyData`
 
-  @param[in]  op   @ref CeedOperator to assemble
-  @param[out] data @ref CeedQFunctionAssemblyData
+  @param[in]  op   `CeedOperator` to assemble
+  @param[out] data `CeedQFunctionAssemblyData`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1238,18 +1238,18 @@ int CeedOperatorGetOperatorAssemblyData(CeedOperator op, CeedOperatorAssemblyDat
 }
 
 /**
-  @brief Create object holding @ref CeedOperator assembly data.
+  @brief Create object holding `CeedOperator` assembly data.
 
-  The @ref CeedOperatorAssemblyData holds an array with references to every active @ref CeedBasis used in the @ref CeedOperator.
-  An array with references to the corresponding active @ref CeedElemRestriction is also stored.
-  For each active @ref CeedBasis, the @ref CeedOperatorAssemblyData holds an array of all input and output @ref CeedEvalMode for this @ref CeedBasis.
-  The @ref CeedOperatorAssemblyData holds an array of offsets for indexing into the assembled @ref CeedQFunction arrays to the row representing each @ref CeedEvalMode.
-  The number of input columns across all active bases for the assembled @ref CeedQFunction is also stored.
-  Lastly, the CeedOperatorAssembly data holds assembled matrices representing the full action of the @ref CeedBasis for all @ref CeedEvalMode.
+  The `CeedOperatorAssemblyData` holds an array with references to every active `CeedBasis` used in the `CeedOperator`.
+  An array with references to the corresponding active `CeedElemRestriction` is also stored.
+  For each active `CeedBasis, the `CeedOperatorAssemblyData` holds an array of all input and output @ref CeedEvalMode for this `CeedBasis`.
+  The `CeedOperatorAssemblyData` holds an array of offsets for indexing into the assembled `CeedQFunction` arrays to the row representing each @ref CeedEvalMode.
+  The number of input columns across all active bases for the assembled `CeedQFunction` is also stored.
+  Lastly, the `CeedOperatorAssembly` data holds assembled matrices representing the full action of the `CeedBasis` for all @ref CeedEvalMode.
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedOperatorAssemblyData 
-  @param[in]  op   @ref CeedOperator to be assembled
-  @param[out] data Address of the variable where the newly created @ref CeedOperatorAssemblyData will be stored
+  @param[in]  ceed `Ceed` object used to create the `CeedOperatorAssemblyData`
+  @param[in]  op   `CeedOperator` to be assembled
+  @param[out] data Address of the variable where the newly created `CeedOperatorAssemblyData` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1397,21 +1397,21 @@ int CeedOperatorAssemblyDataCreate(Ceed ceed, CeedOperator op, CeedOperatorAssem
 }
 
 /**
-  @brief Get @ref CeedOperator @ref CeedEvalMode for assembly.
+  @brief Get `CeedOperator` @ref CeedEvalMode for assembly.
 
   Note: See @ref CeedOperatorAssemblyDataCreate() for a full description of the data stored in this object.
 
-  @param[in]  data                  @ref CeedOperatorAssemblyData
+  @param[in]  data                  `CeedOperatorAssemblyData`
   @param[out] num_active_bases_in   Total number of active bases for input
   @param[out] num_eval_modes_in     Pointer to hold array of numbers of input @ref CeedEvalMode, or `NULL`.
-                                      `eval_modes_in[0]` holds an array of eval modes for the first active @ref CeedBasis.
+                                      `eval_modes_in[0]` holds an array of eval modes for the first active `CeedBasis`.
   @param[out] eval_modes_in         Pointer to hold arrays of input @ref CeedEvalMode, or `NULL`
   @param[out] eval_mode_offsets_in  Pointer to hold arrays of input offsets at each quadrature point
   @param[out] num_active_bases_out  Total number of active bases for output
-  @param[out] num_eval_modes_out    Pointer to hold array of numbers of output @ref CeedEvalModes, or `NULL`
+  @param[out] num_eval_modes_out    Pointer to hold array of numbers of output @ref CeedEvalMode, or `NULL`
   @param[out] eval_modes_out        Pointer to hold arrays of output @ref CeedEvalMode, or `NULL`
   @param[out] eval_mode_offsets_out Pointer to hold arrays of output offsets at each quadrature point
-  @param[out] num_output_components The number of columns in the assembled @ref CeedQFunction matrix for each quadrature point, including contributions of all active bases
+  @param[out] num_output_components The number of columns in the assembled `CeedQFunction` matrix for each quadrature point, including contributions of all active bases
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1434,17 +1434,17 @@ int CeedOperatorAssemblyDataGetEvalModes(CeedOperatorAssemblyData data, CeedInt 
 }
 
 /**
-  @brief Get @ref CeedOperator @ref CeedBasis data for assembly.
+  @brief Get `CeedOperator` `CeedBasis` data for assembly.
 
   Note: See @ref CeedOperatorAssemblyDataCreate() for a full description of the data stored in this object.
 
-  @param[in]  data                 @ref CeedOperatorAssemblyData
+  @param[in]  data                 `CeedOperatorAssemblyData`
   @param[out] num_active_bases_in  Number of active input bases, or `NULL`
-  @param[out] active_bases_in      Pointer to hold active input @ref CeedBasis, or `NULL`
-  @param[out] assembled_bases_in   Pointer to hold assembled active input `B`, or `NULL`
+  @param[out] active_bases_in      Pointer to hold active input `CeedBasis`, or `NULL`
+  @param[out] assembled_bases_in   Pointer to hold assembled active input `B` , or `NULL`
   @param[out] num_active_bases_out Number of active output bases, or `NULL`
-  @param[out] active_bases_out     Pointer to hold active output @ref CeedBasis, or `NULL`
-  @param[out] assembled_bases_out  Pointer to hold assembled active output `B`, or `NULL`
+  @param[out] active_bases_out     Pointer to hold active output `CeedBasis`, or `NULL`
+  @param[out] assembled_bases_out  Pointer to hold assembled active output `B` , or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1561,15 +1561,15 @@ int CeedOperatorAssemblyDataGetBases(CeedOperatorAssemblyData data, CeedInt *num
 }
 
 /**
-  @brief Get @ref CeedOperator @ref CeedBasis data for assembly.
+  @brief Get `CeedOperator` `CeedBasis` data for assembly.
 
   Note: See @ref CeedOperatorAssemblyDataCreate() for a full description of the data stored in this object.
 
-  @param[in]  data                      @ref CeedOperatorAssemblyData
+  @param[in]  data                      `CeedOperatorAssemblyData`
   @param[out] num_active_elem_rstrs_in  Number of active input element restrictions, or `NULL`
-  @param[out] active_elem_rstrs_in      Pointer to hold active input @ref CeedElemRestriction, or `NULL`
+  @param[out] active_elem_rstrs_in      Pointer to hold active input `CeedElemRestriction`, or `NULL`
   @param[out] num_active_elem_rstrs_out Number of active output element restrictions, or `NULL`
-  @param[out] active_elem_rstrs_out     Pointer to hold active output @ref CeedElemRestriction, or `NULL`
+  @param[out] active_elem_rstrs_out     Pointer to hold active output `CeedElemRestriction`, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1586,9 +1586,9 @@ int CeedOperatorAssemblyDataGetElemRestrictions(CeedOperatorAssemblyData data, C
 }
 
 /**
-  @brief Destroy @ref CeedOperatorAssemblyData
+  @brief Destroy `CeedOperatorAssemblyData`
 
-  @param[in,out] data @ref CeedOperatorAssemblyData to destroy
+  @param[in,out] data `CeedOperatorAssemblyData` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1632,10 +1632,10 @@ int CeedOperatorAssemblyDataDestroy(CeedOperatorAssemblyData *data) {
 }
 
 /**
-  @brief Retrieve fallback @ref CeedOperator with a reference @ref Ceed for advanced @ref CeedOperator functionality
+  @brief Retrieve fallback `CeedOperator` with a reference `Ceed` for advanced `CeedOperator` functionality
 
-  @param[in]  op          @ref CeedOperator to retrieve fallback for
-  @param[out] op_fallback Fallback @ref CeedOperator
+  @param[in]  op          `CeedOperator` to retrieve fallback for
+  @param[out] op_fallback Fallback `CeedOperator`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1667,10 +1667,10 @@ int CeedOperatorGetFallback(CeedOperator op, CeedOperator *op_fallback) {
 }
 
 /**
-  @brief Get the parent @ref CeedOperator for a fallback @ref CeedOperator
+  @brief Get the parent `CeedOperator` for a fallback `CeedOperator`
 
-  @param[in]  op     @ref CeedOperator context
-  @param[out] parent Variable to store parent @ref CeedOperator context
+  @param[in]  op     `CeedOperator` context
+  @param[out] parent Variable to store parent `CeedOperator` context
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1682,10 +1682,10 @@ int CeedOperatorGetFallbackParent(CeedOperator op, CeedOperator *parent) {
 }
 
 /**
-  @brief Get the @ref Ceed context of the parent @ref CeedOperator for a fallback @ref CeedOperator
+  @brief Get the `Ceed` context of the parent `CeedOperator` for a fallback `CeedOperator`
 
-  @param[in]  op     @ref CeedOperator context
-  @param[out] parent Variable to store parent @ref Ceed context
+  @param[in]  op     `CeedOperator` context
+  @param[out] parent Variable to store parent `Ceed` context
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1705,19 +1705,19 @@ int CeedOperatorGetFallbackParentCeed(CeedOperator op, Ceed *parent) {
 /// @{
 
 /**
-  @brief Assemble a linear @ref CeedQFunction associated with a @ref CeedOperator.
+  @brief Assemble a linear `CeedQFunction` associated with a `CeedOperator`.
 
-  This returns a @ref CeedVector containing a matrix at each quadrature point providing the action of the @ref CeedQFunction associated with the @ref CeedOperator.
-  The vector `assembled` is of shape `[num_elements, num_input_fields, num_output_fields, num_quad_points]` and contains column-major matrices representing the action of the @ref CeedQFunction for a corresponding quadrature point on an element.
+  This returns a `CeedVector` containing a matrix at each quadrature point providing the action of the `CeedQFunction` associated with the `CeedOperator`.
+  The vector `assembled` is of shape `[num_elements, num_input_fields, num_output_fields, num_quad_points]` and contains column-major matrices representing the action of the `CeedQFunction` for a corresponding quadrature point on an element.
 
-  Inputs and outputs are in the order provided by the user when adding @ref CeedOperator fields.
-  For example, a @ref CeedQFunction with inputs `u` and `gradu` and outputs `gradv` and `v`, provided in that order, would result in an assembled @ref CeedQFunction that consists of `(1 + dim) x (dim + 1)` matrices at each quadrature point acting on the input `[u, du_0, du_1]` and producing the output `[dv_0, dv_1, v]`.
+  Inputs and outputs are in the order provided by the user when adding `CeedOperator` fields.
+  For example, a `CeedQFunction` with inputs `u` and `gradu` and outputs `gradv` and `v` , provided in that order, would result in an assembled `CeedQFunction` that consists of `(1 + dim) x (dim + 1)` matrices at each quadrature point acting on the input ` [u, du_0, du_1]` and producing the output `[dv_0, dv_1, v]`.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
-  @param[out] assembled @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
-  @param[out] rstr      @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
+  @param[in]  op        `CeedOperator` to assemble `CeedQFunction`
+  @param[out] assembled `CeedVector` to store assembled `CeedQFunction` at quadrature points
+  @param[out] rstr      `CeedElemRestriction` for `CeedVector` containing assembled `CeedQFunction`
   @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
@@ -1742,18 +1742,18 @@ int CeedOperatorLinearAssembleQFunction(CeedOperator op, CeedVector *assembled, 
 }
 
 /**
-  @brief Assemble @ref CeedQFunction and store result internally.
+  @brief Assemble `CeedQFunction` and store result internally.
 
   Return copied references of stored data to the caller.
   Caller is responsible for ownership and destruction of the copied references.
   See also @ref CeedOperatorLinearAssembleQFunction().
 
-  Note: If the value of `assembled` or `rstr` passed to this function are non-`NULL`, then it is assumed that they hold valid pointers.
+  Note: If the value of `assembled` or `rstr` passed to this function are non-`NULL` , then it is assumed that they hold valid pointers.
         These objects will be destroyed if `*assembled` or `*rstr` is the only reference to the object.
 
-  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
-  @param[out] assembled @ref CeedVector to store assembled @ref CeedQFunction at quadrature points
-  @param[out] rstr      @ref CeedElemRestriction for @ref CeedVector containing assembled @ref CeedQFunction
+  @param[in]  op        `CeedOperator` to assemble `CeedQFunction`
+  @param[out] assembled `CeedVector` to store assembled `CeedQFunction` at quadrature points
+  @param[out] rstr      `CeedElemRestriction` for `CeedVector` containing assembled `CeedQFunction`
   @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
@@ -1816,16 +1816,16 @@ int CeedOperatorLinearAssembleQFunctionBuildOrUpdate(CeedOperator op, CeedVector
 }
 
 /**
-  @brief Assemble the diagonal of a square linear @ref CeedOperator
+  @brief Assemble the diagonal of a square linear `CeedOperator`
 
-  This overwrites a @ref CeedVector with the diagonal of a linear @ref CeedOperator.
+  This overwrites a `CeedVector` with the diagonal of a linear `CeedOperator`.
 
-  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
+  Note: Currently only non-composite `CeedOperator` with a single field and composite `CeedOperator` with single field sub-operators are supported.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
-  @param[out] assembled @ref CeedVector to store assembled @ref CeedOperator diagonal
+  @param[in]  op        `CeedOperator` to assemble `CeedQFunction`
+  @param[out] assembled `CeedVector` to store assembled `CeedOperator` diagonal
   @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
@@ -1876,16 +1876,16 @@ int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled, Ce
 }
 
 /**
-  @brief Assemble the diagonal of a square linear @ref CeedOperator
+  @brief Assemble the diagonal of a square linear `CeedOperator`.
 
-  This sums into a @ref CeedVector the diagonal of a linear @ref CeedOperator.
+  This sums into a `CeedVector` the diagonal of a linear `CeedOperator`.
 
-  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
+  Note: Currently only non-composite `CeedOperator` with a single field and composite `CeedOperator` with single field sub-operators are supported.
 
   Note: Calling this function asserts that setup is complete and sets the CeedOperator as immutable.
 
-  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
-  @param[out] assembled @ref CeedVector to store assembled @ref CeedOperator diagonal
+  @param[in]  op        `CeedOperator` to assemble `CeedQFunction`
+  @param[out] assembled `CeedVector` to store assembled `CeedOperator` diagonal
   @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure
@@ -1934,7 +1934,7 @@ int CeedOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedVector assembled,
 }
 
 /**
-   @brief Fully assemble the point-block diagonal pattern of a linear @ref CeedOperator.
+   @brief Fully assemble the point-block diagonal pattern of a linear `CeedOperator`.
 
    Expected to be used in conjunction with @ref CeedOperatorLinearAssemblePointBlockDiagonal().
 
@@ -1944,9 +1944,9 @@ int CeedOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedVector assembled,
 
    This will generally be slow unless your operator is low-order.
 
-   Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+   Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-   @param[in]  op          @ref CeedOperator to assemble
+   @param[in]  op          `CeedOperator` to assemble
    @param[out] num_entries Number of entries in coordinate nonzero pattern
    @param[out] rows        Row number for each entry
    @param[out] cols        Column number for each entry
@@ -2037,17 +2037,17 @@ int CeedOperatorLinearAssemblePointBlockDiagonalSymbolic(CeedOperator op, CeedSi
 }
 
 /**
-  @brief Assemble the point block diagonal of a square linear @ref CeedOperator
+  @brief Assemble the point block diagonal of a square linear `CeedOperator`.
 
-  This overwrites a @ref CeedVector with the point block diagonal of a linear @ref CeedOperator.
+  This overwrites a `CeedVector` with the point block diagonal of a linear `CeedOperator`.
 
-  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
+  Note: Currently only non-composite `CeedOperator` with a single field and composite `CeedOperator` with single field sub-operators are supported.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
-  @param[out] assembled @ref CeedVector to store assembled @ref CeedOperator point block diagonal, provided in row-major form with an `num_comp * num_comp` block at each node.
-                          The dimensions of this vector are derived from the active vector for the @ref CeedOperator.
+  @param[in]  op        `CeedOperator` to assemble `CeedQFunction`
+  @param[out] assembled `CeedVector` to store assembled `CeedOperator` point block diagonal, provided in row-major form with an `num_comp * num_comp` block at each node.
+                          The dimensions of this vector are derived from the active vector for the `CeedOperator`.
                           The array has shape `[nodes, component out, component in]`.
   @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
@@ -2099,17 +2099,17 @@ int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op, CeedVector ass
 }
 
 /**
-  @brief Assemble the point block diagonal of a square linear @ref CeedOperator
+  @brief Assemble the point block diagonal of a square linear `CeedOperator`.
 
-  This sums into a @ref CeedVector with the point block diagonal of a linear @ref CeedOperator.
+  This sums into a `CeedVector` with the point block diagonal of a linear `CeedOperator`.
 
-  Note: Currently only non-composite @ref CeedOperator with a single field and composite @ref CeedOperator with single field sub-operators are supported.
+  Note: Currently only non-composite `CeedOperator` with a single field and composite `CeedOperator` with single field sub-operators are supported.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op        @ref CeedOperator to assemble @ref CeedQFunction
-  @param[out] assembled @ref CeedVector to store assembled CeedOperator point block diagonal, provided in row-major form with an `num_comp * num_comp` block at each node.
-                          The dimensions of this vector are derived from the active vector for the @ref CeedOperator.
+  @param[in]  op        `CeedOperator` to assemble `CeedQFunction`
+  @param[out] assembled `CeedVector` to store assembled CeedOperator point block diagonal, provided in row-major form with an `num_comp * num_comp` block at each node.
+                          The dimensions of this vector are derived from the active vector for the `CeedOperator`.
                           The array has shape `[nodes, component out, component in]`.
   @param[in]  request   Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
@@ -2159,7 +2159,7 @@ int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op, CeedVector 
 }
 
 /**
-   @brief Fully assemble the nonzero pattern of a linear @ref CeedOperator.
+   @brief Fully assemble the nonzero pattern of a linear `CeedOperator`.
 
    Expected to be used in conjunction with @ref CeedOperatorLinearAssemble().
 
@@ -2169,9 +2169,9 @@ int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op, CeedVector 
 
    This will generally be slow unless your operator is low-order.
 
-   Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+   Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-   @param[in]  op          @ref CeedOperator to assemble
+   @param[in]  op          `CeedOperator` to assemble
    @param[out] num_entries Number of entries in coordinate nonzero pattern
    @param[out] rows        Row number for each entry
    @param[out] cols        Column number for each entry
@@ -2246,9 +2246,9 @@ int CeedOperatorLinearAssembleSymbolic(CeedOperator op, CeedSize *num_entries, C
 
    This will generally be slow unless your operator is low-order.
 
-   Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+   Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-   @param[in]  op     @ref CeedOperator to assemble
+   @param[in]  op     `CeedOperator` to assemble
    @param[out] values Values to assemble into matrix
 
    @ref User
@@ -2302,14 +2302,14 @@ int CeedOperatorLinearAssemble(CeedOperator op, CeedVector values) {
 }
 
 /**
-  @brief Get the multiplicity of nodes across sub-operators in a composite @ref CeedOperator
+  @brief Get the multiplicity of nodes across sub-operators in a composite `CeedOperator`.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op               Composite @ref CeedOperator
+  @param[in]  op               Composite `CeedOperator`
   @param[in]  num_skip_indices Number of sub-operators to skip
   @param[in]  skip_indices     Array of indices of sub-operators to skip
-  @param[out] mult             Vector to store multiplicity (of size `l_size`)
+  @param[out] mult             Vector to store multiplicity (of size `l_size` )
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2375,17 +2375,17 @@ int CeedCompositeOperatorGetMultiplicity(CeedOperator op, CeedInt num_skip_indic
 }
 
 /**
-  @brief Create a multigrid coarse @ref CeedOperator and level transfer @ref CeedOperator for a @ref CeedOperator, creating the prolongation basis from the fine and coarse grid interpolation.
+  @brief Create a multigrid coarse `CeedOperator` and level transfer `CeedOperator` for a `CeedOperator`, creating the prolongation basis from the fine and coarse grid interpolation.
 
-  Note: Calling this function asserts that setup is complete and sets all four @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets all four `CeedOperator` as immutable.
 
-  @param[in]  op_fine      Fine grid @ref CeedOperator
-  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
-  @param[in]  rstr_coarse  Coarse grid @ref CeedElemRestriction
-  @param[in]  basis_coarse Coarse grid active vector @ref CeedBasis
-  @param[out] op_coarse    Coarse grid @ref CeedOperator
-  @param[out] op_prolong   Coarse to fine @ref CeedOperator, or `NULL`
-  @param[out] op_restrict  Fine to coarse @ref CeedOperator, or `NULL`
+  @param[in]  op_fine      Fine grid `CeedOperator`
+  @param[in]  p_mult_fine  L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction `CeedOperator`
+  @param[in]  rstr_coarse  Coarse grid `CeedElemRestriction`
+  @param[in]  basis_coarse Coarse grid active vector `CeedBasis`
+  @param[out] op_coarse    Coarse grid `CeedOperator`
+  @param[out] op_prolong   Coarse to fine `CeedOperator`, or `NULL`
+  @param[out] op_restrict  Fine to coarse `CeedOperator`, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2411,18 +2411,18 @@ int CeedOperatorMultigridLevelCreate(CeedOperator op_fine, CeedVector p_mult_fin
 }
 
 /**
-  @brief Create a multigrid coarse @ref CeedOperator and level transfer @ref CeedOperator for a @ref CeedOperator with a tensor basis for the active basis.
+  @brief Create a multigrid coarse `CeedOperator` and level transfer `CeedOperator` for a `CeedOperator` with a tensor basis for the active basis.
 
-  Note: Calling this function asserts that setup is complete and sets all four @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets all four `CeedOperator` as immutable.
 
-  @param[in]  op_fine       Fine grid @ref CeedOperator
-  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
-  @param[in]  rstr_coarse   Coarse grid @ref CeedElemRestriction
-  @param[in]  basis_coarse  Coarse grid active vector @ref CeedBasis
-  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction @ref CeedOperator
-  @param[out] op_coarse     Coarse grid @ref CeedOperator
-  @param[out] op_prolong    Coarse to fine @ref CeedOperator, or `NULL`
-  @param[out] op_restrict   Fine to coarse @ref CeedOperator, or `NULL`
+  @param[in]  op_fine       Fine grid `CeedOperator`
+  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction `CeedOperator`
+  @param[in]  rstr_coarse   Coarse grid `CeedElemRestriction`
+  @param[in]  basis_coarse  Coarse grid active vector `CeedBasis`
+  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction `CeedOperator`
+  @param[out] op_coarse     Coarse grid `CeedOperator`
+  @param[out] op_prolong    Coarse to fine `CeedOperator`, or `NULL`
+  @param[out] op_restrict   Fine to coarse `CeedOperator`, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2472,18 +2472,18 @@ int CeedOperatorMultigridLevelCreateTensorH1(CeedOperator op_fine, CeedVector p_
 }
 
 /**
-  @brief Create a multigrid coarse @ref CeedOperator and level transfer @ref CeedOperator for a @ref CeedOperator with a non-tensor basis for the active vector
+  @brief Create a multigrid coarse `CeedOperator` and level transfer `CeedOperator` for a `CeedOperator` with a non-tensor basis for the active vector
 
-  Note: Calling this function asserts that setup is complete and sets all four @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets all four `CeedOperator` as immutable.
 
-  @param[in]  op_fine       Fine grid @ref CeedOperator
-  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction @ref CeedOperator
-  @param[in]  rstr_coarse   Coarse grid @ref CeedElemRestriction
-  @param[in]  basis_coarse  Coarse grid active vector @ref CeedBasis
-  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction @ref CeedOperator
-  @param[out] op_coarse     Coarse grid @ref CeedOperator
-  @param[out] op_prolong    Coarse to fine @ref CeedOperator, or `NULL`
-  @param[out] op_restrict   Fine to coarse @ref CeedOperator, or `NULL`
+  @param[in]  op_fine       Fine grid `CeedOperator`
+  @param[in]  p_mult_fine   L-vector multiplicity in parallel gather/scatter, or `NULL` if not creating prolongation/restriction `CeedOperator`
+  @param[in]  rstr_coarse   Coarse grid `CeedElemRestriction`
+  @param[in]  basis_coarse  Coarse grid active vector `CeedBasis`
+  @param[in]  interp_c_to_f Matrix for coarse to fine interpolation, or `NULL` if not creating prolongation/restriction `CeedOperator`
+  @param[out] op_coarse     Coarse grid `CeedOperator`
+  @param[out] op_prolong    Coarse to fine `CeedOperator`, or `NULL`
+  @param[out] op_restrict   Fine to coarse `CeedOperator`, or `NULL`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -2534,18 +2534,18 @@ int CeedOperatorMultigridLevelCreateH1(CeedOperator op_fine, CeedVector p_mult_f
 }
 
 /**
-  @brief Build a FDM based approximate inverse for each element for a @ref CeedOperator
+  @brief Build a FDM based approximate inverse for each element for a `CeedOperator`.
 
-  This returns a @ref CeedOperator and @ref CeedVector to apply a Fast Diagonalization Method based approximate inverse.
+  This returns a `CeedOperator` and `CeedVector` to apply a Fast Diagonalization Method based approximate inverse.
   This function obtains the simultaneous diagonalization for the 1D mass and Laplacian operators, \f$M = V^T V, K = V^T S V\f$.
-  The assembled @ref CeedQFunction is used to modify the eigenvalues from simultaneous diagonalization and obtain an approximate inverse of the form \f$V^T \hat S V\f$.
-  The @ref CeedOperator must be linear and non-composite.
-  The associated @ref CeedQFunction must therefore also be linear.
+  The assembled `CeedQFunction` is used to modify the eigenvalues from simultaneous diagonalization and obtain an approximate inverse of the form \f$V^T \hat S V\f$.
+  The `CeedOperator` must be linear and non-composite.
+  The associated `CeedQFunction` must therefore also be linear.
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedOperator as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedOperator` as immutable.
 
-  @param[in]  op      @ref CeedOperator to create element inverses
-  @param[out] fdm_inv @ref CeedOperator to apply the action of a FDM based inverse for each element
+  @param[in]  op      `CeedOperator` to create element inverses
+  @param[out] fdm_inv `CeedOperator` to apply the action of a FDM based inverse for each element
   @param[in]  request Address of @ref CeedRequest for non-blocking completion, else @ref CEED_REQUEST_IMMEDIATE
 
   @return An error code: 0 - success, otherwise - failure

--- a/interface/ceed-qfunction-register.c
+++ b/interface/ceed-qfunction-register.c
@@ -16,10 +16,10 @@ static bool register_all_called;
 #undef CEED_GALLERY_QFUNCTION
 
 /**
-  @brief Register the gallery of pre-configured QFunctions.
+  @brief Register the gallery of pre-configured @ref CeedQFunction.
 
-  This is called automatically by CeedQFunctionCreateInteriorByName() and thus normally need not be called by users.
-  Users can call CeedQFunctionRegister() to register additional backends.
+  This is called automatically by @ref CeedQFunctionCreateInteriorByName() and thus normally need not be called by users.
+  Users can call @ref CeedQFunctionRegister() to register additional backends.
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -24,7 +24,7 @@ static struct CeedQFunction_private ceed_qfunction_none;
 /// @addtogroup CeedQFunctionUser
 /// @{
 
-// Indicate that no @ref CeedQFunction is provided by the user
+// Indicate that no `CeedQFunction` is provided by the user
 const CeedQFunction CEED_QFUNCTION_NONE = &ceed_qfunction_none;
 
 /// @}
@@ -47,15 +47,15 @@ static size_t num_qfunctions;
 /// @{
 
 /**
-  @brief Register a gallery @ref CeedQFunction
+  @brief Register a gallery `CeedQFunction`
 
   @param[in] name       Name for this backend to respond to
-  @param[in] source     Absolute path to source of @ref CeedQFunction, "\path\CEED_DIR\gallery\folder\file.h:function_name"
+  @param[in] source     Absolute path to source of `CeedQFunction`, "\path\CEED_DIR\gallery\folder\file.h:function_name"
   @param[in] vec_length Vector length.
                           Caller must ensure that number of quadrature points is a multiple of `vec_length`.
   @param[in] f          Function pointer to evaluate action at quadrature points.
-                          See @ref CeedQFunctionUser.
-  @param[in] init       Initialization function called by @ref CeedQFunctionCreateInteriorByName() when the @ref CeedQFunction is selected.
+                          See `CeedQFunctionUser`.
+  @param[in] init       Initialization function called by @ref CeedQFunctionCreateInteriorByName() when the `CeedQFunction` is selected.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -89,11 +89,11 @@ int CeedQFunctionRegister(const char *name, const char *source, CeedInt vec_leng
 }
 
 /**
-  @brief Set a @ref CeedQFunction field, used by @ref CeedQFunctionAddInput() and @ref CeedQFunctionAddOutput()
+  @brief Set a `CeedQFunction` field, used by @ref CeedQFunctionAddInput() and @ref CeedQFunctionAddOutput()
 
-  @param[out] f           @ref CeedQFunctionField
-  @param[in]  field_name  Name of @ref CeedQFunction field
-  @param[in]  size        Size of @ref CeedQFunction field, (`num_comp * 1`) for @ref CEED_EVAL_NONE and @ref CEED_EVAL_WEIGHT, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (num_comp * 1) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` and `curl_dim = dim` for @ref CEED_EVAL_CURL.
+  @param[out] f           `CeedQFunctionField`
+  @param[in]  field_name  Name of `CeedQFunction` field
+  @param[in]  size        Size of `CeedQFunction` field, (`num_comp * 1`) for @ref CEED_EVAL_NONE and @ref CEED_EVAL_WEIGHT, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (num_comp * 1) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` and `curl_dim = dim` for @ref CEED_EVAL_CURL.
   @param[in]  eval_mode   @ref CEED_EVAL_NONE to use values directly,
                             @ref CEED_EVAL_WEIGHT to use quadrature weights,
                             @ref CEED_EVAL_INTERP to use interpolated values,
@@ -114,9 +114,9 @@ static int CeedQFunctionFieldSet(CeedQFunctionField *f, const char *field_name, 
 }
 
 /**
-  @brief View a field of a @ref CeedQFunction
+  @brief View a field of a `CeedQFunction`
 
-  @param[in] field        @ref CeedQFunction field to view
+  @param[in] field        `CeedQFunction` field to view
   @param[in] field_number Number of field being viewed
   @param[in] in           true for input field, false for output
   @param[in] stream       Stream to view to, e.g., `stdout`
@@ -169,9 +169,9 @@ int CeedQFunctionSetFortranStatus(CeedQFunction qf, bool status) {
 /// @{
 
 /**
-  @brief Get the vector length of a @ref CeedQFunction
+  @brief Get the vector length of a `CeedQFunction`
 
-  @param[in]  qf         @ref CeedQFunction
+  @param[in]  qf         `CeedQFunction`
   @param[out] vec_length Variable to store vector length
 
   @return An error code: 0 - success, otherwise - failure
@@ -184,9 +184,9 @@ int CeedQFunctionGetVectorLength(CeedQFunction qf, CeedInt *vec_length) {
 }
 
 /**
-  @brief Get the number of inputs and outputs to a @ref CeedQFunction
+  @brief Get the number of inputs and outputs to a `CeedQFunction`
 
-  @param[in]  qf         @ref CeedQFunction
+  @param[in]  qf         `CeedQFunction`
   @param[out] num_input  Variable to store number of input fields
   @param[out] num_output Variable to store number of output fields
 
@@ -201,9 +201,9 @@ int CeedQFunctionGetNumArgs(CeedQFunction qf, CeedInt *num_input, CeedInt *num_o
 }
 
 /**
-  @brief Get the name of the user function for a @ref CeedQFunction
+  @brief Get the name of the user function for a `CeedQFunction`
 
-  @param[in]  qf          @ref CeedQFunction
+  @param[in]  qf          `CeedQFunction`
   @param[out] kernel_name Variable to store source path string
 
   @return An error code: 0 - success, otherwise - failure
@@ -233,9 +233,9 @@ int CeedQFunctionGetKernelName(CeedQFunction qf, char **kernel_name) {
 }
 
 /**
-  @brief Get the source path string for a @ref CeedQFunction
+  @brief Get the source path string for a `CeedQFunction`
 
-  @param[in]  qf          @ref CeedQFunction
+  @param[in]  qf          `CeedQFunction`
   @param[out] source_path Variable to store source path string
 
   @return An error code: 0 - success, otherwise - failure
@@ -272,13 +272,13 @@ int CeedQFunctionGetSourcePath(CeedQFunction qf, char **source_path) {
 }
 
 /**
-  @brief Initialize and load @ref CeedQFunction source file into string buffer, including full text of local files in place of `#include "local.h"`.
+  @brief Initialize and load `CeedQFunction` source file into string buffer, including full text of local files in place of `#include "local.h"`.
 
-  The `buffer` is set to `NULL` if there is no @ref CeedQFunction source file.
+  The `buffer` is set to `NULL` if there is no `CeedQFunction` source file.
 
   Note: Caller is responsible for freeing the string buffer with @ref CeedFree().
 
-  @param[in]  qf            @ref CeedQFunction
+  @param[in]  qf            `CeedQFunction`
   @param[out] source_buffer String buffer for source file contents
 
   @return An error code: 0 - success, otherwise - failure
@@ -297,9 +297,9 @@ int CeedQFunctionLoadSourceToBuffer(CeedQFunction qf, char **source_buffer) {
 }
 
 /**
-  @brief Get the User Function for a @ref CeedQFunction
+  @brief Get the User Function for a `CeedQFunction`
 
-  @param[in]  qf @ref CeedQFunction
+  @param[in]  qf `CeedQFunction`
   @param[out] f  Variable to store user function
 
   @return An error code: 0 - success, otherwise - failure
@@ -312,9 +312,9 @@ int CeedQFunctionGetUserFunction(CeedQFunction qf, CeedQFunctionUser *f) {
 }
 
 /**
-  @brief Get global context for a @ref CeedQFunction.
+  @brief Get global context for a `CeedQFunction`.
 
-  Note: For @ref CeedQFunction from the Fortran interface, this function will return the Fortran context @ref CeedQFunctionContext.
+  Note: For `CeedQFunction` from the Fortran interface, this function will return the Fortran context `CeedQFunctionContext`.
 
   @param[in]  qf  CeedQFunction
   @param[out] ctx Variable to store CeedQFunctionContext
@@ -329,9 +329,9 @@ int CeedQFunctionGetContext(CeedQFunction qf, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Get context data of a @ref CeedQFunction
+  @brief Get context data of a `CeedQFunction`
 
-  @param[in]  qf       @ref CeedQFunction
+  @param[in]  qf       `CeedQFunction`
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
@@ -359,9 +359,9 @@ int CeedQFunctionGetContextData(CeedQFunction qf, CeedMemType mem_type, void *da
 }
 
 /**
-  @brief Restore context data of a @ref CeedQFunction
+  @brief Restore context data of a `CeedQFunction`
 
-  @param[in]     qf   @ref CeedQFunction
+  @param[in]     qf   `CeedQFunction`
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -386,12 +386,12 @@ int CeedQFunctionRestoreContextData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Get true user context for a @ref CeedQFunction
+  @brief Get true user context for a `CeedQFunction`
 
-  Note: For all @ref CeedQFunction this function will return the user @ref CeedQFunctionContext and not interface context @ref CeedQFunctionContext, if any such object exists.
+  Note: For all `CeedQFunction` this function will return the user `CeedQFunctionContext` and not interface context `CeedQFunctionContext`, if any such object exists.
 
-  @param[in]  qf  @ref CeedQFunction
-  @param[out] ctx Variable to store @ref CeedQFunctionContext
+  @param[in]  qf  `CeedQFunction`
+  @param[out] ctx Variable to store `CeedQFunctionContext`
 
   @return An error code: 0 - success, otherwise - failure
   @ref Backend
@@ -410,9 +410,9 @@ int CeedQFunctionGetInnerContext(CeedQFunction qf, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Get inner context data of a @ref CeedQFunction
+  @brief Get inner context data of a `CeedQFunction`
 
-  @param[in]  qf       @ref CeedQFunction
+  @param[in]  qf       `CeedQFunction`
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
@@ -440,9 +440,9 @@ int CeedQFunctionGetInnerContextData(CeedQFunction qf, CeedMemType mem_type, voi
 }
 
 /**
-  @brief Restore inner context data of a @ref CeedQFunction
+  @brief Restore inner context data of a `CeedQFunction`
 
-  @param[in]     qf   @ref CeedQFunction
+  @param[in]     qf   `CeedQFunction`
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -467,9 +467,9 @@ int CeedQFunctionRestoreInnerContextData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Determine if @ref CeedQFunction is identity
+  @brief Determine if `CeedQFunction` is identity
 
-  @param[in]  qf          @ref CeedQFunction
+  @param[in]  qf          `CeedQFunction`
   @param[out] is_identity Variable to store identity status
 
   @return An error code: 0 - success, otherwise - failure
@@ -482,9 +482,9 @@ int CeedQFunctionIsIdentity(CeedQFunction qf, bool *is_identity) {
 }
 
 /**
-  @brief Determine if @ref CeedQFunctionContext is writable
+  @brief Determine if `CeedQFunctionContext` is writable
 
-  @param[in]  qf          @ref CeedQFunction
+  @param[in]  qf          `CeedQFunction`
   @param[out] is_writable Variable to store context writeable status
 
   @return An error code: 0 - success, otherwise - failure
@@ -497,9 +497,9 @@ int CeedQFunctionIsContextWritable(CeedQFunction qf, bool *is_writable) {
 }
 
 /**
-  @brief Get backend data of a @ref CeedQFunction
+  @brief Get backend data of a `CeedQFunction`
 
-  @param[in]  qf   @ref CeedQFunction
+  @param[in]  qf   `CeedQFunction`
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -512,9 +512,9 @@ int CeedQFunctionGetData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Set backend data of a @ref CeedQFunction
+  @brief Set backend data of a `CeedQFunction`
 
-  @param[in,out] qf   @ref CeedQFunction
+  @param[in,out] qf   `CeedQFunction`
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -527,9 +527,9 @@ int CeedQFunctionSetData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedQFunction
+  @brief Increment the reference counter for a `CeedQFunction`
 
-  @param[in,out] qf @ref CeedQFunction to increment the reference counter
+  @param[in,out] qf `CeedQFunction` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -541,9 +541,9 @@ int CeedQFunctionReference(CeedQFunction qf) {
 }
 
 /**
-  @brief Estimate number of FLOPs per quadrature required to apply @ref CeedQFunction
+  @brief Estimate number of FLOPs per quadrature required to apply `CeedQFunction`
 
-  @param[in]  qf    @ref CeedQFunction to estimate FLOPs for
+  @param[in]  qf    `CeedQFunction` to estimate FLOPs for
   @param[out] flops Address of variable to hold FLOPs estimate
 
   @ref Backend
@@ -563,18 +563,18 @@ int CeedQFunctionGetFlopsEstimate(CeedQFunction qf, CeedSize *flops) {
 /// @{
 
 /**
-  @brief Create a @ref CeedQFunction for evaluating interior (volumetric) terms
+  @brief Create a `CeedQFunction` for evaluating interior (volumetric) terms
 
-  @param[in]  ceed       @ref Ceed object used to create the @ref CeedQFunction
+  @param[in]  ceed       `Ceed` object used to create the `CeedQFunction`
   @param[in]  vec_length Vector length.
                            Caller must ensure that number of quadrature points is a multiple of `vec_length`.
   @param[in]  f          Function pointer to evaluate action at quadrature points.
-                           See @ref CeedQFunctionUser.
-  @param[in]  source     Absolute path to source of @ref CeedQFunctionUser, "\abs_path\file.h:function_name".
+                           See `CeedQFunctionUser`.
+  @param[in]  source     Absolute path to source of `CeedQFunctionUser`, "\abs_path\file.h:function_name".
                            The entire source file must only contain constructs supported by all targeted backends (i.e. CUDA for `/gpu/cuda`, OpenCL/SYCL for `/gpu/sycl`, etc.).
                            The entire contents of this file and all locally included files are used during JiT compilation for GPU backends.
                            All source files must be at the provided filepath at runtime for JiT to function.
-  @param[out] qf         Address of the variable where the newly created @ref CeedQFunction will be stored
+  @param[out] qf         Address of the variable where the newly created `CeedQFunction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -619,11 +619,11 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length, CeedQFunctionUser
 }
 
 /**
-  @brief Create a @ref CeedQFunction for evaluating interior (volumetric) terms by name
+  @brief Create a `CeedQFunction` for evaluating interior (volumetric) terms by name
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedQFunction
-  @param[in]  name Name of @ref CeedQFunction to use from gallery
-  @param[out] qf   Address of the variable where the newly created @ref CeedQFunction will be stored
+  @param[in]  ceed `Ceed` object used to create the `CeedQFunction`
+  @param[in]  name Name of `CeedQFunction` to use from gallery
+  @param[out] qf   Address of the variable where the newly created `CeedQFunction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -661,17 +661,17 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed, const char *name, CeedQFunction
 }
 
 /**
-  @brief Create an identity @ref CeedQFunction.
+  @brief Create an identity `CeedQFunction`.
 
   Inputs are written into outputs in the order given.
-  This is useful for @ref CeedOperator that can be represented with only the action of a @ref CeedElemRestriction and @ref CeedBasis, such as restriction and prolongation operators for p-multigrid.
-  Backends may optimize @ref CeedOperator with this @ref CeedQFunction to avoid the copy of input data to output fields by using the same memory location for both.
+  This is useful for `CeedOperator that can be represented with only the action of a `CeedElemRestriction` and `CeedBasis`, such as restriction and prolongation operators for p-multigrid.
+  Backends may optimize `CeedOperator` with this `CeedQFunction` to avoid the copy of input data to output fields by using the same memory location for both.
 
-  @param[in]  ceed     @ref Ceed object used to create the @ref CeedQFunction
-  @param[in]  size     Size of the @ref CeedQFunction fields
-  @param[in]  in_mode  @ref CeedEvalMode for input to @ref CeedQFunction
-  @param[in]  out_mode @ref CeedEvalMode for output to @ref CeedQFunction
-  @param[out] qf       Address of the variable where the newly created @ref CeedQFunction will be stored
+  @param[in]  ceed     `Ceed` object used to create the `CeedQFunction`
+  @param[in]  size     Size of the `CeedQFunction` fields
+  @param[in]  in_mode  @ref CeedEvalMode for input to `CeedQFunction`
+  @param[in]  out_mode @ref CeedEvalMode for output to `CeedQFunction`
+  @param[out] qf       Address of the variable where the newly created `CeedQFunction` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -694,14 +694,14 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode in_mode, C
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedQFunction.
+  @brief Copy the pointer to a `CeedQFunction`.
 
   Both pointers should be destroyed with @ref CeedQFunctionDestroy().
 
-  Note: If the value of `*qf_copy` passed to this function is non-NULL, then it is assumed that `*qf_copy` is a pointer to a @ref CeedQFunction.
-        This @ref CeedQFunction will be destroyed if `*qf_copy` is the only reference to this @ref CeedQFunction.
+  Note: If the value of `*qf_copy` passed to this function is non-NULL, then it is assumed that `*qf_copy` is a pointer to a `CeedQFunction`.
+        This `CeedQFunction` will be destroyed if `*qf_copy` is the only reference to this `CeedQFunction`.
 
-  @param[in]  qf      @ref CeedQFunction to copy reference to
+  @param[in]  qf      `CeedQFunction` to copy reference to
   @param[out] qf_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -716,11 +716,11 @@ int CeedQFunctionReferenceCopy(CeedQFunction qf, CeedQFunction *qf_copy) {
 }
 
 /**
-  @brief Add a @ref CeedQFunction input
+  @brief Add a `CeedQFunction` input
 
-  @param[in,out] qf         @ref CeedQFunction
-  @param[in]     field_name Name of @ref CeedQFunction field
-  @param[in]     size       Size of @ref CeedQFunction field, (`num_comp * 1`) for @ref CEED_EVAL_NONE, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (`num_comp * 1`) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` otherwise `curl_dim = dim` for @ref CEED_EVAL_CURL.
+  @param[in,out] qf         `CeedQFunction`
+  @param[in]     field_name Name of `CeedQFunction` field
+  @param[in]     size       Size of `CeedQFunction` field, (`num_comp * 1`) for @ref CEED_EVAL_NONE, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (`num_comp * 1`) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` otherwise `curl_dim = dim` for @ref CEED_EVAL_CURL.
   @param[in]     eval_mode  @ref CEED_EVAL_NONE to use values directly,
                               @ref CEED_EVAL_INTERP to use interpolated values,
                               @ref CEED_EVAL_GRAD to use gradients,
@@ -746,11 +746,11 @@ int CeedQFunctionAddInput(CeedQFunction qf, const char *field_name, CeedInt size
 }
 
 /**
-  @brief Add a @ref CeedQFunction output
+  @brief Add a `CeedQFunction` output
 
-  @param[in,out] qf         @ref CeedQFunction
-  @param[in]     field_name Name of @ref CeedQFunction field
-  @param[in]     size       Size of @ref CeedQFunction field, (`num_comp * 1`) for @ref CEED_EVAL_NONE, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (`num_comp * 1`) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` else dim for @ref CEED_EVAL_CURL.
+  @param[in,out] qf         `CeedQFunction`
+  @param[in]     field_name Name of `CeedQFunction` field
+  @param[in]     size       Size of `CeedQFunction` field, (`num_comp * 1`) for @ref CEED_EVAL_NONE, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (`num_comp * 1`) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` else dim for @ref CEED_EVAL_CURL.
   @param[in]     eval_mode  @ref CEED_EVAL_NONE to use values directly,
                               @ref CEED_EVAL_INTERP to use interpolated values,
                               @ref CEED_EVAL_GRAD to use gradients,
@@ -776,11 +776,11 @@ int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name, CeedInt siz
 }
 
 /**
-  @brief Get the @ref CeedQFunctionField of a @ref CeedQFunction
+  @brief Get the `CeedQFunctionField` of a `CeedQFunction`
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedQFunction as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedQFunction` as immutable.
 
-  @param[in]  qf                @ref CeedQFunction
+  @param[in]  qf                `CeedQFunction`
   @param[out] num_input_fields  Variable to store number of input fields
   @param[out] input_fields      Variable to store input fields
   @param[out] num_output_fields Variable to store number of output fields
@@ -801,9 +801,9 @@ int CeedQFunctionGetFields(CeedQFunction qf, CeedInt *num_input_fields, CeedQFun
 }
 
 /**
-  @brief Get the name of a @ref CeedQFunctionField
+  @brief Get the name of a `CeedQFunctionField`
 
-  @param[in]  qf_field   @ref CeedQFunctionField
+  @param[in]  qf_field   `CeedQFunctionField`
   @param[out] field_name Variable to store the field name
 
   @return An error code: 0 - success, otherwise - failure
@@ -816,9 +816,9 @@ int CeedQFunctionFieldGetName(CeedQFunctionField qf_field, char **field_name) {
 }
 
 /**
-  @brief Get the number of components of a @ref CeedQFunctionField
+  @brief Get the number of components of a `CeedQFunctionField`
 
-  @param[in]  qf_field @ref CeedQFunctionField
+  @param[in]  qf_field `CeedQFunctionField`
   @param[out] size     Variable to store the size of the field
 
   @return An error code: 0 - success, otherwise - failure
@@ -831,9 +831,9 @@ int CeedQFunctionFieldGetSize(CeedQFunctionField qf_field, CeedInt *size) {
 }
 
 /**
-  @brief Get the @ref CeedEvalMode of a @ref CeedQFunctionField
+  @brief Get the @ref CeedEvalMode of a `CeedQFunctionField`
 
-  @param[in]  qf_field  @ref CeedQFunctionField
+  @param[in]  qf_field  `CeedQFunctionField`
   @param[out] eval_mode Variable to store the field evaluation mode
 
   @return An error code: 0 - success, otherwise - failure
@@ -846,9 +846,9 @@ int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedEvalMode *eva
 }
 
 /**
-  @brief Set global context for a @ref CeedQFunction
+  @brief Set global context for a `CeedQFunction`
 
-  @param[in,out] qf  @ref CeedQFunction
+  @param[in,out] qf  `CeedQFunction`
   @param[in]     ctx Context data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -863,18 +863,18 @@ int CeedQFunctionSetContext(CeedQFunction qf, CeedQFunctionContext ctx) {
 }
 
 /**
-  @brief Set writability of @ref CeedQFunctionContext when calling the @ref CeedQFunctionUser.
+  @brief Set writability of `CeedQFunctionContext` when calling the `CeedQFunctionUser`.
 
   The default value is `is_writable == true`.
 
-  Setting `is_writable == true` indicates the @ref CeedQFunctionUser writes into the @ref CeedQFunctionContext and requires memory syncronization after calling @ref CeedQFunctionApply().
+  Setting `is_writable == true` indicates the `CeedQFunctionUser` writes into the `CeedQFunctionContext` and requires memory synchronization after calling @ref CeedQFunctionApply().
 
-  Setting 'is_writable == false' asserts that @ref CeedQFunctionUser does not modify the @ref CeedQFunctionContext.
+  Setting 'is_writable == false' asserts that `CeedQFunctionUser` does not modify the `CeedQFunctionContext`.
   Violating this assertion may lead to inconsistent data.
 
   Setting `is_writable == false` may offer a performance improvement on GPU backends.
 
-  @param[in,out] qf          @ref CeedQFunction
+  @param[in,out] qf          `CeedQFunction`
   @param[in]     is_writable Boolean flag for writability status
 
   @return An error code: 0 - success, otherwise - failure
@@ -887,9 +887,9 @@ int CeedQFunctionSetContextWritable(CeedQFunction qf, bool is_writable) {
 }
 
 /**
-  @brief Set estimated number of FLOPs per quadrature required to apply @ref CeedQFunction
+  @brief Set estimated number of FLOPs per quadrature required to apply `CeedQFunction`
 
-  @param[in]  qf    @ref CeedQFunction to estimate FLOPs for
+  @param[in]  qf    `CeedQFunction` to estimate FLOPs for
   @param[out] flops FLOPs per quadrature point estimate
 
   @ref Backend
@@ -901,9 +901,9 @@ int CeedQFunctionSetUserFlopsEstimate(CeedQFunction qf, CeedSize flops) {
 }
 
 /**
-  @brief View a @ref CeedQFunction
+  @brief View a `CeedQFunction`
 
-  @param[in] qf     @ref CeedQFunction to view
+  @param[in] qf     `CeedQFunction` to view
   @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
@@ -929,10 +929,10 @@ int CeedQFunctionView(CeedQFunction qf, FILE *stream) {
 }
 
 /**
-  @brief Get the @ref Ceed associated with a @ref CeedQFunction
+  @brief Get the `Ceed` associated with a `CeedQFunction`
 
-  @param[in]  qf   @ref CeedQFunction
-  @param[out] ceed Variable to store @ref Ceed
+  @param[in]  qf   `CeedQFunction`
+  @param[out] ceed Variable to store`Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -944,14 +944,14 @@ int CeedQFunctionGetCeed(CeedQFunction qf, Ceed *ceed) {
 }
 
 /**
-  @brief Apply the action of a @ref CeedQFunction
+  @brief Apply the action of a `CeedQFunction`
 
-  Note: Calling this function asserts that setup is complete and sets the @ref CeedQFunction as immutable.
+  Note: Calling this function asserts that setup is complete and sets the `CeedQFunction` as immutable.
 
-  @param[in]  qf @ref CeedQFunction
+  @param[in]  qf `CeedQFunction`
   @param[in]  Q  Number of quadrature points
-  @param[in]  u  Array of input @ref CeedVector
-  @param[out] v  Array of output @ref CeedVector
+  @param[in]  u  Array of input `CeedVector`
+  @param[out] v  Array of output `CeedVector`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -967,9 +967,9 @@ int CeedQFunctionApply(CeedQFunction qf, CeedInt Q, CeedVector *u, CeedVector *v
 }
 
 /**
-  @brief Destroy a @ref CeedQFunction
+  @brief Destroy a `CeedQFunction`
 
-  @param[in,out] qf @ref CeedQFunction to destroy
+  @param[in,out] qf `CeedQFunction` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -24,7 +24,7 @@ static struct CeedQFunction_private ceed_qfunction_none;
 /// @addtogroup CeedQFunctionUser
 /// @{
 
-// Indicate that no QFunction is provided by the user
+// Indicate that no @ref CeedQFunction is provided by the user
 const CeedQFunction CEED_QFUNCTION_NONE = &ceed_qfunction_none;
 
 /// @}
@@ -47,14 +47,15 @@ static size_t num_qfunctions;
 /// @{
 
 /**
-  @brief Register a gallery QFunction
+  @brief Register a gallery @ref CeedQFunction
 
-  @param[in]  name       Name for this backend to respond to
-  @param[in]  source     Absolute path to source of QFunction, "\path\CEED_DIR\gallery\folder\file.h:function_name"
-  @param[in]  vec_length Vector length. Caller must ensure that number of quadrature points is a multiple of vec_length.
-  @param[in]  f          Function pointer to evaluate action at quadrature points.
-                           See \ref CeedQFunctionUser.
-  @param[in]  init       Initialization function called by CeedQFunctionInit() when the QFunction is selected.
+  @param[in] name       Name for this backend to respond to
+  @param[in] source     Absolute path to source of @ref CeedQFunction, "\path\CEED_DIR\gallery\folder\file.h:function_name"
+  @param[in] vec_length Vector length.
+                          Caller must ensure that number of quadrature points is a multiple of `vec_length`.
+  @param[in] f          Function pointer to evaluate action at quadrature points.
+                          See @ref CeedQFunctionUser.
+  @param[in] init       Initialization function called by @ref CeedQFunctionCreateInteriorByName() when the @ref CeedQFunction is selected.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -82,26 +83,23 @@ int CeedQFunctionRegister(const char *name, const char *source, CeedInt vec_leng
     }
   }
   // LCOV_EXCL_START
-  CeedCheck(ierr == 0, NULL, CEED_ERROR_MAJOR, "Too many gallery QFunctions");
+  CeedCheck(ierr == 0, NULL, CEED_ERROR_MAJOR, "Too many gallery CeedQFunctions");
   // LCOV_EXCL_STOP
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Set a CeedQFunction field, used by CeedQFunctionAddInput/Output
+  @brief Set a @ref CeedQFunction field, used by @ref CeedQFunctionAddInput() and @ref CeedQFunctionAddOutput()
 
-  @param[out] f           CeedQFunctionField
-  @param[in]  field_name  Name of QFunction field
-  @param[in]  size        Size of QFunction field, (num_comp * 1) for @ref CEED_EVAL_NONE and @ref CEED_EVAL_WEIGHT,
-(num_comp * 1) for @ref CEED_EVAL_INTERP for an H^1 space or (num_comp * dim) for an H(div) or H(curl) space,
-(num_comp * dim) for @ref CEED_EVAL_GRAD, or (num_comp * 1) for @ref CEED_EVAL_DIV, and
-(num_comp * curl_dim) with curl_dim = 1 if dim < 3 else dim for @ref CEED_EVAL_CURL.
-  @param[in]  eval_mode   \ref CEED_EVAL_NONE to use values directly,
-                            \ref CEED_EVAL_WEIGHT to use quadrature weights,
-                            \ref CEED_EVAL_INTERP to use interpolated values,
-                            \ref CEED_EVAL_GRAD to use gradients,
-                            \ref CEED_EVAL_DIV to use divergence,
-                            \ref CEED_EVAL_CURL to use curl.
+  @param[out] f           @ref CeedQFunctionField
+  @param[in]  field_name  Name of @ref CeedQFunction field
+  @param[in]  size        Size of @ref CeedQFunction field, (`num_comp * 1`) for @ref CEED_EVAL_NONE and @ref CEED_EVAL_WEIGHT, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (num_comp * 1) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` and `curl_dim = dim` for @ref CEED_EVAL_CURL.
+  @param[in]  eval_mode   @ref CEED_EVAL_NONE to use values directly,
+                            @ref CEED_EVAL_WEIGHT to use quadrature weights,
+                            @ref CEED_EVAL_INTERP to use interpolated values,
+                            @ref CEED_EVAL_GRAD to use gradients,
+                            @ref CEED_EVAL_DIV to use divergence,
+                            @ref CEED_EVAL_CURL to use curl
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -116,12 +114,12 @@ static int CeedQFunctionFieldSet(CeedQFunctionField *f, const char *field_name, 
 }
 
 /**
-  @brief View a field of a CeedQFunction
+  @brief View a field of a @ref CeedQFunction
 
-  @param[in] field        QFunction field to view
+  @param[in] field        @ref CeedQFunction field to view
   @param[in] field_number Number of field being viewed
   @param[in] in           true for input field, false for output
-  @param[in] stream       Stream to view to, e.g., stdout
+  @param[in] stream       Stream to view to, e.g., `stdout`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -171,9 +169,9 @@ int CeedQFunctionSetFortranStatus(CeedQFunction qf, bool status) {
 /// @{
 
 /**
-  @brief Get the vector length of a CeedQFunction
+  @brief Get the vector length of a @ref CeedQFunction
 
-  @param[in]  qf         CeedQFunction
+  @param[in]  qf         @ref CeedQFunction
   @param[out] vec_length Variable to store vector length
 
   @return An error code: 0 - success, otherwise - failure
@@ -186,9 +184,9 @@ int CeedQFunctionGetVectorLength(CeedQFunction qf, CeedInt *vec_length) {
 }
 
 /**
-  @brief Get the number of inputs and outputs to a CeedQFunction
+  @brief Get the number of inputs and outputs to a @ref CeedQFunction
 
-  @param[in]  qf         CeedQFunction
+  @param[in]  qf         @ref CeedQFunction
   @param[out] num_input  Variable to store number of input fields
   @param[out] num_output Variable to store number of output fields
 
@@ -203,9 +201,9 @@ int CeedQFunctionGetNumArgs(CeedQFunction qf, CeedInt *num_input, CeedInt *num_o
 }
 
 /**
-  @brief Get the name of the user function for a CeedQFunction
+  @brief Get the name of the user function for a @ref CeedQFunction
 
-  @param[in]  qf          CeedQFunction
+  @param[in]  qf          @ref CeedQFunction
   @param[out] kernel_name Variable to store source path string
 
   @return An error code: 0 - success, otherwise - failure
@@ -235,9 +233,9 @@ int CeedQFunctionGetKernelName(CeedQFunction qf, char **kernel_name) {
 }
 
 /**
-  @brief Get the source path string for a CeedQFunction
+  @brief Get the source path string for a @ref CeedQFunction
 
-  @param[in]  qf          CeedQFunction
+  @param[in]  qf          @ref CeedQFunction
   @param[out] source_path Variable to store source path string
 
   @return An error code: 0 - success, otherwise - failure
@@ -274,13 +272,13 @@ int CeedQFunctionGetSourcePath(CeedQFunction qf, char **source_path) {
 }
 
 /**
-  @brief Initialize and load QFunction source file into string buffer, including full text of local files in place of `#include "local.h"`.
+  @brief Initialize and load @ref CeedQFunction source file into string buffer, including full text of local files in place of `#include "local.h"`.
 
-  The `buffer` is set to `NULL` if there is no QFunction source file.
+  The `buffer` is set to `NULL` if there is no @ref CeedQFunction source file.
 
-  Note: Caller is responsible for freeing the string buffer with `CeedFree()`.
+  Note: Caller is responsible for freeing the string buffer with @ref CeedFree().
 
-  @param[in]  qf            CeedQFunction
+  @param[in]  qf            @ref CeedQFunction
   @param[out] source_buffer String buffer for source file contents
 
   @return An error code: 0 - success, otherwise - failure
@@ -299,9 +297,9 @@ int CeedQFunctionLoadSourceToBuffer(CeedQFunction qf, char **source_buffer) {
 }
 
 /**
-  @brief Get the User Function for a CeedQFunction
+  @brief Get the User Function for a @ref CeedQFunction
 
-  @param[in]  qf CeedQFunction
+  @param[in]  qf @ref CeedQFunction
   @param[out] f  Variable to store user function
 
   @return An error code: 0 - success, otherwise - failure
@@ -314,9 +312,9 @@ int CeedQFunctionGetUserFunction(CeedQFunction qf, CeedQFunctionUser *f) {
 }
 
 /**
-  @brief Get global context for a CeedQFunction.
+  @brief Get global context for a @ref CeedQFunction.
 
-  Note: For QFunctions from the Fortran interface, this function will return the Fortran context CeedQFunctionContext.
+  Note: For @ref CeedQFunction from the Fortran interface, this function will return the Fortran context @ref CeedQFunctionContext.
 
   @param[in]  qf  CeedQFunction
   @param[out] ctx Variable to store CeedQFunctionContext
@@ -331,9 +329,9 @@ int CeedQFunctionGetContext(CeedQFunction qf, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Get context data of a CeedQFunction
+  @brief Get context data of a @ref CeedQFunction
 
-  @param[in]  qf       CeedQFunction
+  @param[in]  qf       @ref CeedQFunction
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
@@ -361,9 +359,9 @@ int CeedQFunctionGetContextData(CeedQFunction qf, CeedMemType mem_type, void *da
 }
 
 /**
-  @brief Restore context data of a CeedQFunction
+  @brief Restore context data of a @ref CeedQFunction
 
-  @param[in]     qf   CeedQFunction
+  @param[in]     qf   @ref CeedQFunction
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -388,13 +386,12 @@ int CeedQFunctionRestoreContextData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Get true user context for a CeedQFunction
+  @brief Get true user context for a @ref CeedQFunction
 
-  Note: For all QFunctions this function will return the user CeedQFunctionContext and not interface context CeedQFunctionContext, if any
-such object exists.
+  Note: For all @ref CeedQFunction this function will return the user @ref CeedQFunctionContext and not interface context @ref CeedQFunctionContext, if any such object exists.
 
-  @param[in]  qf  CeedQFunction
-  @param[out] ctx Variable to store CeedQFunctionContext
+  @param[in]  qf  @ref CeedQFunction
+  @param[out] ctx Variable to store @ref CeedQFunctionContext
 
   @return An error code: 0 - success, otherwise - failure
   @ref Backend
@@ -413,9 +410,9 @@ int CeedQFunctionGetInnerContext(CeedQFunction qf, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Get inner context data of a CeedQFunction
+  @brief Get inner context data of a @ref CeedQFunction
 
-  @param[in]  qf       CeedQFunction
+  @param[in]  qf       @ref CeedQFunction
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
@@ -443,9 +440,9 @@ int CeedQFunctionGetInnerContextData(CeedQFunction qf, CeedMemType mem_type, voi
 }
 
 /**
-  @brief Restore inner context data of a CeedQFunction
+  @brief Restore inner context data of a @ref CeedQFunction
 
-  @param[in]     qf   CeedQFunction
+  @param[in]     qf   @ref CeedQFunction
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -470,9 +467,9 @@ int CeedQFunctionRestoreInnerContextData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Determine if QFunction is identity
+  @brief Determine if @ref CeedQFunction is identity
 
-  @param[in]  qf          CeedQFunction
+  @param[in]  qf          @ref CeedQFunction
   @param[out] is_identity Variable to store identity status
 
   @return An error code: 0 - success, otherwise - failure
@@ -485,9 +482,9 @@ int CeedQFunctionIsIdentity(CeedQFunction qf, bool *is_identity) {
 }
 
 /**
-  @brief Determine if QFunctionContext is writable
+  @brief Determine if @ref CeedQFunctionContext is writable
 
-  @param[in]  qf          CeedQFunction
+  @param[in]  qf          @ref CeedQFunction
   @param[out] is_writable Variable to store context writeable status
 
   @return An error code: 0 - success, otherwise - failure
@@ -500,9 +497,9 @@ int CeedQFunctionIsContextWritable(CeedQFunction qf, bool *is_writable) {
 }
 
 /**
-  @brief Get backend data of a CeedQFunction
+  @brief Get backend data of a @ref CeedQFunction
 
-  @param[in]  qf   CeedQFunction
+  @param[in]  qf   @ref CeedQFunction
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -515,9 +512,9 @@ int CeedQFunctionGetData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Set backend data of a CeedQFunction
+  @brief Set backend data of a @ref CeedQFunction
 
-  @param[in,out] qf   CeedQFunction
+  @param[in,out] qf   @ref CeedQFunction
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -530,9 +527,9 @@ int CeedQFunctionSetData(CeedQFunction qf, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a CeedQFunction
+  @brief Increment the reference counter for a @ref CeedQFunction
 
-  @param[in,out] qf CeedQFunction to increment the reference counter
+  @param[in,out] qf @ref CeedQFunction to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -544,9 +541,9 @@ int CeedQFunctionReference(CeedQFunction qf) {
 }
 
 /**
-  @brief Estimate number of FLOPs per quadrature required to apply QFunction
+  @brief Estimate number of FLOPs per quadrature required to apply @ref CeedQFunction
 
-  @param[in]  qf    QFunction to estimate FLOPs for
+  @param[in]  qf    @ref CeedQFunction to estimate FLOPs for
   @param[out] flops Address of variable to hold FLOPs estimate
 
   @ref Backend
@@ -566,22 +563,22 @@ int CeedQFunctionGetFlopsEstimate(CeedQFunction qf, CeedSize *flops) {
 /// @{
 
 /**
-  @brief Create a CeedQFunction for evaluating interior (volumetric) terms.
+  @brief Create a @ref CeedQFunction for evaluating interior (volumetric) terms
 
-  @param[in]  ceed       Ceed object where the CeedQFunction will be created
-  @param[in]  vec_length Vector length. Caller must ensure that number of quadrature points is a multiple of vec_length.
+  @param[in]  ceed       @ref Ceed object used to create the @ref CeedQFunction
+  @param[in]  vec_length Vector length.
+                           Caller must ensure that number of quadrature points is a multiple of `vec_length`.
   @param[in]  f          Function pointer to evaluate action at quadrature points.
-                           See \ref CeedQFunctionUser.
-  @param[in]  source     Absolute path to source of QFunction, "\abs_path\file.h:function_name".
-                           The entire source file must only contain constructs supported by all targeted backends (i.e. CUDA for `/gpu/cuda`,
-                           OpenCL/SYCL for `/gpu/sycl`, etc.).
+                           See @ref CeedQFunctionUser.
+  @param[in]  source     Absolute path to source of @ref CeedQFunctionUser, "\abs_path\file.h:function_name".
+                           The entire source file must only contain constructs supported by all targeted backends (i.e. CUDA for `/gpu/cuda`, OpenCL/SYCL for `/gpu/sycl`, etc.).
                            The entire contents of this file and all locally included files are used during JiT compilation for GPU backends.
                            All source files must be at the provided filepath at runtime for JiT to function.
-  @param[out] qf         Address of the variable where the newly created CeedQFunction will be stored
+  @param[out] qf         Address of the variable where the newly created @ref CeedQFunction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
-  See \ref CeedQFunctionUser for details on the call-back function @a f's arguments.
+  See \ref CeedQFunctionUser for details on the call-back function `f` arguments.
 
   @ref User
 **/
@@ -592,7 +589,7 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length, CeedQFunctionUser
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "QFunction"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support QFunctionCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionCreateInterior");
     CeedCall(CeedQFunctionCreateInterior(delegate, vec_length, f, source, qf));
     return CEED_ERROR_SUCCESS;
   }
@@ -622,11 +619,11 @@ int CeedQFunctionCreateInterior(Ceed ceed, CeedInt vec_length, CeedQFunctionUser
 }
 
 /**
-  @brief Create a CeedQFunction for evaluating interior (volumetric) terms by name.
+  @brief Create a @ref CeedQFunction for evaluating interior (volumetric) terms by name
 
-  @param[in]  ceed Ceed object where the CeedQFunction will be created
-  @param[in]  name Name of QFunction to use from gallery
-  @param[out] qf   Address of the variable where the newly created CeedQFunction will be stored
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedQFunction
+  @param[in]  name Name of @ref CeedQFunction to use from gallery
+  @param[out] qf   Address of the variable where the newly created @ref CeedQFunction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -637,7 +634,7 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed, const char *name, CeedQFunction
 
   CeedCall(CeedQFunctionRegisterAll());
   // Find matching backend
-  CeedCheck(name, ceed, CEED_ERROR_INCOMPLETE, "No QFunction name provided");
+  CeedCheck(name, ceed, CEED_ERROR_INCOMPLETE, "No CeedQFunction name provided");
   for (size_t i = 0; i < num_qfunctions; i++) {
     size_t      n;
     const char *curr_name = gallery_qfunctions[i].name;
@@ -648,7 +645,7 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed, const char *name, CeedQFunction
       match_index = i;
     }
   }
-  CeedCheck(match_len > 0, ceed, CEED_ERROR_UNSUPPORTED, "No suitable gallery QFunction");
+  CeedCheck(match_len > 0, ceed, CEED_ERROR_UNSUPPORTED, "No suitable gallery CeedQFunction");
 
   // Create QFunction
   CeedCall(CeedQFunctionCreateInterior(ceed, gallery_qfunctions[match_index].vec_length, gallery_qfunctions[match_index].f,
@@ -664,19 +661,17 @@ int CeedQFunctionCreateInteriorByName(Ceed ceed, const char *name, CeedQFunction
 }
 
 /**
-  @brief Create an identity CeedQFunction.
+  @brief Create an identity @ref CeedQFunction.
 
   Inputs are written into outputs in the order given.
-  This is useful for CeedOperators that can be represented with only the action of a CeedElemRestriction and CeedBasis, such as restriction
-and prolongation operators for p-multigrid.
-  Backends may optimize CeedOperators with this CeedQFunction to avoid the copy of input data to output fields by using the same memory location for
-both.
+  This is useful for @ref CeedOperator that can be represented with only the action of a @ref CeedElemRestriction and @ref CeedBasis, such as restriction and prolongation operators for p-multigrid.
+  Backends may optimize @ref CeedOperator with this @ref CeedQFunction to avoid the copy of input data to output fields by using the same memory location for both.
 
-  @param[in]  ceed     Ceed object where the CeedQFunction will be created
-  @param[in]  size     Size of the QFunction fields
-  @param[in]  in_mode  CeedEvalMode for input to CeedQFunction
-  @param[in]  out_mode CeedEvalMode for output to CeedQFunction
-  @param[out] qf       Address of the variable where the newly created CeedQFunction will be stored
+  @param[in]  ceed     @ref Ceed object used to create the @ref CeedQFunction
+  @param[in]  size     Size of the @ref CeedQFunction fields
+  @param[in]  in_mode  @ref CeedEvalMode for input to @ref CeedQFunction
+  @param[in]  out_mode @ref CeedEvalMode for output to @ref CeedQFunction
+  @param[out] qf       Address of the variable where the newly created @ref CeedQFunction will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -699,14 +694,14 @@ int CeedQFunctionCreateIdentity(Ceed ceed, CeedInt size, CeedEvalMode in_mode, C
 }
 
 /**
-  @brief Copy the pointer to a CeedQFunction.
+  @brief Copy the pointer to a @ref CeedQFunction.
 
-  Both pointers should be destroyed with `CeedQFunctionDestroy()`.
+  Both pointers should be destroyed with @ref CeedQFunctionDestroy().
 
-  Note: If the value of `qf_copy` passed to this function is non-NULL, then it is assumed that `*qf_copy` is a pointer to a CeedQFunction.
-        This CeedQFunction will be destroyed if `*qf_copy` is the only reference to this CeedQFunction.
+  Note: If the value of `*qf_copy` passed to this function is non-NULL, then it is assumed that `*qf_copy` is a pointer to a @ref CeedQFunction.
+        This @ref CeedQFunction will be destroyed if `*qf_copy` is the only reference to this @ref CeedQFunction.
 
-  @param[in]  qf      CeedQFunction to copy reference to
+  @param[in]  qf      @ref CeedQFunction to copy reference to
   @param[out] qf_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -721,19 +716,16 @@ int CeedQFunctionReferenceCopy(CeedQFunction qf, CeedQFunction *qf_copy) {
 }
 
 /**
-  @brief Add a CeedQFunction input
+  @brief Add a @ref CeedQFunction input
 
-  @param[in,out] qf         CeedQFunction
-  @param[in]     field_name Name of QFunction field
-  @param[in]     size       Size of QFunction field, (num_comp * 1) for @ref CEED_EVAL_NONE,
-(num_comp * 1) for @ref CEED_EVAL_INTERP for an H^1 space or (num_comp * dim) for an H(div) or H(curl) space,
-(num_comp * dim) for @ref CEED_EVAL_GRAD, or (num_comp * 1) for @ref CEED_EVAL_DIV, and
-(num_comp * curl_dim) with curl_dim = 1 if dim < 3 else dim for @ref CEED_EVAL_CURL.
-  @param[in]     eval_mode  \ref CEED_EVAL_NONE to use values directly,
-                              \ref CEED_EVAL_INTERP to use interpolated values,
-                              \ref CEED_EVAL_GRAD to use gradients,
-                              \ref CEED_EVAL_DIV to use divergence,
-                              \ref CEED_EVAL_CURL to use curl.
+  @param[in,out] qf         @ref CeedQFunction
+  @param[in]     field_name Name of @ref CeedQFunction field
+  @param[in]     size       Size of @ref CeedQFunction field, (`num_comp * 1`) for @ref CEED_EVAL_NONE, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (`num_comp * 1`) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` otherwise `curl_dim = dim` for @ref CEED_EVAL_CURL.
+  @param[in]     eval_mode  @ref CEED_EVAL_NONE to use values directly,
+                              @ref CEED_EVAL_INTERP to use interpolated values,
+                              @ref CEED_EVAL_GRAD to use gradients,
+                              @ref CEED_EVAL_DIV to use divergence,
+                              @ref CEED_EVAL_CURL to use curl
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -754,32 +746,29 @@ int CeedQFunctionAddInput(CeedQFunction qf, const char *field_name, CeedInt size
 }
 
 /**
-  @brief Add a CeedQFunction output
+  @brief Add a @ref CeedQFunction output
 
-  @param[in,out] qf         CeedQFunction
-  @param[in]     field_name Name of QFunction field
-  @param[in]     size       Size of QFunction field, (num_comp * 1) for @ref CEED_EVAL_NONE,
-(num_comp * 1) for @ref CEED_EVAL_INTERP for an H^1 space or (num_comp * dim) for an H(div) or H(curl) space,
-(num_comp * dim) for @ref CEED_EVAL_GRAD, or (num_comp * 1) for @ref CEED_EVAL_DIV, and
-(num_comp * curl_dim) with curl_dim = 1 if dim < 3 else dim for @ref CEED_EVAL_CURL.
-  @param[in]     eval_mode  \ref CEED_EVAL_NONE to use values directly,
-                              \ref CEED_EVAL_INTERP to use interpolated values,
-                              \ref CEED_EVAL_GRAD to use gradients,
-                              \ref CEED_EVAL_DIV to use divergence,
-                              \ref CEED_EVAL_CURL to use curl.
+  @param[in,out] qf         @ref CeedQFunction
+  @param[in]     field_name Name of @ref CeedQFunction field
+  @param[in]     size       Size of @ref CeedQFunction field, (`num_comp * 1`) for @ref CEED_EVAL_NONE, (`num_comp * 1`) for @ref CEED_EVAL_INTERP for an \f$H^1\f$ space or (`num_comp * dim`) for an \f$H(\mathrm{div})\f$ or \f$H(\mathrm{curl})\f$ space, (`num_comp * dim`) for @ref CEED_EVAL_GRAD, or (`num_comp * 1`) for @ref CEED_EVAL_DIV, and (`num_comp * curl_dim`) with `curl_dim = 1` if `dim < 3` else dim for @ref CEED_EVAL_CURL.
+  @param[in]     eval_mode  @ref CEED_EVAL_NONE to use values directly,
+                              @ref CEED_EVAL_INTERP to use interpolated values,
+                              @ref CEED_EVAL_GRAD to use gradients,
+                              @ref CEED_EVAL_DIV to use divergence,
+                              @ref CEED_EVAL_CURL to use curl.
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name, CeedInt size, CeedEvalMode eval_mode) {
-  CeedCheck(!qf->is_immutable, qf->ceed, CEED_ERROR_MAJOR, "QFunction cannot be changed after set as immutable");
-  CeedCheck(eval_mode != CEED_EVAL_WEIGHT, qf->ceed, CEED_ERROR_DIMENSION, "Cannot create QFunction output with CEED_EVAL_WEIGHT");
+  CeedCheck(!qf->is_immutable, qf->ceed, CEED_ERROR_MAJOR, "CeedQFunction cannot be changed after set as immutable");
+  CeedCheck(eval_mode != CEED_EVAL_WEIGHT, qf->ceed, CEED_ERROR_DIMENSION, "Cannot create CeedQFunction output with CEED_EVAL_WEIGHT");
   for (CeedInt i = 0; i < qf->num_input_fields; i++) {
-    CeedCheck(strcmp(field_name, qf->input_fields[i]->field_name), qf->ceed, CEED_ERROR_MINOR, "QFunction field names must be unique");
+    CeedCheck(strcmp(field_name, qf->input_fields[i]->field_name), qf->ceed, CEED_ERROR_MINOR, "CeedQFunction field names must be unique");
   }
   for (CeedInt i = 0; i < qf->num_output_fields; i++) {
-    CeedCheck(strcmp(field_name, qf->output_fields[i]->field_name), qf->ceed, CEED_ERROR_MINOR, "QFunction field names must be unique");
+    CeedCheck(strcmp(field_name, qf->output_fields[i]->field_name), qf->ceed, CEED_ERROR_MINOR, "CeedQFunction field names must be unique");
   }
   CeedCall(CeedQFunctionFieldSet(&qf->output_fields[qf->num_output_fields], field_name, size, eval_mode));
   qf->num_output_fields++;
@@ -787,11 +776,11 @@ int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name, CeedInt siz
 }
 
 /**
-  @brief Get the CeedQFunctionFields of a CeedQFunction
+  @brief Get the @ref CeedQFunctionField of a @ref CeedQFunction
 
-  Note: Calling this function asserts that setup is complete and sets the CeedQFunction as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedQFunction as immutable.
 
-  @param[in]  qf                CeedQFunction
+  @param[in]  qf                @ref CeedQFunction
   @param[out] num_input_fields  Variable to store number of input fields
   @param[out] input_fields      Variable to store input fields
   @param[out] num_output_fields Variable to store number of output fields
@@ -812,9 +801,9 @@ int CeedQFunctionGetFields(CeedQFunction qf, CeedInt *num_input_fields, CeedQFun
 }
 
 /**
-  @brief Get the name of a CeedQFunctionField
+  @brief Get the name of a @ref CeedQFunctionField
 
-  @param[in]  qf_field   CeedQFunctionField
+  @param[in]  qf_field   @ref CeedQFunctionField
   @param[out] field_name Variable to store the field name
 
   @return An error code: 0 - success, otherwise - failure
@@ -827,9 +816,9 @@ int CeedQFunctionFieldGetName(CeedQFunctionField qf_field, char **field_name) {
 }
 
 /**
-  @brief Get the number of components of a CeedQFunctionField
+  @brief Get the number of components of a @ref CeedQFunctionField
 
-  @param[in]  qf_field CeedQFunctionField
+  @param[in]  qf_field @ref CeedQFunctionField
   @param[out] size     Variable to store the size of the field
 
   @return An error code: 0 - success, otherwise - failure
@@ -842,9 +831,9 @@ int CeedQFunctionFieldGetSize(CeedQFunctionField qf_field, CeedInt *size) {
 }
 
 /**
-  @brief Get the CeedEvalMode of a CeedQFunctionField
+  @brief Get the @ref CeedEvalMode of a @ref CeedQFunctionField
 
-  @param[in]  qf_field  CeedQFunctionField
+  @param[in]  qf_field  @ref CeedQFunctionField
   @param[out] eval_mode Variable to store the field evaluation mode
 
   @return An error code: 0 - success, otherwise - failure
@@ -857,9 +846,9 @@ int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedEvalMode *eva
 }
 
 /**
-  @brief Set global context for a CeedQFunction
+  @brief Set global context for a @ref CeedQFunction
 
-  @param[in,out] qf  CeedQFunction
+  @param[in,out] qf  @ref CeedQFunction
   @param[in]     ctx Context data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -874,20 +863,19 @@ int CeedQFunctionSetContext(CeedQFunction qf, CeedQFunctionContext ctx) {
 }
 
 /**
-  @brief Set writability of CeedQFunctionContext when calling the `CeedQFunctionUser`.
+  @brief Set writability of @ref CeedQFunctionContext when calling the @ref CeedQFunctionUser.
 
   The default value is `is_writable == true`.
 
-  Setting `is_writable == true` indicates the `CeedQFunctionUser` writes into the CeedQFunctionContextData and requires memory syncronization
-after calling `CeedQFunctionApply()`.
+  Setting `is_writable == true` indicates the @ref CeedQFunctionUser writes into the @ref CeedQFunctionContext and requires memory syncronization after calling @ref CeedQFunctionApply().
 
-  Setting 'is_writable == false' asserts that `CeedQFunctionUser` does not modify the CeedQFunctionContextData.
+  Setting 'is_writable == false' asserts that @ref CeedQFunctionUser does not modify the @ref CeedQFunctionContext.
   Violating this assertion may lead to inconsistent data.
 
   Setting `is_writable == false` may offer a performance improvement on GPU backends.
 
-  @param[in,out] qf          CeedQFunction
-  @param[in]     is_writable Writability status
+  @param[in,out] qf          @ref CeedQFunction
+  @param[in]     is_writable Boolean flag for writability status
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -899,9 +887,9 @@ int CeedQFunctionSetContextWritable(CeedQFunction qf, bool is_writable) {
 }
 
 /**
-  @brief Set estimated number of FLOPs per quadrature required to apply QFunction
+  @brief Set estimated number of FLOPs per quadrature required to apply @ref CeedQFunction
 
-  @param[in]  qf    QFunction to estimate FLOPs for
+  @param[in]  qf    @ref CeedQFunction to estimate FLOPs for
   @param[out] flops FLOPs per quadrature point estimate
 
   @ref Backend
@@ -913,10 +901,10 @@ int CeedQFunctionSetUserFlopsEstimate(CeedQFunction qf, CeedSize flops) {
 }
 
 /**
-  @brief View a CeedQFunction
+  @brief View a @ref CeedQFunction
 
-  @param[in] qf     CeedQFunction to view
-  @param[in] stream Stream to write; typically stdout/stderr or a file
+  @param[in] qf     @ref CeedQFunction to view
+  @param[in] stream Stream to write; typically `stdout` or a file
 
   @return Error code: 0 - success, otherwise - failure
 
@@ -941,10 +929,10 @@ int CeedQFunctionView(CeedQFunction qf, FILE *stream) {
 }
 
 /**
-  @brief Get the Ceed associated with a CeedQFunction
+  @brief Get the @ref Ceed associated with a @ref CeedQFunction
 
-  @param[in]  qf   CeedQFunction
-  @param[out] ceed Variable to store Ceed
+  @param[in]  qf   @ref CeedQFunction
+  @param[out] ceed Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -956,21 +944,21 @@ int CeedQFunctionGetCeed(CeedQFunction qf, Ceed *ceed) {
 }
 
 /**
-  @brief Apply the action of a CeedQFunction
+  @brief Apply the action of a @ref CeedQFunction
 
-  Note: Calling this function asserts that setup is complete and sets the CeedQFunction as immutable.
+  Note: Calling this function asserts that setup is complete and sets the @ref CeedQFunction as immutable.
 
-  @param[in]  qf CeedQFunction
+  @param[in]  qf @ref CeedQFunction
   @param[in]  Q  Number of quadrature points
-  @param[in]  u  Array of input CeedVectors
-  @param[out] v  Array of output CeedVectors
+  @param[in]  u  Array of input @ref CeedVector
+  @param[out] v  Array of output @ref CeedVector
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedQFunctionApply(CeedQFunction qf, CeedInt Q, CeedVector *u, CeedVector *v) {
-  CeedCheck(qf->Apply, qf->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support QFunctionApply");
+  CeedCheck(qf->Apply, qf->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionApply");
   CeedCheck(Q % qf->vec_length == 0, qf->ceed, CEED_ERROR_DIMENSION,
             "Number of quadrature points %" CeedInt_FMT " must be a multiple of %" CeedInt_FMT, Q, qf->vec_length);
   qf->is_immutable = true;
@@ -979,9 +967,9 @@ int CeedQFunctionApply(CeedQFunction qf, CeedInt Q, CeedVector *u, CeedVector *v
 }
 
 /**
-  @brief Destroy a CeedQFunction
+  @brief Destroy a @ref CeedQFunction
 
-  @param[in,out] qf CeedQFunction to destroy
+  @param[in,out] qf @ref CeedQFunction to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -23,9 +23,9 @@
 /// @{
 
 /**
-  @brief Get index for @ref CeedQFunctionContext field
+  @brief Get index for `CeedQFunctionContext` field
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_name  Name of field
   @param[out] field_index Index of field, or `-1` if field is not registered
 
@@ -42,9 +42,9 @@ int CeedQFunctionContextGetFieldIndex(CeedQFunctionContext ctx, const char *fiel
 }
 
 /**
-  @brief Common function for registering @ref CeedQFunctionContext fields
+  @brief Common function for registering `CeedQFunctionContext` fields
 
-  @param[in,out] ctx               @ref CeedQFunctionContext
+  @param[in,out] ctx               `CeedQFunctionContext`
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
   @param[in]     field_description Description of field, or `NULL` for none
@@ -99,9 +99,9 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx, const char *fi
 }
 
 /**
-  @brief Destroy user data held by @ref CeedQFunctionContext, using function set by @ref CeedQFunctionContextSetDataDestroy(), if applicable
+  @brief Destroy user data held by `CeedQFunctionContext`, using function set by @ref CeedQFunctionContextSetDataDestroy(), if applicable
 
-  @param[in,out] ctx @ref CeedQFunctionContext to destroy user data
+  @param[in,out] ctx `CeedQFunctionContext` to destroy user data
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -135,10 +135,10 @@ static int CeedQFunctionContextDestroyData(CeedQFunctionContext ctx) {
 /// @{
 
 /**
-  @brief Get the @ref Ceed associated with a @ref CeedQFunctionContext
+  @brief Get the `Ceed` associated with a `CeedQFunctionContext`
 
-  @param[in]  ctx  @ref CeedQFunctionContext
-  @param[out] ceed Variable to store @ref Ceed
+  @param[in]  ctx  `CeedQFunctionContext`
+  @param[out] ceed Variable to store `Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -150,9 +150,9 @@ int CeedQFunctionContextGetCeed(CeedQFunctionContext ctx, Ceed *ceed) {
 }
 
 /**
-  @brief Check for valid data in a @ref CeedQFunctionContext
+  @brief Check for valid data in a `CeedQFunctionContext`
 
-  @param[in]  ctx            @ref CeedQFunctionContext to check validity
+  @param[in]  ctx            `CeedQFunctionContext` to check validity
   @param[out] has_valid_data Variable to store validity
 
   @return An error code: 0 - success, otherwise - failure
@@ -166,9 +166,9 @@ int CeedQFunctionContextHasValidData(CeedQFunctionContext ctx, bool *has_valid_d
 }
 
 /**
-  @brief Check for borrowed data of a specific @ref CeedMemType in a @ref CeedQFunctionContext
+  @brief Check for borrowed data of a specific @ref CeedMemType in a `CeedQFunctionContext`
 
-  @param[in]  ctx                       @ref CeedQFunctionContext to check
+  @param[in]  ctx                       `CeedQFunctionContext` to check
   @param[in]  mem_type                  Memory type to check
   @param[out] has_borrowed_data_of_type Variable to store result
 
@@ -183,9 +183,9 @@ int CeedQFunctionContextHasBorrowedDataOfType(CeedQFunctionContext ctx, CeedMemT
 }
 
 /**
-  @brief Get the state of a @ref CeedQFunctionContext
+  @brief Get the state of a `CeedQFunctionContext`
 
-  @param[in]  ctx   @ref CeedQFunctionContext to retrieve state
+  @param[in]  ctx   `CeedQFunctionContext` to retrieve state
   @param[out] state Variable to store state
 
   @return An error code: 0 - success, otherwise - failure
@@ -198,9 +198,9 @@ int CeedQFunctionContextGetState(CeedQFunctionContext ctx, uint64_t *state) {
 }
 
 /**
-  @brief Get backend data of a @ref CeedQFunctionContext
+  @brief Get backend data of a `CeedQFunctionContext`
 
-  @param[in]  ctx  @ref CeedQFunctionContext
+  @param[in]  ctx  `CeedQFunctionContext`
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -213,9 +213,9 @@ int CeedQFunctionContextGetBackendData(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
-  @brief Set backend data of a @ref CeedQFunctionContext
+  @brief Set backend data of a `CeedQFunctionContext`
 
-  @param[in,out] ctx  @ref CeedQFunctionContext
+  @param[in,out] ctx  `CeedQFunctionContext`
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -228,9 +228,9 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
-  @brief Get label for a registered @ref CeedQFunctionContext field, or `NULL` if no field has been registered with this `field_name`
+  @brief Get label for a registered `CeedQFunctionContext` field, or `NULL` if no field has been registered with this `field_name`
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_name  Name of field to retrieve label
   @param[out] field_label Variable to field label
 
@@ -252,9 +252,9 @@ int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx, const char *fiel
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field
+  @brief Set `CeedQFunctionContext` field
 
-  @param[in,out] ctx         @ref CeedQFunctionContext
+  @param[in,out] ctx         `CeedQFunctionContext`
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[in]     values      Value to set
@@ -284,9 +284,9 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx, CeedContextFieldLab
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field data, read-only
+  @brief Get `CeedQFunctionContext` field data, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label of field to read
   @param[in]  field_type  Type of field to read
   @param[out] num_values  Number of values in the field label
@@ -322,9 +322,9 @@ int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFiel
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field data, read-only
+  @brief Restore `CeedQFunctionContext` field data, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label of field to restore
   @param[in]  field_type  Type of field to restore
   @param[out] values      Pointer to context values
@@ -345,9 +345,9 @@ int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContext
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field holding double precision values
+  @brief Set `CeedQFunctionContext` field holding double precision values
 
-  @param[in,out] ctx         @ref CeedQFunctionContext
+  @param[in,out] ctx         `CeedQFunctionContext`
   @param[in]     field_label Label for field to set
   @param[in]     values      Values to set
 
@@ -362,9 +362,9 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabe
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field holding double precision values, read-only
+  @brief Get `CeedQFunctionContext` field holding double precision values, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label for field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -380,9 +380,9 @@ int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextField
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field holding double precision values, read-only
+  @brief Restore `CeedQFunctionContext` field holding double precision values, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label for field to restore
   @param[out] values      Pointer to context values
 
@@ -414,9 +414,9 @@ int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field holding `int32` values, read-only
+  @brief Get `CeedQFunctionContext` field holding `int32` values, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label for field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -432,9 +432,9 @@ int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldL
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field holding `int32` values, read-only
+  @brief Restore `CeedQFunctionContext` field holding `int32` values, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label for field to restore
   @param[out] values      Pointer to context values
 
@@ -449,9 +449,9 @@ int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFi
 }
 
 /**
-  @brief Set @ref CeedQFunctionContext field holding boolean values
+  @brief Set `CeedQFunctionContext` field holding boolean values
 
-  @param[in,out] ctx         @ref CeedQFunctionContext
+  @param[in,out] ctx         `CeedQFunctionContext`
   @param[in]     field_label Label for field to set
   @param[in]     values      Values to set
 
@@ -466,9 +466,9 @@ int CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLab
 }
 
 /**
-  @brief Get @ref CeedQFunctionContext field holding boolean values, read-only
+  @brief Get `CeedQFunctionContext` field holding boolean values, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label for field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -484,9 +484,9 @@ int CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFiel
 }
 
 /**
-  @brief Restore @ref CeedQFunctionContext field holding boolean values, read-only
+  @brief Restore `CeedQFunctionContext` field holding boolean values, read-only
 
-  @param[in]  ctx         @ref CeedQFunctionContext
+  @param[in]  ctx         `CeedQFunctionContext`
   @param[in]  field_label Label for field to restore
   @param[out] values      Pointer to context values
 
@@ -501,9 +501,9 @@ int CeedQFunctionContextRestoreBooleanRead(CeedQFunctionContext ctx, CeedContext
 }
 
 /**
-  @brief Get additional destroy routine for @ref CeedQFunctionContext user data
+  @brief Get additional destroy routine for `CeedQFunctionContext` user data
 
-  @param[in] ctx         @ref CeedQFunctionContext to get user destroy function
+  @param[in] ctx         `CeedQFunctionContext` to get user destroy function
   @param[out] f_mem_type Memory type to use when passing data into `f`
   @param[out] f          Additional routine to use to destroy user data
 
@@ -518,9 +518,9 @@ int CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx, CeedMemType *f_
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedQFunctionContext
+  @brief Increment the reference counter for a `CeedQFunctionContext`
 
-  @param[in,out] ctx @ref CeedQFunctionContext to increment the reference counter
+  @param[in,out] ctx `CeedQFunctionContext` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -540,10 +540,10 @@ int CeedQFunctionContextReference(CeedQFunctionContext ctx) {
 /// @{
 
 /**
-  @brief Create a @ref CeedQFunctionContext for storing @ref CeedQFunction user context data
+  @brief Create a `CeedQFunctionContext` for storing `CeedQFunctionContext` user context data
 
-  @param[in]  ceed @ref Ceed object used to create the @ref CeedQFunctionContext
-  @param[out] ctx  Address of the variable where the newly created @ref CeedQFunctionContext will be stored
+  @param[in]  ceed `Ceed` object used to create the `CeedQFunctionContext`
+  @param[out] ctx  Address of the variable where the newly created `CeedQFunctionContext` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -567,12 +567,12 @@ int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedQFunctionContext.
+  @brief Copy the pointer to a `CeedQFunctionContext`.
 
   Both pointers should be destroyed with @ref CeedQFunctionContextDestroy().
 
-  Note: If the value of `*ctx_copy` passed to this function is non-`NULL`, then it is assumed that `*ctx_copy` is a pointer to a @ref CeedQFunctionContext.
-        This @ref CeedQFunctionContext will be destroyed if `*ctx_copy` is the only reference to this @ref CeedQFunctionContext.
+  Note: If the value of `*ctx_copy` passed to this function is non-`NULL`, then it is assumed that `*ctx_copy` is a pointer to a `CeedQFunctionContext`.
+        This `CeedQFunctionContext` will be destroyed if `*ctx_copy` is the only reference to this `CeedQFunctionContext`.
 
   @param[in]     ctx      CeedQFunctionContext to copy reference to
   @param[in,out] ctx_copy Variable to store copied reference
@@ -589,12 +589,12 @@ int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx, CeedQFunctionCon
 }
 
 /**
-  @brief Set the data used by a @ref CeedQFunctionContext, freeing any previously allocated data if applicable.
+  @brief Set the data used by a `CeedQFunctionContext`, freeing any previously allocated data if applicable.
 
   The backend may copy values to a different @ref CeedMemType, such as during @ref CeedQFunctionApply().
   See also @ref CeedQFunctionContextTakeData().
 
-  @param[in,out] ctx       @ref CeedQFunctionContext
+  @param[in,out] ctx       `CeedQFunctionContext`
   @param[in]     mem_type  Memory type of the data being passed
   @param[in]     copy_mode Copy mode for the data
   @param[in]     size      Size of data, in bytes
@@ -616,11 +616,11 @@ int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 }
 
 /**
-  @brief Take ownership of the data in a @ref CeedQFunctionContext via the specified memory type.
+  @brief Take ownership of the data in a `CeedQFunctionContext` via the specified memory type.
 
   The caller is responsible for managing and freeing the memory.
 
-  @param[in]  ctx      @ref CeedQFunctionContext to access
+  @param[in]  ctx      `CeedQFunctionContext` to access
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
@@ -649,17 +649,17 @@ int CeedQFunctionContextTakeData(CeedQFunctionContext ctx, CeedMemType mem_type,
 }
 
 /**
-  @brief Get read/write access to a @ref CeedQFunctionContext via the specified memory type.
+  @brief Get read/write access to a `CeedQFunctionContext` via the specified memory type.
 
   Restore access with @ref CeedQFunctionContextRestoreData().
 
-  @param[in]  ctx      @ref CeedQFunctionContext to access
+  @param[in]  ctx      `CeedQFunctionContext` to access
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
 
   @note The @ref CeedQFunctionContextGetData() and @ref CeedQFunctionContextRestoreData() functions provide access to array pointers in the desired memory space.
-        Pairing get/restore allows the @ref CeedQFunctionContext to track access.
+        Pairing get/restore allows the `CeedQFunctionContext` to track access.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -681,17 +681,17 @@ int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 }
 
 /**
-  @brief Get read only access to a @ref CeedQFunctionContext via the specified memory type.
+  @brief Get read only access to a `CeedQFunctionContext` via the specified memory type.
 
   Restore access with @ref CeedQFunctionContextRestoreData().
 
-  @param[in]  ctx      @ref CeedQFunctionContext to access
+  @param[in]  ctx      `CeedQFunctionContext` to access
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
 
   @note The @ref CeedQFunctionContextGetDataRead() and @ref CeedQFunctionContextRestoreDataRead() functions provide access to array pointers in the desired memory space.
-        Pairing get/restore allows the @ref CeedQFunctionContext to track access.
+        Pairing get/restore allows the `CeedQFunctionContext` to track access.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -714,7 +714,7 @@ int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_ty
 /**
   @brief Restore data obtained using @ref CeedQFunctionContextGetData()
 
-  @param[in]     ctx  @ref CeedQFunctionContext to restore
+  @param[in]     ctx  `CeedQFunctionContext` to restore
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -733,7 +733,7 @@ int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
 /**
   @brief Restore data obtained using @ref CeedQFunctionContextGetDataRead()
 
-  @param[in]     ctx  @ref CeedQFunctionContext to restore
+  @param[in]     ctx  `CeedQFunctionContext` to restore
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -750,9 +750,9 @@ int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
-  @brief Register a @ref CeedQFunctionContext field holding double precision values
+  @brief Register a `CeedQFunctionContext` field holding double precision values
 
-  @param[in,out] ctx               @ref CeedQFunctionContext
+  @param[in,out] ctx               `CeedQFunctionContext`
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
   @param[in]     num_values        Number of values to register, must be contiguous in memory
@@ -768,7 +768,7 @@ int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx, const char *fie
 }
 
 /**
-  @brief Register a @ref CeedQFunctionContext field holding `int32` values
+  @brief Register a `CeedQFunctionContext` field holding `int32` values
 
   @param[in,out] ctx               CeedQFunctionContext
   @param[in]     field_name        Name of field to register
@@ -786,9 +786,9 @@ int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx, const char *fiel
 }
 
 /**
-  @brief Register a @ref CeedQFunctionContext field holding boolean values
+  @brief Register a `CeedQFunctionContext` field holding boolean values
 
-  @param[in,out] ctx               @ref CeedQFunctionContext
+  @param[in,out] ctx               `CeedQFunctionContext`
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
   @param[in]     num_values        Number of values to register, must be contiguous in memory
@@ -804,9 +804,9 @@ int CeedQFunctionContextRegisterBoolean(CeedQFunctionContext ctx, const char *fi
 }
 
 /**
-  @brief Get labels for all registered @ref CeedQFunctionContext fields
+  @brief Get labels for all registered `CeedQFunctionContext` fields
 
-  @param[in]  ctx          @ref CeedQFunctionContext
+  @param[in]  ctx          `CeedQFunctionContext`
   @param[out] field_labels Variable to hold array of field labels
   @param[out] num_fields   Length of field descriptions array
 
@@ -821,7 +821,7 @@ int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx, const CeedCo
 }
 
 /**
-  @brief Get the descriptive information about a @ref CeedContextFieldLabel
+  @brief Get the descriptive information about a `CeedContextFieldLabel`
 
   @param[in]  label             @ref CeedContextFieldLabel
   @param[out] field_name        Name of labeled field
@@ -847,7 +847,7 @@ int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char 
 /**
   @brief Get data size for a Context
 
-  @param[in]  ctx      @ref CeedQFunctionContext
+  @param[in]  ctx      `CeedQFunctionContext`
   @param[out] ctx_size Variable to store size of context data values
 
   @return An error code: 0 - success, otherwise - failure
@@ -860,9 +860,9 @@ int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx, size_t *ctx_siz
 }
 
 /**
-  @brief View a @ref CeedQFunctionContext
+  @brief View a `CeedQFunctionContext`
 
-  @param[in] ctx    @ref CeedQFunctionContext to view
+  @param[in] ctx    `CeedQFunctionContext` to view
   @param[in] stream Filestream to write to
 
   @return An error code: 0 - success, otherwise - failure
@@ -881,9 +881,9 @@ int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream) {
 }
 
 /**
-  @brief Set additional destroy routine for @ref CeedQFunctionContext user data
+  @brief Set additional destroy routine for `CeedQFunctionContext` user data
 
-  @param[in,out] ctx        @ref CeedQFunctionContext to set user destroy function
+  @param[in,out] ctx        `CeedQFunctionContext` to set user destroy function
   @param[in]     f_mem_type Memory type to use when passing data into `f`
   @param[in]     f          Additional routine to use to destroy user data
 
@@ -899,9 +899,9 @@ int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_m
 }
 
 /**
-  @brief Destroy a @ref CeedQFunctionContext
+  @brief Destroy a `CeedQFunctionContext`
 
-  @param[in,out] ctx @ref CeedQFunctionContext to destroy
+  @param[in,out] ctx `CeedQFunctionContext` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -23,11 +23,11 @@
 /// @{
 
 /**
-  @brief Get index for QFunctionContext field
+  @brief Get index for @ref CeedQFunctionContext field
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_name  Name of field
-  @param[out] field_index Index of field, or -1 if field is not registered
+  @param[out] field_index Index of field, or `-1` if field is not registered
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -42,13 +42,13 @@ int CeedQFunctionContextGetFieldIndex(CeedQFunctionContext ctx, const char *fiel
 }
 
 /**
-  @brief Common function for registering QFunctionContext fields
+  @brief Common function for registering @ref CeedQFunctionContext fields
 
-  @param[in,out] ctx               CeedQFunctionContext
+  @param[in,out] ctx               @ref CeedQFunctionContext
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
-  @param[in]     field_description Description of field, or NULL for none
-  @param[in]     field_type        Field data type, such as double, int32, or bool
+  @param[in]     field_description Description of field, or `NULL` for none
+  @param[in]     field_type        @ref CeedContextFieldType
   @param[in]     num_values        Number of values to register, must be contiguous in memory
 
   @return An error code: 0 - success, otherwise - failure
@@ -99,9 +99,9 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx, const char *fi
 }
 
 /**
-  @brief Destroy user data held by CeedQFunctionContext, using function set by CeedQFunctionContextSetDataDestroy, if applicable
+  @brief Destroy user data held by @ref CeedQFunctionContext, using function set by @ref CeedQFunctionContextSetDataDestroy(), if applicable
 
-  @param[in,out] ctx CeedQFunctionContext to destroy user data
+  @param[in,out] ctx @ref CeedQFunctionContext to destroy user data
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -135,10 +135,10 @@ static int CeedQFunctionContextDestroyData(CeedQFunctionContext ctx) {
 /// @{
 
 /**
-  @brief Get the Ceed associated with a CeedQFunctionContext
+  @brief Get the @ref Ceed associated with a @ref CeedQFunctionContext
 
-  @param[in]  ctx  CeedQFunctionContext
-  @param[out] ceed Variable to store Ceed
+  @param[in]  ctx  @ref CeedQFunctionContext
+  @param[out] ceed Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -150,9 +150,9 @@ int CeedQFunctionContextGetCeed(CeedQFunctionContext ctx, Ceed *ceed) {
 }
 
 /**
-  @brief Check for valid data in a CeedQFunctionContext
+  @brief Check for valid data in a @ref CeedQFunctionContext
 
-  @param[in]  ctx            CeedQFunctionContext to check validity
+  @param[in]  ctx            @ref CeedQFunctionContext to check validity
   @param[out] has_valid_data Variable to store validity
 
   @return An error code: 0 - success, otherwise - failure
@@ -160,15 +160,15 @@ int CeedQFunctionContextGetCeed(CeedQFunctionContext ctx, Ceed *ceed) {
   @ref Backend
 **/
 int CeedQFunctionContextHasValidData(CeedQFunctionContext ctx, bool *has_valid_data) {
-  CeedCheck(ctx->HasValidData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasValidData");
+  CeedCheck(ctx->HasValidData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextHasValidData");
   CeedCall(ctx->HasValidData(ctx, has_valid_data));
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Check for borrowed data of a specific CeedMemType in a CeedQFunctionContext
+  @brief Check for borrowed data of a specific @ref CeedMemType in a @ref CeedQFunctionContext
 
-  @param[in]  ctx                       CeedQFunctionContext to check
+  @param[in]  ctx                       @ref CeedQFunctionContext to check
   @param[in]  mem_type                  Memory type to check
   @param[out] has_borrowed_data_of_type Variable to store result
 
@@ -177,15 +177,15 @@ int CeedQFunctionContextHasValidData(CeedQFunctionContext ctx, bool *has_valid_d
   @ref Backend
 **/
 int CeedQFunctionContextHasBorrowedDataOfType(CeedQFunctionContext ctx, CeedMemType mem_type, bool *has_borrowed_data_of_type) {
-  CeedCheck(ctx->HasBorrowedDataOfType, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasBorrowedDataOfType");
+  CeedCheck(ctx->HasBorrowedDataOfType, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextHasBorrowedDataOfType");
   CeedCall(ctx->HasBorrowedDataOfType(ctx, mem_type, has_borrowed_data_of_type));
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get the state of a CeedQFunctionContext
+  @brief Get the state of a @ref CeedQFunctionContext
 
-  @param[in]  ctx   CeedQFunctionContext to retrieve state
+  @param[in]  ctx   @ref CeedQFunctionContext to retrieve state
   @param[out] state Variable to store state
 
   @return An error code: 0 - success, otherwise - failure
@@ -198,9 +198,9 @@ int CeedQFunctionContextGetState(CeedQFunctionContext ctx, uint64_t *state) {
 }
 
 /**
-  @brief Get backend data of a CeedQFunctionContext
+  @brief Get backend data of a @ref CeedQFunctionContext
 
-  @param[in]  ctx  CeedQFunctionContext
+  @param[in]  ctx  @ref CeedQFunctionContext
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -213,9 +213,9 @@ int CeedQFunctionContextGetBackendData(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
-  @brief Set backend data of a CeedQFunctionContext
+  @brief Set backend data of a @ref CeedQFunctionContext
 
-  @param[in,out] ctx  CeedQFunctionContext
+  @param[in,out] ctx  @ref CeedQFunctionContext
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -228,9 +228,9 @@ int CeedQFunctionContextSetBackendData(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
-  @brief Get label for a registered QFunctionContext field, or `NULL` if no field has been registered with this `field_name`
+  @brief Get label for a registered @ref CeedQFunctionContext field, or `NULL` if no field has been registered with this `field_name`
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_name  Name of field to retrieve label
   @param[out] field_label Variable to field label
 
@@ -252,9 +252,9 @@ int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx, const char *fiel
 }
 
 /**
-  @brief Set QFunctionContext field
+  @brief Set @ref CeedQFunctionContext field
 
-  @param[in,out] ctx         CeedQFunctionContext
+  @param[in,out] ctx         @ref CeedQFunctionContext
   @param[in]     field_label Label of field to set
   @param[in]     field_type  Type of field to set
   @param[in]     values      Value to set
@@ -284,9 +284,9 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx, CeedContextFieldLab
 }
 
 /**
-  @brief Get QFunctionContext field data, read-only
+  @brief Get @ref CeedQFunctionContext field data, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label of field to read
   @param[in]  field_type  Type of field to read
   @param[out] num_values  Number of values in the field label
@@ -322,9 +322,9 @@ int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFiel
 }
 
 /**
-  @brief Restore QFunctionContext field data, read-only
+  @brief Restore @ref CeedQFunctionContext field data, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label of field to restore
   @param[in]  field_type  Type of field to restore
   @param[out] values      Pointer to context values
@@ -345,9 +345,9 @@ int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContext
 }
 
 /**
-  @brief Set QFunctionContext field holding double precision values
+  @brief Set @ref CeedQFunctionContext field holding double precision values
 
-  @param[in,out] ctx         CeedQFunctionContext
+  @param[in,out] ctx         @ref CeedQFunctionContext
   @param[in]     field_label Label for field to set
   @param[in]     values      Values to set
 
@@ -362,9 +362,9 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabe
 }
 
 /**
-  @brief Get QFunctionContext field holding double precision values, read-only
+  @brief Get @ref CeedQFunctionContext field holding double precision values, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label for field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -380,9 +380,9 @@ int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextField
 }
 
 /**
-  @brief Restore QFunctionContext field holding double precision values, read-only
+  @brief Restore @ref CeedQFunctionContext field holding double precision values, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label for field to restore
   @param[out] values      Pointer to context values
 
@@ -397,7 +397,7 @@ int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextF
 }
 
 /**
-  @brief Set QFunctionContext field holding int32 values
+  @brief Set CeedQFunctionContext field holding `int32` values
 
   @param[in,out] ctx         CeedQFunctionContext
   @param[in]     field_label Label for field to set
@@ -414,9 +414,9 @@ int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel
 }
 
 /**
-  @brief Get QFunctionContext field holding int32 values, read-only
+  @brief Get @ref CeedQFunctionContext field holding `int32` values, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label for field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -432,9 +432,9 @@ int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldL
 }
 
 /**
-  @brief Restore QFunctionContext field holding int32 values, read-only
+  @brief Restore @ref CeedQFunctionContext field holding `int32` values, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label for field to restore
   @param[out] values      Pointer to context values
 
@@ -449,9 +449,9 @@ int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFi
 }
 
 /**
-  @brief Set QFunctionContext field holding boolean values
+  @brief Set @ref CeedQFunctionContext field holding boolean values
 
-  @param[in,out] ctx         CeedQFunctionContext
+  @param[in,out] ctx         @ref CeedQFunctionContext
   @param[in]     field_label Label for field to set
   @param[in]     values      Values to set
 
@@ -466,9 +466,9 @@ int CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLab
 }
 
 /**
-  @brief Get QFunctionContext field holding boolean values, read-only
+  @brief Get @ref CeedQFunctionContext field holding boolean values, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label for field to get
   @param[out] num_values  Number of values in the field label
   @param[out] values      Pointer to context values
@@ -484,9 +484,9 @@ int CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFiel
 }
 
 /**
-  @brief Restore QFunctionContext field holding boolean values, read-only
+  @brief Restore @ref CeedQFunctionContext field holding boolean values, read-only
 
-  @param[in]  ctx         CeedQFunctionContext
+  @param[in]  ctx         @ref CeedQFunctionContext
   @param[in]  field_label Label for field to restore
   @param[out] values      Pointer to context values
 
@@ -501,9 +501,9 @@ int CeedQFunctionContextRestoreBooleanRead(CeedQFunctionContext ctx, CeedContext
 }
 
 /**
-  @brief Get additional destroy routine for CeedQFunctionContext user data
+  @brief Get additional destroy routine for @ref CeedQFunctionContext user data
 
-  @param[in] ctx         CeedQFunctionContext to get user destroy function
+  @param[in] ctx         @ref CeedQFunctionContext to get user destroy function
   @param[out] f_mem_type Memory type to use when passing data into `f`
   @param[out] f          Additional routine to use to destroy user data
 
@@ -518,9 +518,9 @@ int CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx, CeedMemType *f_
 }
 
 /**
-  @brief Increment the reference counter for a CeedQFunctionContext
+  @brief Increment the reference counter for a @ref CeedQFunctionContext
 
-  @param[in,out] ctx CeedQFunctionContext to increment the reference counter
+  @param[in,out] ctx @ref CeedQFunctionContext to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -540,10 +540,10 @@ int CeedQFunctionContextReference(CeedQFunctionContext ctx) {
 /// @{
 
 /**
-  @brief Create a CeedQFunctionContext for storing CeedQFunction user context data
+  @brief Create a @ref CeedQFunctionContext for storing @ref CeedQFunction user context data
 
-  @param[in]  ceed Ceed object where the CeedQFunctionContext will be created
-  @param[out] ctx  Address of the variable where the newly created CeedQFunctionContext will be stored
+  @param[in]  ceed @ref Ceed object used to create the @ref CeedQFunctionContext
+  @param[out] ctx  Address of the variable where the newly created @ref CeedQFunctionContext will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -554,7 +554,7 @@ int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "Context"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support ContextCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextCreate");
     CeedCall(CeedQFunctionContextCreate(delegate, ctx));
     return CEED_ERROR_SUCCESS;
   }
@@ -567,12 +567,12 @@ int CeedQFunctionContextCreate(Ceed ceed, CeedQFunctionContext *ctx) {
 }
 
 /**
-  @brief Copy the pointer to a CeedQFunctionContext.
+  @brief Copy the pointer to a @ref CeedQFunctionContext.
 
-  Both pointers should be destroyed with `CeedQFunctionContextDestroy()`.
+  Both pointers should be destroyed with @ref CeedQFunctionContextDestroy().
 
-  Note: If the value of `ctx_copy` passed to this function is non-NULL, then it is assumed that `ctx_copy` is a pointer to a
-        CeedQFunctionContext. This CeedQFunctionContext will be destroyed if `ctx_copy` is the only reference to this CeedQFunctionContext.
+  Note: If the value of `*ctx_copy` passed to this function is non-`NULL`, then it is assumed that `*ctx_copy` is a pointer to a @ref CeedQFunctionContext.
+        This @ref CeedQFunctionContext will be destroyed if `*ctx_copy` is the only reference to this @ref CeedQFunctionContext.
 
   @param[in]     ctx      CeedQFunctionContext to copy reference to
   @param[in,out] ctx_copy Variable to store copied reference
@@ -589,12 +589,12 @@ int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx, CeedQFunctionCon
 }
 
 /**
-  @brief Set the data used by a CeedQFunctionContext, freeing any previously allocated data if applicable.
+  @brief Set the data used by a @ref CeedQFunctionContext, freeing any previously allocated data if applicable.
 
-  The backend may copy values to a different memtype, such as during @ref CeedQFunctionApply().
+  The backend may copy values to a different @ref CeedMemType, such as during @ref CeedQFunctionApply().
   See also @ref CeedQFunctionContextTakeData().
 
-  @param[in,out] ctx       CeedQFunctionContext
+  @param[in,out] ctx       @ref CeedQFunctionContext
   @param[in]     mem_type  Memory type of the data being passed
   @param[in]     copy_mode Copy mode for the data
   @param[in]     size      Size of data, in bytes
@@ -605,7 +605,7 @@ int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx, CeedQFunctionCon
   @ref User
 **/
 int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, CeedCopyMode copy_mode, size_t size, void *data) {
-  CeedCheck(ctx->SetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support ContextSetData");
+  CeedCheck(ctx->SetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextSetData");
   CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextDestroyData(ctx));
@@ -616,11 +616,11 @@ int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 }
 
 /**
-  @brief Take ownership of the data in a CeedQFunctionContext via the specified memory type.
+  @brief Take ownership of the data in a @ref CeedQFunctionContext via the specified memory type.
 
   The caller is responsible for managing and freeing the memory.
 
-  @param[in]  ctx      CeedQFunctionContext to access
+  @param[in]  ctx      @ref CeedQFunctionContext to access
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
@@ -636,7 +636,7 @@ int CeedQFunctionContextTakeData(CeedQFunctionContext ctx, CeedMemType mem_type,
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
   CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to take, must set data");
 
-  CeedCheck(ctx->TakeData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TakeData");
+  CeedCheck(ctx->TakeData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextTakeData");
   CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextHasBorrowedDataOfType(ctx, mem_type, &has_borrowed_data_of_type));
@@ -649,18 +649,17 @@ int CeedQFunctionContextTakeData(CeedQFunctionContext ctx, CeedMemType mem_type,
 }
 
 /**
-  @brief Get read/write access to a CeedQFunctionContext via the specified memory type.
+  @brief Get read/write access to a @ref CeedQFunctionContext via the specified memory type.
 
   Restore access with @ref CeedQFunctionContextRestoreData().
 
-  @param[in]  ctx      CeedQFunctionContext to access
+  @param[in]  ctx      @ref CeedQFunctionContext to access
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
 
-  @note The CeedQFunctionContextGetData() and @ref CeedQFunctionContextRestoreData() functions provide access to array pointers in the desired memory
-space.
-        Pairing get/restore allows the Context to track access.
+  @note The @ref CeedQFunctionContextGetData() and @ref CeedQFunctionContextRestoreData() functions provide access to array pointers in the desired memory space.
+        Pairing get/restore allows the @ref CeedQFunctionContext to track access.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -669,7 +668,7 @@ space.
 int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
   bool has_valid_data = true;
 
-  CeedCheck(ctx->GetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetData");
+  CeedCheck(ctx->GetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextGetData");
   CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
   CeedCheck(ctx->num_readers == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, a process has read access");
 
@@ -682,18 +681,17 @@ int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 }
 
 /**
-  @brief Get read only access to a CeedQFunctionContext via the specified memory type.
+  @brief Get read only access to a @ref CeedQFunctionContext via the specified memory type.
 
   Restore access with @ref CeedQFunctionContextRestoreData().
 
-  @param[in]  ctx      CeedQFunctionContext to access
+  @param[in]  ctx      @ref CeedQFunctionContext to access
   @param[in]  mem_type Memory type on which to access the data.
                          If the backend uses a different memory type, this will perform a copy.
   @param[out] data     Data on memory type mem_type
 
-  @note The CeedQFunctionContextGetDataRead() and @ref CeedQFunctionContextRestoreDataRead() functions provide access to array pointers in the desired
-memory space.
-        Pairing get/restore allows the Context to track access.
+  @note The @ref CeedQFunctionContextGetDataRead() and @ref CeedQFunctionContextRestoreDataRead() functions provide access to array pointers in the desired memory space.
+        Pairing get/restore allows the @ref CeedQFunctionContext to track access.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -702,7 +700,7 @@ memory space.
 int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
   bool has_valid_data = true;
 
-  CeedCheck(ctx->GetDataRead, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetDataRead");
+  CeedCheck(ctx->GetDataRead, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextGetDataRead");
   CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
@@ -716,7 +714,7 @@ int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_ty
 /**
   @brief Restore data obtained using @ref CeedQFunctionContextGetData()
 
-  @param[in]     ctx  CeedQFunctionContext to restore
+  @param[in]     ctx  @ref CeedQFunctionContext to restore
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -735,7 +733,7 @@ int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
 /**
   @brief Restore data obtained using @ref CeedQFunctionContextGetDataRead()
 
-  @param[in]     ctx  CeedQFunctionContext to restore
+  @param[in]     ctx  @ref CeedQFunctionContext to restore
   @param[in,out] data Data to restore
 
   @return An error code: 0 - success, otherwise - failure
@@ -752,13 +750,13 @@ int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
-  @brief Register QFunctionContext a field holding double precision values
+  @brief Register a @ref CeedQFunctionContext field holding double precision values
 
-  @param[in,out] ctx               CeedQFunctionContext
+  @param[in,out] ctx               @ref CeedQFunctionContext
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
   @param[in]     num_values        Number of values to register, must be contiguous in memory
-  @param[in]     field_description Description of field, or NULL for none
+  @param[in]     field_description Description of field, or `NULL` for none
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -770,13 +768,13 @@ int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx, const char *fie
 }
 
 /**
-  @brief Register QFunctionContext a field holding int32 values
+  @brief Register a @ref CeedQFunctionContext field holding `int32` values
 
   @param[in,out] ctx               CeedQFunctionContext
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
   @param[in]     num_values        Number of values to register, must be contiguous in memory
-  @param[in]     field_description Description of field, or NULL for none
+  @param[in]     field_description Description of field, or `NULL` for none
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -788,13 +786,13 @@ int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx, const char *fiel
 }
 
 /**
-  @brief Register QFunctionContext a field holding boolean values
+  @brief Register a @ref CeedQFunctionContext field holding boolean values
 
-  @param[in,out] ctx               CeedQFunctionContext
+  @param[in,out] ctx               @ref CeedQFunctionContext
   @param[in]     field_name        Name of field to register
   @param[in]     field_offset      Offset of field to register
   @param[in]     num_values        Number of values to register, must be contiguous in memory
-  @param[in]     field_description Description of field, or NULL for none
+  @param[in]     field_description Description of field, or `NULL` for none
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -806,9 +804,9 @@ int CeedQFunctionContextRegisterBoolean(CeedQFunctionContext ctx, const char *fi
 }
 
 /**
-  @brief Get labels for all registered QFunctionContext fields
+  @brief Get labels for all registered @ref CeedQFunctionContext fields
 
-  @param[in]  ctx          CeedQFunctionContext
+  @param[in]  ctx          @ref CeedQFunctionContext
   @param[out] field_labels Variable to hold array of field labels
   @param[out] num_fields   Length of field descriptions array
 
@@ -823,14 +821,14 @@ int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx, const CeedCo
 }
 
 /**
-  @brief Get the descriptive information about a CeedContextFieldLabel
+  @brief Get the descriptive information about a @ref CeedContextFieldLabel
 
-  @param[in]  label             CeedContextFieldLabel
+  @param[in]  label             @ref CeedContextFieldLabel
   @param[out] field_name        Name of labeled field
   @param[out] field_offset      Offset of field registered
   @param[out] num_values        Number of values registered
   @param[out] field_description Description of field, or NULL for none
-  @param[out] field_type        CeedContextFieldType
+  @param[out] field_type        @ref CeedContextFieldType
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -849,7 +847,7 @@ int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char 
 /**
   @brief Get data size for a Context
 
-  @param[in]  ctx      CeedQFunctionContext
+  @param[in]  ctx      @ref CeedQFunctionContext
   @param[out] ctx_size Variable to store size of context data values
 
   @return An error code: 0 - success, otherwise - failure
@@ -862,9 +860,9 @@ int CeedQFunctionContextGetContextSize(CeedQFunctionContext ctx, size_t *ctx_siz
 }
 
 /**
-  @brief View a CeedQFunctionContext
+  @brief View a @ref CeedQFunctionContext
 
-  @param[in] ctx    CeedQFunctionContext to view
+  @param[in] ctx    @ref CeedQFunctionContext to view
   @param[in] stream Filestream to write to
 
   @return An error code: 0 - success, otherwise - failure
@@ -883,9 +881,9 @@ int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream) {
 }
 
 /**
-  @brief Set additional destroy routine for CeedQFunctionContext user data
+  @brief Set additional destroy routine for @ref CeedQFunctionContext user data
 
-  @param[in,out] ctx        CeedQFunctionContext to set user destroy function
+  @param[in,out] ctx        @ref CeedQFunctionContext to set user destroy function
   @param[in]     f_mem_type Memory type to use when passing data into `f`
   @param[in]     f          Additional routine to use to destroy user data
 
@@ -901,9 +899,9 @@ int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_m
 }
 
 /**
-  @brief Destroy a CeedQFunctionContext
+  @brief Destroy a @ref CeedQFunctionContext
 
-  @param[in,out] ctx CeedQFunctionContext to destroy
+  @param[in,out] ctx @ref CeedQFunctionContext to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-register.c
+++ b/interface/ceed-register.c
@@ -18,8 +18,8 @@ static bool register_all_called;
 /**
   @brief Register all pre-configured backends.
 
-  This is called automatically by CeedInit() and thus normally need not be called by users.
-  Users can call CeedRegister() to register additional backends.
+  This is called automatically by @ref CeedInit() and thus normally need not be called by users.
+  Users can call @ref CeedRegister() to register additional backends.
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -20,10 +20,10 @@
 /// @{
 
 /**
-  @brief Create a CeedTensorContract object for a CeedBasis
+  @brief Create a @ref CeedTensorContract object for a @ref CeedBasis
 
-  @param[in]  ceed     Ceed object where the CeedTensorContract will be created
-  @param[out] contract Address of the variable where the newly created CeedTensorContract will be stored.
+  @param[in]  ceed     @ref Ceed object used to create the @ref CeedTensorContract
+  @param[out] contract Address of the variable where the newly created @ref CeedTensorContract will be stored.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -34,7 +34,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "TensorContract"));
-    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support TensorContractCreate");
+    CeedCheck(delegate, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedTensorContractCreate");
     CeedCall(CeedTensorContractCreate(delegate, contract));
     return CEED_ERROR_SUCCESS;
   }
@@ -49,17 +49,17 @@ int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
   @brief Apply tensor contraction
 
   Contracts on the middle index
-  NOTRANSPOSE: v_ajc = t_jb u_abc
-  TRANSPOSE:   v_ajc = t_bj u_abc
-  If add != 0, "=" is replaced by "+="
+  NOTRANSPOSE: `v_ajc = t_jb u_abc`
+  TRANSPOSE:   `v_ajc = t_bj u_abc`
+  If `add != 0`, `=` is replaced by `+=`
 
-  @param[in]  contract CeedTensorContract to use
-  @param[in]  A        First index of u, v
-  @param[in]  B        Middle index of u, one index of t
-  @param[in]  C        Last index of u, v
-  @param[in]  J        Middle index of v, one index of t
+  @param[in]  contract @ref CeedTensorContract to use
+  @param[in]  A        First index of `u`, `v`
+  @param[in]  B        Middle index of `u`, one index of `t`
+  @param[in]  C        Last index of `u`, `v`
+  @param[in]  J        Middle index of `v`, one index of `t`
   @param[in]  t        Tensor array to contract against
-  @param[in]  t_mode   Transpose mode for t, \ref CEED_NOTRANSPOSE for t_jb \ref CEED_TRANSPOSE for t_bj
+  @param[in]  t_mode   Transpose mode for `t`, @ref CEED_NOTRANSPOSE for `t_jb` @ref CEED_TRANSPOSE for `t_bj`
   @param[in]  add      Add mode
   @param[in]  u        Input array
   @param[out] v        Output array
@@ -78,18 +78,18 @@ int CeedTensorContractApply(CeedTensorContract contract, CeedInt A, CeedInt B, C
   @brief Apply tensor contraction
 
   Contracts on the middle index
-  NOTRANSPOSE: v_dajc = t_djb u_abc
-  TRANSPOSE:   v_ajc  = t_dbj u_dabc
-  If add != 0, "=" is replaced by "+="
+  NOTRANSPOSE: `v_dajc = t_djb u_abc`
+  TRANSPOSE:   `v_ajc  = t_dbj u_dabc`
+  If `add != 0`, `=` is replaced by `+=`
 
-  @param[in]  contract CeedTensorContract to use
-  @param[in]  A        First index of u, second index of v
-  @param[in]  B        Middle index of u, one of last two indices of t
-  @param[in]  C        Last index of u, v
-  @param[in]  D        First index of v, first index of t
-  @param[in]  J        Third index of v, one of last two indices of t
+  @param[in]  contract @ref CeedTensorContract to use
+  @param[in]  A        First index of `u`, second index of `v`
+  @param[in]  B        Middle index of `u`, one of last two indices of `t`
+  @param[in]  C        Last index of `u`, `v`
+  @param[in]  D        First index of `v`, first index of `t`
+  @param[in]  J        Third index of `v`, one of last two indices of `t`
   @param[in]  t        Tensor array to contract against
-  @param[in]  t_mode   Transpose mode for t, \ref CEED_NOTRANSPOSE for t_djb \ref CEED_TRANSPOSE for t_dbj
+  @param[in]  t_mode   Transpose mode for `t`, @ref CEED_NOTRANSPOSE for `t_djb` @ref CEED_TRANSPOSE for `t_dbj`
   @param[in]  add      Add mode
   @param[in]  u        Input array
   @param[out] v        Output array
@@ -113,10 +113,10 @@ int CeedTensorContractStridedApply(CeedTensorContract contract, CeedInt A, CeedI
 }
 
 /**
-  @brief Get Ceed associated with a CeedTensorContract
+  @brief Get @ref Ceed associated with a @ref CeedTensorContract
 
-  @param[in]  contract CeedTensorContract
-  @param[out] ceed     Variable to store Ceed
+  @param[in]  contract @ref CeedTensorContract
+  @param[out] ceed     Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -128,9 +128,9 @@ int CeedTensorContractGetCeed(CeedTensorContract contract, Ceed *ceed) {
 }
 
 /**
-  @brief Get backend data of a CeedTensorContract
+  @brief Get backend data of a @ref CeedTensorContract
 
-  @param[in]  contract CeedTensorContract
+  @param[in]  contract @ref CeedTensorContract
   @param[out] data     Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -143,9 +143,9 @@ int CeedTensorContractGetData(CeedTensorContract contract, void *data) {
 }
 
 /**
-  @brief Set backend data of a CeedTensorContract
+  @brief Set backend data of a @ref CeedTensorContract
 
-  @param[in,out] contract CeedTensorContract
+  @param[in,out] contract @ref CeedTensorContract
   @param[in]     data     Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -158,9 +158,9 @@ int CeedTensorContractSetData(CeedTensorContract contract, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a CeedTensorContract
+  @brief Increment the reference counter for a @ref CeedTensorContract
 
-  @param[in,out] contract CeedTensorContract to increment the reference counter
+  @param[in,out] contract @ref CeedTensorContract to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -172,14 +172,14 @@ int CeedTensorContractReference(CeedTensorContract contract) {
 }
 
 /**
-  @brief Copy the pointer to a CeedTensorContract.
+  @brief Copy the pointer to a @ref CeedTensorContract.
 
-  Both pointers should be destroyed with `CeedTensorContractDestroy()`.
+  Both pointers should be destroyed with @ref CeedTensorContractDestroy().
 
-  Note: If the value of `tensor_copy` passed to this function is non-NULL, then it is assumed that `tensor_copy` is a pointer to a CeedTensorContract.
-        This CeedTensorContract will be destroyed if `tensor_copy` is the only reference to this CeedVector.
+  Note: If the value of `*tensor_copy` passed to this function is non-`NULL`, then it is assumed that `*tensor_copy` is a pointer to a @ref CeedTensorContract.
+        This @ref CeedTensorContract will be destroyed if `*tensor_copy` is the only reference to this @ref CeedTensorContract.
 
-  @param[in]     tensor      CeedTensorContract to copy reference to
+  @param[in]     tensor      @ref CeedTensorContract to copy reference to
   @param[in,out] tensor_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -194,9 +194,9 @@ int CeedTensorContractReferenceCopy(CeedTensorContract tensor, CeedTensorContrac
 }
 
 /**
-  @brief Destroy a CeedTensorContract
+  @brief Destroy a @ref CeedTensorContract
 
-  @param[in,out] contract CeedTensorContract to destroy
+  @param[in,out] contract @ref CeedTensorContract to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-tensor.c
+++ b/interface/ceed-tensor.c
@@ -20,10 +20,10 @@
 /// @{
 
 /**
-  @brief Create a @ref CeedTensorContract object for a @ref CeedBasis
+  @brief Create a `CeedTensorContract` object for a `CeedBasis`
 
-  @param[in]  ceed     @ref Ceed object used to create the @ref CeedTensorContract
-  @param[out] contract Address of the variable where the newly created @ref CeedTensorContract will be stored.
+  @param[in]  ceed     `Ceed` object used to create the `CeedTensorContract`
+  @param[out] contract Address of the variable where the newly created `CeedTensorContract` will be stored.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -53,7 +53,7 @@ int CeedTensorContractCreate(Ceed ceed, CeedTensorContract *contract) {
   TRANSPOSE:   `v_ajc = t_bj u_abc`
   If `add != 0`, `=` is replaced by `+=`
 
-  @param[in]  contract @ref CeedTensorContract to use
+  @param[in]  contract `CeedTensorContract` to use
   @param[in]  A        First index of `u`, `v`
   @param[in]  B        Middle index of `u`, one index of `t`
   @param[in]  C        Last index of `u`, `v`
@@ -82,7 +82,7 @@ int CeedTensorContractApply(CeedTensorContract contract, CeedInt A, CeedInt B, C
   TRANSPOSE:   `v_ajc  = t_dbj u_dabc`
   If `add != 0`, `=` is replaced by `+=`
 
-  @param[in]  contract @ref CeedTensorContract to use
+  @param[in]  contract `CeedTensorContract` to use
   @param[in]  A        First index of `u`, second index of `v`
   @param[in]  B        Middle index of `u`, one of last two indices of `t`
   @param[in]  C        Last index of `u`, `v`
@@ -113,10 +113,10 @@ int CeedTensorContractStridedApply(CeedTensorContract contract, CeedInt A, CeedI
 }
 
 /**
-  @brief Get @ref Ceed associated with a @ref CeedTensorContract
+  @brief Get `Ceed` associated with a `CeedTensorContract`
 
-  @param[in]  contract @ref CeedTensorContract
-  @param[out] ceed     Variable to store @ref Ceed
+  @param[in]  contract `CeedTensorContract`
+  @param[out] ceed     Variable to store `Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -128,9 +128,9 @@ int CeedTensorContractGetCeed(CeedTensorContract contract, Ceed *ceed) {
 }
 
 /**
-  @brief Get backend data of a @ref CeedTensorContract
+  @brief Get backend data of a `CeedTensorContract`
 
-  @param[in]  contract @ref CeedTensorContract
+  @param[in]  contract `CeedTensorContract`
   @param[out] data     Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -143,9 +143,9 @@ int CeedTensorContractGetData(CeedTensorContract contract, void *data) {
 }
 
 /**
-  @brief Set backend data of a @ref CeedTensorContract
+  @brief Set backend data of a `CeedTensorContract`
 
-  @param[in,out] contract @ref CeedTensorContract
+  @param[in,out] contract `CeedTensorContract`
   @param[in]     data     Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -158,9 +158,9 @@ int CeedTensorContractSetData(CeedTensorContract contract, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedTensorContract
+  @brief Increment the reference counter for a `CeedTensorContract`
 
-  @param[in,out] contract @ref CeedTensorContract to increment the reference counter
+  @param[in,out] contract `CeedTensorContract` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -172,14 +172,14 @@ int CeedTensorContractReference(CeedTensorContract contract) {
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedTensorContract.
+  @brief Copy the pointer to a `CeedTensorContract`.
 
   Both pointers should be destroyed with @ref CeedTensorContractDestroy().
 
-  Note: If the value of `*tensor_copy` passed to this function is non-`NULL`, then it is assumed that `*tensor_copy` is a pointer to a @ref CeedTensorContract.
-        This @ref CeedTensorContract will be destroyed if `*tensor_copy` is the only reference to this @ref CeedTensorContract.
+  Note: If the value of `*tensor_copy` passed to this function is non-`NULL`, then it is assumed that `*tensor_copy` is a pointer to a `CeedTensorContract`.
+        This `CeedTensorContract` will be destroyed if `*tensor_copy` is the only reference to this `CeedTensorContract`.
 
-  @param[in]     tensor      @ref CeedTensorContract to copy reference to
+  @param[in]     tensor      `CeedTensorContract` to copy reference to
   @param[in,out] tensor_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -194,9 +194,9 @@ int CeedTensorContractReferenceCopy(CeedTensorContract tensor, CeedTensorContrac
 }
 
 /**
-  @brief Destroy a @ref CeedTensorContract
+  @brief Destroy a `CeedTensorContract`
 
-  @param[in,out] contract @ref CeedTensorContract to destroy
+  @param[in,out] contract `CeedTensorContract` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -25,7 +25,7 @@ static struct CeedVector_private ceed_vector_none;
 /// @addtogroup CeedVectorUser
 /// @{
 
-/// Indicate that vector will be provided as an explicit argument to CeedOperatorApply().
+/// Indicate that vector will be provided as an explicit argument to @ref CeedOperatorApply().
 const CeedVector CEED_VECTOR_ACTIVE = &ceed_vector_active;
 
 /// Indicate that no vector is applicable (i.e., for @ref CEED_EVAL_WEIGHT).
@@ -40,9 +40,9 @@ const CeedVector CEED_VECTOR_NONE = &ceed_vector_none;
 /// @{
 
 /**
-  @brief Check for valid data in a CeedVector
+  @brief Check for valid data in a @ref CeedVector
 
-  @param[in]  vec             CeedVector to check validity
+  @param[in]  vec             @ref CeedVector to check validity
   @param[out] has_valid_array Variable to store validity
 
   @return An error code: 0 - success, otherwise - failure
@@ -50,7 +50,7 @@ const CeedVector CEED_VECTOR_NONE = &ceed_vector_none;
   @ref Backend
 **/
 int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array) {
-  CeedCheck(vec->HasValidArray, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasValidArray");
+  CeedCheck(vec->HasValidArray, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedVectorHasValidArray");
   if (vec->length == 0) {
     *has_valid_array = true;
     return CEED_ERROR_SUCCESS;
@@ -60,9 +60,9 @@ int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array) {
 }
 
 /**
-  @brief Check for borrowed array of a specific CeedMemType in a CeedVector
+  @brief Check for borrowed array of a specific @ref CeedMemType in a @ref CeedVector
 
-  @param[in]  vec                        CeedVector to check
+  @param[in]  vec                        @ref CeedVector to check
   @param[in]  mem_type                   Memory type to check
   @param[out] has_borrowed_array_of_type Variable to store result
 
@@ -71,15 +71,15 @@ int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array) {
   @ref Backend
 **/
 int CeedVectorHasBorrowedArrayOfType(CeedVector vec, CeedMemType mem_type, bool *has_borrowed_array_of_type) {
-  CeedCheck(vec->HasBorrowedArrayOfType, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support HasBorrowedArrayOfType");
+  CeedCheck(vec->HasBorrowedArrayOfType, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedVectorHasBorrowedArrayOfType");
   CeedCall(vec->HasBorrowedArrayOfType(vec, mem_type, has_borrowed_array_of_type));
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Get the state of a CeedVector
+  @brief Get the state of a @ref CeedVector
 
-  @param[in]  vec    CeedVector to retrieve state
+  @param[in]  vec    @ref CeedVector to retrieve state
   @param[out] state  Variable to store state
 
   @return An error code: 0 - success, otherwise - failure
@@ -92,9 +92,9 @@ int CeedVectorGetState(CeedVector vec, uint64_t *state) {
 }
 
 /**
-  @brief Get the backend data of a CeedVector
+  @brief Get the backend data of a @ref CeedVector
 
-  @param[in]  vec  CeedVector to retrieve state
+  @param[in]  vec  @ref CeedVector to retrieve state
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -107,9 +107,9 @@ int CeedVectorGetData(CeedVector vec, void *data) {
 }
 
 /**
-  @brief Set the backend data of a CeedVector
+  @brief Set the backend data of a @ref CeedVector
 
-  @param[in,out] vec  CeedVector to retrieve state
+  @param[in,out] vec  @ref CeedVector to retrieve state
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -122,9 +122,9 @@ int CeedVectorSetData(CeedVector vec, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a CeedVector
+  @brief Increment the reference counter for a @ref CeedVector
 
-  @param[in,out] vec CeedVector to increment the reference counter
+  @param[in,out] vec @ref CeedVector to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -144,11 +144,11 @@ int CeedVectorReference(CeedVector vec) {
 /// @{
 
 /**
-  @brief Create a CeedVector of the specified length (does not allocate memory)
+  @brief Create a @ref CeedVector of the specified length (does not allocate memory)
 
-  @param[in]  ceed   Ceed object where the CeedVector will be created
+  @param[in]  ceed   @ref Ceed object used to create the @ref CeedVector
   @param[in]  length Length of vector
-  @param[out] vec    Address of the variable where the newly created CeedVector will be stored
+  @param[out] vec    Address of the variable where the newly created @ref CeedVector will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -174,14 +174,14 @@ int CeedVectorCreate(Ceed ceed, CeedSize length, CeedVector *vec) {
 }
 
 /**
-  @brief Copy the pointer to a CeedVector.
+  @brief Copy the pointer to a @ref CeedVector.
 
-  Both pointers should be destroyed with `CeedVectorDestroy()`.
+  Both pointers should be destroyed with @ref CeedVectorDestroy().
 
-  Note: If the value of `vec_copy` passed to this function is non-NULL, then it is assumed that `vec_copy` is a pointer to a CeedVector.
-        This CeedVector will be destroyed if `vec_copy` is the only reference to this CeedVector.
+  Note: If the value of `*vec_copy` passed to this function is non-`NULL`, then it is assumed that `*vec_copy` is a pointer to a @ref CeedVector.
+        This @ref CeedVector will be destroyed if `*vec_copy` is the only reference to this @ref CeedVector.
 
-  @param[in]     vec      CeedVector to copy reference to
+  @param[in]     vec      @ref CeedVector to copy reference to
   @param[in,out] vec_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -196,15 +196,15 @@ int CeedVectorReferenceCopy(CeedVector vec, CeedVector *vec_copy) {
 }
 
 /**
-  @brief Copy a CeedVector into a different CeedVector.
+  @brief Copy a @ref CeedVector into a different @ref CeedVector.
 
-  Both pointers should be destroyed with `CeedVectorDestroy()`.
+  Both pointers should be destroyed with @ref CeedVectorDestroy().
 
-  Note: If `*vec_copy` is non-NULL, then it is assumed that `*vec_copy` is a pointer to a CeedVector.
-        This CeedVector will be destroyed if `*vec_copy` is the only reference to this CeedVector.
+  Note: If `*vec_copy` is non-`NULL`, then it is assumed that `*vec_copy` is a pointer to a @ref CeedVector.
+        This @ref CeedVector will be destroyed if `*vec_copy` is the only reference to this @ref CeedVector.
 
-  @param[in]     vec      CeedVector to copy
-  @param[in,out] vec_copy Variable to store copied CeedVector to
+  @param[in]     vec      @ref CeedVector to copy
+  @param[in,out] vec_copy Variable to store copied @ref CeedVector to
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -235,15 +235,15 @@ int CeedVectorCopy(CeedVector vec, CeedVector vec_copy) {
 }
 
 /**
-  @brief Set the array used by a CeedVector, freeing any previously allocated array if applicable.
+  @brief Set the array used by a @ref CeedVector, freeing any previously allocated array if applicable.
 
-  The backend may copy values to a different memtype, such as during @ref CeedOperatorApply().
+  The backend may copy values to a different @ref CeedMemType, such as during @ref CeedOperatorApply().
   See also @ref CeedVectorSyncArray() and @ref CeedVectorTakeArray().
 
-  @param[in,out] vec       CeedVector
+  @param[in,out] vec       @ref CeedVector
   @param[in]     mem_type  Memory type of the array being passed
   @param[in]     copy_mode Copy mode for the array
-  @param[in]     array     Array to be used, or NULL with @ref CEED_COPY_VALUES to have the library allocate
+  @param[in]     array     Array to be used, or `NULL` with @ref CEED_COPY_VALUES to have the library allocate
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -260,9 +260,9 @@ int CeedVectorSetArray(CeedVector vec, CeedMemType mem_type, CeedCopyMode copy_m
 }
 
 /**
-  @brief Set the CeedVector to a constant value
+  @brief Set the @ref CeedVector to a constant value
 
-  @param[in,out] vec   CeedVector
+  @param[in,out] vec   @ref CeedVector
   @param[in]     value Value to be used
 
   @return An error code: 0 - success, otherwise - failure
@@ -286,13 +286,13 @@ int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
 }
 
 /**
-  @brief Sync the CeedVector to a specified memtype.
+  @brief Sync the @ref CeedVector to a specified `mem_type`.
 
   This function is used to force synchronization of arrays set with @ref CeedVectorSetArray().
-  If the requested memtype is already synchronized, this function results in a no-op.
+  If the requested `mem_type` is already synchronized, this function results in a no-op.
 
-  @param[in,out] vec      CeedVector
-  @param[in]     mem_type Memtype to be synced
+  @param[in,out] vec      @ref CeedVector
+  @param[in]     mem_type @ref CeedMemType to be synced
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -315,15 +315,15 @@ int CeedVectorSyncArray(CeedVector vec, CeedMemType mem_type) {
 }
 
 /**
-  @brief Take ownership of the CeedVector array set by @ref CeedVectorSetArray() with @ref CEED_USE_POINTER and remove the array from the CeedVector.
+  @brief Take ownership of the @ref CeedVector array set by @ref CeedVectorSetArray() with @ref CEED_USE_POINTER and remove the array from the @ref CeedVector.
 
   The caller is responsible for managing and freeing the array.
   This function will error if @ref CeedVectorSetArray() was not previously called with @ref CEED_USE_POINTER for the corresponding mem_type.
 
-  @param[in,out] vec      CeedVector
+  @param[in,out] vec      @ref CeedVector
   @param[in]     mem_type Memory type on which to take the array.
                             If the backend uses a different memory type, this will perform a copy.
-  @param[out]    array    Array on memory type mem_type, or NULL if array pointer is not required
+  @param[out]    array    Array on memory type `mem_type`, or `NULL` if array pointer is not required
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -353,17 +353,17 @@ int CeedVectorTakeArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array
 }
 
 /**
-  @brief Get read/write access to a CeedVector via the specified memory type.
+  @brief Get read/write access to a @ref CeedVector via the specified memory type.
 
   Restore access with @ref CeedVectorRestoreArray().
 
-  @param[in,out] vec      CeedVector to access
+  @param[in,out] vec      @ref CeedVector to access
   @param[in]     mem_type Memory type on which to access the array.
                             If the backend uses a different memory type, this will perform a copy.
-  @param[out]    array    Array on memory type mem_type
+  @param[out]    array    Array on memory type `mem_type`
 
-  @note The CeedVectorGetArray* and CeedVectorRestoreArray* functions provide access to array pointers in the desired memory space.
-        Pairing get/restore allows the Vector to track access, thus knowing if norms or other operations may need to be recomputed.
+  @note The @ref CeedVectorGetArray() and @ref CeedVectorRestoreArray() functions provide access to array pointers in the desired memory space.
+        Pairing get/restore allows the @ref CeedVector to track access, thus knowing if norms or other operations may need to be recomputed.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -390,14 +390,14 @@ int CeedVectorGetArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array)
 }
 
 /**
-  @brief Get read-only access to a CeedVector via the specified memory type.
+  @brief Get read-only access to a @ref CeedVector via the specified memory type.
 
   Restore access with @ref CeedVectorRestoreArrayRead().
 
-  @param[in]  vec      CeedVector to access
-  @param[in]  mem_type Memory type on which to access the array. If the backend uses a different memory type, this will perform a copy (possibly
-cached).
-  @param[out] array    Array on memory type mem_type
+  @param[in]  vec      @ref CeedVector to access
+  @param[in]  mem_type Memory type on which to access the array.
+                         If the backend uses a different memory type, this will perform a copy (possibly cached).
+  @param[out] array    Array on memory type `mem_type`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -423,21 +423,21 @@ int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mem_type, const CeedScala
 }
 
 /**
-  @brief Get write access to a CeedVector via the specified memory type.
+  @brief Get write access to a @ref CeedVector via the specified memory type.
 
   Restore access with @ref CeedVectorRestoreArray().
   All old values should be assumed to be invalid.
 
-  @param[in,out] vec      CeedVector to access
+  @param[in,out] vec      @ref CeedVector to access
   @param[in]     mem_type Memory type on which to access the array.
-  @param[out]    array    Array on memory type mem_type
+  @param[out]    array    Array on memory type `mem_type`
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
 **/
 int CeedVectorGetArrayWrite(CeedVector vec, CeedMemType mem_type, CeedScalar **array) {
-  CeedCheck(vec->GetArrayWrite, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support GetArrayWrite");
+  CeedCheck(vec->GetArrayWrite, vec->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedVectorGetArrayWrite");
   CeedCheck(vec->state % 2 == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, the access lock is already in use");
   CeedCheck(vec->num_readers == 0, vec->ceed, CEED_ERROR_ACCESS, "Cannot grant CeedVector array access, a process has read access");
 
@@ -453,7 +453,7 @@ int CeedVectorGetArrayWrite(CeedVector vec, CeedMemType mem_type, CeedScalar **a
 /**
   @brief Restore an array obtained using @ref CeedVectorGetArray() or @ref CeedVectorGetArrayWrite()
 
-  @param[in,out] vec   CeedVector to restore
+  @param[in,out] vec   @ref CeedVector to restore
   @param[in,out] array Array of vector data
 
   @return An error code: 0 - success, otherwise - failure
@@ -471,7 +471,7 @@ int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
 /**
   @brief Restore an array obtained using @ref CeedVectorGetArrayRead()
 
-  @param[in]     vec   CeedVector to restore
+  @param[in]     vec   @ref CeedVector to restore
   @param[in,out] array Array of vector data
 
   @return An error code: 0 - success, otherwise - failure
@@ -488,13 +488,12 @@ int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
 }
 
 /**
-  @brief Get the norm of a CeedVector.
+  @brief Get the norm of a @ref CeedVector.
 
-  Note: This operation is local to the CeedVector.
-        This function will likely not provide the desired results for the norm of the libCEED portion of a parallel vector or a CeedVector with
-duplicated or hanging nodes.
+  Note: This operation is local to the @ref CeedVector.
+        This function will likely not provide the desired results for the norm of the libCEED portion of a parallel vector or a @ref CeedVector with duplicated or hanging nodes.
 
-  @param[in]  vec       CeedVector to retrieve maximum value
+  @param[in]  vec       @ref CeedVector to retrieve maximum value
   @param[in]  norm_type Norm type @ref CEED_NORM_1, @ref CEED_NORM_2, or @ref CEED_NORM_MAX
   @param[out] norm      Variable to store norm value
 
@@ -548,9 +547,9 @@ int CeedVectorNorm(CeedVector vec, CeedNormType norm_type, CeedScalar *norm) {
 }
 
 /**
-  @brief Compute x = alpha x
+  @brief Compute `x = alpha x`
 
-  @param[in,out] x     vector for scaling
+  @param[in,out] x     @ref CeedVector for scaling
   @param[in]     alpha scaling factor
 
   @return An error code: 0 - success, otherwise - failure
@@ -583,11 +582,11 @@ int CeedVectorScale(CeedVector x, CeedScalar alpha) {
 }
 
 /**
-  @brief Compute y = alpha x + y
+  @brief Compute `y = alpha x + y`
 
-  @param[in,out] y     target vector for sum
+  @param[in,out] y     target @ref CeedVector for sum
   @param[in]     alpha scaling factor
-  @param[in]     x     second vector, must be different than y
+  @param[in]     x     second @ref CeedVector, must be different than ``y`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -640,12 +639,12 @@ int CeedVectorAXPY(CeedVector y, CeedScalar alpha, CeedVector x) {
 }
 
 /**
-  @brief Compute y = alpha x + beta y
+  @brief Compute `y = alpha x + beta y`
 
-  @param[in,out] y     target vector for sum
+  @param[in,out] y     target @ref CeedVector for sum
   @param[in]     alpha first scaling factor
   @param[in]     beta  second scaling factor
-  @param[in]     x     second vector, must be different than y
+  @param[in]     x     second @ref CeedVector, must be different than `y`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -698,13 +697,13 @@ int CeedVectorAXPBY(CeedVector y, CeedScalar alpha, CeedScalar beta, CeedVector 
 }
 
 /**
-  @brief Compute the pointwise multiplication w = x .* y.
+  @brief Compute the pointwise multiplication \f$w = x .* y\f$.
 
-  Any subset of x, y, and w may be the same vector.
+  Any subset of `x`, `y`, and `w` may be the same @ref CeedVector.
 
-  @param[out] w target vector for the product
-  @param[in]  x first vector for product
-  @param[in]  y second vector for the product
+  @param[out] w target @ref CeedVector for the product
+  @param[in]  x first @ref CeedVector for product
+  @param[in]  y second @ref CeedVector for the product
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -776,9 +775,9 @@ int CeedVectorPointwiseMult(CeedVector w, CeedVector x, CeedVector y) {
 }
 
 /**
-  @brief Take the reciprocal of a CeedVector.
+  @brief Take the reciprocal of a @ref CeedVector.
 
-  @param[in,out] vec CeedVector to take reciprocal
+  @param[in,out] vec @ref CeedVector to take reciprocal
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -816,15 +815,15 @@ int CeedVectorReciprocal(CeedVector vec) {
 }
 
 /**
-  @brief View a CeedVector
+  @brief View a @ref CeedVector
 
   Note: It is safe to use any unsigned values for `start` or `stop` and any nonzero integer for `step`.
-        Any portion of the provided range that is outside the range of valid indices for the CeedVector will be ignored.
+        Any portion of the provided range that is outside the range of valid indices for the @ref CeedVector will be ignored.
 
-  @param[in] vec    CeedVector to view
-  @param[in] start  Index of first CeedVector entry to view
-  @param[in] stop   Index of last CeedVector entry to view
-  @param[in] step   Step between CeedVector entries to view
+  @param[in] vec    @ref CeedVector to view
+  @param[in] start  Index of first @ref CeedVector entry to view
+  @param[in] stop   Index of last @ref CeedVector entry to view
+  @param[in] step   Step between @ref CeedVector entries to view
   @param[in] fp_fmt Printing format
   @param[in] stream Filestream to write to
 
@@ -854,9 +853,9 @@ int CeedVectorViewRange(CeedVector vec, CeedSize start, CeedSize stop, CeedInt s
 }
 
 /**
-  @brief View a CeedVector
+  @brief View a @ref CeedVector
 
-  @param[in] vec    CeedVector to view
+  @param[in] vec    @ref CeedVector to view
   @param[in] fp_fmt Printing format
   @param[in] stream Filestream to write to
 
@@ -870,10 +869,10 @@ int CeedVectorView(CeedVector vec, const char *fp_fmt, FILE *stream) {
 }
 
 /**
-  @brief Get the Ceed associated with a CeedVector
+  @brief Get the @ref Ceed associated with a @ref CeedVector
 
-  @param[in]  vec  CeedVector to retrieve state
-  @param[out] ceed Variable to store ceed
+  @param[in]  vec  @ref CeedVector to retrieve state
+  @param[out] ceed Variable to store @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -885,9 +884,9 @@ int CeedVectorGetCeed(CeedVector vec, Ceed *ceed) {
 }
 
 /**
-  @brief Get the length of a CeedVector
+  @brief Get the length of a @ref CeedVector
 
-  @param[in]  vec    CeedVector to retrieve length
+  @param[in]  vec    @ref CeedVector to retrieve length
   @param[out] length Variable to store length
 
   @return An error code: 0 - success, otherwise - failure
@@ -900,9 +899,9 @@ int CeedVectorGetLength(CeedVector vec, CeedSize *length) {
 }
 
 /**
-  @brief Destroy a CeedVector
+  @brief Destroy a @ref CeedVector
 
-  @param[in,out] vec CeedVector to destroy
+  @param[in,out] vec @ref CeedVector to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -40,9 +40,9 @@ const CeedVector CEED_VECTOR_NONE = &ceed_vector_none;
 /// @{
 
 /**
-  @brief Check for valid data in a @ref CeedVector
+  @brief Check for valid data in a `CeedVector`
 
-  @param[in]  vec             @ref CeedVector to check validity
+  @param[in]  vec             `CeedVector` to check validity
   @param[out] has_valid_array Variable to store validity
 
   @return An error code: 0 - success, otherwise - failure
@@ -60,9 +60,9 @@ int CeedVectorHasValidArray(CeedVector vec, bool *has_valid_array) {
 }
 
 /**
-  @brief Check for borrowed array of a specific @ref CeedMemType in a @ref CeedVector
+  @brief Check for borrowed array of a specific @ref CeedMemType in a `CeedVector`
 
-  @param[in]  vec                        @ref CeedVector to check
+  @param[in]  vec                        `CeedVector` to check
   @param[in]  mem_type                   Memory type to check
   @param[out] has_borrowed_array_of_type Variable to store result
 
@@ -77,9 +77,9 @@ int CeedVectorHasBorrowedArrayOfType(CeedVector vec, CeedMemType mem_type, bool 
 }
 
 /**
-  @brief Get the state of a @ref CeedVector
+  @brief Get the state of a `CeedVector`
 
-  @param[in]  vec    @ref CeedVector to retrieve state
+  @param[in]  vec    `CeedVector` to retrieve state
   @param[out] state  Variable to store state
 
   @return An error code: 0 - success, otherwise - failure
@@ -92,9 +92,9 @@ int CeedVectorGetState(CeedVector vec, uint64_t *state) {
 }
 
 /**
-  @brief Get the backend data of a @ref CeedVector
+  @brief Get the backend data of a `CeedVector`
 
-  @param[in]  vec  @ref CeedVector to retrieve state
+  @param[in]  vec  `CeedVector` to retrieve state
   @param[out] data Variable to store data
 
   @return An error code: 0 - success, otherwise - failure
@@ -107,9 +107,9 @@ int CeedVectorGetData(CeedVector vec, void *data) {
 }
 
 /**
-  @brief Set the backend data of a @ref CeedVector
+  @brief Set the backend data of a `CeedVector`
 
-  @param[in,out] vec  @ref CeedVector to retrieve state
+  @param[in,out] vec  `CeedVector` to retrieve state
   @param[in]     data Data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -122,9 +122,9 @@ int CeedVectorSetData(CeedVector vec, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref CeedVector
+  @brief Increment the reference counter for a `CeedVector`
 
-  @param[in,out] vec @ref CeedVector to increment the reference counter
+  @param[in,out] vec `CeedVector` to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -144,11 +144,11 @@ int CeedVectorReference(CeedVector vec) {
 /// @{
 
 /**
-  @brief Create a @ref CeedVector of the specified length (does not allocate memory)
+  @brief Create a `CeedVector` of the specified length (does not allocate memory)
 
-  @param[in]  ceed   @ref Ceed object used to create the @ref CeedVector
+  @param[in]  ceed   `Ceed` object used to create the `CeedVector`
   @param[in]  length Length of vector
-  @param[out] vec    Address of the variable where the newly created @ref CeedVector will be stored
+  @param[out] vec    Address of the variable where the newly created `CeedVector` will be stored
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -174,14 +174,14 @@ int CeedVectorCreate(Ceed ceed, CeedSize length, CeedVector *vec) {
 }
 
 /**
-  @brief Copy the pointer to a @ref CeedVector.
+  @brief Copy the pointer to a `CeedVector`.
 
   Both pointers should be destroyed with @ref CeedVectorDestroy().
 
-  Note: If the value of `*vec_copy` passed to this function is non-`NULL`, then it is assumed that `*vec_copy` is a pointer to a @ref CeedVector.
-        This @ref CeedVector will be destroyed if `*vec_copy` is the only reference to this @ref CeedVector.
+  Note: If the value of `*vec_copy` passed to this function is non-`NULL`, then it is assumed that `*vec_copy` is a pointer to a `CeedVector`.
+        This `CeedVector` will be destroyed if `*vec_copy` is the only reference to this `CeedVector`.
 
-  @param[in]     vec      @ref CeedVector to copy reference to
+  @param[in]     vec      `CeedVector` to copy reference to
   @param[in,out] vec_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -196,15 +196,15 @@ int CeedVectorReferenceCopy(CeedVector vec, CeedVector *vec_copy) {
 }
 
 /**
-  @brief Copy a @ref CeedVector into a different @ref CeedVector.
+  @brief Copy a `CeedVector` into a different `CeedVector`.
 
   Both pointers should be destroyed with @ref CeedVectorDestroy().
 
-  Note: If `*vec_copy` is non-`NULL`, then it is assumed that `*vec_copy` is a pointer to a @ref CeedVector.
-        This @ref CeedVector will be destroyed if `*vec_copy` is the only reference to this @ref CeedVector.
+  Note: If `*vec_copy` is non-`NULL`, then it is assumed that `*vec_copy` is a pointer to a `CeedVector`.
+        This `CeedVector` will be destroyed if `*vec_copy` is the only reference to this `CeedVector`.
 
-  @param[in]     vec      @ref CeedVector to copy
-  @param[in,out] vec_copy Variable to store copied @ref CeedVector to
+  @param[in]     vec      `CeedVector` to copy
+  @param[in,out] vec_copy Variable to store copied `CeedVector` to
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -235,12 +235,12 @@ int CeedVectorCopy(CeedVector vec, CeedVector vec_copy) {
 }
 
 /**
-  @brief Set the array used by a @ref CeedVector, freeing any previously allocated array if applicable.
+  @brief Set the array used by a `CeedVector`, freeing any previously allocated array if applicable.
 
   The backend may copy values to a different @ref CeedMemType, such as during @ref CeedOperatorApply().
   See also @ref CeedVectorSyncArray() and @ref CeedVectorTakeArray().
 
-  @param[in,out] vec       @ref CeedVector
+  @param[in,out] vec       `CeedVector`
   @param[in]     mem_type  Memory type of the array being passed
   @param[in]     copy_mode Copy mode for the array
   @param[in]     array     Array to be used, or `NULL` with @ref CEED_COPY_VALUES to have the library allocate
@@ -260,9 +260,9 @@ int CeedVectorSetArray(CeedVector vec, CeedMemType mem_type, CeedCopyMode copy_m
 }
 
 /**
-  @brief Set the @ref CeedVector to a constant value
+  @brief Set the `CeedVector` to a constant value
 
-  @param[in,out] vec   @ref CeedVector
+  @param[in,out] vec   `CeedVector`
   @param[in]     value Value to be used
 
   @return An error code: 0 - success, otherwise - failure
@@ -286,12 +286,12 @@ int CeedVectorSetValue(CeedVector vec, CeedScalar value) {
 }
 
 /**
-  @brief Sync the @ref CeedVector to a specified `mem_type`.
+  @brief Sync the `CeedVector` to a specified `mem_type`.
 
   This function is used to force synchronization of arrays set with @ref CeedVectorSetArray().
   If the requested `mem_type` is already synchronized, this function results in a no-op.
 
-  @param[in,out] vec      @ref CeedVector
+  @param[in,out] vec      `CeedVector`
   @param[in]     mem_type @ref CeedMemType to be synced
 
   @return An error code: 0 - success, otherwise - failure
@@ -315,12 +315,12 @@ int CeedVectorSyncArray(CeedVector vec, CeedMemType mem_type) {
 }
 
 /**
-  @brief Take ownership of the @ref CeedVector array set by @ref CeedVectorSetArray() with @ref CEED_USE_POINTER and remove the array from the @ref CeedVector.
+  @brief Take ownership of the `CeedVector` array set by @ref CeedVectorSetArray() with @ref CEED_USE_POINTER and remove the array from the `CeedVector`.
 
   The caller is responsible for managing and freeing the array.
   This function will error if @ref CeedVectorSetArray() was not previously called with @ref CEED_USE_POINTER for the corresponding mem_type.
 
-  @param[in,out] vec      @ref CeedVector
+  @param[in,out] vec      `CeedVector`
   @param[in]     mem_type Memory type on which to take the array.
                             If the backend uses a different memory type, this will perform a copy.
   @param[out]    array    Array on memory type `mem_type`, or `NULL` if array pointer is not required
@@ -353,17 +353,17 @@ int CeedVectorTakeArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array
 }
 
 /**
-  @brief Get read/write access to a @ref CeedVector via the specified memory type.
+  @brief Get read/write access to a `CeedVector` via the specified memory type.
 
   Restore access with @ref CeedVectorRestoreArray().
 
-  @param[in,out] vec      @ref CeedVector to access
+  @param[in,out] vec      `CeedVector` to access
   @param[in]     mem_type Memory type on which to access the array.
                             If the backend uses a different memory type, this will perform a copy.
   @param[out]    array    Array on memory type `mem_type`
 
   @note The @ref CeedVectorGetArray() and @ref CeedVectorRestoreArray() functions provide access to array pointers in the desired memory space.
-        Pairing get/restore allows the @ref CeedVector to track access, thus knowing if norms or other operations may need to be recomputed.
+        Pairing get/restore allows the `CeedVector` to track access, thus knowing if norms or other operations may need to be recomputed.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -390,11 +390,11 @@ int CeedVectorGetArray(CeedVector vec, CeedMemType mem_type, CeedScalar **array)
 }
 
 /**
-  @brief Get read-only access to a @ref CeedVector via the specified memory type.
+  @brief Get read-only access to a `CeedVector` via the specified memory type.
 
   Restore access with @ref CeedVectorRestoreArrayRead().
 
-  @param[in]  vec      @ref CeedVector to access
+  @param[in]  vec      `CeedVector` to access
   @param[in]  mem_type Memory type on which to access the array.
                          If the backend uses a different memory type, this will perform a copy (possibly cached).
   @param[out] array    Array on memory type `mem_type`
@@ -423,12 +423,12 @@ int CeedVectorGetArrayRead(CeedVector vec, CeedMemType mem_type, const CeedScala
 }
 
 /**
-  @brief Get write access to a @ref CeedVector via the specified memory type.
+  @brief Get write access to a `CeedVector` via the specified memory type.
 
   Restore access with @ref CeedVectorRestoreArray().
   All old values should be assumed to be invalid.
 
-  @param[in,out] vec      @ref CeedVector to access
+  @param[in,out] vec      `CeedVector` to access
   @param[in]     mem_type Memory type on which to access the array.
   @param[out]    array    Array on memory type `mem_type`
 
@@ -453,7 +453,7 @@ int CeedVectorGetArrayWrite(CeedVector vec, CeedMemType mem_type, CeedScalar **a
 /**
   @brief Restore an array obtained using @ref CeedVectorGetArray() or @ref CeedVectorGetArrayWrite()
 
-  @param[in,out] vec   @ref CeedVector to restore
+  @param[in,out] vec   `CeedVector` to restore
   @param[in,out] array Array of vector data
 
   @return An error code: 0 - success, otherwise - failure
@@ -471,7 +471,7 @@ int CeedVectorRestoreArray(CeedVector vec, CeedScalar **array) {
 /**
   @brief Restore an array obtained using @ref CeedVectorGetArrayRead()
 
-  @param[in]     vec   @ref CeedVector to restore
+  @param[in]     vec   `CeedVector` to restore
   @param[in,out] array Array of vector data
 
   @return An error code: 0 - success, otherwise - failure
@@ -488,12 +488,12 @@ int CeedVectorRestoreArrayRead(CeedVector vec, const CeedScalar **array) {
 }
 
 /**
-  @brief Get the norm of a @ref CeedVector.
+  @brief Get the norm of a `CeedVector`.
 
-  Note: This operation is local to the @ref CeedVector.
-        This function will likely not provide the desired results for the norm of the libCEED portion of a parallel vector or a @ref CeedVector with duplicated or hanging nodes.
+  Note: This operation is local to the `CeedVector`.
+        This function will likely not provide the desired results for the norm of the libCEED portion of a parallel vector or a `CeedVector` with duplicated or hanging nodes.
 
-  @param[in]  vec       @ref CeedVector to retrieve maximum value
+  @param[in]  vec       `CeedVector` to retrieve maximum value
   @param[in]  norm_type Norm type @ref CEED_NORM_1, @ref CEED_NORM_2, or @ref CEED_NORM_MAX
   @param[out] norm      Variable to store norm value
 
@@ -549,7 +549,7 @@ int CeedVectorNorm(CeedVector vec, CeedNormType norm_type, CeedScalar *norm) {
 /**
   @brief Compute `x = alpha x`
 
-  @param[in,out] x     @ref CeedVector for scaling
+  @param[in,out] x     `CeedVector` for scaling
   @param[in]     alpha scaling factor
 
   @return An error code: 0 - success, otherwise - failure
@@ -584,9 +584,9 @@ int CeedVectorScale(CeedVector x, CeedScalar alpha) {
 /**
   @brief Compute `y = alpha x + y`
 
-  @param[in,out] y     target @ref CeedVector for sum
+  @param[in,out] y     target `CeedVector` for sum
   @param[in]     alpha scaling factor
-  @param[in]     x     second @ref CeedVector, must be different than ``y`
+  @param[in]     x     second `CeedVector`, must be different than ``y`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -641,10 +641,10 @@ int CeedVectorAXPY(CeedVector y, CeedScalar alpha, CeedVector x) {
 /**
   @brief Compute `y = alpha x + beta y`
 
-  @param[in,out] y     target @ref CeedVector for sum
+  @param[in,out] y     target `CeedVector` for sum
   @param[in]     alpha first scaling factor
   @param[in]     beta  second scaling factor
-  @param[in]     x     second @ref CeedVector, must be different than `y`
+  @param[in]     x     second `CeedVector`, must be different than `y`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -699,11 +699,11 @@ int CeedVectorAXPBY(CeedVector y, CeedScalar alpha, CeedScalar beta, CeedVector 
 /**
   @brief Compute the pointwise multiplication \f$w = x .* y\f$.
 
-  Any subset of `x`, `y`, and `w` may be the same @ref CeedVector.
+  Any subset of `x`, `y`, and `w` may be the same `CeedVector`.
 
-  @param[out] w target @ref CeedVector for the product
-  @param[in]  x first @ref CeedVector for product
-  @param[in]  y second @ref CeedVector for the product
+  @param[out] w target `CeedVector` for the product
+  @param[in]  x first `CeedVector` for product
+  @param[in]  y second `CeedVector` for the product
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -775,9 +775,9 @@ int CeedVectorPointwiseMult(CeedVector w, CeedVector x, CeedVector y) {
 }
 
 /**
-  @brief Take the reciprocal of a @ref CeedVector.
+  @brief Take the reciprocal of a `CeedVector`.
 
-  @param[in,out] vec @ref CeedVector to take reciprocal
+  @param[in,out] vec `CeedVector` to take reciprocal
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -815,15 +815,15 @@ int CeedVectorReciprocal(CeedVector vec) {
 }
 
 /**
-  @brief View a @ref CeedVector
+  @brief View a `CeedVector`
 
   Note: It is safe to use any unsigned values for `start` or `stop` and any nonzero integer for `step`.
-        Any portion of the provided range that is outside the range of valid indices for the @ref CeedVector will be ignored.
+        Any portion of the provided range that is outside the range of valid indices for the `CeedVector` will be ignored.
 
-  @param[in] vec    @ref CeedVector to view
-  @param[in] start  Index of first @ref CeedVector entry to view
-  @param[in] stop   Index of last @ref CeedVector entry to view
-  @param[in] step   Step between @ref CeedVector entries to view
+  @param[in] vec    `CeedVector` to view
+  @param[in] start  Index of first `CeedVector` entry to view
+  @param[in] stop   Index of last `CeedVector` entry to view
+  @param[in] step   Step between `CeedVector` entries to view
   @param[in] fp_fmt Printing format
   @param[in] stream Filestream to write to
 
@@ -853,9 +853,9 @@ int CeedVectorViewRange(CeedVector vec, CeedSize start, CeedSize stop, CeedInt s
 }
 
 /**
-  @brief View a @ref CeedVector
+  @brief View a `CeedVector`
 
-  @param[in] vec    @ref CeedVector to view
+  @param[in] vec    `CeedVector` to view
   @param[in] fp_fmt Printing format
   @param[in] stream Filestream to write to
 
@@ -869,10 +869,10 @@ int CeedVectorView(CeedVector vec, const char *fp_fmt, FILE *stream) {
 }
 
 /**
-  @brief Get the @ref Ceed associated with a @ref CeedVector
+  @brief Get the `Ceed` associated with a `CeedVector`
 
-  @param[in]  vec  @ref CeedVector to retrieve state
-  @param[out] ceed Variable to store @ref Ceed
+  @param[in]  vec  `CeedVector` to retrieve state
+  @param[out] ceed Variable to store `Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -884,9 +884,9 @@ int CeedVectorGetCeed(CeedVector vec, Ceed *ceed) {
 }
 
 /**
-  @brief Get the length of a @ref CeedVector
+  @brief Get the length of a `CeedVector`
 
-  @param[in]  vec    @ref CeedVector to retrieve length
+  @param[in]  vec    `CeedVector` to retrieve length
   @param[out] length Variable to store length
 
   @return An error code: 0 - success, otherwise - failure
@@ -899,9 +899,9 @@ int CeedVectorGetLength(CeedVector vec, CeedSize *length) {
 }
 
 /**
-  @brief Destroy a @ref CeedVector
+  @brief Destroy a `CeedVector`
 
-  @param[in,out] vec @ref CeedVector to destroy
+  @param[in,out] vec `CeedVector` to destroy
 
   @return An error code: 0 - success, otherwise - failure
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -41,8 +41,8 @@ static size_t num_backends;
 /**
   @brief Request immediate completion
 
-  This predefined constant is passed as the \ref CeedRequest argument to interfaces when the caller wishes for the operation to be performed
-immediately. The code
+  This predefined constant is passed as the @ref CeedRequest argument to interfaces when the caller wishes for the operation to be performed immediately.
+  The code
 
   @code
     CeedOperatorApply(op, ..., CEED_REQUEST_IMMEDIATE);
@@ -63,8 +63,8 @@ CeedRequest *const CEED_REQUEST_IMMEDIATE = &ceed_request_immediate;
 /**
   @brief Request ordered completion
 
-  This predefined constant is passed as the \ref CeedRequest argument to interfaces when the caller wishes for the operation to be completed in the
-  order that it is submitted to the device. It is typically used in a construct such as:
+  This predefined constant is passed as the @ref CeedRequest argument to interfaces when the caller wishes for the operation to be completed in the order that it is submitted to the device.
+  It is typically used in a construct such as:
 
   @code
     CeedRequest request;
@@ -83,11 +83,11 @@ CeedRequest *const CEED_REQUEST_IMMEDIATE = &ceed_request_immediate;
 CeedRequest *const CEED_REQUEST_ORDERED = &ceed_request_ordered;
 
 /**
-  @brief Wait for a CeedRequest to complete.
+  @brief Wait for a @ref CeedRequest to complete.
 
-  Calling CeedRequestWait on a NULL request is a no-op.
+  Calling `CeedRequestWait()` on a `NULL` request is a no-op.
 
-  @param req Address of CeedRequest to wait for; zeroed on completion.
+  @param[in,out] req Address of @ref CeedRequest to wait for; zeroed on completion.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -109,13 +109,13 @@ int CeedRequestWait(CeedRequest *req) {
 /**
   @brief Register a Ceed backend internally.
 
-  Note: Backends should call `CeedRegister` instead.
+  Note: Backends should call @ref CeedRegister() instead.
 
-  @param[in] prefix    Prefix of resources for this backend to respond to.
-                         For example, the reference backend responds to "/cpu/self".
-  @param[in] init      Initialization function called by CeedInit() when the backend is selected to drive the requested resource.
-  @param[in] priority  Integer priority.
-                         Lower values are preferred in case the resource requested by CeedInit() has non-unique best prefix match.
+  @param[in] prefix   Prefix of resources for this backend to respond to.
+                        For example, the reference backend responds to "/cpu/self".
+  @param[in] init     Initialization function called by @ref CeedInit() when the backend is selected to drive the requested resource
+  @param[in] priority Integer priority.
+                        Lower values are preferred in case the resource requested by @ref CeedInit() has non-unique best prefix match.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -150,11 +150,11 @@ int CeedRegisterImpl(const char *prefix, int (*init)(const char *, Ceed), unsign
 /// @{
 
 /**
-  @brief Return value of CEED_DEBUG environment variable
+  @brief Return value of `CEED_DEBUG` environment variable
 
-  @param[in] ceed Ceed context
+  @param[in] ceed @ref Ceed context
 
-  @return boolean value: true  - debugging mode enabled
+  @return Boolean value: true  - debugging mode enabled
                          false - debugging mode disabled
 
   @ref Backend
@@ -164,9 +164,9 @@ bool CeedDebugFlag(const Ceed ceed) { return ceed->is_debug; }
 // LCOV_EXCL_STOP
 
 /**
-  @brief Return value of CEED_DEBUG environment variable
+  @brief Return value of `CEED_DEBUG` environment variable
 
-  @return boolean value: true  - debugging mode enabled
+  @return Boolean value: true  - debugging mode enabled
                          false - debugging mode disabled
 
   @ref Backend
@@ -178,8 +178,8 @@ bool CeedDebugFlagEnv(void) { return getenv("CEED_DEBUG") || getenv("DEBUG") || 
 /**
   @brief Print debugging information in color
 
-  @param color   Color to print
-  @param format  Printing format
+  @param[in] color  Color to print
+  @param[in] format Printing format
 
   @ref Backend
 **/
@@ -198,20 +198,20 @@ void CeedDebugImpl256(const unsigned char color, const char *format, ...) {
 // LCOV_EXCL_STOP
 
 /**
-  @brief Allocate an array on the host; use CeedMalloc()
+  @brief Allocate an array on the host; use @ref CeedMalloc().
 
   Memory usage can be tracked by the library.
   This ensures sufficient alignment for vectorization and should be used for large allocations.
 
   @param[in]  n    Number of units to allocate
   @param[in]  unit Size of each unit
-  @param[out] p    Address of pointer to hold the result.
+  @param[out] p    Address of pointer to hold the result
 
   @return An error code: 0 - success, otherwise - failure
 
-  @sa CeedFree()
-
   @ref Backend
+
+  @sa CeedFree()
 **/
 int CeedMallocArray(size_t n, size_t unit, void *p) {
   int ierr = posix_memalign((void **)p, CEED_ALIGN, n * unit);
@@ -220,19 +220,19 @@ int CeedMallocArray(size_t n, size_t unit, void *p) {
 }
 
 /**
-  @brief Allocate a cleared (zeroed) array on the host; use CeedCalloc()
+  @brief Allocate a cleared (zeroed) array on the host; use @ref CeedCalloc().
 
   Memory usage can be tracked by the library.
 
   @param[in]  n    Number of units to allocate
   @param[in]  unit Size of each unit
-  @param[out] p    Address of pointer to hold the result.
+  @param[out] p    Address of pointer to hold the result
 
   @return An error code: 0 - success, otherwise - failure
 
-  @sa CeedFree()
-
   @ref Backend
+
+  @sa CeedFree()
 **/
 int CeedCallocArray(size_t n, size_t unit, void *p) {
   *(void **)p = calloc(n, unit);
@@ -241,19 +241,19 @@ int CeedCallocArray(size_t n, size_t unit, void *p) {
 }
 
 /**
-  @brief Reallocate an array on the host; use CeedRealloc()
+  @brief Reallocate an array on the host; use @ref CeedRealloc().
 
   Memory usage can be tracked by the library.
 
   @param[in]  n    Number of units to allocate
   @param[in]  unit Size of each unit
-  @param[out] p    Address of pointer to hold the result.
+  @param[out] p    Address of pointer to hold the result
 
   @return An error code: 0 - success, otherwise - failure
 
-  @sa CeedFree()
-
   @ref Backend
+
+  @sa CeedFree()
 **/
 int CeedReallocArray(size_t n, size_t unit, void *p) {
   *(void **)p = realloc(*(void **)p, n * unit);
@@ -262,7 +262,7 @@ int CeedReallocArray(size_t n, size_t unit, void *p) {
 }
 
 /**
-  @brief Allocate a cleared string buffer on the host
+  @brief Allocate a cleared string buffer on the host.
 
   Memory usage can be tracked by the library.
 
@@ -271,9 +271,9 @@ int CeedReallocArray(size_t n, size_t unit, void *p) {
 
   @return An error code: 0 - success, otherwise - failure
 
-  @sa CeedFree()
-
   @ref Backend
+
+  @sa CeedFree()
 **/
 int CeedStringAllocCopy(const char *source, char **copy) {
   size_t len = strlen(source);
@@ -282,11 +282,14 @@ int CeedStringAllocCopy(const char *source, char **copy) {
   return CEED_ERROR_SUCCESS;
 }
 
-/** Free memory allocated using CeedMalloc() or CeedCalloc()
+/** Free memory allocated using @ref CeedMalloc() or @ref CeedCalloc()
 
-  @param[in,out] p  address of pointer to memory.
-                      This argument is of type void* to avoid needing a cast, but is the address of the pointer (which is zeroed) rather than the
-pointer.
+  @param[in,out] p Address of pointer to memory.
+                     This argument is of type `void*` to avoid needing a cast, but is the address of the pointer (which is zeroed) rather than the pointer.
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
 **/
 int CeedFree(void *p) {
   free(*(void **)p);
@@ -299,9 +302,9 @@ int CeedFree(void *p) {
 
   @param[in] prefix   Prefix of resources for this backend to respond to.
                         For example, the reference backend responds to "/cpu/self".
-  @param[in] init     Initialization function called by CeedInit() when the backend is selected to drive the requested resource.
+  @param[in] init     Initialization function called by @ref CeedInit() when the backend is selected to drive the requested resource
   @param[in] priority Integer priority.
-                        Lower values are preferred in case the resource requested by CeedInit() has non-unique best prefix match.
+                        Lower values are preferred in case the resource requested by @ref CeedInit() has non-unique best prefix match.
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -316,7 +319,7 @@ int CeedRegister(const char *prefix, int (*init)(const char *, Ceed), unsigned i
 /**
   @brief Return debugging status flag
 
-  @param[in]  ceed     Ceed context to get debugging flag
+  @param[in]  ceed     @ref Ceed context to get debugging flag
   @param[out] is_debug Variable to store debugging flag
 
   @return An error code: 0 - success, otherwise - failure
@@ -331,9 +334,9 @@ int CeedIsDebug(Ceed ceed, bool *is_debug) {
 /**
   @brief Get the root of the requested resource
 
-  @param[in]  ceed          Ceed context to get resource name of
-  @param[in]  resource      ull user specified resource
-  @param[in]  delineator    Delineator to break resource_root and resource_spec
+  @param[in]  ceed          @ref Ceed context to get resource name of
+  @param[in]  resource      Full user specified resource
+  @param[in]  delineator    Delineator to break `resource_root` and `resource_spec`
   @param[out] resource_root Variable to store resource root
 
   @return An error code: 0 - success, otherwise - failure
@@ -350,9 +353,9 @@ int CeedGetResourceRoot(Ceed ceed, const char *resource, const char *delineator,
 }
 
 /**
-  @brief Retrieve a parent Ceed context
+  @brief Retrieve a parent @ref Ceed context
 
-  @param[in]  ceed   Ceed context to retrieve parent of
+  @param[in]  ceed   @ref Ceed context to retrieve parent of
   @param[out] parent Address to save the parent to
 
   @return An error code: 0 - success, otherwise - failure
@@ -369,9 +372,9 @@ int CeedGetParent(Ceed ceed, Ceed *parent) {
 }
 
 /**
-  @brief Retrieve a delegate Ceed context
+  @brief Retrieve a delegate @ref Ceed context
 
-  @param[in]  ceed     Ceed context to retrieve delegate of
+  @param[in]  ceed     @ref Ceed context to retrieve delegate of
   @param[out] delegate Address to save the delegate to
 
   @return An error code: 0 - success, otherwise - failure
@@ -384,12 +387,12 @@ int CeedGetDelegate(Ceed ceed, Ceed *delegate) {
 }
 
 /**
-  @brief Set a delegate Ceed context
+  @brief Set a delegate @ref Ceed context
 
-  This function allows a Ceed context to set a delegate Ceed context.
-  All backend implementations default to the delegate Ceed context, unless overridden.
+  This function allows a @ref Ceed context to set a delegate @ref Ceed context.
+  All backend implementations default to the delegate @ref Ceed context, unless overridden.
 
-  @param[in]  ceed     Ceed context to set delegate of
+  @param[in]  ceed     @ref Ceed context to set delegate of
   @param[out] delegate Address to set the delegate to
 
   @return An error code: 0 - success, otherwise - failure
@@ -403,9 +406,9 @@ int CeedSetDelegate(Ceed ceed, Ceed delegate) {
 }
 
 /**
-  @brief Retrieve a delegate Ceed context for a specific object type
+  @brief Retrieve a delegate @ref Ceed context for a specific object type
 
-  @param[in]  ceed     Ceed context to retrieve delegate of
+  @param[in]  ceed     @ref Ceed context to retrieve delegate of
   @param[out] delegate Address to save the delegate to
   @param[in]  obj_name Name of the object type to retrieve delegate for
 
@@ -428,14 +431,14 @@ int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *obj_name) {
 }
 
 /**
-  @brief Set a delegate Ceed context for a specific object type
+  @brief Set a delegate @ref Ceed context for a specific object type
 
-  This function allows a Ceed context to set a delegate Ceed context for a given type of Ceed object.
-  All backend implementations default to the delegate Ceed context for this object.
-  For example, CeedSetObjectDelegate(ceed, delegate, "Basis") uses delegate implementations for all CeedBasis backend functions.
+  This function allows a @ref Ceed context to set a delegate @ref Ceed context for a given type of @ref Ceed object.
+  All backend implementations default to the delegate @ref Ceed context for this object.
+  For example, `CeedSetObjectDelegate(ceed, delegate, "Basis")` uses delegate implementations for all @ref CeedBasis backend functions.
 
-  @param[in,out] ceed     Ceed context to set delegate of
-  @param[in]     delegate Ceed context to use for delegation
+  @param[in,out] ceed     @ref Ceed context to set delegate of
+  @param[in]     delegate @ref Ceed context to use for delegation
   @param[in]     obj_name Name of the object type to set delegate for
 
   @return An error code: 0 - success, otherwise - failure
@@ -463,9 +466,9 @@ int CeedSetObjectDelegate(Ceed ceed, Ceed delegate, const char *obj_name) {
 }
 
 /**
-  @brief Get the fallback resource for CeedOperators
+  @brief Get the fallback resource for @ref CeedOperator
 
-  @param[in]  ceed     Ceed context
+  @param[in]  ceed     @ref Ceed context
   @param[out] resource Variable to store fallback resource
 
   @return An error code: 0 - success, otherwise - failure
@@ -478,10 +481,10 @@ int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource) {
 }
 
 /**
-  @brief Get the fallback Ceed for CeedOperators
+  @brief Get the fallback @ref Ceed for @ref CeedOperator
 
-  @param[in]  ceed          Ceed context
-  @param[out] fallback_ceed Variable to store fallback Ceed
+  @param[in]  ceed          @ref Ceed context
+  @param[out] fallback_ceed Variable to store fallback @ref Ceed
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -511,12 +514,12 @@ int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed) {
 }
 
 /**
-  @brief Set the fallback resource for CeedOperators.
+  @brief Set the fallback resource for @ref CeedOperator.
 
   The current resource, if any, is freed by calling this function.
-  This string is freed upon the destruction of the Ceed context.
+  This string is freed upon the destruction of the @ref Ceed context.
 
-  @param[in,out] ceed     Ceed context
+  @param[in,out] ceed     @ref Ceed context
   @param[in]     resource Fallback resource to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -536,9 +539,9 @@ int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource) {
 }
 
 /**
-  @brief Flag Ceed context as deterministic
+  @brief Flag @ref Ceed context as deterministic
 
-  @param[in]  ceed             Ceed to flag as deterministic
+  @param[in]  ceed             @ref Ceed to flag as deterministic
   @param[out] is_deterministic Deterministic status to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -551,14 +554,13 @@ int CeedSetDeterministic(Ceed ceed, bool is_deterministic) {
 }
 
 /**
-  @brief Set a backend function
+  @brief Set a backend function.
 
   This function is used for a backend to set the function associated with the Ceed objects.
-  For example, CeedSetBackendFunction(ceed, "Ceed", ceed, "VectorCreate", BackendVectorCreate) sets the backend implementation of 'CeedVectorCreate'
-and CeedSetBackendFunction(ceed, "Basis", basis, "Apply", BackendBasisApply) sets the backend implementation of 'CeedBasisApply'.
+  For example, `CeedSetBackendFunction(ceed, "Ceed", ceed, "VectorCreate", BackendVectorCreate)` sets the backend implementation of @ref CeedVectorCreate() and `CeedSetBackendFunction(ceed, "Basis", basis, "Apply", BackendBasisApply)` sets the backend implementation of @ref CeedBasisApply().
   Note, the prefix 'Ceed' is not required for the object type ("Basis" vs "CeedBasis").
 
-  @param[in]  ceed      Ceed context for error handling
+  @param[in]  ceed      @ref Ceed context for error handling
   @param[in]  type      Type of Ceed object to set function for
   @param[out] object    Ceed object to set function for
   @param[in]  func_name Name of function to set
@@ -593,9 +595,9 @@ int CeedSetBackendFunction(Ceed ceed, const char *type, void *object, const char
 }
 
 /**
-  @brief Retrieve backend data for a Ceed context
+  @brief Retrieve backend data for a @ref Ceed context
 
-  @param[in]  ceed Ceed context to retrieve data of
+  @param[in]  ceed @ref Ceed context to retrieve data of
   @param[out] data Address to save data to
 
   @return An error code: 0 - success, otherwise - failure
@@ -608,9 +610,9 @@ int CeedGetData(Ceed ceed, void *data) {
 }
 
 /**
-  @brief Set backend data for a Ceed context
+  @brief Set backend data for a @ref Ceed context
 
-  @param[in,out] ceed Ceed context to set data of
+  @param[in,out] ceed @ref Ceed context to set data of
   @param[in]     data Address of data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -623,9 +625,9 @@ int CeedSetData(Ceed ceed, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a Ceed context
+  @brief Increment the reference counter for a @ref Ceed context
 
-  @param[in,out] ceed Ceed context to increment the reference counter
+  @param[in,out] ceed @ref Ceed context to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -645,10 +647,9 @@ int CeedReference(Ceed ceed) {
 /// @{
 
 /**
-  @brief Get the list of available resource names for Ceed contexts
+  @brief Get the list of available resource names for @ref Ceed contexts
 
-  Note: The caller is responsible for `free()`ing the resources and priorities arrays, but should not `free()` the contents of the resources
-array.
+  Note: The caller is responsible for `free()`ing the resources and priorities arrays, but should not `free()` the contents of the resources array.
 
   @param[out] n          Number of available resources
   @param[out] resources  List of available resource names
@@ -687,18 +688,18 @@ int CeedRegistryGetList(size_t *n, char ***const resources, CeedInt **priorities
 // LCOV_EXCL_STOP
 
 /**
-  @brief Initialize a \ref Ceed context to use the specified resource.
+  @brief Initialize a @ref Ceed context to use the specified resource.
 
-  Note: Prefixing the resource with "help:" (e.g. "help:/cpu/self") will result in CeedInt printing the current libCEED version number and a
-list of current available backend resources to stderr.
+  Note: Prefixing the resource with "help:" (e.g. "help:/cpu/self") will result in @ref CeedInt() printing the current libCEED version number and a list of current available backend resources to `stderr`.
 
   @param[in]  resource Resource to use, e.g., "/cpu/self"
   @param[out] ceed     The library context
-  @sa CeedRegister() CeedDestroy()
 
   @return An error code: 0 - success, otherwise - failure
 
   @ref User
+
+  @sa CeedRegister() CeedDestroy()
 **/
 int CeedInit(const char *resource, Ceed *ceed) {
   size_t match_len = 0, match_index = UINT_MAX, match_priority = CEED_MAX_BACKEND_PRIORITY, priority;
@@ -897,9 +898,9 @@ int CeedInit(const char *resource, Ceed *ceed) {
 }
 
 /**
-  @brief Set the GPU stream for a Ceed context
+  @brief Set the GPU stream for a @ref Ceed context
 
-  @param[in,out] ceed   Ceed context to set the stream
+  @param[in,out] ceed   @ref Ceed context to set the stream
   @param[in]     handle Handle to GPU stream
 
   @return An error code: 0 - success, otherwise - failure
@@ -907,7 +908,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
   @ref User
 **/
 int CeedSetStream(Ceed ceed, void *handle) {
-  CeedCheck(handle, ceed, CEED_ERROR_INCOMPATIBLE, "Stream handle must be non-null");
+  CeedCheck(handle, ceed, CEED_ERROR_INCOMPATIBLE, "Stream handle must be non-NULL");
   if (ceed->SetStream) {
     CeedCall(ceed->SetStream(ceed, handle));
   } else {
@@ -921,14 +922,14 @@ int CeedSetStream(Ceed ceed, void *handle) {
 }
 
 /**
-  @brief Copy the pointer to a Ceed context.
+  @brief Copy the pointer to a @ref Ceed context.
 
-  Both pointers should be destroyed with `CeedDestroy()`.
+  Both pointers should be destroyed with @ref CeedDestroy().
 
-  Note: If the value of `ceed_copy` passed to this function is non-NULL, then it is assumed that `ceed_copy` is a pointer to a Ceed context.
-        This Ceed context will be destroyed if `ceed_copy` is the only reference to this Ceed context.
+  Note: If the value of `*ceed_copy` passed to this function is non-`NULL`, then it is assumed that `*ceed_copy` is a pointer to a @ref Ceed context.
+        This @ref Ceed context will be destroyed if `*ceed_copy` is the only reference to this @ref Ceed context.
 
-  @param[in]     ceed      Ceed context to copy reference to
+  @param[in]     ceed      @ref Ceed context to copy reference to
   @param[in,out] ceed_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -943,9 +944,9 @@ int CeedReferenceCopy(Ceed ceed, Ceed *ceed_copy) {
 }
 
 /**
-  @brief Get the full resource name for a Ceed context
+  @brief Get the full resource name for a @ref Ceed context
 
-  @param[in]  ceed     Ceed context to get resource name of
+  @param[in]  ceed     @ref Ceed context to get resource name of
   @param[out] resource Variable to store resource name
 
   @return An error code: 0 - success, otherwise - failure
@@ -958,9 +959,9 @@ int CeedGetResource(Ceed ceed, const char **resource) {
 }
 
 /**
-  @brief Return Ceed context preferred memory type
+  @brief Return @ref Ceed context preferred memory type
 
-  @param[in]  ceed     Ceed context to get preferred memory type of
+  @param[in]  ceed     @ref Ceed context to get preferred memory type of
   @param[out] mem_type Address to save preferred memory type to
 
   @return An error code: 0 - success, otherwise - failure
@@ -984,9 +985,9 @@ int CeedGetPreferredMemType(Ceed ceed, CeedMemType *mem_type) {
 }
 
 /**
-  @brief Get deterministic status of Ceed
+  @brief Get deterministic status of @ref Ceed context
 
-  @param[in]  ceed             Ceed
+  @param[in]  ceed             @ref Ceed context
   @param[out] is_deterministic Variable to store deterministic status
 
   @return An error code: 0 - success, otherwise - failure
@@ -999,9 +1000,9 @@ int CeedIsDeterministic(Ceed ceed, bool *is_deterministic) {
 }
 
 /**
-  @brief Set additional JiT source root for Ceed
+  @brief Set additional JiT source root for @ref Ceed context
 
-  @param[in,out] ceed            Ceed
+  @param[in,out] ceed            @ref Ceed context
   @param[in]     jit_source_root Absolute path to additional JiT source directory
 
   @return An error code: 0 - success, otherwise - failure
@@ -1024,9 +1025,9 @@ int CeedAddJitSourceRoot(Ceed ceed, const char *jit_source_root) {
 }
 
 /**
-  @brief View a Ceed
+  @brief View a @ref Ceed
 
-  @param[in] ceed   Ceed to view
+  @param[in] ceed   @ref Ceed to view
   @param[in] stream Filestream to write to
 
   @return An error code: 0 - success, otherwise - failure
@@ -1047,9 +1048,9 @@ int CeedView(Ceed ceed, FILE *stream) {
 }
 
 /**
-  @brief Destroy a Ceed context
+  @brief Destroy a @ref Ceed
 
-  @param[in,out] ceed Address of Ceed context to destroy
+  @param[in,out] ceed Address of @ref Ceed context to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1096,7 +1097,9 @@ const char *CeedErrorFormat(Ceed ceed, const char *format, va_list *args) {
 // LCOV_EXCL_STOP
 
 /**
-  @brief Error handling implementation; use \ref CeedError instead.
+  @brief Error handling implementation; use @ref CeedError() instead.
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1124,7 +1127,9 @@ int CeedErrorImpl(Ceed ceed, const char *filename, int lineno, const char *func,
 /**
   @brief Error handler that returns without printing anything.
 
-  Pass this to CeedSetErrorHandler() to obtain this error handling behavior.
+  Pass this to @ref CeedSetErrorHandler() to obtain this error handling behavior.
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1137,7 +1142,9 @@ int CeedErrorReturn(Ceed ceed, const char *filename, int line_no, const char *fu
 /**
   @brief Error handler that stores the error message for future use and returns the error.
 
-  Pass this to CeedSetErrorHandler() to obtain this error handling behavior.
+  Pass this to @ref CeedSetErrorHandler() to obtain this error handling behavior.
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1155,9 +1162,11 @@ int CeedErrorStore(Ceed ceed, const char *filename, int line_no, const char *fun
 // LCOV_EXCL_STOP
 
 /**
-  @brief Error handler that prints to stderr and aborts
+  @brief Error handler that prints to `stderr` and aborts
 
-  Pass this to CeedSetErrorHandler() to obtain this error handling behavior.
+  Pass this to @ref CeedSetErrorHandler() to obtain this error handling behavior.
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1172,11 +1181,13 @@ int CeedErrorAbort(Ceed ceed, const char *filename, int line_no, const char *fun
 // LCOV_EXCL_STOP
 
 /**
-  @brief Error handler that prints to stderr and exits
+  @brief Error handler that prints to `stderr` and exits.
 
-  Pass this to CeedSetErrorHandler() to obtain this error handling behavior.
+  Pass this to @ref CeedSetErrorHandler() to obtain this error handling behavior.
 
-  In contrast to CeedErrorAbort(), this exits without a signal, so atexit() handlers (e.g., as used by gcov) are run.
+  In contrast to @ref CeedErrorAbort(), this exits without a signal, so `atexit()` handlers (e.g., as used by gcov) are run.
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1192,8 +1203,10 @@ int CeedErrorExit(Ceed ceed, const char *filename, int line_no, const char *func
 /**
   @brief Set error handler
 
-  A default error handler is set in CeedInit().
-  Use this function to change the error handler to CeedErrorReturn(), CeedErrorAbort(), or a user-defined error handler.
+  A default error handler is set in @ref CeedInit().
+  Use this function to change the error handler to @ref CeedErrorReturn(), @ref CeedErrorAbort(), or a user-defined error handler.
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1207,10 +1220,12 @@ int CeedSetErrorHandler(Ceed ceed, CeedErrorHandler handler) {
 /**
   @brief Get error message
 
-  The error message is only stored when using the error handler CeedErrorStore()
+  The error message is only stored when using the error handler @ref CeedErrorStore()
 
-  @param[in]  ceed    Ceed context to retrieve error message
+  @param[in]  ceed    @ref Ceed context to retrieve error message
   @param[out] err_msg Char pointer to hold error message
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1222,12 +1237,14 @@ int CeedGetErrorMessage(Ceed ceed, const char **err_msg) {
 }
 
 /**
-  @brief Restore error message
+  @brief Restore error message.
 
-  The error message is only stored when using the error handler CeedErrorStore()
+  The error message is only stored when using the error handler @ref CeedErrorStore().
 
-  @param[in]  ceed    Ceed context to restore error message
+  @param[in]  ceed    @ref Ceed context to restore error message
   @param[out] err_msg Char pointer that holds error message
+
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
 **/
@@ -1240,7 +1257,7 @@ int CeedResetErrorMessage(Ceed ceed, const char **err_msg) {
 }
 
 /**
-  @brief Get libCEED library version info
+  @brief Get libCEED library version information.
 
   libCEED version numbers have the form major.minor.patch.
   Non-release versions may contain unstable interfaces.
@@ -1250,18 +1267,20 @@ int CeedResetErrorMessage(Ceed ceed, const char **err_msg) {
   @param[out] patch   Patch (subminor) version of the library
   @param[out] release True for releases; false for development branches
 
-  The caller may pass NULL for any arguments that are not needed.
+  The caller may pass `NULL` for any arguments that are not needed.
 
-  @sa CEED_VERSION_GE()
+  @return An error code: 0 - success, otherwise - failure
 
   @ref Developer
+
+  @sa CEED_VERSION_GE()
 */
 int CeedGetVersion(int *major, int *minor, int *patch, bool *release) {
   if (major) *major = CEED_VERSION_MAJOR;
   if (minor) *minor = CEED_VERSION_MINOR;
   if (patch) *patch = CEED_VERSION_PATCH;
   if (release) *release = CEED_VERSION_RELEASE;
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /**
@@ -1269,11 +1288,13 @@ int CeedGetVersion(int *major, int *minor, int *patch, bool *release) {
 
   @param[out] scalar_type Type of libCEED scalars
 
+  @return An error code: 0 - success, otherwise - failure
+
   @ref Developer
 */
 int CeedGetScalarType(CeedScalarType *scalar_type) {
   *scalar_type = CEED_SCALAR_TYPE;
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /// @}

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -85,7 +85,7 @@ CeedRequest *const CEED_REQUEST_ORDERED = &ceed_request_ordered;
 /**
   @brief Wait for a @ref CeedRequest to complete.
 
-  Calling `CeedRequestWait()` on a `NULL` request is a no-op.
+  Calling @ref CeedRequestWait() on a `NULL` request is a no-op.
 
   @param[in,out] req Address of @ref CeedRequest to wait for; zeroed on completion.
 
@@ -152,7 +152,7 @@ int CeedRegisterImpl(const char *prefix, int (*init)(const char *, Ceed), unsign
 /**
   @brief Return value of `CEED_DEBUG` environment variable
 
-  @param[in] ceed @ref Ceed context
+  @param[in] ceed `Ceed` context
 
   @return Boolean value: true  - debugging mode enabled
                          false - debugging mode disabled
@@ -298,7 +298,7 @@ int CeedFree(void *p) {
 }
 
 /**
-  @brief Register a Ceed backend
+  @brief Register a `Ceed` backend
 
   @param[in] prefix   Prefix of resources for this backend to respond to.
                         For example, the reference backend responds to "/cpu/self".
@@ -319,7 +319,7 @@ int CeedRegister(const char *prefix, int (*init)(const char *, Ceed), unsigned i
 /**
   @brief Return debugging status flag
 
-  @param[in]  ceed     @ref Ceed context to get debugging flag
+  @param[in]  ceed     `Ceed` context to get debugging flag
   @param[out] is_debug Variable to store debugging flag
 
   @return An error code: 0 - success, otherwise - failure
@@ -334,7 +334,7 @@ int CeedIsDebug(Ceed ceed, bool *is_debug) {
 /**
   @brief Get the root of the requested resource
 
-  @param[in]  ceed          @ref Ceed context to get resource name of
+  @param[in]  ceed          `Ceed` context to get resource name of
   @param[in]  resource      Full user specified resource
   @param[in]  delineator    Delineator to break `resource_root` and `resource_spec`
   @param[out] resource_root Variable to store resource root
@@ -353,9 +353,9 @@ int CeedGetResourceRoot(Ceed ceed, const char *resource, const char *delineator,
 }
 
 /**
-  @brief Retrieve a parent @ref Ceed context
+  @brief Retrieve a parent `Ceed` context
 
-  @param[in]  ceed   @ref Ceed context to retrieve parent of
+  @param[in]  ceed   `Ceed` context to retrieve parent of
   @param[out] parent Address to save the parent to
 
   @return An error code: 0 - success, otherwise - failure
@@ -372,9 +372,9 @@ int CeedGetParent(Ceed ceed, Ceed *parent) {
 }
 
 /**
-  @brief Retrieve a delegate @ref Ceed context
+  @brief Retrieve a delegate `Ceed` context
 
-  @param[in]  ceed     @ref Ceed context to retrieve delegate of
+  @param[in]  ceed     `Ceed` context to retrieve delegate of
   @param[out] delegate Address to save the delegate to
 
   @return An error code: 0 - success, otherwise - failure
@@ -387,12 +387,12 @@ int CeedGetDelegate(Ceed ceed, Ceed *delegate) {
 }
 
 /**
-  @brief Set a delegate @ref Ceed context
+  @brief Set a delegate `Ceed` context
 
-  This function allows a @ref Ceed context to set a delegate @ref Ceed context.
-  All backend implementations default to the delegate @ref Ceed context, unless overridden.
+  This function allows a `Ceed` context to set a delegate `Ceed` context.
+  All backend implementations default to the delegate `Ceed` context, unless overridden.
 
-  @param[in]  ceed     @ref Ceed context to set delegate of
+  @param[in]  ceed     `Ceed` context to set delegate of
   @param[out] delegate Address to set the delegate to
 
   @return An error code: 0 - success, otherwise - failure
@@ -406,9 +406,9 @@ int CeedSetDelegate(Ceed ceed, Ceed delegate) {
 }
 
 /**
-  @brief Retrieve a delegate @ref Ceed context for a specific object type
+  @brief Retrieve a delegate `Ceed` context for a specific object type
 
-  @param[in]  ceed     @ref Ceed context to retrieve delegate of
+  @param[in]  ceed     `Ceed` context to retrieve delegate of
   @param[out] delegate Address to save the delegate to
   @param[in]  obj_name Name of the object type to retrieve delegate for
 
@@ -431,14 +431,14 @@ int CeedGetObjectDelegate(Ceed ceed, Ceed *delegate, const char *obj_name) {
 }
 
 /**
-  @brief Set a delegate @ref Ceed context for a specific object type
+  @brief Set a delegate `Ceed` context for a specific object type
 
-  This function allows a @ref Ceed context to set a delegate @ref Ceed context for a given type of @ref Ceed object.
-  All backend implementations default to the delegate @ref Ceed context for this object.
-  For example, `CeedSetObjectDelegate(ceed, delegate, "Basis")` uses delegate implementations for all @ref CeedBasis backend functions.
+  This function allows a `Ceed` context to set a delegate `Ceed` context for a given type of `Ceed` object.
+  All backend implementations default to the delegate `Ceed` context for this object.
+  For example, `CeedSetObjectDelegate(ceed, delegate, "Basis")` uses delegate implementations for all `CeedBasis` backend functions.
 
-  @param[in,out] ceed     @ref Ceed context to set delegate of
-  @param[in]     delegate @ref Ceed context to use for delegation
+  @param[in,out] ceed     `Ceed` context to set delegate of
+  @param[in]     delegate `Ceed` context to use for delegation
   @param[in]     obj_name Name of the object type to set delegate for
 
   @return An error code: 0 - success, otherwise - failure
@@ -466,9 +466,9 @@ int CeedSetObjectDelegate(Ceed ceed, Ceed delegate, const char *obj_name) {
 }
 
 /**
-  @brief Get the fallback resource for @ref CeedOperator
+  @brief Get the fallback resource for `CeedOperator`
 
-  @param[in]  ceed     @ref Ceed context
+  @param[in]  ceed     `Ceed` context
   @param[out] resource Variable to store fallback resource
 
   @return An error code: 0 - success, otherwise - failure
@@ -481,10 +481,10 @@ int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource) {
 }
 
 /**
-  @brief Get the fallback @ref Ceed for @ref CeedOperator
+  @brief Get the fallback `Ceed` for `CeedOperator`
 
-  @param[in]  ceed          @ref Ceed context
-  @param[out] fallback_ceed Variable to store fallback @ref Ceed
+  @param[in]  ceed          `Ceed` context
+  @param[out] fallback_ceed Variable to store fallback `Ceed`
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -514,12 +514,12 @@ int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed) {
 }
 
 /**
-  @brief Set the fallback resource for @ref CeedOperator.
+  @brief Set the fallback resource for `CeedOperator`.
 
   The current resource, if any, is freed by calling this function.
-  This string is freed upon the destruction of the @ref Ceed context.
+  This string is freed upon the destruction of the `Ceed` context.
 
-  @param[in,out] ceed     @ref Ceed context
+  @param[in,out] ceed     `Ceed` context
   @param[in]     resource Fallback resource to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -539,9 +539,9 @@ int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource) {
 }
 
 /**
-  @brief Flag @ref Ceed context as deterministic
+  @brief Flag `Ceed` context as deterministic
 
-  @param[in]  ceed             @ref Ceed to flag as deterministic
+  @param[in]  ceed             `Ceed` to flag as deterministic
   @param[out] is_deterministic Deterministic status to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -560,7 +560,7 @@ int CeedSetDeterministic(Ceed ceed, bool is_deterministic) {
   For example, `CeedSetBackendFunction(ceed, "Ceed", ceed, "VectorCreate", BackendVectorCreate)` sets the backend implementation of @ref CeedVectorCreate() and `CeedSetBackendFunction(ceed, "Basis", basis, "Apply", BackendBasisApply)` sets the backend implementation of @ref CeedBasisApply().
   Note, the prefix 'Ceed' is not required for the object type ("Basis" vs "CeedBasis").
 
-  @param[in]  ceed      @ref Ceed context for error handling
+  @param[in]  ceed      `Ceed` context for error handling
   @param[in]  type      Type of Ceed object to set function for
   @param[out] object    Ceed object to set function for
   @param[in]  func_name Name of function to set
@@ -595,9 +595,9 @@ int CeedSetBackendFunction(Ceed ceed, const char *type, void *object, const char
 }
 
 /**
-  @brief Retrieve backend data for a @ref Ceed context
+  @brief Retrieve backend data for a `Ceed` context
 
-  @param[in]  ceed @ref Ceed context to retrieve data of
+  @param[in]  ceed `Ceed` context to retrieve data of
   @param[out] data Address to save data to
 
   @return An error code: 0 - success, otherwise - failure
@@ -610,9 +610,9 @@ int CeedGetData(Ceed ceed, void *data) {
 }
 
 /**
-  @brief Set backend data for a @ref Ceed context
+  @brief Set backend data for a `Ceed` context
 
-  @param[in,out] ceed @ref Ceed context to set data of
+  @param[in,out] ceed `Ceed` context to set data of
   @param[in]     data Address of data to set
 
   @return An error code: 0 - success, otherwise - failure
@@ -625,9 +625,9 @@ int CeedSetData(Ceed ceed, void *data) {
 }
 
 /**
-  @brief Increment the reference counter for a @ref Ceed context
+  @brief Increment the reference counter for a `Ceed` context
 
-  @param[in,out] ceed @ref Ceed context to increment the reference counter
+  @param[in,out] ceed `Ceed` context to increment the reference counter
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -647,7 +647,7 @@ int CeedReference(Ceed ceed) {
 /// @{
 
 /**
-  @brief Get the list of available resource names for @ref Ceed contexts
+  @brief Get the list of available resource names for `Ceed` contexts
 
   Note: The caller is responsible for `free()`ing the resources and priorities arrays, but should not `free()` the contents of the resources array.
 
@@ -688,7 +688,7 @@ int CeedRegistryGetList(size_t *n, char ***const resources, CeedInt **priorities
 // LCOV_EXCL_STOP
 
 /**
-  @brief Initialize a @ref Ceed context to use the specified resource.
+  @brief Initialize a `Ceed` context to use the specified resource.
 
   Note: Prefixing the resource with "help:" (e.g. "help:/cpu/self") will result in @ref CeedInt() printing the current libCEED version number and a list of current available backend resources to `stderr`.
 
@@ -898,9 +898,9 @@ int CeedInit(const char *resource, Ceed *ceed) {
 }
 
 /**
-  @brief Set the GPU stream for a @ref Ceed context
+  @brief Set the GPU stream for a `Ceed` context
 
-  @param[in,out] ceed   @ref Ceed context to set the stream
+  @param[in,out] ceed   `Ceed` context to set the stream
   @param[in]     handle Handle to GPU stream
 
   @return An error code: 0 - success, otherwise - failure
@@ -922,14 +922,14 @@ int CeedSetStream(Ceed ceed, void *handle) {
 }
 
 /**
-  @brief Copy the pointer to a @ref Ceed context.
+  @brief Copy the pointer to a `Ceed` context.
 
   Both pointers should be destroyed with @ref CeedDestroy().
 
-  Note: If the value of `*ceed_copy` passed to this function is non-`NULL`, then it is assumed that `*ceed_copy` is a pointer to a @ref Ceed context.
-        This @ref Ceed context will be destroyed if `*ceed_copy` is the only reference to this @ref Ceed context.
+  Note: If the value of `*ceed_copy` passed to this function is non-`NULL`, then it is assumed that `*ceed_copy` is a pointer to a `Ceed` context.
+        This `Ceed` context will be destroyed if `*ceed_copy` is the only reference to this `Ceed` context.
 
-  @param[in]     ceed      @ref Ceed context to copy reference to
+  @param[in]     ceed      `Ceed` context to copy reference to
   @param[in,out] ceed_copy Variable to store copied reference
 
   @return An error code: 0 - success, otherwise - failure
@@ -944,9 +944,9 @@ int CeedReferenceCopy(Ceed ceed, Ceed *ceed_copy) {
 }
 
 /**
-  @brief Get the full resource name for a @ref Ceed context
+  @brief Get the full resource name for a `Ceed` context
 
-  @param[in]  ceed     @ref Ceed context to get resource name of
+  @param[in]  ceed     `Ceed` context to get resource name of
   @param[out] resource Variable to store resource name
 
   @return An error code: 0 - success, otherwise - failure
@@ -959,9 +959,9 @@ int CeedGetResource(Ceed ceed, const char **resource) {
 }
 
 /**
-  @brief Return @ref Ceed context preferred memory type
+  @brief Return `Ceed` context preferred memory type
 
-  @param[in]  ceed     @ref Ceed context to get preferred memory type of
+  @param[in]  ceed     `Ceed` context to get preferred memory type of
   @param[out] mem_type Address to save preferred memory type to
 
   @return An error code: 0 - success, otherwise - failure
@@ -985,9 +985,9 @@ int CeedGetPreferredMemType(Ceed ceed, CeedMemType *mem_type) {
 }
 
 /**
-  @brief Get deterministic status of @ref Ceed context
+  @brief Get deterministic status of `Ceed` context
 
-  @param[in]  ceed             @ref Ceed context
+  @param[in]  ceed             `Ceed` context
   @param[out] is_deterministic Variable to store deterministic status
 
   @return An error code: 0 - success, otherwise - failure
@@ -1000,9 +1000,9 @@ int CeedIsDeterministic(Ceed ceed, bool *is_deterministic) {
 }
 
 /**
-  @brief Set additional JiT source root for @ref Ceed context
+  @brief Set additional JiT source root for `Ceed` context
 
-  @param[in,out] ceed            @ref Ceed context
+  @param[in,out] ceed            `Ceed` context
   @param[in]     jit_source_root Absolute path to additional JiT source directory
 
   @return An error code: 0 - success, otherwise - failure
@@ -1025,9 +1025,9 @@ int CeedAddJitSourceRoot(Ceed ceed, const char *jit_source_root) {
 }
 
 /**
-  @brief View a @ref Ceed
+  @brief View a `Ceed`
 
-  @param[in] ceed   @ref Ceed to view
+  @param[in] ceed   `Ceed` to view
   @param[in] stream Filestream to write to
 
   @return An error code: 0 - success, otherwise - failure
@@ -1048,9 +1048,9 @@ int CeedView(Ceed ceed, FILE *stream) {
 }
 
 /**
-  @brief Destroy a @ref Ceed
+  @brief Destroy a `Ceed`
 
-  @param[in,out] ceed Address of @ref Ceed context to destroy
+  @param[in,out] ceed Address of `Ceed` context to destroy
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1222,7 +1222,7 @@ int CeedSetErrorHandler(Ceed ceed, CeedErrorHandler handler) {
 
   The error message is only stored when using the error handler @ref CeedErrorStore()
 
-  @param[in]  ceed    @ref Ceed context to retrieve error message
+  @param[in]  ceed    `Ceed` context to retrieve error message
   @param[out] err_msg Char pointer to hold error message
 
   @return An error code: 0 - success, otherwise - failure
@@ -1241,7 +1241,7 @@ int CeedGetErrorMessage(Ceed ceed, const char **err_msg) {
 
   The error message is only stored when using the error handler @ref CeedErrorStore().
 
-  @param[in]  ceed    @ref Ceed context to restore error message
+  @param[in]  ceed    `Ceed` context to restore error message
   @param[out] err_msg Char pointer that holds error message
 
   @return An error code: 0 - success, otherwise - failure


### PR DESCRIPTION
Fixes #1393 -

- [x] consistently use `@ref` vs `\ref`
- [x] swap away from `@a` to ref args since Sphinx doesn't use it
- [x] minor wording fixes
- [x] consistently use code formatting for arguments referenced in sentences
- [x] Consistent capitalization and spacing in arg lists