### PR TITLE
Update PETSc examples to use VecP2C and VecC2P

### DIFF
--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -171,10 +171,8 @@ int main(int argc, char **argv) {
                                  ceed_data, false, (CeedVector)NULL, (CeedVector *)NULL));
 
   // Setup output vector
-  PetscScalar *v;
   PetscCall(VecZeroEntries(V_loc));
-  PetscCall(VecGetArrayAndMemType(V_loc, &v, &mem_type));
-  CeedVectorSetArray(ceed_data->y_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, v);
+  PetscCall(VecP2C(V_loc, &mem_type, ceed_data->y_ceed));
 
   // Compute the mesh volume using the mass operator: area = 1^T \cdot M \cdot 1
   if (!test_mode) {
@@ -188,8 +186,7 @@ int main(int argc, char **argv) {
   CeedOperatorApply(ceed_data->op_apply, ceed_data->x_ceed, ceed_data->y_ceed, CEED_REQUEST_IMMEDIATE);
 
   // Gather output vector
-  CeedVectorTakeArray(ceed_data->y_ceed, CEED_MEM_HOST, NULL);
-  PetscCall(VecRestoreArrayAndMemType(V_loc, &v));
+  PetscCall(VecC2P(ceed_data->y_ceed, mem_type, V_loc));
   PetscCall(VecZeroEntries(V));
   PetscCall(DMLocalToGlobalBegin(dm, V_loc, ADD_VALUES, V));
   PetscCall(DMLocalToGlobalEnd(dm, V_loc, ADD_VALUES, V));

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -557,8 +557,8 @@ int main(int argc, char **argv) {
   CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_x, 2, Q, bp_options[bp_choice].q_mode, &basis_x);
 
   // CEED restrictions
-  CreateRestriction(ceed, mesh_elem, P, num_comp_u, &elem_restr_u);
-  CreateRestriction(ceed, mesh_elem, 2, dim, &elem_restr_x);
+  PetscCall(CreateRestriction(ceed, mesh_elem, P, num_comp_u, &elem_restr_u));
+  PetscCall(CreateRestriction(ceed, mesh_elem, 2, dim, &elem_restr_x));
   CeedInt num_elem = mesh_elem[0] * mesh_elem[1] * mesh_elem[2];
   CeedElemRestrictionCreateStrided(ceed, num_elem, Q * Q * Q, num_comp_u, num_comp_u * num_elem * Q * Q * Q, CEED_STRIDES_BACKEND, &elem_restr_u_i);
   CeedElemRestrictionCreateStrided(ceed, num_elem, Q * Q * Q, bp_options[bp_choice].q_data_size,

--- a/examples/petsc/src/libceedsetup.c
+++ b/examples/petsc/src/libceedsetup.c
@@ -189,17 +189,14 @@ PetscErrorCode CeedLevelTransferSetup(DM dm, Ceed ceed, CeedInt level, CeedInt n
   //   restriction between the p-multigrid levels and the coarse grid eval.
   // ---------------------------------------------------------------------------
   // Place in libCEED array
-  const PetscScalar *m;
-  PetscMemType       m_mem_type;
-  PetscCall(VecGetArrayReadAndMemType(fine_mult, &m, &m_mem_type));
-  CeedVectorSetArray(data[level]->x_ceed, MemTypeP2C(m_mem_type), CEED_USE_POINTER, (CeedScalar *)m);
+  PetscMemType m_mem_type;
+  PetscCall(VecReadP2C(fine_mult, &m_mem_type, data[level]->x_ceed));
 
   CeedOperatorMultigridLevelCreate(data[level]->op_apply, data[level]->x_ceed, data[level - 1]->elem_restr_u, basis_u, &op_apply, &op_prolong,
                                    &op_restrict);
 
   // Restore PETSc vector
-  CeedVectorTakeArray(data[level]->x_ceed, MemTypeP2C(m_mem_type), (CeedScalar **)&m);
-  PetscCall(VecRestoreArrayReadAndMemType(fine_mult, &m));
+  PetscCall(VecReadC2P(data[level]->x_ceed, m_mem_type, fine_mult));
   PetscCall(VecZeroEntries(fine_mult));
   // -- Save libCEED data
   data[level - 1]->op_apply = op_apply;


### PR DESCRIPTION
Updates all of the examples except for `bpsraw.c` (not sure what's going on with that one) to use the PETSc/libCEED memory utilities. 