### PR TITLE
Silence compiler warning for `-Wstrict-prototypes`

### DIFF
--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -222,7 +222,7 @@ CEED_INTERN int CeedFree(void *p);
 #define CeedCalloc(n, p) CeedCallocArray((n), sizeof(**(p)), p)
 #define CeedRealloc(n, p) CeedReallocArray((n), sizeof(**(p)), p)
 
-/* Allow users to call CeedSetBackendFunctionImpl using incompatible pointer types */
+/* Allows calling CeedSetBackendFunctionImpl using incompatible pointer types */
 #define CeedSetBackendFunction(ceed, type, object, func_name, f) CeedSetBackendFunctionImpl(ceed, type, object, func_name, (void (*)(void))f)
 
 CEED_EXTERN int CeedRegister(const char *prefix, int (*init)(const char *, Ceed), unsigned int priority);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -223,7 +223,7 @@ CEED_INTERN int CeedFree(void *p);
 #define CeedRealloc(n, p) CeedReallocArray((n), sizeof(**(p)), p)
 
 /* Allow users to call CeedSetBackendFunctionImpl using incompatible pointer types */
-#define CeedSetBackendFunction(ceed, type, object, func_name, f) CeedSetBackendFunctionImpl(ceed, type, object, func_name, (int (*)(void))f)
+#define CeedSetBackendFunction(ceed, type, object, func_name, f) CeedSetBackendFunctionImpl(ceed, type, object, func_name, (void (*)(void))f)
 
 CEED_EXTERN int CeedRegister(const char *prefix, int (*init)(const char *, Ceed), unsigned int priority);
 CEED_EXTERN int CeedRegisterImpl(const char *prefix, int (*init)(const char *, Ceed), unsigned int priority);
@@ -239,7 +239,7 @@ CEED_EXTERN int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource
 CEED_EXTERN int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed);
 CEED_EXTERN int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource);
 CEED_EXTERN int CeedSetDeterministic(Ceed ceed, bool is_deterministic);
-CEED_EXTERN int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)(void));
+CEED_EXTERN int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const char *func_name, void (*f)(void));
 CEED_EXTERN int CeedGetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedSetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedReference(Ceed ceed);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -222,6 +222,9 @@ CEED_INTERN int CeedFree(void *p);
 #define CeedCalloc(n, p) CeedCallocArray((n), sizeof(**(p)), p)
 #define CeedRealloc(n, p) CeedReallocArray((n), sizeof(**(p)), p)
 
+/* Allow users to call CeedSetBackendFunctionImpl using incompatible pointer types */
+#define CeedSetBackendFunction(ceed, type, object, func_name, f) CeedSetBackendFunctionImpl(ceed, type, object, func_name, (int (*)(void))f)
+
 CEED_EXTERN int CeedRegister(const char *prefix, int (*init)(const char *, Ceed), unsigned int priority);
 CEED_EXTERN int CeedRegisterImpl(const char *prefix, int (*init)(const char *, Ceed), unsigned int priority);
 
@@ -236,7 +239,7 @@ CEED_EXTERN int CeedGetOperatorFallbackResource(Ceed ceed, const char **resource
 CEED_EXTERN int CeedGetOperatorFallbackCeed(Ceed ceed, Ceed *fallback_ceed);
 CEED_EXTERN int CeedSetOperatorFallbackResource(Ceed ceed, const char *resource);
 CEED_EXTERN int CeedSetDeterministic(Ceed ceed, bool is_deterministic);
-CEED_EXTERN int CeedSetBackendFunction(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)());
+CEED_EXTERN int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)(void));
 CEED_EXTERN int CeedGetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedSetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedReference(Ceed ceed);

--- a/interface/ceed-qfunction-register.c
+++ b/interface/ceed-qfunction-register.c
@@ -27,7 +27,7 @@ static bool register_all_called;
 
   @ref User
 **/
-int CeedQFunctionRegisterAll() {
+int CeedQFunctionRegisterAll(void) {
   int ierr = 0;
 
   CeedPragmaCritical(CeedQFunctionRegisterAll) {

--- a/interface/ceed-register.c
+++ b/interface/ceed-register.c
@@ -27,7 +27,7 @@ static bool register_all_called;
 
   @ref User
 **/
-int CeedRegisterAll() {
+int CeedRegisterAll(void) {
   int ierr = 0;
 
   CeedPragmaCritical(CeedRegisterAll) {

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -570,7 +570,7 @@ int CeedSetDeterministic(Ceed ceed, bool is_deterministic) {
 
   @ref Backend
 **/
-int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)(void)) {
+int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const char *func_name, void (*f)(void)) {
   char lookup_name[CEED_MAX_RESOURCE_LEN + 1] = "";
 
   // Build lookup name
@@ -584,7 +584,7 @@ int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const 
       size_t offset          = ceed->f_offsets[i].offset;
       int (**fpointer)(void) = (int (**)(void))((char *)object + offset);  // *NOPAD*
 
-      *fpointer = f;
+      *fpointer = (int (*)(void))f;
       return CEED_ERROR_SUCCESS;
     }
   }

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -570,7 +570,7 @@ int CeedSetDeterministic(Ceed ceed, bool is_deterministic) {
 
   @ref Backend
 **/
-int CeedSetBackendFunction(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)()) {
+int CeedSetBackendFunctionImpl(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)(void)) {
   char lookup_name[CEED_MAX_RESOURCE_LEN + 1] = "";
 
   // Build lookup name


### PR DESCRIPTION
Building with Clang 17 and `PEDANTIC=1`, I get:

```
./include/ceed/backend.h:239:114: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
  239 | CEED_EXTERN int CeedSetBackendFunction(Ceed ceed, const char *type, void *object, const char *func_name, int (*f)());
```

This PR resolves these errors.