### PR TITLE
Fix CeedVectorAXPBY Implementations

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -691,7 +691,7 @@ static int CeedVectorAXPY_Cuda(CeedVector y, CeedScalar alpha, CeedVector x) {
 // Compute y = alpha x + beta y on the host
 //------------------------------------------------------------------------------
 static int CeedHostAXPBY_Cuda(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedSize length) {
-  for (CeedSize i = 0; i < length; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
+  for (CeedSize i = 0; i < length; i++) y_array[i] = alpha * x_array[i] + beta * y_array[i];
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -654,7 +654,7 @@ static int CeedVectorAXPY_Hip(CeedVector y, CeedScalar alpha, CeedVector x) {
 // Compute y = alpha x + beta y on the host
 //------------------------------------------------------------------------------
 static int CeedHostAXPBY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedScalar beta, CeedScalar *x_array, CeedSize length) {
-  for (CeedSize i = 0; i < length; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
+  for (CeedSize i = 0; i < length; i++) y_array[i] = alpha * x_array[i] + beta * y_array[i];
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -689,7 +689,7 @@ int CeedVectorAXPBY(CeedVector y, CeedScalar alpha, CeedScalar beta, CeedVector 
   assert(x_array);
   assert(y_array);
 
-  for (CeedSize i = 0; i < n_y; i++) y_array[i] += alpha * x_array[i] + beta * y_array[i];
+  for (CeedSize i = 0; i < n_y; i++) y_array[i] = alpha * x_array[i] + beta * y_array[i];
 
   CeedCall(CeedVectorRestoreArray(y, &y_array));
   CeedCall(CeedVectorRestoreArrayRead(x, &x_array));

--- a/python/tests/test-1-vector.py
+++ b/python/tests/test-1-vector.py
@@ -341,7 +341,7 @@ def test_125(ceed_resource, capsys):
 
     y.axpby(-0.5, 1.0, x)
     with y.array() as b:
-        assert np.allclose(1.5 * a, b)
+        assert np.allclose(0.5 * a, b)
 
 # -------------------------------------------------------------------------------
 # Test vector copy

--- a/rust/libceed/src/vector.rs
+++ b/rust/libceed/src/vector.rs
@@ -679,7 +679,7 @@ impl<'a> Vector<'a> {
     ///
     /// y = y.axpby(-0.5, 1.0, &x)?;
     /// for (i, y) in y.view()?.iter().enumerate() {
-    ///     assert_eq!(*y, (i as Scalar) * 1.5, "Value not set correctly");
+    ///     assert_eq!(*y, (i as Scalar) * 0.5, "Value not set correctly");
     /// }
     /// # Ok(())
     /// # }

--- a/tests/t125-vector.c
+++ b/tests/t125-vector.c
@@ -39,9 +39,9 @@ int main(int argc, char **argv) {
 
     CeedVectorGetArrayRead(y, CEED_MEM_HOST, &read_array);
     for (CeedInt i = 0; i < len; i++) {
-      if (fabs(read_array[i] - (10.0 + i) * 1.5) > 1e-14) {
+      if (fabs(read_array[i] - (10.0 + i) * 0.5) > 1e-14) {
         // LCOV_EXCL_START
-        printf("Error in alpha x + y at index %" CeedInt_FMT ", computed: %f actual: %f\n", i, read_array[i], (10.0 + i) * 1.5);
+        printf("Error in alpha x + y at index %" CeedInt_FMT ", computed: %f actual: %f\n", i, read_array[i], (10.0 + i) * 0.5);
         // LCOV_EXCL_STOP
       }
     }


### PR DESCRIPTION
Right now, `CeedVectorAXPBY` is implemented incorrectly in host/ref code as:
$$\mathbf{y} = \mathbf{y} + a\mathbf{x} + b\mathbf{y}$$

This PR corrects the implementation to:
$$\mathbf{y} = a\mathbf{x} + b\mathbf{y}$$
