### PR TITLE
fluids: Ensure all outputs are set in QFunctions

### DIFF
--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -267,10 +267,12 @@ CEED_QFUNCTION(IFunction_Advection)(void *ctx, CeedInt Q, const CeedScalar *cons
   // Outputs
   CeedScalar(*v)[CEED_Q_VLA]     = (CeedScalar(*)[CEED_Q_VLA])out[0];
   CeedScalar(*dv)[5][CEED_Q_VLA] = (CeedScalar(*)[5][CEED_Q_VLA])out[1];
+  CeedScalar *jac_data           = out[2];
 
   AdvectionContext context     = (AdvectionContext)ctx;
   const CeedScalar CtauS       = context->CtauS;
   const CeedScalar strong_form = context->strong_form;
+  const CeedScalar zeros[14]   = {0.};
 
   // Quadrature Point Loop
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
@@ -341,6 +343,7 @@ CEED_QFUNCTION(IFunction_Advection)(void *ctx, CeedInt Q, const CeedScalar *cons
           dv[j][4][i] += wdetJ * TauS * strong_res * uX[j];
           break;
       }
+    StoredValuesPack(Q, i, 0, 14, zeros, jac_data);
   }  // End Quadrature Point Loop
 
   return 0;

--- a/examples/fluids/qfunctions/advection2d.h
+++ b/examples/fluids/qfunctions/advection2d.h
@@ -262,10 +262,12 @@ CEED_QFUNCTION(IFunction_Advection2d)(void *ctx, CeedInt Q, const CeedScalar *co
   // Outputs
   CeedScalar(*v)[CEED_Q_VLA]     = (CeedScalar(*)[CEED_Q_VLA])out[0];
   CeedScalar(*dv)[5][CEED_Q_VLA] = (CeedScalar(*)[5][CEED_Q_VLA])out[1];
+  CeedScalar *jac_data           = out[2];
 
   AdvectionContext context     = (AdvectionContext)ctx;
   const CeedScalar CtauS       = context->CtauS;
   const CeedScalar strong_form = context->strong_form;
+  const CeedScalar zeros[14]   = {0.};
 
   // Quadrature Point Loop
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
@@ -342,6 +344,7 @@ CEED_QFUNCTION(IFunction_Advection2d)(void *ctx, CeedInt Q, const CeedScalar *co
           dv[j][4][i] += wdetJ * TauS * strong_res * uX[j];
           break;
       }
+    StoredValuesPack(Q, i, 0, 14, zeros, jac_data);
   }  // End Quadrature Point Loop
 
   return 0;

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -145,6 +145,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q, const CeedScalar *const *in
 
   // Outputs
   CeedScalar(*v)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  CeedScalar(*jac_data_sur)  = out[1];
 
   const BlasiusContext     context     = (BlasiusContext)ctx;
   const bool               is_implicit = context->implicit;
@@ -159,6 +160,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q, const CeedScalar *const *in
   const bool               weakT       = context->weakT;
   const CeedScalar         rho_0       = P0 / (Rd * T_inf);
   const CeedScalar         x0          = U_inf * rho_0 / (mu * 25 / Square(delta0));
+  const CeedScalar         zeros[11]   = {0.};
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     CeedScalar wdetJb, norm[3];
@@ -194,6 +196,7 @@ CEED_QFUNCTION(Blasius_Inflow)(void *ctx, CeedInt Q, const CeedScalar *const *in
     CeedScalar       Flux[5];
     FluxTotal_Boundary(Flux_inviscid, stress, Fe, norm, Flux);
     for (CeedInt j = 0; j < 5; j++) v[j][i] = -wdetJb * Flux[j];
+    StoredValuesPack(Q, i, 0, 11, zeros, jac_data_sur);
   }
   return 0;
 }

--- a/examples/fluids/qfunctions/eulervortex.h
+++ b/examples/fluids/qfunctions/eulervortex.h
@@ -411,10 +411,12 @@ CEED_QFUNCTION(IFunction_Euler)(void *ctx, CeedInt Q, const CeedScalar *const *i
   // Outputs
   CeedScalar(*v)[CEED_Q_VLA]     = (CeedScalar(*)[CEED_Q_VLA])out[0];
   CeedScalar(*dv)[5][CEED_Q_VLA] = (CeedScalar(*)[5][CEED_Q_VLA])out[1];
+  CeedScalar *jac_data           = out[2];
 
-  EulerContext     context = (EulerContext)ctx;
-  const CeedScalar c_tau   = context->c_tau;
-  const CeedScalar gamma   = 1.4;
+  EulerContext     context   = (EulerContext)ctx;
+  const CeedScalar c_tau     = context->c_tau;
+  const CeedScalar gamma     = 1.4;
+  const CeedScalar zeros[14] = {0.};
 
   // Quadrature Point Loop
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
@@ -533,6 +535,7 @@ CEED_QFUNCTION(IFunction_Euler)(void *ctx, CeedInt Q, const CeedScalar *const *i
         }
         break;
     }
+    StoredValuesPack(Q, i, 0, 14, zeros, jac_data);
   }  // End Quadrature Point Loop
 
   // Return

--- a/examples/fluids/qfunctions/freestream_bc.h
+++ b/examples/fluids/qfunctions/freestream_bc.h
@@ -346,6 +346,7 @@ CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *con
   const FreestreamContext        context     = (FreestreamContext)ctx;
   const NewtonianIdealGasContext newt_ctx    = &context->newtonian_ctx;
   const bool                     is_implicit = newt_ctx->is_implicit;
+  const CeedScalar               zeros[6]    = {0.};
 
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
     const CeedScalar qi[5] = {q[0][i], q[1][i], q[2][i], q[3][i], q[4][i]};
@@ -369,6 +370,7 @@ CEED_QFUNCTION_HELPER int Freestream(void *ctx, CeedInt Q, const CeedScalar *con
     for (CeedInt j = 0; j < 5; j++) v[j][i] = -wdetJb * Flux[j];
 
     StoredValuesPack(Q, i, 0, 5, qi, jac_data_sur);
+    StoredValuesPack(Q, i, 5, 6, zeros, jac_data_sur);  // Every output value must be set
   }
   return 0;
 }


### PR DESCRIPTION
- In support of #1420

The issue was mostly with un-set `jac_data*` arrays. This was never a problem because the data that wasn't set never gets read. I made a [note in the BC refactor issue](https://github.com/CEED/libCEED/issues/1090#issuecomment-1848677236) to try and alleviate this issue.