### PR TITLE
fluids: Misc refactor/updates for advection and stabilization

### DIFF
--- a/examples/fluids/index.md
+++ b/examples/fluids/index.md
@@ -271,11 +271,11 @@ $$
 
 $$
 \mathcal{F} = \sqrt{ \rho^2 \left [ \left(\frac{2C_t}{\Delta t}\right)^2
-+ \bm u \cdot (\bm u \cdot  \bm g)
-+ C_v \mu^2 \Vert \bm g \Vert_F ^2\right]}
++ \bm u \cdot (\bm u \cdot  \bm g)\right]
++ C_v \mu^2 \Vert \bm g \Vert_F ^2}
 $$
 
-where $\bm g = \nabla_{\bm x} \bm{X} \cdot \nabla_{\bm x} \bm{X}$ is the metric tensor and $\Vert \cdot \Vert_F$ is the Frobenius norm.
+where $\bm g = \nabla_{\bm x} \bm{X}^T \cdot \nabla_{\bm x} \bm{X}$ is the metric tensor and $\Vert \cdot \Vert_F$ is the Frobenius norm.
 This formulation is currently not available in the Euler code.
 
 In the Euler code, we follow {cite}`hughesetal2010` in defining a $3\times 3$ diagonal stabilization according to spatial criterion 2 (equation 27) as follows.

--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -278,7 +278,7 @@ CEED_QFUNCTION(Advection)(void *ctx, CeedInt Q, const CeedScalar *const *in, Cee
     //   field u.
     CeedScalar uX[3];
     for (CeedInt j = 0; j < 3; j++) uX[j] = dXdx[j][0] * u[0] + dXdx[j][1] * u[1] + dXdx[j][2] * u[2];
-    const CeedScalar TauS = CtauS / sqrt(uX[0] * uX[0] + uX[1] * uX[1] + uX[2] * uX[2]);
+    const CeedScalar TauS = CtauS / sqrt(Dot3(uX, uX));
     for (CeedInt j = 0; j < 3; j++) dv[j][4][i] -= wdetJ * TauS * strong_conv * uX[j];
   }  // End Quadrature Point Loop
 

