### PR TITLE
Minor function signature fix caught with ASan

### DIFF
--- a/backends/ref/ceed-ref-vector.c
+++ b/backends/ref/ceed-ref-vector.c
@@ -135,7 +135,7 @@ static int CeedVectorGetArray_Ref(CeedVector vec, CeedMemType mem_type, CeedScal
 //------------------------------------------------------------------------------
 // Vector Get Array Write
 //------------------------------------------------------------------------------
-static int CeedVectorGetArrayWrite_Ref(CeedVector vec, CeedMemType mem_type, const CeedScalar **array) {
+static int CeedVectorGetArrayWrite_Ref(CeedVector vec, CeedMemType mem_type, CeedScalar **array) {
   CeedVector_Ref *impl;
 
   CeedCallBackend(CeedVectorGetData(vec, &impl));


### PR DESCRIPTION
Silences the following warning:

```
libCEED/interface/ceed-vector.c:445:5: runtime error: call to function CeedVectorGetArrayWrite_Ref through pointer to incorrect function type 'int (*)(struct CeedVector_private *, CeedMemType, double **)'
ceed-ref-vector.c:138: note: CeedVectorGetArrayWrite_Ref defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior libCEED/interface/ceed-vector.c:445:5
```