### PR TITLE
test: Fix test name for PETSc bps

### DIFF
--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -24,8 +24,8 @@
 //     ./bps -problem bp5 -degree 3 -ceed /cpu/self
 //     ./bps -problem bp6 -degree 3 -ceed /gpu/cuda
 //
-//TESTARGS(name="BP3, hex elements") -ceed {ceed_resource} -test -problem bp3 -degree 3 -ksp_max_it_clip 50,50 -simplex
-//TESTARGS(name="BP5, tet elements") -ceed {ceed_resource} -test -problem bp5 -degree 3 -ksp_max_it_clip 15,15
+//TESTARGS(name="BP3, tet elements") -ceed {ceed_resource} -test -problem bp3 -degree 3 -ksp_max_it_clip 50,50 -simplex
+//TESTARGS(name="BP5, hex elements") -ceed {ceed_resource} -test -problem bp5 -degree 3 -ksp_max_it_clip 15,15
 
 /// @file
 /// CEED BPs example using PETSc with DMPlex


### PR DESCRIPTION
The name of the tests for the `petsc-bps` examples is backwards; `tet` should be with the `-simplex` flag and `hex` should be without it.