### PR TITLE
Improve vectorization for CPU curl-oriented element restriction transpose

### DIFF
--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -75,7 +75,7 @@ int CeedPermutePadOrients(const bool *orients, bool *block_orients, CeedInt num_
 /**
   @brief Permute and pad curl-conforming orientations for a blocked `CeedElemRestriction`
 
-  @param[in]  curl_orients       Array of shape `[num_elem, 3 * elem_size]`
+  @param[in]  curl_orients       Array of shape `[num_elem, elem_size]`
   @param[out] block_curl_orients Array of permuted and padded array values of shape `[num_block, elem_size, block_size]`
   @param[in]  num_block          Number of blocks
   @param[in]  num_elem           Number of elements


### PR DESCRIPTION
This is a minor change which produces some modest speedups for low-order operators in particular.