--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -154,16 +154,17 @@ CEED_QFUNCTION_HELPER CeedInt Exact_Advection(CeedInt dim, CeedScalar time, cons
       q[4]                  = r > half_width ? 0. : cos(2 * M_PI * r / half_width + M_PI) + 1.;
     } break;
     case ADVECTIONIC_SKEW: {
-      CeedScalar skewed_barrier[3]  = {wind[0], wind[1], 0};
-      CeedScalar inflow_to_point[3] = {x - context->lx / 2, y, 0};
-      CeedScalar cross_product[3]   = {0};
+      CeedScalar       skewed_barrier[3]  = {wind[0], wind[1], 0};
+      CeedScalar       inflow_to_point[3] = {x - context->lx / 2, y, 0};
+      CeedScalar       cross_product[3]   = {0};
+      const CeedScalar boundary_threshold = 20 * CEED_EPSILON;
       Cross3(skewed_barrier, inflow_to_point, cross_product);
 
-      q[4] = cross_product[2] > 0 ? 0 : 1;
-      if ((x < 5 * CEED_EPSILON && wind[0] < 5 * CEED_EPSILON) ||                // outflow at -x boundary
-          (y < 5 * CEED_EPSILON && wind[1] < 5 * CEED_EPSILON) ||                // outflow at -y boundary
-          (x > context->lx - 5 * CEED_EPSILON && wind[0] > 5 * CEED_EPSILON) ||  // outflow at +x boundary
-          (y > context->ly - 5 * CEED_EPSILON && wind[1] > 5 * CEED_EPSILON)     // outflow at +y boundary
+      q[4] = cross_product[2] > boundary_threshold ? 0 : 1;
+      if ((x < boundary_threshold && wind[0] < boundary_threshold) ||                // outflow at -x boundary
+          (y < boundary_threshold && wind[1] < boundary_threshold) ||                // outflow at -y boundary
+          (x > context->lx - boundary_threshold && wind[0] > boundary_threshold) ||  // outflow at +x boundary
+          (y > context->ly - boundary_threshold && wind[1] > boundary_threshold)     // outflow at +y boundary
       ) {
         q[4] = 0;
       }

--- a/examples/fluids/qfunctions/stabilization.h
+++ b/examples/fluids/qfunctions/stabilization.h
@@ -29,14 +29,15 @@ CEED_QFUNCTION_HELPER void dYFromTau(CeedScalar Y[5], CeedScalar Tau_d[3], CeedS
 // *****************************************************************************
 // Helper functions for computing the stabilization terms
 // *****************************************************************************
-CEED_QFUNCTION_HELPER void StabilizationMatrix(NewtonianIdealGasContext gas, State s, CeedScalar Tau_d[3], CeedScalar R[5], CeedScalar stab[5][3]) {
+CEED_QFUNCTION_HELPER void StabilizationMatrix(NewtonianIdealGasContext gas, State s, CeedScalar Tau_d[3], CeedScalar strong_residual[5],
+                                               CeedScalar stab[5][3]) {
   CeedScalar        dY[5];
   StateConservative dF[3];
   // Zero stab so all future terms can safely sum into it
   for (CeedInt i = 0; i < 5; i++) {
     for (CeedInt j = 0; j < 3; j++) stab[i][j] = 0;
   }
-  dYFromTau(R, Tau_d, dY);
+  dYFromTau(strong_residual, Tau_d, dY);
   State ds = StateFromY_fwd(gas, s, dY);
   FluxInviscid_fwd(gas, s, ds, dF);
   for (CeedInt i = 0; i < 3; i++) {
@@ -49,19 +50,19 @@ CEED_QFUNCTION_HELPER void StabilizationMatrix(NewtonianIdealGasContext gas, Sta
 CEED_QFUNCTION_HELPER void Stabilization(NewtonianIdealGasContext gas, State s, CeedScalar Tau_d[3], State ds[3], CeedScalar U_dot[5],
                                          const CeedScalar body_force[5], CeedScalar stab[5][3]) {
   // -- Stabilization method: none (Galerkin), SU, or SUPG
-  CeedScalar R[5] = {0};
+  CeedScalar strong_residual[5] = {0};
   switch (gas->stabilization) {
     case STAB_NONE:
       break;
     case STAB_SU:
-      FluxInviscidStrong(gas, s, ds, R);
+      FluxInviscidStrong(gas, s, ds, strong_residual);
       break;
     case STAB_SUPG:
-      FluxInviscidStrong(gas, s, ds, R);
-      for (CeedInt j = 0; j < 5; j++) R[j] += U_dot[j] - body_force[j];
+      FluxInviscidStrong(gas, s, ds, strong_residual);
+      for (CeedInt j = 0; j < 5; j++) strong_residual[j] += U_dot[j] - body_force[j];
       break;
   }
-  StabilizationMatrix(gas, s, Tau_d, R, stab);
+  StabilizationMatrix(gas, s, Tau_d, strong_residual, stab);
 }
 
 // *****************************************************************************

--- a/examples/fluids/qfunctions/stabilization.h
+++ b/examples/fluids/qfunctions/stabilization.h
@@ -103,11 +103,11 @@ CEED_QFUNCTION_HELPER void Tau_diagPrim(NewtonianIdealGasContext gas, State s, c
 
   dts = Ctau_t / dt;
 
-  tau = rho * rho *
-            ((4. * dts * dts) + u[0] * (u[0] * gijd[0] + 2. * (u[1] * gijd[1] + u[2] * gijd[3])) + u[1] * (u[1] * gijd[2] + 2. * u[2] * gijd[4]) +
+  tau = Square(rho) *
+            (4. * Square(dts) + u[0] * (u[0] * gijd[0] + 2. * (u[1] * gijd[1] + u[2] * gijd[3])) + u[1] * (u[1] * gijd[2] + 2. * u[2] * gijd[4]) +
              u[2] * u[2] * gijd[5]) +
-        Ctau_v * mu * mu *
-            (gijd[0] * gijd[0] + gijd[2] * gijd[2] + gijd[5] * gijd[5] + +2. * (gijd[1] * gijd[1] + gijd[3] * gijd[3] + gijd[4] * gijd[4]));
+        Ctau_v * Square(mu) *
+            (Square(gijd[0]) + Square(gijd[2]) + Square(gijd[5]) + +2. * (Square(gijd[1]) + Square(gijd[3]) + Square(gijd[4])));
 
   fact = sqrt(tau);
 


### PR DESCRIPTION
Various small changes to the fluids advection example and stabilization
- Refactor diagonal $\tau$ calculation to use the `Mat` and `Dot` utility functions
  - This was primarily to make sure my own understanding and future implementation of stabilization parameters was correct
- Correct documentation on $\tau$ formulation
- Increase the threshold for the skew advection problem initial condition
  - Had problems with 3rd order not quite getting there
- Convert the Advection problem to use the newtonian State structs
  - Not a perfect match, but helps utilize some of the gradient utilities already in use.
  - Also updated to use `Mat` and `Dot` utilities when appropriate.