### PR TITLE
Fallback to sycl/ref from gen for non-tensor bases

### DIFF
--- a/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
@@ -48,6 +48,22 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
   CeedCallBackend(CeedOperatorGetFields(op, &num_input_fields, &op_input_fields, &num_output_fields, &op_output_fields));
   CeedCallBackend(CeedQFunctionGetFields(qf, NULL, &qf_input_fields, NULL, &qf_output_fields));
 
+  // Check for tensor-product bases
+  {
+    bool has_tensor_bases;
+
+    CeedCallBackend(CeedOperatorHasTensorBases(op, &has_tensor_bases));
+    // -- Fallback to ref if not all bases are tensor-product
+    if (!has_tensor_bases) {
+      CeedOperator op_fallback;
+
+      CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "Falling back to sycl/ref CeedOperator due to non-tensor bases");
+      CeedCallBackend(CeedOperatorGetFallback(op, &op_fallback));
+      CeedCallBackend(CeedOperatorApplyAdd(op_fallback, input_vec, output_vec, request));
+      return CEED_ERROR_SUCCESS;
+    }
+  }
+
   // Creation of the operator
   CeedCallBackend(CeedOperatorBuildKernel_Sycl_gen(op));
 


### PR DESCRIPTION
Mirror #1476 for SYCL. Copy-pasted from the GPU code that works in CI, so should be fine for Sycl.