### PR TITLE
Efficiently use in-order and out-of-order queues in the SYCL backends

### DIFF
--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
@@ -742,6 +742,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
 
   // Copy the struct (containing device addresses) from the host to the device
   std::vector<sycl::event> e;
+
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl::event copy_B       = sycl_data->sycl_queue.copy<Fields_Sycl>(&h_B, impl->B, 1, e);

--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
@@ -741,9 +741,12 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
   code << "// -----------------------------------------------------------------------------\n\n";
 
   // Copy the struct (containing device addresses) from the host to the device
-  sycl::event copy_B       = sycl_data->sycl_queue.copy<Fields_Sycl>(&h_B, impl->B, 1);
-  sycl::event copy_G       = sycl_data->sycl_queue.copy<Fields_Sycl>(&h_G, impl->G, 1);
-  sycl::event copy_indices = sycl_data->sycl_queue.copy<FieldsInt_Sycl>(&h_indices, impl->indices, 1);
+  std::vector<sycl::event> e;
+  if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
+
+  sycl::event copy_B       = sycl_data->sycl_queue.copy<Fields_Sycl>(&h_B, impl->B, 1, e);
+  sycl::event copy_G       = sycl_data->sycl_queue.copy<Fields_Sycl>(&h_G, impl->G, 1, e);
+  sycl::event copy_indices = sycl_data->sycl_queue.copy<FieldsInt_Sycl>(&h_indices, impl->indices, 1, e);
   // These copies can happen while the JIT is being done
   CeedCallSycl(ceed, sycl::event::wait_and_throw({copy_B, copy_G, copy_indices}));
 

--- a/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
@@ -137,6 +137,7 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
 
   //-----------
   std::vector<sycl::event> e;
