### PR TITLE
Formatting and comment improvements for PETSc examples

### DIFF
--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -103,7 +103,6 @@ static PetscErrorCode CreateRestriction(Ceed ceed, const CeedInt mesh_elem[3], C
   // Setup CEED restriction
   CeedElemRestrictionCreate(ceed, num_elem, P * P * P, num_comp, 1, m_nodes[0] * m_nodes[1] * m_nodes[2] * num_comp, CEED_MEM_HOST, CEED_OWN_POINTER,
                             idx, elem_restr);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -228,7 +227,6 @@ static PetscErrorCode MatMult_Mass(Mat A, Vec X, Vec Y) {
   PetscMemType         x_mem_type, y_mem_type;
 
   PetscFunctionBeginUser;
-
   PetscCall(MatShellGetContext(A, &op_apply_ctx));
 
   // Global-to-local
@@ -266,7 +264,6 @@ static PetscErrorCode MatMult_Diff(Mat A, Vec X, Vec Y) {
   PetscMemType         x_mem_type, y_mem_type;
 
   PetscFunctionBeginUser;
-
   PetscCall(MatShellGetContext(A, &op_apply_ctx));
 
   // Global-to-local
@@ -294,7 +291,6 @@ static PetscErrorCode MatMult_Diff(Mat A, Vec X, Vec Y) {
   PetscCall(VecScatterEnd(op_apply_ctx->g_to_g_D, X, Y, INSERT_VALUES, SCATTER_FORWARD));
   PetscCall(VecScatterBegin(op_apply_ctx->l_to_g_0, op_apply_ctx->Y_loc, Y, ADD_VALUES, SCATTER_FORWARD));
   PetscCall(VecScatterEnd(op_apply_ctx->l_to_g_0, op_apply_ctx->Y_loc, Y, ADD_VALUES, SCATTER_FORWARD));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -306,7 +302,6 @@ static PetscErrorCode ComputeErrorMax(OperatorApplyContext op_apply_ctx, CeedOpe
   CeedSize     length;
 
   PetscFunctionBeginUser;
-
   CeedVectorGetLength(target, &length);
   CeedVectorCreate(op_apply_ctx->ceed, length, &collocated_error);
 
@@ -337,7 +332,6 @@ static PetscErrorCode ComputeErrorMax(OperatorApplyContext op_apply_ctx, CeedOpe
 
   // Cleanup
   CeedVectorDestroy(&collocated_error);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/petsc/dmswarm.c
+++ b/examples/petsc/dmswarm.c
@@ -301,7 +301,6 @@ PetscScalar EvalU_Sphere(PetscInt dim, const PetscScalar x[]) {
 
 PetscErrorCode EvalU_Poly_proj(PetscInt dim, PetscReal t, const PetscReal x[], PetscInt num_comp, PetscScalar *u, void *ctx) {
   PetscFunctionBeginUser;
-
   const PetscScalar f_x = EvalU_Poly(dim, x);
 
   for (PetscInt c = 0; c < num_comp; c++) u[c] = (c + 1.0) * f_x;
@@ -310,7 +309,6 @@ PetscErrorCode EvalU_Poly_proj(PetscInt dim, PetscReal t, const PetscReal x[], P
 
 PetscErrorCode EvalU_Tanh_proj(PetscInt dim, PetscReal t, const PetscReal x[], PetscInt num_comp, PetscScalar *u, void *ctx) {
   PetscFunctionBeginUser;
-
   const PetscScalar f_x = EvalU_Tanh(dim, x);
 
   for (PetscInt c = 0; c < num_comp; c++) u[c] = (c + 1.0) * f_x;
@@ -319,7 +317,6 @@ PetscErrorCode EvalU_Tanh_proj(PetscInt dim, PetscReal t, const PetscReal x[], P
 
 PetscErrorCode EvalU_Sphere_proj(PetscInt dim, PetscReal t, const PetscReal x[], PetscInt num_comp, PetscScalar *u, void *ctx) {
   PetscFunctionBeginUser;
-
   const PetscScalar f_x = EvalU_Sphere(dim, x);
 
   for (PetscInt c = 0; c < num_comp; c++) u[c] = (c + 1.0) * f_x;

--- a/examples/petsc/include/areaproblemdata.h
+++ b/examples/petsc/include/areaproblemdata.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Problem data for area examples
+
 #ifndef libceed_petsc_examples_area_problem_data_h
 #define libceed_petsc_examples_area_problem_data_h
 

--- a/examples/petsc/include/bpsproblemdata.h
+++ b/examples/petsc/include/bpsproblemdata.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Problem data for BPs
+
 #ifndef libceed_petsc_examples_bps_problem_data_h
 #define libceed_petsc_examples_bps_problem_data_h
 

--- a/examples/petsc/include/libceedsetup.h
+++ b/examples/petsc/include/libceedsetup.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Setup functions for BPs
+
 #ifndef libceed_petsc_examples_setup_h
 #define libceed_petsc_examples_setup_h
 

--- a/examples/petsc/include/matops.h
+++ b/examples/petsc/include/matops.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Operations for PETSc MatShell
+
 #ifndef libceed_petsc_examples_matops_h
 #define libceed_petsc_examples_matops_h
 

--- a/examples/petsc/include/petscutils.h
+++ b/examples/petsc/include/petscutils.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Utility functions for using PETSc with libCEED
+
 #ifndef libceed_petsc_examples_utils_h
 #define libceed_petsc_examples_utils_h
 

--- a/examples/petsc/include/petscversion.h
+++ b/examples/petsc/include/petscversion.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Petsc version check
+
 #ifndef libceed_petsc_examples_version_h
 #define libceed_petsc_examples_version_h
 

--- a/examples/petsc/include/sphereproblemdata.h
+++ b/examples/petsc/include/sphereproblemdata.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Problem data for BPS sphere examples
+
 #ifndef libceed_petsc_examples_sphere_problem_data_h
 #define libceed_petsc_examples_sphere_problem_data_h
 

--- a/examples/petsc/include/structs.h
+++ b/examples/petsc/include/structs.h
@@ -1,3 +1,13 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Data structures for PETSc examples
+
 #ifndef libceed_petsc_examples_structs_h
 #define libceed_petsc_examples_structs_h
 

--- a/examples/petsc/qfunctions/swarm/swarmmass.h
+++ b/examples/petsc/qfunctions/swarm/swarmmass.h
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
+
 #ifndef SWARM_MASS_H
 #define SWARM_MASS_H
 

--- a/examples/petsc/src/libceedsetup.c
+++ b/examples/petsc/src/libceedsetup.c
@@ -1,3 +1,10 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
 #include "../include/libceedsetup.h"
 
 #include <stdio.h>
@@ -9,7 +16,6 @@
 // -----------------------------------------------------------------------------
 PetscErrorCode CeedDataDestroy(CeedInt i, CeedData data) {
   PetscFunctionBeginUser;
-
   CeedVectorDestroy(&data->q_data);
   CeedVectorDestroy(&data->x_ceed);
   CeedVectorDestroy(&data->y_ceed);
@@ -26,7 +32,6 @@ PetscErrorCode CeedDataDestroy(CeedInt i, CeedData data) {
     CeedOperatorDestroy(&data->op_restrict);
   }
   PetscCall(PetscFree(data));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 
@@ -163,7 +168,6 @@ PetscErrorCode SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt to
   data->x_ceed          = x_ceed;
   data->y_ceed          = y_ceed;
   data->q_data_size     = q_data_size;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 

--- a/examples/petsc/src/matops.c
+++ b/examples/petsc/src/matops.c
@@ -7,7 +7,6 @@
 // -----------------------------------------------------------------------------
 PetscErrorCode SetupApplyOperatorCtx(MPI_Comm comm, DM dm, Ceed ceed, CeedData ceed_data, Vec X_loc, OperatorApplyContext op_apply_ctx) {
   PetscFunctionBeginUser;
-
   op_apply_ctx->comm  = comm;
   op_apply_ctx->dm    = dm;
   op_apply_ctx->X_loc = X_loc;
@@ -16,7 +15,6 @@ PetscErrorCode SetupApplyOperatorCtx(MPI_Comm comm, DM dm, Ceed ceed, CeedData c
   op_apply_ctx->y_ceed = ceed_data->y_ceed;
   op_apply_ctx->op     = ceed_data->op_apply;
   op_apply_ctx->ceed   = ceed;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -26,7 +24,6 @@ PetscErrorCode SetupApplyOperatorCtx(MPI_Comm comm, DM dm, Ceed ceed, CeedData c
 PetscErrorCode SetupErrorOperatorCtx(MPI_Comm comm, DM dm, Ceed ceed, CeedData ceed_data, Vec X_loc, CeedOperator op_error,
                                      OperatorApplyContext op_error_ctx) {
   PetscFunctionBeginUser;
-
   op_error_ctx->comm  = comm;
   op_error_ctx->dm    = dm;
   op_error_ctx->X_loc = X_loc;
@@ -35,7 +32,6 @@ PetscErrorCode SetupErrorOperatorCtx(MPI_Comm comm, DM dm, Ceed ceed, CeedData c
   op_error_ctx->y_ceed = ceed_data->y_ceed;
   op_error_ctx->op     = op_error;
   op_error_ctx->ceed   = ceed;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -46,7 +42,6 @@ PetscErrorCode MatGetDiag(Mat A, Vec D) {
   OperatorApplyContext op_apply_ctx;
 
   PetscFunctionBeginUser;
-
   PetscCall(MatShellGetContext(A, &op_apply_ctx));
 
   // Compute Diagonal via libCEED
@@ -62,7 +57,6 @@ PetscErrorCode MatGetDiag(Mat A, Vec D) {
   PetscCall(VecC2P(op_apply_ctx->y_ceed, mem_type, op_apply_ctx->Y_loc));
   PetscCall(VecZeroEntries(D));
   PetscCall(DMLocalToGlobal(op_apply_ctx->dm, op_apply_ctx->Y_loc, ADD_VALUES, D));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -73,7 +67,6 @@ PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, OperatorApplyContext op_apply_ctx) 
   PetscMemType x_mem_type, y_mem_type;
 
   PetscFunctionBeginUser;
-
   // Global-to-local
   PetscCall(DMGlobalToLocal(op_apply_ctx->dm, X, INSERT_VALUES, op_apply_ctx->X_loc));
 
@@ -91,7 +84,6 @@ PetscErrorCode ApplyLocal_Ceed(Vec X, Vec Y, OperatorApplyContext op_apply_ctx) 
   // Local-to-global
   PetscCall(VecZeroEntries(Y));
   PetscCall(DMLocalToGlobal(op_apply_ctx->dm, op_apply_ctx->Y_loc, ADD_VALUES, Y));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -102,12 +94,10 @@ PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y) {
   OperatorApplyContext op_apply_ctx;
 
   PetscFunctionBeginUser;
-
   PetscCall(MatShellGetContext(A, &op_apply_ctx));
 
   // libCEED for local action of residual evaluator
   PetscCall(ApplyLocal_Ceed(X, Y, op_apply_ctx));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -119,7 +109,6 @@ PetscErrorCode MatMult_Prolong(Mat A, Vec X, Vec Y) {
   PetscMemType        c_mem_type, f_mem_type;
 
   PetscFunctionBeginUser;
-
   PetscCall(MatShellGetContext(A, &pr_restr_ctx));
 
   // Global-to-local
@@ -143,7 +132,6 @@ PetscErrorCode MatMult_Prolong(Mat A, Vec X, Vec Y) {
   // Local-to-global
   PetscCall(VecZeroEntries(Y));
   PetscCall(DMLocalToGlobal(pr_restr_ctx->dmf, pr_restr_ctx->loc_vec_f, ADD_VALUES, Y));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -155,7 +143,6 @@ PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y) {
   PetscMemType        c_mem_type, f_mem_type;
 
   PetscFunctionBeginUser;
-
   PetscCall(MatShellGetContext(A, &pr_restr_ctx));
 
   // Global-to-local
@@ -179,7 +166,6 @@ PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y) {
   // Local-to-global
   PetscCall(VecZeroEntries(Y));
   PetscCall(DMLocalToGlobal(pr_restr_ctx->dmc, pr_restr_ctx->loc_vec_c, ADD_VALUES, Y));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -188,13 +174,13 @@ PetscErrorCode MatMult_Restrict(Mat A, Vec X, Vec Y) {
 // -----------------------------------------------------------------------------
 PetscErrorCode ComputeL2Error(Vec X, PetscScalar *l2_error, OperatorApplyContext op_error_ctx) {
   Vec E;
+
   PetscFunctionBeginUser;
   PetscCall(VecDuplicate(X, &E));
   PetscCall(ApplyLocal_Ceed(X, E, op_error_ctx));
   PetscScalar error_sq = 1.0;
   PetscCall(VecSum(E, &error_sq));
   *l2_error = sqrt(error_sq);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/petsc/src/petscutils.c
+++ b/examples/petsc/src/petscutils.c
@@ -1,3 +1,10 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
 #include "../include/petscutils.h"
 
 // -----------------------------------------------------------------------------
@@ -70,7 +77,6 @@ PetscErrorCode Kershaw(DM dm_orig, PetscScalar eps) {
   PetscScalar *c;
 
   PetscFunctionBeginUser;
-
   PetscCall(DMGetCoordinatesLocal(dm_orig, &coord));
   PetscCall(VecGetLocalSize(coord, &ncoord));
   PetscCall(VecGetArray(coord, &c));
@@ -115,12 +121,10 @@ static PetscErrorCode CreateBCLabel(DM dm, const char name[]) {
   DMLabel label;
 
   PetscFunctionBeginUser;
-
   PetscCall(DMCreateLabel(dm, name));
   PetscCall(DMGetLabel(dm, name, &label));
   PetscCall(DMPlexMarkBoundaryFaces(dm, PETSC_DETERMINE, label));
   PetscCall(DMPlexLabelComplete(dm, label));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -135,7 +139,6 @@ PetscErrorCode SetupDMByDegree(DM dm, PetscInt p_degree, PetscInt q_extra, Petsc
   PetscBool is_simplex = PETSC_TRUE;
 
   PetscFunctionBeginUser;
-
   // Check if simplex or tensor-product mesh
   PetscCall(DMPlexIsSimplex(dm, &is_simplex));
   // Setup FE
@@ -178,7 +181,6 @@ PetscErrorCode SetupDMByDegree(DM dm, PetscInt p_degree, PetscInt q_extra, Petsc
     PetscCall(DMPlexSetClosurePermutationTensor(dm_coord, PETSC_DETERMINE, NULL));
   }
   PetscCall(PetscFEDestroy(&fe));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -189,12 +191,10 @@ PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height, DMLab
   PetscInt num_elem, elem_size, num_dof, num_comp, *elem_restr_offsets;
 
   PetscFunctionBeginUser;
-
   PetscCall(DMPlexGetLocalOffsets(dm, domain_label, value, height, 0, &num_elem, &elem_size, &num_comp, &num_dof, &elem_restr_offsets));
 
   CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp, 1, num_dof, CEED_MEM_HOST, CEED_COPY_VALUES, elem_restr_offsets, elem_restr);
   PetscCall(PetscFree(elem_restr_offsets));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -226,7 +226,6 @@ PetscErrorCode DMFieldToDSField(DM dm, DMLabel domain_label, PetscInt dm_field, 
   PetscInt        num_fields;
 
   PetscFunctionBeginUser;
-
   // Translate dm_field to ds_field
   PetscCall(DMGetRegionDS(dm, domain_label, &field_is, &ds, NULL));
   PetscCall(ISGetIndices(field_is, &fields));
@@ -240,7 +239,6 @@ PetscErrorCode DMFieldToDSField(DM dm, DMLabel domain_label, PetscInt dm_field, 
   PetscCall(ISRestoreIndices(field_is, &fields));
 
   if (*ds_field == -1) SETERRQ(PetscObjectComm((PetscObject)dm), PETSC_ERR_SUP, "Could not find dm_field %" PetscInt_FMT " in DS", dm_field);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -261,7 +259,6 @@ PetscErrorCode BasisCreateFromTabulation(Ceed ceed, DM dm, DMLabel domain_label,
   PetscInt           dim, num_comp, P, Q;
 
   PetscFunctionBeginUser;
-
   // General basis information
   PetscCall(PetscFEGetSpatialDimension(fe, &dim));
   PetscCall(PetscFEGetNumComponents(fe, &num_comp));
@@ -337,7 +334,6 @@ PetscErrorCode BasisCreateFromTabulation(Ceed ceed, DM dm, DMLabel domain_label,
   PetscCall(PetscFree(q_points));
   PetscCall(PetscFree(interp));
   PetscCall(PetscFree(grad));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -353,7 +349,6 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
   PetscInt        ds_field   = -1;
 
   PetscFunctionBeginUser;
-
   // Get element information
   PetscCall(DMGetRegionDS(dm, domain_label, NULL, &ds, NULL));
   PetscCall(DMFieldToDSField(dm, domain_label, dm_field, &ds_field));
@@ -388,7 +383,6 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
 
     CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp, P_1d, Q_1d, bp_data.q_mode, basis);
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -434,7 +428,6 @@ PetscErrorCode CreateDistributedDM(RunParams rp, DM *dm) {
 
   PetscCall(DMSetFromOptions(*dm));
   PetscCall(DMViewFromOptions(*dm, NULL, "-dm_view"));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/petsc/src/swarmutils.c
+++ b/examples/petsc/src/swarmutils.c
@@ -1,3 +1,10 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
 #include "../include/swarmutils.h"
 #include "../qfunctions/swarm/swarmmass.h"
 
@@ -205,7 +212,6 @@ PetscErrorCode DMSwarmCeedContextCreate(DM dm_swarm, const char *ceed_resource, 
   CeedBasisDestroy(&basis_x);
   CeedVectorDestroy(&x_ref_points);
   CeedVectorDestroy(&q_data_points);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -248,7 +254,6 @@ PetscErrorCode DMSwarmPICFieldC2P(DM dm_swarm, const char *field, CeedVector x_c
 // ------------------------------------------------------------------------------------------------
 PetscErrorCode DMSwarmInitalizePointLocations(DM dm_swarm, PointSwarmType point_swarm_type, PetscInt num_points, PetscInt num_points_per_cell) {
   PetscFunctionBeginUser;
-
   switch (point_swarm_type) {
     case SWARM_GAUSS:
     case SWARM_UNIFORM: {
@@ -513,7 +518,6 @@ PetscErrorCode DMSwarmProjectFromSwarmToCells(DM dm_swarm, const char *field, Ve
   MPI_Comm           comm;
 
   PetscFunctionBeginUser;
-
   PetscOptionsBegin(PETSC_COMM_WORLD, NULL, "Swarm-to-Mesh Projection Options", NULL);
   PetscCall(PetscOptionsBool("-test", "Testing mode (do not print unless error is large)", NULL, test_mode, &test_mode, NULL));
   PetscOptionsEnd();
@@ -587,6 +591,5 @@ PetscErrorCode DMSwarmProjectFromSwarmToCells(DM dm_swarm, const char *field, Ve
   PetscCall(VecDestroy(&B_mesh));
   PetscCall(MatDestroy(&M));
   PetscCall(KSPDestroy(&ksp));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
Adds the CEED copyright header to all files in `examples/petsc` and updates all usage of `PetscFunctionBeginUser`/`PetscFunctionReturn` to match PETSc formatting guidelines (remove newlines after/before, respectively).