### PR TITLE
fluids: Stats don't overwrite solution on first-step failure

### DIFF
--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -597,7 +597,7 @@ PetscErrorCode TSMonitor_TurbulenceStatistics(TS ts, PetscInt steps, PetscReal s
   PetscFunctionBeginUser;
   PetscCall(TSGetConvergedReason(ts, &reason));
   // Do not collect or process on the first step of the run (ie. on the initial condition)
-  if (steps == user->app_ctx->cont_steps && reason == TS_CONVERGED_ITERATING) PetscFunctionReturn(PETSC_SUCCESS);
+  if (steps == user->app_ctx->cont_steps) PetscFunctionReturn(PETSC_SUCCESS);
 
   PetscBool run_processing_and_viewer = (steps % viewer_interval == 0 && viewer_interval != -1) || reason != TS_CONVERGED_ITERATING;
 


### PR DESCRIPTION
When you have an initial condition from a previous problem, it might fail on the first step. This will cause `reason != TS_CONVERGED_ITERATING` and thus it will continue on with the rest of the TSMonitor routine. If you have a stats file from that initial condition, it will be overwritten.

Regardless of the overwriting behavior, it *never* makes sense to write out a stats file on the first step; Using left-rectangle rule for the time averaging integration, the initial step should *never* be used, thus there is nothing to collect or write.