+
   if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 
   CeedCallSycl(ceed, ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {

--- a/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
@@ -136,8 +136,8 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
   sycl::nd_range<3> kernel_range(global_range, local_range);
 
   //-----------
-  // Order queue
-  sycl::event e = ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier();
+  std::vector<sycl::event> e;
+  if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 
   CeedCallSycl(ceed, ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
     cgh.depends_on(e);

--- a/backends/sycl-gen/ceed-sycl-gen.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen.sycl.cpp
@@ -34,13 +34,13 @@ static int CeedInit_Sycl_gen(const char *resource, Ceed ceed) {
 
   CeedCallBackend(CeedInit("/gpu/sycl/shared", &ceed_shared));
   CeedCallBackend(CeedSetDelegate(ceed, ceed_shared));
-  CeedCallBackend(CeedSetStream_Sycl(ceed_shared,&(data->sycl_queue)));
+  CeedCallBackend(CeedSetStream_Sycl(ceed_shared, &(data->sycl_queue)));
 
   CeedCallBackend(CeedSetOperatorFallbackResource(ceed, fallback_resource));
 
   Ceed ceed_fallback = NULL;
   CeedCallBackend(CeedGetOperatorFallbackCeed(ceed, &ceed_fallback));
-  CeedCallBackend(CeedSetStream_Sycl(ceed_fallback,&(data->sycl_queue)));
+  CeedCallBackend(CeedSetStream_Sycl(ceed_fallback, &(data->sycl_queue)));
 
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Ceed", ceed, "QFunctionCreate", CeedQFunctionCreate_Sycl_gen));
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Ceed", ceed, "OperatorCreate", CeedOperatorCreate_Sycl_gen));

--- a/backends/sycl-gen/ceed-sycl-gen.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen.sycl.cpp
@@ -33,14 +33,14 @@ static int CeedInit_Sycl_gen(const char *resource, Ceed ceed) {
   CeedCallBackend(CeedInit_Sycl(ceed, resource));
 
   CeedCallBackend(CeedInit("/gpu/sycl/shared", &ceed_shared));
-
-  CeedCallBackend(CeedGetData(ceed_shared, &shared_data));
-  // Need to use the same queue everywhere for correct synchronization
-  shared_data->sycl_queue = data->sycl_queue;
-
   CeedCallBackend(CeedSetDelegate(ceed, ceed_shared));
+  CeedCallBackend(CeedSetStream_Sycl(ceed_shared,&(data->sycl_queue)));
 
   CeedCallBackend(CeedSetOperatorFallbackResource(ceed, fallback_resource));
+
+  Ceed ceed_fallback = NULL;
+  CeedCallBackend(CeedGetOperatorFallbackCeed(ceed, &ceed_fallback));
+  CeedCallBackend(CeedSetStream_Sycl(ceed_fallback,&(data->sycl_queue)));
 
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Ceed", ceed, "QFunctionCreate", CeedQFunctionCreate_Sycl_gen));
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Ceed", ceed, "OperatorCreate", CeedOperatorCreate_Sycl_gen));

--- a/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
@@ -252,7 +252,7 @@ static int CeedBasisApplyWeight_Sycl(sycl::queue &sycl_queue, CeedInt num_elem, 
 
   std::vector<sycl::event> e;
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
-  
+
   sycl_queue.parallel_for<CeedBasisSyclWeight>(kernel_range, e, [=](sycl::item<3> work_item) {
     if (dim == 1) w[work_item.get_linear_id()] = q_weight_1d[work_item[2]];
     if (dim == 2) w[work_item.get_linear_id()] = q_weight_1d[work_item[2]] * q_weight_1d[work_item[1]];

--- a/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
@@ -50,6 +50,7 @@ static int CeedBasisApplyInterp_Sycl(sycl::queue &sycl_queue, const SyclModule_t
   sycl::nd_range<1>   kernel_range(global_range, local_range);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.submit([&](sycl::handler &cgh) {
@@ -152,6 +153,7 @@ static int CeedBasisApplyGrad_Sycl(sycl::queue &sycl_queue, const SyclModule_t &
   sycl::nd_range<1>   kernel_range(global_range, local_range);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.submit([&](sycl::handler &cgh) {
@@ -251,6 +253,7 @@ static int CeedBasisApplyWeight_Sycl(sycl::queue &sycl_queue, CeedInt num_elem, 
   sycl::range<3> kernel_range(num_elem * num_quad_z, num_quad_y, num_quad_x);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.parallel_for<CeedBasisSyclWeight>(kernel_range, e, [=](sycl::item<3> work_item) {
@@ -287,6 +290,7 @@ static int CeedBasisApply_Sycl(CeedBasis basis, const CeedInt num_elem, CeedTran
     CeedSize length;
     CeedCallBackend(CeedVectorGetLength(v, &length));
     std::vector<sycl::event> e;
+
     if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
     data->sycl_queue.fill<CeedScalar>(d_v, 0, length, e);
   }
@@ -347,6 +351,7 @@ static int CeedBasisApplyNonTensorInterp_Sycl(sycl::queue &sycl_queue, CeedInt n
   sycl::range<2> kernel_range(num_elem, v_size);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.parallel_for<CeedBasisSyclInterpNT>(kernel_range, e, [=](sycl::id<2> indx) {
@@ -392,6 +397,7 @@ static int CeedBasisApplyNonTensorGrad_Sycl(sycl::queue &sycl_queue, CeedInt num
   sycl::range<2> kernel_range(num_elem, v_size);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.parallel_for<CeedBasisSyclGradNT>(kernel_range, e, [=](sycl::id<2> indx) {
@@ -431,6 +437,7 @@ static int CeedBasisApplyNonTensorWeight_Sycl(sycl::queue &sycl_queue, CeedInt n
   sycl::range<2> kernel_range(num_elem, num_qpts);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.parallel_for<CeedBasisSyclWeightNT>(kernel_range, e, [=](sycl::id<2> indx) {
@@ -571,6 +578,7 @@ int CeedBasisCreateTensorH1_Sycl(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const 
   impl->op_len    = Q_1d * P_1d;
 
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   CeedCallSycl(ceed, impl->d_q_weight_1d = sycl::malloc_device<CeedScalar>(Q_1d, data->sycl_device, data->sycl_context));
@@ -625,6 +633,7 @@ int CeedBasisCreateH1_Sycl(CeedElemTopology topo, CeedInt dim, CeedInt num_nodes
   impl->num_qpts  = num_qpts;
 
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   CeedCallSycl(ceed, impl->d_q_weight = sycl::malloc_device<CeedScalar>(num_qpts, data->sycl_device, data->sycl_context));

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1092,7 +1092,7 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
 
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
       sycl_data->sycl_queue.copy<CeedScalar>(grad_in, &asmb->d_B_in[mat_start], dim * elem_size * num_qpts, {e});
-      mat_start += dim * elem_size * num_qpts;      
+      mat_start += dim * elem_size * num_qpts;
     }
   }
 

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1091,7 +1091,7 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
       std::vector<sycl::event> e;
 
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(grad_in, &asmb->d_B_in[mat_start], dim * elem_size * num_qpts, {e});
+      sycl_data->sycl_queue.copy<CeedScalar>(grad_in, &asmb->d_B_in[mat_start], dim * elem_size * num_qpts, e);
       mat_start += dim * elem_size * num_qpts;
     }
   }

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -827,8 +827,8 @@ static int CeedOperatorLinearDiagonal_Sycl(sycl::queue &sycl_queue, const bool i
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.parallel_for<CeedOperatorSyclLinearDiagonal>(kernel_range, e, [=](sycl::id<1> idx) {
-    const CeedInt tid = idx % nnodes;
-    const CeedInt e   = idx / nnodes;
+    const CeedInt tid = idx % num_nodes;
+    const CeedInt e   = idx / num_nodes;
 
     // Compute the diagonal of B^T D B
     // Each element

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -750,9 +750,11 @@ static inline int CeedOperatorAssembleDiagonalSetup_Sycl(CeedOperator op) {
   for (CeedInt i = 0; i < num_e_mode_out; i++) has_eval_none = has_eval_none || (e_mode_out[i] == CEED_EVAL_NONE);
 
   std::vector<sycl::event> e;
+
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
 
   std::vector<sycl::event> copy_events;
+
   if (has_eval_none) {
     CeedCallBackend(CeedCalloc(num_qpts * num_nodes, &identity));
     for (CeedSize i = 0; i < (num_nodes < num_qpts ? num_nodes : num_qpts); i++) identity[i * num_nodes + i] = 1.0;
@@ -821,6 +823,7 @@ static int CeedOperatorLinearDiagonal_Sycl(sycl::queue &sycl_queue, const bool i
   sycl::range<1> kernel_range(num_elem * num_nodes);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
 
   sycl_queue.parallel_for<CeedOperatorSyclLinearDiagonal>(kernel_range, e, [=](sycl::id<1> idx) {
@@ -1080,11 +1083,13 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
 
     if (eval_mode == CEED_EVAL_INTERP) {
       std::vector<sycl::event> e;
+
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
       sycl_data->sycl_queue.copy<CeedScalar>(interp_in, &asmb->d_B_in[mat_start], elem_size * num_qpts, e);
       mat_start += elem_size * num_qpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
       std::vector<sycl::event> e;
+
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
       sycl_data->sycl_queue.copy<CeedScalar>(grad_in, &asmb->d_B_in[mat_start], dim * elem_size * num_qpts, {e});
       mat_start += dim * elem_size * num_qpts;      
@@ -1110,11 +1115,13 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
 
     if (eval_mode == CEED_EVAL_INTERP) {
       std::vector<sycl::event> e;
+
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
       sycl_data->sycl_queue.copy<CeedScalar>(interp_out, &asmb->d_B_out[mat_start], elem_size * num_qpts, e);
       mat_start += elem_size * num_qpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
       std::vector<sycl::event> e;
+
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
       sycl_data->sycl_queue.copy<CeedScalar>(grad_out, &asmb->d_B_out[mat_start], dim * elem_size * num_qpts, e);
       mat_start += dim * elem_size * num_qpts;
@@ -1159,6 +1166,7 @@ static int CeedOperatorLinearAssemble_Sycl(sycl::queue &sycl_queue, const CeedOp
   sycl::range<3> kernel_range(num_elem, block_size_y, block_size_x);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for<CeedOperatorSyclLinearAssemble>(kernel_range, e, [=](sycl::id<3> idx) {
     const int e = idx.get(0);  // Element index

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1081,7 +1081,7 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
     if (eval_mode == CEED_EVAL_INTERP) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(interp_in, &asmb->d_B_in[mat_start], elem_size * num_qpts, {e});
+      sycl_data->sycl_queue.copy<CeedScalar>(interp_in, &asmb->d_B_in[mat_start], elem_size * num_qpts, e);
       mat_start += elem_size * num_qpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
       std::vector<sycl::event> e;
@@ -1111,12 +1111,12 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
     if (eval_mode == CEED_EVAL_INTERP) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(interp_out, &asmb->d_B_out[mat_start], elem_size * num_qpts, {e});
+      sycl_data->sycl_queue.copy<CeedScalar>(interp_out, &asmb->d_B_out[mat_start], elem_size * num_qpts, e);
       mat_start += elem_size * num_qpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(grad_out, &asmb->d_B_out[mat_start], dim * elem_size * num_qpts, {e});
+      sycl_data->sycl_queue.copy<CeedScalar>(grad_out, &asmb->d_B_out[mat_start], dim * elem_size * num_qpts, e);
       mat_start += dim * elem_size * num_qpts;
     }
   }
@@ -1160,7 +1160,7 @@ static int CeedOperatorLinearAssemble_Sycl(sycl::queue &sycl_queue, const CeedOp
 
   std::vector<sycl::event> e;
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
-  sycl_queue.parallel_for<CeedOperatorSyclLinearAssemble>(kernel_range, {e}, [=](sycl::id<3> idx) {
+  sycl_queue.parallel_for<CeedOperatorSyclLinearAssemble>(kernel_range, e, [=](sycl::id<3> idx) {
     const int e = idx.get(0);  // Element index
     const int l = idx.get(1);  // The output column index of each B^TDB operation
     const int i = idx.get(2);  // The output row index of each B^TDB operation

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1081,12 +1081,12 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
     if (eval_mode == CEED_EVAL_INTERP) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(interp_in, &asmb->d_B_in[mat_start], elem_size * num_qpts, e);
+      sycl_data->sycl_queue.copy<CeedScalar>(interp_in, &asmb->d_B_in[mat_start], elem_size * num_qpts, {e});
       mat_start += elem_size * num_qpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(grad_in, &asmb->d_B_in[mat_start], dim * elem_size * num_qpts, e);
+      sycl_data->sycl_queue.copy<CeedScalar>(grad_in, &asmb->d_B_in[mat_start], dim * elem_size * num_qpts, {e});
       mat_start += dim * elem_size * num_qpts;      
     }
   }
@@ -1111,12 +1111,12 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
     if (eval_mode == CEED_EVAL_INTERP) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(interp_out, &asmb->d_B_out[mat_start], elem_size * num_qpts, e);
+      sycl_data->sycl_queue.copy<CeedScalar>(interp_out, &asmb->d_B_out[mat_start], elem_size * num_qpts, {e});
       mat_start += elem_size * num_qpts;
     } else if (eval_mode == CEED_EVAL_GRAD) {
       std::vector<sycl::event> e;
       if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-      sycl_data->sycl_queue.copy<CeedScalar>(grad_out, &asmb->d_B_out[mat_start], dim * elem_size * num_qpts, e);
+      sycl_data->sycl_queue.copy<CeedScalar>(grad_out, &asmb->d_B_out[mat_start], dim * elem_size * num_qpts, {e});
       mat_start += dim * elem_size * num_qpts;
     }
   }
@@ -1160,7 +1160,7 @@ static int CeedOperatorLinearAssemble_Sycl(sycl::queue &sycl_queue, const CeedOp
 
   std::vector<sycl::event> e;
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
-  sycl_queue.parallel_for<CeedOperatorSyclLinearAssemble>(kernel_range, e, [=](sycl::id<3> idx) {
+  sycl_queue.parallel_for<CeedOperatorSyclLinearAssemble>(kernel_range, {e}, [=](sycl::id<3> idx) {
     const int e = idx.get(0);  // Element index
     const int l = idx.get(1);  // The output column index of each B^TDB operation
     const int i = idx.get(2);  // The output row index of each B^TDB operation

--- a/backends/sycl-ref/ceed-sycl-ref-qfunction.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunction.sycl.cpp
@@ -59,6 +59,7 @@ static int CeedQFunctionApply_Sycl(CeedQFunction qf, CeedInt Q, CeedVector *U, C
   CeedCallBackend(CeedQFunctionGetInnerContextData(qf, CEED_MEM_DEVICE, &context_data));
 
   std::vector<sycl::event> e;
+
   if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 
   // Launch as a basic parallel_for over Q quadrature points

--- a/backends/sycl-ref/ceed-sycl-ref-qfunction.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunction.sycl.cpp
@@ -58,12 +58,12 @@ static int CeedQFunctionApply_Sycl(CeedQFunction qf, CeedInt Q, CeedVector *U, C
   // Get context data
   CeedCallBackend(CeedQFunctionGetInnerContextData(qf, CEED_MEM_DEVICE, &context_data));
 
-  // Order queue
-  sycl::event e = ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier();
+  std::vector<sycl::event> e;
+  if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 
   // Launch as a basic parallel_for over Q quadrature points
   ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
-    cgh.depends_on({e});
+    cgh.depends_on(e);
 
     int iarg{};
     cgh.set_arg(iarg, context_data);

--- a/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
@@ -38,6 +38,7 @@ static inline int CeedQFunctionContextSyncH2D_Sycl(const CeedQFunctionContext ct
     impl->d_data = impl->d_data_owned;
   }
   std::vector<sycl::event> e;
+
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
   sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, e);
   CeedCallSycl(ceed, copy_event.wait_and_throw());
@@ -70,6 +71,7 @@ static inline int CeedQFunctionContextSyncD2H_Sycl(const CeedQFunctionContext ct
   }
 
   std::vector<sycl::event> e;
+
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
   sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, e);
   CeedCallSycl(ceed, copy_event.wait_and_throw());
@@ -195,6 +197,7 @@ static int CeedQFunctionContextSetDataDevice_Sycl(const CeedQFunctionContext ctx
   CeedCallBackend(CeedGetData(ceed, &sycl_data));
 
   std::vector<sycl::event> e;
+
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
 
   // Wait for all work to finish before freeing memory

--- a/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
@@ -39,7 +39,7 @@ static inline int CeedQFunctionContextSyncH2D_Sycl(const CeedQFunctionContext ct
   }
   std::vector<sycl::event> e;
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, e);
+  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, {e});
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
@@ -71,7 +71,7 @@ static inline int CeedQFunctionContextSyncD2H_Sycl(const CeedQFunctionContext ct
 
   std::vector<sycl::event> e;
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, e);
+  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, {e});
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
@@ -39,7 +39,7 @@ static inline int CeedQFunctionContextSyncH2D_Sycl(const CeedQFunctionContext ct
   }
   std::vector<sycl::event> e;
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, {e});
+  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, e);
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
@@ -71,7 +71,7 @@ static inline int CeedQFunctionContextSyncD2H_Sycl(const CeedQFunctionContext ct
 
   std::vector<sycl::event> e;
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, {e});
+  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, e);
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
@@ -37,8 +37,8 @@ static inline int CeedQFunctionContextSyncH2D_Sycl(const CeedQFunctionContext ct
     CeedCallSycl(ceed, impl->d_data_owned = sycl::malloc_device(ctx_size, sycl_data->sycl_device, sycl_data->sycl_context));
     impl->d_data = impl->d_data_owned;
   }
-  // Order queue
-  sycl::event e          = sycl_data->sycl_queue.ext_oneapi_submit_barrier();
+  std::vector<sycl::event> e;
+  if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
   sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, {e});
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
@@ -69,8 +69,8 @@ static inline int CeedQFunctionContextSyncD2H_Sycl(const CeedQFunctionContext ct
     impl->h_data = impl->h_data_owned;
   }
 
-  // Order queue
-  sycl::event e          = sycl_data->sycl_queue.ext_oneapi_submit_barrier();
+  std::vector<sycl::event> e;
+  if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
   sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, {e});
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
@@ -194,8 +194,8 @@ static int CeedQFunctionContextSetDataDevice_Sycl(const CeedQFunctionContext ctx
   CeedCallBackend(CeedQFunctionContextGetCeed(ctx, &ceed));
   CeedCallBackend(CeedGetData(ceed, &sycl_data));
 
-  // Order queue
-  sycl::event e = sycl_data->sycl_queue.ext_oneapi_submit_barrier();
+  std::vector<sycl::event> e;
+  if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
 
   // Wait for all work to finish before freeing memory
   if (impl->d_data_owned) {
@@ -260,8 +260,8 @@ static int CeedQFunctionContextTakeData_Sycl(const CeedQFunctionContext ctx, con
   CeedCallBackend(CeedQFunctionContextGetBackendData(ctx, &impl));
   CeedCallBackend(CeedGetData(ceed, &ceedSycl));
 
-  // Order queue
-  ceedSycl->sycl_queue.ext_oneapi_submit_barrier();
+  // Order queue if needed
+  if (!ceedSycl->sycl_queue.is_in_order()) ceedSycl->sycl_queue.ext_oneapi_submit_barrier();
 
   // Sync data to requested mem_type
   CeedCallBackend(CeedQFunctionContextNeedSync_Sycl(ctx, mem_type, &need_sync));

--- a/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunctioncontext.sycl.cpp
@@ -39,7 +39,7 @@ static inline int CeedQFunctionContextSyncH2D_Sycl(const CeedQFunctionContext ct
   }
   std::vector<sycl::event> e;
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, {e});
+  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, impl->h_data, ctx_size, e);
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
@@ -71,7 +71,7 @@ static inline int CeedQFunctionContextSyncD2H_Sycl(const CeedQFunctionContext ct
 
   std::vector<sycl::event> e;
   if (!sycl_data->sycl_queue.is_in_order()) e = {sycl_data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, {e});
+  sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->h_data, impl->d_data, ctx_size, e);
   CeedCallSycl(ceed, copy_event.wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
@@ -212,7 +212,7 @@ static int CeedQFunctionContextSetDataDevice_Sycl(const CeedQFunctionContext ctx
       CeedCallSycl(ceed, impl->d_data_owned = sycl::malloc_device(ctx_size, sycl_data->sycl_device, sycl_data->sycl_context));
       impl->d_data_borrowed  = NULL;
       impl->d_data           = impl->d_data_owned;
-      sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, data, ctx_size, {e});
+      sycl::event copy_event = sycl_data->sycl_queue.memcpy(impl->d_data, data, ctx_size, e);
       CeedCallSycl(ceed, copy_event.wait_and_throw());
     } break;
     case CEED_OWN_POINTER: {

--- a/backends/sycl-ref/ceed-sycl-restriction.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-restriction.sycl.cpp
@@ -35,6 +35,7 @@ static int CeedElemRestrictionStridedNoTranspose_Sycl(sycl::queue &sycl_queue, c
   sycl::range<1> kernel_range(num_elem * elem_size);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for<CeedElemRestrSyclStridedNT>(kernel_range, e, [=](sycl::id<1> node) {
     const CeedInt loc_node = node % elem_size;
@@ -61,6 +62,7 @@ static int CeedElemRestrictionOffsetNoTranspose_Sycl(sycl::queue &sycl_queue, co
   sycl::range<1> kernel_range(num_elem * elem_size);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for<CeedElemRestrSyclOffsetNT>(kernel_range, e, [=](sycl::id<1> node) {
     const CeedInt ind      = indices[node];
@@ -89,6 +91,7 @@ static int CeedElemRestrictionStridedTranspose_Sycl(sycl::queue &sycl_queue, con
   sycl::range<1> kernel_range(num_elem * elem_size);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for<CeedElemRestrSyclStridedT>(kernel_range, e, [=](sycl::id<1> node) {
     const CeedInt loc_node = node % elem_size;
@@ -118,6 +121,7 @@ static int CeedElemRestrictionOffsetTranspose_Sycl(sycl::queue &sycl_queue, cons
   sycl::range<1> kernel_range(num_nodes * num_comp);
 
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for<CeedElemRestrSyclOffsetT>(kernel_range, e, [=](sycl::id<1> id) {
     const CeedInt node    = id % num_nodes;
@@ -303,6 +307,7 @@ static int CeedElemRestrictionOffset_Sycl(const CeedElemRestriction rstr, const 
   CeedCallBackend(CeedGetData(ceed, &data));
 
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   // -- L-vector indices

--- a/backends/sycl-ref/ceed-sycl-restriction.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-restriction.sycl.cpp
@@ -34,9 +34,9 @@ static int CeedElemRestrictionStridedNoTranspose_Sycl(sycl::queue &sycl_queue, c
   const CeedInt  stride_elem  = impl->strides[2];
   sycl::range<1> kernel_range(num_elem * elem_size);
 
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for<CeedElemRestrSyclStridedNT>(kernel_range, {e}, [=](sycl::id<1> node) {
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for<CeedElemRestrSyclStridedNT>(kernel_range, e, [=](sycl::id<1> node) {
     const CeedInt loc_node = node % elem_size;
     const CeedInt elem     = node / elem_size;
 
@@ -60,9 +60,9 @@ static int CeedElemRestrictionOffsetNoTranspose_Sycl(sycl::queue &sycl_queue, co
 
   sycl::range<1> kernel_range(num_elem * elem_size);
 
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for<CeedElemRestrSyclOffsetNT>(kernel_range, {e}, [=](sycl::id<1> node) {
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for<CeedElemRestrSyclOffsetNT>(kernel_range, e, [=](sycl::id<1> node) {
     const CeedInt ind      = indices[node];
     const CeedInt loc_node = node % elem_size;
     const CeedInt elem     = node / elem_size;
@@ -88,9 +88,9 @@ static int CeedElemRestrictionStridedTranspose_Sycl(sycl::queue &sycl_queue, con
 
   sycl::range<1> kernel_range(num_elem * elem_size);
 
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for<CeedElemRestrSyclStridedT>(kernel_range, {e}, [=](sycl::id<1> node) {
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for<CeedElemRestrSyclStridedT>(kernel_range, e, [=](sycl::id<1> node) {
     const CeedInt loc_node = node % elem_size;
     const CeedInt elem     = node / elem_size;
 
@@ -117,9 +117,9 @@ static int CeedElemRestrictionOffsetTranspose_Sycl(sycl::queue &sycl_queue, cons
 
   sycl::range<1> kernel_range(num_nodes * num_comp);
 
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for<CeedElemRestrSyclOffsetT>(kernel_range, {e}, [=](sycl::id<1> id) {
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for<CeedElemRestrSyclOffsetT>(kernel_range, e, [=](sycl::id<1> id) {
     const CeedInt node    = id % num_nodes;
     const CeedInt comp    = id / num_nodes;
     const CeedInt ind     = l_vec_indices[node];
@@ -302,18 +302,18 @@ static int CeedElemRestrictionOffset_Sycl(const CeedElemRestriction rstr, const 
   // Copy data to device
   CeedCallBackend(CeedGetData(ceed, &data));
 
-  // Order queue
-  sycl::event e = data->sycl_queue.ext_oneapi_submit_barrier();
+  std::vector<sycl::event> e;
+  if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   // -- L-vector indices
   CeedCallSycl(ceed, impl->d_l_vec_indices = sycl::malloc_device<CeedInt>(num_nodes, data->sycl_device, data->sycl_context));
-  sycl::event copy_lvec = data->sycl_queue.copy<CeedInt>(l_vec_indices, impl->d_l_vec_indices, num_nodes, {e});
+  sycl::event copy_lvec = data->sycl_queue.copy<CeedInt>(l_vec_indices, impl->d_l_vec_indices, num_nodes, e);
   // -- Transpose offsets
   CeedCallSycl(ceed, impl->d_t_offsets = sycl::malloc_device<CeedInt>(size_offsets, data->sycl_device, data->sycl_context));
-  sycl::event copy_offsets = data->sycl_queue.copy<CeedInt>(t_offsets, impl->d_t_offsets, size_offsets, {e});
+  sycl::event copy_offsets = data->sycl_queue.copy<CeedInt>(t_offsets, impl->d_t_offsets, size_offsets, e);
   // -- Transpose indices
   CeedCallSycl(ceed, impl->d_t_indices = sycl::malloc_device<CeedInt>(size_indices, data->sycl_device, data->sycl_context));
-  sycl::event copy_indices = data->sycl_queue.copy<CeedInt>(t_indices, impl->d_t_indices, size_indices, {e});
+  sycl::event copy_indices = data->sycl_queue.copy<CeedInt>(t_indices, impl->d_t_indices, size_indices, e);
 
   // Wait for all copies to complete and handle exceptions
   CeedCallSycl(ceed, sycl::event::wait_and_throw({copy_lvec, copy_offsets, copy_indices}));

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -61,9 +61,7 @@ static inline int CeedVectorSyncH2D_Sycl(const CeedVector vec) {
   // Copy from host to device
   std::vector<sycl::event> e;
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e});
-  // Wait for copy to finish and handle exceptions.
-  CeedCallSycl(ceed, copy_event.wait_and_throw());
+  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, e).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 
@@ -95,9 +93,7 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
   // Copy from device to host
   std::vector<sycl::event> e;
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-  sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e});
-  // Wait for copy to finish and handle exceptions.
-  CeedCallSycl(ceed, copy_event.wait_and_throw());
+  CeedCallSycl(ceed,data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, e).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -333,8 +333,7 @@ static int CeedVectorTakeArray_Sycl(CeedVector vec, CeedMemType mem_type, CeedSc
   CeedCallBackend(CeedGetData(ceed, &data));
 
   // Order queue if needed
-  if (!data->sycl_queue.is_in_order()) 
-    data->sycl_queue.ext_oneapi_submit_barrier();
+  if (!data->sycl_queue.is_in_order()) data->sycl_queue.ext_oneapi_submit_barrier();
 
   // Sync array to requested mem_type
   CeedCallBackend(CeedVectorSyncArray(vec, mem_type));
@@ -457,17 +456,17 @@ static int CeedVectorNorm_Sycl(CeedVector vec, CeedNormType type, CeedScalar *no
   switch (type) {
     case CEED_NORM_1: {
       // Order queue
-      auto        sumReduction = sycl::reduction(impl->reduction_norm, sycl::plus<>(), {sycl::property::reduction::initialize_to_identity{}});
+      auto sumReduction = sycl::reduction(impl->reduction_norm, sycl::plus<>(), {sycl::property::reduction::initialize_to_identity{}});
       data->sycl_queue.parallel_for(length, e, sumReduction, [=](sycl::id<1> i, auto &sum) { sum += abs(d_array[i]); }).wait_and_throw();
     } break;
     case CEED_NORM_2: {
       // Order queue
-      auto        sumReduction = sycl::reduction(impl->reduction_norm, sycl::plus<>(), {sycl::property::reduction::initialize_to_identity{}});
+      auto sumReduction = sycl::reduction(impl->reduction_norm, sycl::plus<>(), {sycl::property::reduction::initialize_to_identity{}});
       data->sycl_queue.parallel_for(length, e, sumReduction, [=](sycl::id<1> i, auto &sum) { sum += (d_array[i] * d_array[i]); }).wait_and_throw();
     } break;
     case CEED_NORM_MAX: {
       // Order queue
-      auto        maxReduction = sycl::reduction(impl->reduction_norm, sycl::maximum<>(), {sycl::property::reduction::initialize_to_identity{}});
+      auto maxReduction = sycl::reduction(impl->reduction_norm, sycl::maximum<>(), {sycl::property::reduction::initialize_to_identity{}});
       data->sycl_queue.parallel_for(length, e, maxReduction, [=](sycl::id<1> i, auto &max) { max.combine(abs(d_array[i])); }).wait_and_throw();
     } break;
   }

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -61,13 +61,7 @@ static inline int CeedVectorSyncH2D_Sycl(const CeedVector vec) {
   // Copy from host to device
   std::vector<sycl::event> e;
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-<<<<<<< HEAD
-  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, e).wait_and_throw());
-=======
-  sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e});
-  // Wait for copy to finish and handle exceptions.
-  CeedCallSycl(ceed, copy_event.wait_and_throw());
->>>>>>> 10c7a557 (Efficiently use both in-order and out-of-order sycl queues. (#59))
+  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e}).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 
@@ -99,13 +93,7 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
   // Copy from device to host
   std::vector<sycl::event> e;
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-<<<<<<< HEAD
-  CeedCallSycl(ceed,data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, e).wait_and_throw());
-=======
-  sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e});
-  // Wait for copy to finish and handle exceptions.
-  CeedCallSycl(ceed, copy_event.wait_and_throw());
->>>>>>> 10c7a557 (Efficiently use both in-order and out-of-order sycl queues. (#59))
+  CeedCallSycl(ceed,data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e}).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -62,7 +62,7 @@ static inline int CeedVectorSyncH2D_Sycl(const CeedVector vec) {
   std::vector<sycl::event> e;
 
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e}).wait_and_throw());
+  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, e).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 
@@ -95,7 +95,7 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
   std::vector<sycl::event> e;
 
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e}).wait_and_throw());
+  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, e).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -58,8 +58,9 @@ static inline int CeedVectorSyncH2D_Sycl(const CeedVector vec) {
     impl->d_array = impl->d_array_owned;
   }
 
-  sycl::event e = data->sycl_queue.ext_oneapi_submit_barrier();
   // Copy from host to device
+  std::vector<sycl::event> e;
+  if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
   sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e});
   // Wait for copy to finish and handle exceptions.
   CeedCallSycl(ceed, copy_event.wait_and_throw());
@@ -91,9 +92,9 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
     impl->h_array = impl->h_array_owned;
   }
 
-  // Order queue
-  sycl::event e = data->sycl_queue.ext_oneapi_submit_barrier();
   // Copy from device to host
+  std::vector<sycl::event> e;
+  if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
   sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e});
   // Wait for copy to finish and handle exceptions.
   CeedCallSycl(ceed, copy_event.wait_and_throw());
@@ -207,8 +208,9 @@ static int CeedVectorSetArrayDevice_Sycl(const CeedVector vec, const CeedCopyMod
   CeedCallBackend(CeedGetData(ceed, &data));
   CeedCallBackend(CeedVectorGetLength(vec, &length));
 
-  // Order queue
-  sycl::event e = data->sycl_queue.ext_oneapi_submit_barrier();
+  // Order queue if needed.
+  std::vector<sycl::event> e;
+  if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   switch (copy_mode) {
     case CEED_COPY_VALUES: {
@@ -216,9 +218,8 @@ static int CeedVectorSetArrayDevice_Sycl(const CeedVector vec, const CeedCopyMod
         CeedCallSycl(ceed, impl->d_array_owned = sycl::malloc_device<CeedScalar>(length, data->sycl_device, data->sycl_context));
       }
       if (array) {
-        sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(array, impl->d_array_owned, length, {e});
         // Wait for copy to finish and handle exceptions.
-        CeedCallSycl(ceed, copy_event.wait_and_throw());
+        CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(array, impl->d_array_owned, length, e).wait_and_throw());
       }
       impl->d_array_borrowed = NULL;
       impl->d_array          = impl->d_array_owned;
@@ -278,9 +279,9 @@ static int CeedHostSetValue_Sycl(CeedScalar *h_array, CeedSize length, CeedScala
 // Set device array to value
 //------------------------------------------------------------------------------
 static int CeedDeviceSetValue_Sycl(sycl::queue &sycl_queue, CeedScalar *d_array, CeedSize length, CeedScalar val) {
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.fill(d_array, val, length, {e});
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.fill(d_array, val, length, e);
   return CEED_ERROR_SUCCESS;
 }
 
@@ -335,8 +336,9 @@ static int CeedVectorTakeArray_Sycl(CeedVector vec, CeedMemType mem_type, CeedSc
   CeedCallBackend(CeedVectorGetData(vec, &impl));
   CeedCallBackend(CeedGetData(ceed, &data));
 
-  // Order queue
-  data->sycl_queue.ext_oneapi_submit_barrier();
+  // Order queue if needed
+  if (!data->sycl_queue.is_in_order()) 
+    data->sycl_queue.ext_oneapi_submit_barrier();
 
   // Sync array to requested mem_type
   CeedCallBackend(CeedVectorSyncArray(vec, mem_type));
@@ -452,24 +454,25 @@ static int CeedVectorNorm_Sycl(CeedVector vec, CeedNormType type, CeedScalar *no
 
   // Compute norm
   CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &d_array));
+
+  std::vector<sycl::event> e;
+  if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
+
   switch (type) {
     case CEED_NORM_1: {
       // Order queue
-      sycl::event e            = data->sycl_queue.ext_oneapi_submit_barrier();
       auto        sumReduction = sycl::reduction(impl->reduction_norm, sycl::plus<>(), {sycl::property::reduction::initialize_to_identity{}});
-      data->sycl_queue.parallel_for(length, {e}, sumReduction, [=](sycl::id<1> i, auto &sum) { sum += abs(d_array[i]); }).wait_and_throw();
+      data->sycl_queue.parallel_for(length, e, sumReduction, [=](sycl::id<1> i, auto &sum) { sum += abs(d_array[i]); }).wait_and_throw();
     } break;
     case CEED_NORM_2: {
       // Order queue
-      sycl::event e            = data->sycl_queue.ext_oneapi_submit_barrier();
       auto        sumReduction = sycl::reduction(impl->reduction_norm, sycl::plus<>(), {sycl::property::reduction::initialize_to_identity{}});
-      data->sycl_queue.parallel_for(length, {e}, sumReduction, [=](sycl::id<1> i, auto &sum) { sum += (d_array[i] * d_array[i]); }).wait_and_throw();
+      data->sycl_queue.parallel_for(length, e, sumReduction, [=](sycl::id<1> i, auto &sum) { sum += (d_array[i] * d_array[i]); }).wait_and_throw();
     } break;
     case CEED_NORM_MAX: {
       // Order queue
-      sycl::event e            = data->sycl_queue.ext_oneapi_submit_barrier();
       auto        maxReduction = sycl::reduction(impl->reduction_norm, sycl::maximum<>(), {sycl::property::reduction::initialize_to_identity{}});
-      data->sycl_queue.parallel_for(length, {e}, maxReduction, [=](sycl::id<1> i, auto &max) { max.combine(abs(d_array[i])); }).wait_and_throw();
+      data->sycl_queue.parallel_for(length, e, maxReduction, [=](sycl::id<1> i, auto &max) { max.combine(abs(d_array[i])); }).wait_and_throw();
     } break;
   }
   // L2 norm - square root over reduced value
@@ -493,9 +496,9 @@ static int CeedHostReciprocal_Sycl(CeedScalar *h_array, CeedSize length) {
 // Take reciprocal of a vector on device
 //------------------------------------------------------------------------------
 static int CeedDeviceReciprocal_Sycl(sycl::queue &sycl_queue, CeedScalar *d_array, CeedSize length) {
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for(length, {e}, [=](sycl::id<1> i) {
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) {
     if (std::fabs(d_array[i]) > CEED_EPSILON) d_array[i] = 1. / d_array[i];
   });
   return CEED_ERROR_SUCCESS;
@@ -533,9 +536,9 @@ static int CeedHostScale_Sycl(CeedScalar *x_array, CeedScalar alpha, CeedSize le
 // Compute x = alpha x on device
 //------------------------------------------------------------------------------
 static int CeedDeviceScale_Sycl(sycl::queue &sycl_queue, CeedScalar *x_array, CeedScalar alpha, CeedSize length) {
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for(length, {e}, [=](sycl::id<1> i) { x_array[i] *= alpha; });
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) { x_array[i] *= alpha; });
   return CEED_ERROR_SUCCESS;
 }
 
@@ -571,9 +574,9 @@ static int CeedHostAXPY_Sycl(CeedScalar *y_array, CeedScalar alpha, CeedScalar *
 // Compute y = alpha x + y on device
 //------------------------------------------------------------------------------
 static int CeedDeviceAXPY_Sycl(sycl::queue &sycl_queue, CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedSize length) {
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for(length, {e}, [=](sycl::id<1> i) { y_array[i] += alpha * x_array[i]; });
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) { y_array[i] += alpha * x_array[i]; });
   return CEED_ERROR_SUCCESS;
 }
 
@@ -616,9 +619,9 @@ static int CeedHostPointwiseMult_Sycl(CeedScalar *w_array, CeedScalar *x_array, 
 // Compute the pointwise multiplication w = x .* y on device (impl in .cu file)
 //------------------------------------------------------------------------------
 static int CeedDevicePointwiseMult_Sycl(sycl::queue &sycl_queue, CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedSize length) {
-  // Order queue
-  sycl::event e = sycl_queue.ext_oneapi_submit_barrier();
-  sycl_queue.parallel_for(length, {e}, [=](sycl::id<1> i) { w_array[i] = x_array[i] * y_array[i]; });
+  std::vector<sycl::event> e;
+  if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
+  sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) { w_array[i] = x_array[i] * y_array[i]; });
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -60,6 +60,7 @@ static inline int CeedVectorSyncH2D_Sycl(const CeedVector vec) {
 
   // Copy from host to device
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
   CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e}).wait_and_throw());
   return CEED_ERROR_SUCCESS;
@@ -92,6 +93,7 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
 
   // Copy from device to host
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
   CeedCallSycl(ceed,data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e}).wait_and_throw());
   return CEED_ERROR_SUCCESS;
@@ -206,6 +208,7 @@ static int CeedVectorSetArrayDevice_Sycl(const CeedVector vec, const CeedCopyMod
 
   // Order queue if needed.
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   switch (copy_mode) {
@@ -276,6 +279,7 @@ static int CeedHostSetValue_Sycl(CeedScalar *h_array, CeedSize length, CeedScala
 //------------------------------------------------------------------------------
 static int CeedDeviceSetValue_Sycl(sycl::queue &sycl_queue, CeedScalar *d_array, CeedSize length, CeedScalar val) {
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.fill(d_array, val, length, e);
   return CEED_ERROR_SUCCESS;
@@ -451,6 +455,7 @@ static int CeedVectorNorm_Sycl(CeedVector vec, CeedNormType type, CeedScalar *no
   CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &d_array));
 
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   switch (type) {
@@ -492,6 +497,7 @@ static int CeedHostReciprocal_Sycl(CeedScalar *h_array, CeedSize length) {
 //------------------------------------------------------------------------------
 static int CeedDeviceReciprocal_Sycl(sycl::queue &sycl_queue, CeedScalar *d_array, CeedSize length) {
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) {
     if (std::fabs(d_array[i]) > CEED_EPSILON) d_array[i] = 1. / d_array[i];
@@ -532,6 +538,7 @@ static int CeedHostScale_Sycl(CeedScalar *x_array, CeedScalar alpha, CeedSize le
 //------------------------------------------------------------------------------
 static int CeedDeviceScale_Sycl(sycl::queue &sycl_queue, CeedScalar *x_array, CeedScalar alpha, CeedSize length) {
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) { x_array[i] *= alpha; });
   return CEED_ERROR_SUCCESS;
@@ -570,6 +577,7 @@ static int CeedHostAXPY_Sycl(CeedScalar *y_array, CeedScalar alpha, CeedScalar *
 //------------------------------------------------------------------------------
 static int CeedDeviceAXPY_Sycl(sycl::queue &sycl_queue, CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedSize length) {
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) { y_array[i] += alpha * x_array[i]; });
   return CEED_ERROR_SUCCESS;
@@ -615,6 +623,7 @@ static int CeedHostPointwiseMult_Sycl(CeedScalar *w_array, CeedScalar *x_array, 
 //------------------------------------------------------------------------------
 static int CeedDevicePointwiseMult_Sycl(sycl::queue &sycl_queue, CeedScalar *w_array, CeedScalar *x_array, CeedScalar *y_array, CeedSize length) {
   std::vector<sycl::event> e;
+
   if (!sycl_queue.is_in_order()) e = {sycl_queue.ext_oneapi_submit_barrier()};
   sycl_queue.parallel_for(length, e, [=](sycl::id<1> i) { w_array[i] = x_array[i] * y_array[i]; });
   return CEED_ERROR_SUCCESS;

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -61,7 +61,13 @@ static inline int CeedVectorSyncH2D_Sycl(const CeedVector vec) {
   // Copy from host to device
   std::vector<sycl::event> e;
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
+<<<<<<< HEAD
   CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, e).wait_and_throw());
+=======
+  sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->h_array, impl->d_array, length, {e});
+  // Wait for copy to finish and handle exceptions.
+  CeedCallSycl(ceed, copy_event.wait_and_throw());
+>>>>>>> 10c7a557 (Efficiently use both in-order and out-of-order sycl queues. (#59))
   return CEED_ERROR_SUCCESS;
 }
 
@@ -93,7 +99,13 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
   // Copy from device to host
   std::vector<sycl::event> e;
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
+<<<<<<< HEAD
   CeedCallSycl(ceed,data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, e).wait_and_throw());
+=======
+  sycl::event copy_event = data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e});
+  // Wait for copy to finish and handle exceptions.
+  CeedCallSycl(ceed, copy_event.wait_and_throw());
+>>>>>>> 10c7a557 (Efficiently use both in-order and out-of-order sycl queues. (#59))
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -95,7 +95,7 @@ static inline int CeedVectorSyncD2H_Sycl(const CeedVector vec) {
   std::vector<sycl::event> e;
 
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
-  CeedCallSycl(ceed,data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e}).wait_and_throw());
+  CeedCallSycl(ceed, data->sycl_queue.copy<CeedScalar>(impl->d_array, impl->h_array, length, {e}).wait_and_throw());
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
@@ -65,7 +65,6 @@ int CeedBasisApplyTensor_Sycl_shared(CeedBasis basis, const CeedInt num_elem, Ce
 
       std::vector<sycl::event> e;
       if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
-
       ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(e);
         cgh.set_args(num_elem, impl->d_interp_1d, d_u, d_v);

--- a/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
@@ -83,7 +83,7 @@ int CeedBasisApplyTensor_Sycl_shared(CeedBasis basis, const CeedInt num_elem, Ce
       //-----------
       sycl::kernel     *grad_kernel = (t_mode == CEED_TRANSPOSE) ? impl->grad_transpose_kernel : impl->grad_kernel;
       const CeedScalar *d_grad_1d   = (impl->d_collo_grad_1d) ? impl->d_collo_grad_1d : impl->d_grad_1d;
-     
+
       std::vector<sycl::event> e;
       if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 

--- a/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
@@ -64,6 +64,7 @@ int CeedBasisApplyTensor_Sycl_shared(CeedBasis basis, const CeedInt num_elem, Ce
       sycl::kernel *interp_kernel = (t_mode == CEED_TRANSPOSE) ? impl->interp_transpose_kernel : impl->interp_kernel;
 
       std::vector<sycl::event> e;
+
       if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
       ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(e);
@@ -85,6 +86,7 @@ int CeedBasisApplyTensor_Sycl_shared(CeedBasis basis, const CeedInt num_elem, Ce
       const CeedScalar *d_grad_1d   = (impl->d_collo_grad_1d) ? impl->d_collo_grad_1d : impl->d_grad_1d;
 
       std::vector<sycl::event> e;
+
       if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 
       ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
@@ -103,6 +105,7 @@ int CeedBasisApplyTensor_Sycl_shared(CeedBasis basis, const CeedInt num_elem, Ce
       sycl::nd_range<3> kernel_range(global_range, local_range);
       //-----------
       std::vector<sycl::event> e;
+
       if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
 
       ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
@@ -191,6 +194,7 @@ int CeedBasisCreateTensorH1_Sycl_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d,
   CeedCallBackend(ComputeLocalRange(ceed, dim, Q_1d, impl->weight_local_range));
 
   std::vector<sycl::event> e;
+
   if (!data->sycl_queue.is_in_order()) e = {data->sycl_queue.ext_oneapi_submit_barrier()};
 
   // Copy basis data to GPU

--- a/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared-basis.sycl.cpp
@@ -65,7 +65,7 @@ int CeedBasisApplyTensor_Sycl_shared(CeedBasis basis, const CeedInt num_elem, Ce
 
       std::vector<sycl::event> e;
       if (!ceed_Sycl->sycl_queue.is_in_order()) e = {ceed_Sycl->sycl_queue.ext_oneapi_submit_barrier()};
-      
+
       ceed_Sycl->sycl_queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(e);
         cgh.set_args(num_elem, impl->d_interp_1d, d_u, d_v);

--- a/backends/sycl-shared/ceed-sycl-shared.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared.sycl.cpp
@@ -41,14 +41,7 @@ static int CeedInit_Sycl_shared(const char *resource, Ceed ceed) {
   CeedCallBackend(CeedInit_Sycl(ceed, resource));
 
   CeedCallBackend(CeedInit(ref_resource.str().c_str(), &ceed_ref));
-
-  CeedCallBackend(CeedGetData(ceed_ref, &ref_data));
-
-  // Need to use the same queue everywhere for correct synchronization
-  ref_data->sycl_queue   = data->sycl_queue;
-  ref_data->sycl_context = data->sycl_context;
-  ref_data->sycl_device  = data->sycl_device;
-
+  CeedCallBackend(CeedSetStream_Sycl(ceed_ref,&(data->sycl_queue)));
   CeedCallBackend(CeedSetDelegate(ceed, ceed_ref));
 
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Ceed", ceed, "BasisCreateTensorH1", CeedBasisCreateTensorH1_Sycl_shared));

--- a/backends/sycl-shared/ceed-sycl-shared.sycl.cpp
+++ b/backends/sycl-shared/ceed-sycl-shared.sycl.cpp
@@ -41,7 +41,7 @@ static int CeedInit_Sycl_shared(const char *resource, Ceed ceed) {
   CeedCallBackend(CeedInit_Sycl(ceed, resource));
 
   CeedCallBackend(CeedInit(ref_resource.str().c_str(), &ceed_ref));
-  CeedCallBackend(CeedSetStream_Sycl(ceed_ref,&(data->sycl_queue)));
+  CeedCallBackend(CeedSetStream_Sycl(ceed_ref, &(data->sycl_queue)));
   CeedCallBackend(CeedSetDelegate(ceed, ceed_ref));
 
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Ceed", ceed, "BasisCreateTensorH1", CeedBasisCreateTensorH1_Sycl_shared));

--- a/backends/sycl/ceed-sycl-common.sycl.cpp
+++ b/backends/sycl/ceed-sycl-common.sycl.cpp
@@ -64,7 +64,7 @@ int CeedInit_Sycl(Ceed ceed, const char *resource) {
   };
 
   sycl::context sycl_context{sycl_device.get_platform().get_devices()};
-  sycl::queue   sycl_queue{sycl_context, sycl_device, sycl_async_handler,  sycl::property::queue::in_order{}};
+  sycl::queue   sycl_queue{sycl_context, sycl_device, sycl_async_handler, sycl::property::queue::in_order{}};
 
   CeedCallBackend(CeedGetData(ceed, &data));
 


### PR DESCRIPTION
* Adds the flexibility to use in-order out-of-order queues depending upon the host application.

* Default to in-order queues.

* Only order queue as necessary for efficiency (if it is out of order).

* Sets the same queue recursively through a hierarchy of Ceed objects (for the Ceed_parent and Ceed_delegate objects).