### PR TITLE
fluids: Support higher-order geometry

### DIFF
--- a/examples/fluids/src/dm_utils.c
+++ b/examples/fluids/src/dm_utils.c
@@ -406,8 +406,8 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
   @param[in]   setup_faces     Flag to setup face geometry
   @param[in]   setup_coords    Flag to setup coordinate spaces
   @param[in]   degree          Polynomial orders of field
-  @param[in]   coord_order     Polynomial order of coordinate basis, or `RATEL_DECIDE` for default
-  @param[in]   q_extra         Additional quadrature order, or `RATEL_DECIDE` for default
+  @param[in]   coord_order     Polynomial order of coordinate basis, or `PETSC_DECIDE` for default
+  @param[in]   q_extra         Additional quadrature order
   @param[in]   num_fields      Number of fields in solution vector
   @param[in]   field_sizes     Array of number of components for each field
   @param[out]  dm              `DM` to setup
@@ -453,8 +453,7 @@ PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_co
     PetscCall(PetscDualSpaceGetOrder(fe_coord_dual_space, &fe_coord_order));
 
     // Create FE for coordinates
-    PetscCheck(fe_coord_order == 1 || coord_order == 1, comm, PETSC_ERR_USER_INPUT,
-               "Only linear mesh geometry supported. Recieved %" PetscInt_FMT " order", fe_coord_order);
+    if (coord_order != PETSC_DECIDE) fe_coord_order = coord_order;
     PetscCall(PetscFECreateLagrange(comm, dim, num_comp_coord, is_simplex, fe_coord_order, q_order, &fe_coord_new));
     if (setup_faces) PetscCall(PetscFEGetHeightSubspace(fe_coord_new, 1, &fe_coord_face_new));
     PetscCall(DMSetCoordinateDisc(dm, fe_coord_new, PETSC_TRUE));
@@ -502,8 +501,8 @@ PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm) {
   @param[in]   setup_faces     Flag to setup face geometry
   @param[in]   setup_coords    Flag to setup coordinate spaces
   @param[in]   degree          Polynomial orders of field
-  @param[in]   coord_order     Polynomial order of coordinate basis, or `RATEL_DECIDE` for default
-  @param[in]   q_extra         Additional quadrature order, or `RATEL_DECIDE` for default
+  @param[in]   coord_order     Polynomial order of coordinate basis, or `PETSC_DECIDE` for default
+  @param[in]   q_extra         Additional quadrature order
   @param[in]   num_fields      Number of fields in solution vector
   @param[in]   field_sizes     Array of number of components for each field
   @param[out]  dm              `DM` to setup

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -43,7 +43,7 @@ PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_
   PetscInt num_comp_q = 5;
   PetscFunctionBeginUser;
 
-  PetscCall(DMSetupByOrderBegin_FEM(PETSC_TRUE, PETSC_TRUE, degree, 1, q_extra, 1, &num_comp_q, dm));
+  PetscCall(DMSetupByOrderBegin_FEM(PETSC_TRUE, PETSC_TRUE, degree, PETSC_DECIDE, q_extra, 1, &num_comp_q, dm));
 
   {  // Add strong boundary conditions to DM
     DMLabel label;


### PR DESCRIPTION
Really, verify support for higher-order geometry that was already present.

To verify, I took the `vortexshedding.yaml` problem, made the mesh higher order in gmsh, then ran with that higher order geometry. Result can be seen below:
![image](https://github.com/CEED/libCEED/assets/20801821/a6fae178-9865-4f54-92e6-426c22d759d8)

Upper image has 2nd order geometry, lower has 1st order geometry. Both have 2nd order solutions on them. Below is the same, but just showing the mesh:
![image](https://github.com/CEED/libCEED/assets/20801821/928ae182-ede7-4321-8537-4830eee80134)
