### PR TITLE
Use CeedSize for rstr vec len checks

### DIFF
--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -276,6 +276,7 @@ CEED_EXTERN int CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedIn
 CEED_EXTERN int CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points);
 CEED_EXTERN int CeedElemRestrictionGetMaxPointsInElement(CeedElemRestriction rstr, CeedInt *max_points);
 CEED_EXTERN int CeedElemRestrictionGetLVectorSize(CeedElemRestriction rstr, CeedSize *l_size);
+CEED_EXTERN int CeedElemRestrictionGetEVectorSize(CeedElemRestriction rstr, CeedSize *e_size);
 CEED_EXTERN int CeedElemRestrictionGetNumComponents(CeedElemRestriction rstr, CeedInt *num_comp);
 CEED_EXTERN int CeedElemRestrictionGetNumBlocks(CeedElemRestriction rstr, CeedInt *num_block);
 CEED_EXTERN int CeedElemRestrictionGetBlockSize(CeedElemRestriction rstr, CeedInt *block_size);


### PR DESCRIPTION
This should fix the overflow with size comparisons. Swapped up some variable names and used getters while I was in there. Eventually I'd like to strip out all use of reaching into other Ceed object's private data (like reaching into a Vec's data from a ElemRestriction).