### PR TITLE
GPU - Avoid calling diagonal assembly kernels if input arrays are null pointers

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -809,25 +809,28 @@ static inline int CeedOperatorAssembleDiagonalCore_Cuda(CeedOperator op, CeedVec
   }
   CeedCallBackend(CeedVectorSetValue(elem_diag, 0.0));
 
-  // Assemble element operator diagonals
-  CeedCallBackend(CeedVectorGetArray(elem_diag, CEED_MEM_DEVICE, &elem_diag_array));
-  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
-  CeedCallBackend(CeedElemRestrictionGetNumElements(diag_rstr, &num_elem));
+  // Only assemble diagonal if the basis has nodes, otherwise inputs are null pointers
+  if (diag->num_nodes > 0) {
+    // Assemble element operator diagonals
+    CeedCallBackend(CeedVectorGetArray(elem_diag, CEED_MEM_DEVICE, &elem_diag_array));
+    CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
+    CeedCallBackend(CeedElemRestrictionGetNumElements(diag_rstr, &num_elem));
 
-  // Compute the diagonal of B^T D B
-  int   elem_per_block = 1;
-  int   grid           = num_elem / elem_per_block + ((num_elem / elem_per_block * elem_per_block < num_elem) ? 1 : 0);
-  void *args[]         = {(void *)&num_elem, &diag->d_identity,  &diag->d_interp_in,  &diag->d_grad_in,    &diag->d_interp_out,
-                          &diag->d_grad_out, &diag->d_e_mode_in, &diag->d_e_mode_out, &assembled_qf_array, &elem_diag_array};
-  if (is_point_block) {
-    CeedCallBackend(CeedRunKernelDim_Cuda(ceed, diag->linearPointBlock, grid, diag->num_nodes, 1, elem_per_block, args));
-  } else {
-    CeedCallBackend(CeedRunKernelDim_Cuda(ceed, diag->linearDiagonal, grid, diag->num_nodes, 1, elem_per_block, args));
+    // Compute the diagonal of B^T D B
+    int   elem_per_block = 1;
+    int   grid           = num_elem / elem_per_block + ((num_elem / elem_per_block * elem_per_block < num_elem) ? 1 : 0);
+    void *args[]         = {(void *)&num_elem, &diag->d_identity,  &diag->d_interp_in,  &diag->d_grad_in,    &diag->d_interp_out,
+                            &diag->d_grad_out, &diag->d_e_mode_in, &diag->d_e_mode_out, &assembled_qf_array, &elem_diag_array};
+    if (is_point_block) {
+      CeedCallBackend(CeedRunKernelDim_Cuda(ceed, diag->linearPointBlock, grid, diag->num_nodes, 1, elem_per_block, args));
+    } else {
+      CeedCallBackend(CeedRunKernelDim_Cuda(ceed, diag->linearDiagonal, grid, diag->num_nodes, 1, elem_per_block, args));
+    }
+
+    // Restore arrays
+    CeedCallBackend(CeedVectorRestoreArray(elem_diag, &elem_diag_array));
+    CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
   }
-
-  // Restore arrays
-  CeedCallBackend(CeedVectorRestoreArray(elem_diag, &elem_diag_array));
-  CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
 
   // Assemble local operator diagonal
   CeedCallBackend(CeedElemRestrictionApply(diag_rstr, CEED_TRANSPOSE, elem_diag, assembled, request));


### PR DESCRIPTION
Resolves issue described in #1434 by only applying diagonal assembly kernels when the input arrays are set to valid memory addresses, i.e., when the number of basis nodes is non-zero.

Closes #1434.

We may want a similar fix for the full assembly kernels as well.