### PR TITLE
Reduce reaching into private data

### DIFF
--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -344,6 +344,8 @@ CEED_EXTERN int CeedQFunctionIsIdentity(CeedQFunction qf, bool *is_identity);
 CEED_EXTERN int CeedQFunctionIsContextWritable(CeedQFunction qf, bool *is_writable);
 CEED_EXTERN int CeedQFunctionGetData(CeedQFunction qf, void *data);
 CEED_EXTERN int CeedQFunctionSetData(CeedQFunction qf, void *data);
+CEED_EXTERN int CeedQFunctionIsImmutable(CeedQFunction qf, bool *is_immutable);
+CEED_EXTERN int CeedQFunctionSetImmutable(CeedQFunction qf);
 CEED_EXTERN int CeedQFunctionReference(CeedQFunction qf);
 CEED_EXTERN int CeedQFunctionGetFlopsEstimate(CeedQFunction qf, CeedSize *flops);
 
@@ -410,6 +412,7 @@ CEED_EXTERN int CeedOperatorGetActiveElemRestrictions(CeedOperator op, CeedElemR
                                                       CeedElemRestriction *active_output_rstr);
 CEED_EXTERN int CeedOperatorGetNumArgs(CeedOperator op, CeedInt *num_args);
 CEED_EXTERN int CeedOperatorHasTensorBases(CeedOperator op, bool *has_tensor_bases);
+CEED_EXTERN int CeedOperatorIsImmutable(CeedOperator op, bool *is_immutable);
 CEED_EXTERN int CeedOperatorIsSetupDone(CeedOperator op, bool *is_setup_done);
 CEED_EXTERN int CeedOperatorGetQFunction(CeedOperator op, CeedQFunction *qf);
 CEED_EXTERN int CeedOperatorIsComposite(CeedOperator op, bool *is_composite);
@@ -426,7 +429,7 @@ CEED_INTERN int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A, con
 CEED_EXTERN int CeedQRFactorization(Ceed ceed, CeedScalar *mat, CeedScalar *tau, CeedInt m, CeedInt n);
 CEED_EXTERN int CeedHouseholderApplyQ(CeedScalar *mat_A, const CeedScalar *mat_Q, const CeedScalar *tau, CeedTransposeMode t_mode, CeedInt m,
                                       CeedInt n, CeedInt k, CeedInt row, CeedInt col);
-CEED_EXTERN int CeedMatrixPseudoinverse(Ceed ceed, CeedScalar *mat, CeedInt m, CeedInt n, CeedScalar *mat_pinv);
+CEED_EXTERN int CeedMatrixPseudoinverse(Ceed ceed, const CeedScalar *mat, CeedInt m, CeedInt n, CeedScalar *mat_pinv);
 CEED_EXTERN int CeedSymmetricSchurDecomposition(Ceed ceed, CeedScalar *mat, CeedScalar *lambda, CeedInt n);
 CEED_EXTERN int CeedSimultaneousDiagonalization(Ceed ceed, CeedScalar *mat_A, CeedScalar *mat_B, CeedScalar *x, CeedScalar *lambda, CeedInt n);
 

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -360,6 +360,7 @@ CEED_EXTERN int CeedQFunctionDestroy(CeedQFunction *qf);
 CEED_EXTERN int CeedQFunctionFieldGetName(CeedQFunctionField qf_field, char **field_name);
 CEED_EXTERN int CeedQFunctionFieldGetSize(CeedQFunctionField qf_field, CeedInt *size);
 CEED_EXTERN int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedEvalMode *eval_mode);
+CEED_EXTERN int CeedQFunctionFieldGetData(CeedQFunctionField qf_field, char **field_name, CeedInt *size, CeedEvalMode *eval_mode);
 
 /** Handle for the user provided @ref CeedQFunctionContextDestroy() callback function
 
@@ -458,6 +459,7 @@ CEED_EXTERN int CeedOperatorFieldGetName(CeedOperatorField op_field, char **fiel
 CEED_EXTERN int CeedOperatorFieldGetElemRestriction(CeedOperatorField op_field, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedOperatorFieldGetBasis(CeedOperatorField op_field, CeedBasis *basis);
 CEED_EXTERN int CeedOperatorFieldGetVector(CeedOperatorField op_field, CeedVector *vec);
+CEED_EXTERN int CeedOperatorFieldGetData(CeedOperatorField op_field, char **field_name, CeedElemRestriction *rstr, CeedBasis *basis, CeedVector *vec);
 
 /**
   @brief Return integer power

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -39,9 +39,7 @@ static int CeedOperatorCheckField(Ceed ceed, CeedQFunctionField qf_field, CeedEl
   CeedEvalMode eval_mode;
 
   // Field data
-  CeedCall(CeedQFunctionFieldGetName(qf_field, &field_name));
-  CeedCall(CeedQFunctionFieldGetSize(qf_field, &size));
-  CeedCall(CeedQFunctionFieldGetEvalMode(qf_field, &eval_mode));
+  CeedCall(CeedQFunctionFieldGetData(qf_field, &field_name, &size, &eval_mode));
 
   // Restriction
   CeedCheck((rstr == CEED_ELEMRESTRICTION_NONE) == (eval_mode == CEED_EVAL_WEIGHT), ceed, CEED_ERROR_INCOMPATIBLE,
@@ -107,11 +105,8 @@ static int CeedOperatorFieldView(CeedOperatorField op_field, CeedQFunctionField 
   CeedBasis    basis;
 
   // Field data
-  CeedCall(CeedQFunctionFieldGetName(qf_field, &field_name));
-  CeedCall(CeedQFunctionFieldGetSize(qf_field, &size));
-  CeedCall(CeedQFunctionFieldGetEvalMode(qf_field, &eval_mode));
-  CeedCall(CeedOperatorFieldGetVector(op_field, &vec));
-  CeedCall(CeedOperatorFieldGetBasis(op_field, &basis));
+  CeedCall(CeedQFunctionFieldGetData(qf_field, &field_name, &size, &eval_mode));
+  CeedCall(CeedOperatorFieldGetData(op_field, NULL, NULL, &basis, &vec));
 
   fprintf(stream,
           "%s    %s field %" CeedInt_FMT
@@ -1141,8 +1136,8 @@ int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOper
 /**
   @brief Get the name of a `CeedOperator` Field
 
-  @param[in]  op_field    `CeedOperator` Field
-  @param[out] field_name  Variable to store the field name
+  @param[in]  op_field   `CeedOperator` Field
+  @param[out] field_name Variable to store the field name
 
   @return An error code: 0 - success, otherwise - failure
 
@@ -1195,6 +1190,29 @@ int CeedOperatorFieldGetBasis(CeedOperatorField op_field, CeedBasis *basis) {
 **/
 int CeedOperatorFieldGetVector(CeedOperatorField op_field, CeedVector *vec) {
   *vec = op_field->vec;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get the data of a `CeedOperator` Field.
+
+  Any arguments set as `NULL` are ignored.
+
+  @param[in]  op_field   `CeedOperator` Field
+  @param[out] field_name Variable to store the field name
+  @param[out] rstr       Variable to store `CeedElemRestriction`
+  @param[out] basis      Variable to store `CeedBasis`
+  @param[out] vec        Variable to store `CeedVector`
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+int CeedOperatorFieldGetData(CeedOperatorField op_field, char **field_name, CeedElemRestriction *rstr, CeedBasis *basis, CeedVector *vec) {
+  if (field_name) CeedCall(CeedOperatorFieldGetName(op_field, field_name));
+  if (rstr) CeedCall(CeedOperatorFieldGetElemRestriction(op_field, rstr));
+  if (basis) CeedCall(CeedOperatorFieldGetBasis(op_field, basis));
+  if (vec) CeedCall(CeedOperatorFieldGetVector(op_field, vec));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -35,13 +35,17 @@
   @ref Developer
 **/
 static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, CeedQFunction *qf_fallback) {
-  char *source_path_with_name = NULL;
+  char               *source_path_with_name = NULL;
+  CeedInt             num_input_fields, num_output_fields;
+  Ceed                ceed;
+  CeedQFunctionField *input_fields, *output_fields;
 
   // Check if NULL qf passed in
   if (!qf) return CEED_ERROR_SUCCESS;
 
-  CeedDebug256(qf->ceed, 1, "---------- CeedOperator Fallback ----------\n");
-  CeedDebug(qf->ceed, "Creating fallback CeedQFunction\n");
+  CeedCall(CeedQFunctionGetCeed(qf, &ceed));
+  CeedDebug256(ceed, 1, "---------- CeedOperator Fallback ----------\n");
+  CeedDebug(ceed, "Creating fallback CeedQFunction\n");
 
   if (qf->source_path) {
     size_t path_len = strlen(qf->source_path), name_len = strlen(qf->kernel_name);
@@ -53,18 +57,40 @@ static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, Cee
     CeedCall(CeedCalloc(1, &source_path_with_name));
   }
 
-  CeedCall(CeedQFunctionCreateInterior(fallback_ceed, qf->vec_length, qf->function, source_path_with_name, qf_fallback));
+  {
+    CeedInt           vec_length;
+    CeedQFunctionUser f;
+
+    CeedCall(CeedQFunctionGetVectorLength(qf, &vec_length));
+    CeedCall(CeedQFunctionGetUserFunction(qf, &f));
+    CeedCall(CeedQFunctionCreateInterior(fallback_ceed, vec_length, f, source_path_with_name, qf_fallback));
+  }
   {
     CeedQFunctionContext ctx;
 
     CeedCall(CeedQFunctionGetContext(qf, &ctx));
     CeedCall(CeedQFunctionSetContext(*qf_fallback, ctx));
   }
-  for (CeedInt i = 0; i < qf->num_input_fields; i++) {
-    CeedCall(CeedQFunctionAddInput(*qf_fallback, qf->input_fields[i]->field_name, qf->input_fields[i]->size, qf->input_fields[i]->eval_mode));
+  CeedCall(CeedQFunctionGetFields(qf, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
+  for (CeedInt i = 0; i < num_input_fields; i++) {
+    char        *field_name;
+    CeedInt      size;
+    CeedEvalMode eval_mode;
+
+    CeedCall(CeedQFunctionFieldGetName(input_fields[i], &field_name));
+    CeedCall(CeedQFunctionFieldGetSize(input_fields[i], &size));
+    CeedCall(CeedQFunctionFieldGetEvalMode(input_fields[i], &eval_mode));
+    CeedCall(CeedQFunctionAddInput(*qf_fallback, field_name, size, eval_mode));
   }
-  for (CeedInt i = 0; i < qf->num_output_fields; i++) {
-    CeedCall(CeedQFunctionAddOutput(*qf_fallback, qf->output_fields[i]->field_name, qf->output_fields[i]->size, qf->output_fields[i]->eval_mode));
+  for (CeedInt i = 0; i < num_output_fields; i++) {
+    char        *field_name;
+    CeedInt      size;
+    CeedEvalMode eval_mode;
+
+    CeedCall(CeedQFunctionFieldGetName(output_fields[i], &field_name));
+    CeedCall(CeedQFunctionFieldGetSize(output_fields[i], &size));
+    CeedCall(CeedQFunctionFieldGetEvalMode(output_fields[i], &eval_mode));
+    CeedCall(CeedQFunctionAddOutput(*qf_fallback, field_name, size, eval_mode));
   }
   CeedCall(CeedFree(&source_path_with_name));
   return CEED_ERROR_SUCCESS;
@@ -80,19 +106,20 @@ static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, Cee
   @ref Developer
 **/
 static int CeedOperatorCreateFallback(CeedOperator op) {
-  Ceed         ceed_fallback;
   bool         is_composite;
+  Ceed         ceed, ceed_fallback;
   CeedOperator op_fallback;
 
   // Check not already created
   if (op->op_fallback) return CEED_ERROR_SUCCESS;
 
   // Fallback Ceed
-  CeedCall(CeedGetOperatorFallbackCeed(op->ceed, &ceed_fallback));
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
+  CeedCall(CeedGetOperatorFallbackCeed(ceed, &ceed_fallback));
   if (!ceed_fallback) return CEED_ERROR_SUCCESS;
 
-  CeedDebug256(op->ceed, 1, "---------- CeedOperator Fallback ----------\n");
-  CeedDebug(op->ceed, "Creating fallback CeedOperator\n");
+  CeedDebug256(ceed, 1, "---------- CeedOperator Fallback ----------\n");
+  CeedDebug(ceed, "Creating fallback CeedOperator\n");
 
   // Clone Op
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
@@ -110,19 +137,38 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
       CeedCall(CeedCompositeOperatorAddSub(op_fallback, op_sub_fallback));
     }
   } else {
-    CeedQFunction qf_fallback = NULL, dqf_fallback = NULL, dqfT_fallback = NULL;
+    CeedInt            num_input_fields, num_output_fields;
+    CeedQFunction      qf_fallback = NULL, dqf_fallback = NULL, dqfT_fallback = NULL;
+    CeedOperatorField *input_fields, *output_fields;
 
     CeedCall(CeedQFunctionCreateFallback(ceed_fallback, op->qf, &qf_fallback));
     CeedCall(CeedQFunctionCreateFallback(ceed_fallback, op->dqf, &dqf_fallback));
     CeedCall(CeedQFunctionCreateFallback(ceed_fallback, op->dqfT, &dqfT_fallback));
     CeedCall(CeedOperatorCreate(ceed_fallback, qf_fallback, dqf_fallback, dqfT_fallback, &op_fallback));
-    for (CeedInt i = 0; i < op->qf->num_input_fields; i++) {
-      CeedCall(CeedOperatorSetField(op_fallback, op->input_fields[i]->field_name, op->input_fields[i]->elem_rstr, op->input_fields[i]->basis,
-                                    op->input_fields[i]->vec));
+    CeedCall(CeedOperatorGetFields(op, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
+    for (CeedInt i = 0; i < num_input_fields; i++) {
+      char               *field_name;
+      CeedVector          vec;
+      CeedElemRestriction rstr;
+      CeedBasis           basis;
+
+      CeedCall(CeedOperatorFieldGetName(input_fields[i], &field_name));
+      CeedCall(CeedOperatorFieldGetVector(input_fields[i], &vec));
+      CeedCall(CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr));
+      CeedCall(CeedOperatorFieldGetBasis(input_fields[i], &basis));
+      CeedCall(CeedOperatorSetField(op_fallback, field_name, rstr, basis, vec));
     }
-    for (CeedInt i = 0; i < op->qf->num_output_fields; i++) {
-      CeedCall(CeedOperatorSetField(op_fallback, op->output_fields[i]->field_name, op->output_fields[i]->elem_rstr, op->output_fields[i]->basis,
-                                    op->output_fields[i]->vec));
+    for (CeedInt i = 0; i < num_output_fields; i++) {
+      char               *field_name;
+      CeedVector          vec;
+      CeedElemRestriction rstr;
+      CeedBasis           basis;
+
+      CeedCall(CeedOperatorFieldGetName(output_fields[i], &field_name));
+      CeedCall(CeedOperatorFieldGetVector(output_fields[i], &vec));
+      CeedCall(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr));
+      CeedCall(CeedOperatorFieldGetBasis(output_fields[i], &basis));
+      CeedCall(CeedOperatorSetField(op_fallback, field_name, rstr, basis, vec));
     }
     CeedCall(CeedQFunctionAssemblyDataReferenceCopy(op->qf_assembled, &op_fallback->qf_assembled));
     // Cleanup
@@ -722,10 +768,12 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset, CeedVecto
 static int CeedSingleOperatorAssemblyCountEntries(CeedOperator op, CeedSize *num_entries) {
   bool                is_composite;
   CeedInt             num_elem_in, elem_size_in, num_comp_in, num_elem_out, elem_size_out, num_comp_out;
+  Ceed                ceed;
   CeedElemRestriction rstr_in, rstr_out;
 
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
-  CeedCheck(!is_composite, op->ceed, CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+  CeedCheck(!is_composite, ceed, CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
 
   CeedCall(CeedOperatorGetActiveElemRestrictions(op, &rstr_in, &rstr_out));
   CeedCall(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
@@ -733,7 +781,7 @@ static int CeedSingleOperatorAssemblyCountEntries(CeedOperator op, CeedSize *num
   CeedCall(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
   if (rstr_in != rstr_out) {
     CeedCall(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
-    CeedCheck(num_elem_in == num_elem_out, op->ceed, CEED_ERROR_UNSUPPORTED,
+    CeedCheck(num_elem_in == num_elem_out, ceed, CEED_ERROR_UNSUPPORTED,
               "Active input and output operator restrictions must have the same number of elements");
     CeedCall(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
     CeedCall(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
@@ -766,9 +814,10 @@ static int CeedSingleOperatorMultigridLevel(CeedOperator op_fine, CeedVector p_m
                                             CeedBasis basis_c_to_f, CeedOperator *op_coarse, CeedOperator *op_prolong, CeedOperator *op_restrict) {
   bool                is_composite;
   Ceed                ceed;
-  CeedInt             num_comp;
+  CeedInt             num_comp, num_input_fields, num_output_fields;
   CeedVector          mult_vec         = NULL;
   CeedElemRestriction rstr_p_mult_fine = NULL, rstr_fine = NULL;
+  CeedOperatorField  *input_fields, *output_fields;
 
   CeedCall(CeedOperatorGetCeed(op_fine, &ceed));
 
@@ -778,24 +827,44 @@ static int CeedSingleOperatorMultigridLevel(CeedOperator op_fine, CeedVector p_m
 
   // Coarse Grid
   CeedCall(CeedOperatorCreate(ceed, op_fine->qf, op_fine->dqf, op_fine->dqfT, op_coarse));
+  CeedCall(CeedOperatorGetFields(op_fine, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
   // -- Clone input fields
-  for (CeedInt i = 0; i < op_fine->qf->num_input_fields; i++) {
-    if (op_fine->input_fields[i]->vec == CEED_VECTOR_ACTIVE) {
-      rstr_fine = op_fine->input_fields[i]->elem_rstr;
-      CeedCall(CeedOperatorSetField(*op_coarse, op_fine->input_fields[i]->field_name, rstr_coarse, basis_coarse, CEED_VECTOR_ACTIVE));
+  for (CeedInt i = 0; i < num_input_fields; i++) {
+    char               *field_name;
+    CeedVector          vec;
+    CeedElemRestriction rstr;
+    CeedBasis           basis;
+
+    CeedCall(CeedOperatorFieldGetName(input_fields[i], &field_name));
+    CeedCall(CeedOperatorFieldGetVector(input_fields[i], &vec));
+    if (vec == CEED_VECTOR_ACTIVE) {
+      rstr  = rstr_coarse;
+      basis = basis_coarse;
+      CeedCall(CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr_fine));
     } else {
-      CeedCall(CeedOperatorSetField(*op_coarse, op_fine->input_fields[i]->field_name, op_fine->input_fields[i]->elem_rstr,
-                                    op_fine->input_fields[i]->basis, op_fine->input_fields[i]->vec));
+      CeedCall(CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr));
+      CeedCall(CeedOperatorFieldGetBasis(input_fields[i], &basis));
     }
+    CeedCall(CeedOperatorSetField(*op_coarse, field_name, rstr, basis, vec));
   }
   // -- Clone output fields
-  for (CeedInt i = 0; i < op_fine->qf->num_output_fields; i++) {
-    if (op_fine->output_fields[i]->vec == CEED_VECTOR_ACTIVE) {
-      CeedCall(CeedOperatorSetField(*op_coarse, op_fine->output_fields[i]->field_name, rstr_coarse, basis_coarse, CEED_VECTOR_ACTIVE));
+  for (CeedInt i = 0; i < num_output_fields; i++) {
+    char               *field_name;
+    CeedVector          vec;
+    CeedElemRestriction rstr;
+    CeedBasis           basis;
+
+    CeedCall(CeedOperatorFieldGetName(output_fields[i], &field_name));
+    CeedCall(CeedOperatorFieldGetVector(output_fields[i], &vec));
+    if (vec == CEED_VECTOR_ACTIVE) {
+      rstr  = rstr_coarse;
+      basis = basis_coarse;
+      CeedCall(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr_fine));
     } else {
-      CeedCall(CeedOperatorSetField(*op_coarse, op_fine->output_fields[i]->field_name, op_fine->output_fields[i]->elem_rstr,
-                                    op_fine->output_fields[i]->basis, op_fine->output_fields[i]->vec));
+      CeedCall(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr));
+      CeedCall(CeedOperatorFieldGetBasis(output_fields[i], &basis));
     }
+    CeedCall(CeedOperatorSetField(*op_coarse, field_name, rstr, basis, vec));
   }
   // -- Clone QFunctionAssemblyData
   CeedCall(CeedQFunctionAssemblyDataReferenceCopy(op_fine->qf_assembled, &(*op_coarse)->qf_assembled));
@@ -1646,13 +1715,14 @@ int CeedOperatorGetFallback(CeedOperator op, CeedOperator *op_fallback) {
   if (!op->op_fallback) CeedCall(CeedOperatorCreateFallback(op));
   if (op->op_fallback) {
     bool is_debug;
+    Ceed ceed;
 
-    CeedCall(CeedIsDebug(op->ceed, &is_debug));
+    CeedCall(CeedOperatorGetCeed(op, &ceed));
+    CeedCall(CeedIsDebug(ceed, &is_debug));
     if (is_debug) {
-      Ceed        ceed, ceed_fallback;
+      Ceed        ceed_fallback;
       const char *resource, *resource_fallback;
 
-      CeedCall(CeedOperatorGetCeed(op, &ceed));
       CeedCall(CeedGetOperatorFallbackCeed(ceed, &ceed_fallback));
       CeedCall(CeedGetResource(ceed, &resource));
       CeedCall(CeedGetResource(ceed_fallback, &resource_fallback));
@@ -1731,11 +1801,13 @@ int CeedOperatorLinearAssembleQFunction(CeedOperator op, CeedVector *assembled, 
     CeedCall(op->LinearAssembleQFunction(op, assembled, rstr, request));
   } else {
     // Operator fallback
+    Ceed         ceed;
     CeedOperator op_fallback;
 
+    CeedCall(CeedOperatorGetCeed(op, &ceed));
     CeedCall(CeedOperatorGetFallback(op, &op_fallback));
     if (op_fallback) CeedCall(CeedOperatorLinearAssembleQFunction(op_fallback, assembled, rstr, request));
-    else return CeedError(op->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedOperatorLinearAssembleQFunction");
+    else return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedOperatorLinearAssembleQFunction");
   }
   return CEED_ERROR_SUCCESS;
 }
@@ -1805,11 +1877,13 @@ int CeedOperatorLinearAssembleQFunctionBuildOrUpdate(CeedOperator op, CeedVector
     CeedCall(CeedElemRestrictionDestroy(&assembled_rstr));
   } else {
     // Operator fallback
+    Ceed         ceed;
     CeedOperator op_fallback;
 
+    CeedCall(CeedOperatorGetCeed(op, &ceed));
     CeedCall(CeedOperatorGetFallback(op, &op_fallback));
     if (op_fallback) CeedCall(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op_fallback, assembled, rstr, request));
-    else return CeedError(op->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedOperatorLinearAssembleQFunctionUpdate");
+    else return CeedError(ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedOperatorLinearAssembleQFunctionUpdate");
   }
   return CEED_ERROR_SUCCESS;
 }
@@ -1834,12 +1908,14 @@ int CeedOperatorLinearAssembleQFunctionBuildOrUpdate(CeedOperator op, CeedVector
 int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled, CeedRequest *request) {
   bool     is_composite;
   CeedSize input_size = 0, output_size = 0;
+  Ceed     ceed;
 
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCall(CeedOperatorCheckReady(op));
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
 
   CeedCall(CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size));
-  CeedCheck(input_size == output_size, op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  CeedCheck(input_size == output_size, ceed, CEED_ERROR_DIMENSION, "Operator must be square");
 
   // Early exit for empty operator
   if (!is_composite) {
@@ -1894,12 +1970,14 @@ int CeedOperatorLinearAssembleDiagonal(CeedOperator op, CeedVector assembled, Ce
 int CeedOperatorLinearAssembleAddDiagonal(CeedOperator op, CeedVector assembled, CeedRequest *request) {
   bool     is_composite;
   CeedSize input_size = 0, output_size = 0;
+  Ceed     ceed;
 
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCall(CeedOperatorCheckReady(op));
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
 
   CeedCall(CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size));
-  CeedCheck(input_size == output_size, op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  CeedCheck(input_size == output_size, ceed, CEED_ERROR_DIMENSION, "Operator must be square");
 
   // Early exit for empty operator
   if (!is_composite) {
@@ -2057,12 +2135,14 @@ int CeedOperatorLinearAssemblePointBlockDiagonalSymbolic(CeedOperator op, CeedSi
 int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op, CeedVector assembled, CeedRequest *request) {
   bool     is_composite;
   CeedSize input_size = 0, output_size = 0;
+  Ceed     ceed;
 
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCall(CeedOperatorCheckReady(op));
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
 
   CeedCall(CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size));
-  CeedCheck(input_size == output_size, op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  CeedCheck(input_size == output_size, ceed, CEED_ERROR_DIMENSION, "Operator must be square");
 
   // Early exit for empty operator
   if (!is_composite) {
@@ -2119,12 +2199,14 @@ int CeedOperatorLinearAssemblePointBlockDiagonal(CeedOperator op, CeedVector ass
 int CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op, CeedVector assembled, CeedRequest *request) {
   bool     is_composite;
   CeedSize input_size = 0, output_size = 0;
+  Ceed     ceed;
 
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCall(CeedOperatorCheckReady(op));
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
 
   CeedCall(CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size));
-  CeedCheck(input_size == output_size, op->ceed, CEED_ERROR_DIMENSION, "Operator must be square");
+  CeedCheck(input_size == output_size, ceed, CEED_ERROR_DIMENSION, "Operator must be square");
 
   // Early exit for empty operator
   if (!is_composite) {

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -77,9 +77,7 @@ static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, Cee
     CeedInt      size;
     CeedEvalMode eval_mode;
 
-    CeedCall(CeedQFunctionFieldGetName(input_fields[i], &field_name));
-    CeedCall(CeedQFunctionFieldGetSize(input_fields[i], &size));
-    CeedCall(CeedQFunctionFieldGetEvalMode(input_fields[i], &eval_mode));
+    CeedCall(CeedQFunctionFieldGetData(input_fields[i], &field_name, &size, &eval_mode));
     CeedCall(CeedQFunctionAddInput(*qf_fallback, field_name, size, eval_mode));
   }
   for (CeedInt i = 0; i < num_output_fields; i++) {
@@ -87,9 +85,7 @@ static int CeedQFunctionCreateFallback(Ceed fallback_ceed, CeedQFunction qf, Cee
     CeedInt      size;
     CeedEvalMode eval_mode;
 
-    CeedCall(CeedQFunctionFieldGetName(output_fields[i], &field_name));
-    CeedCall(CeedQFunctionFieldGetSize(output_fields[i], &size));
-    CeedCall(CeedQFunctionFieldGetEvalMode(output_fields[i], &eval_mode));
+    CeedCall(CeedQFunctionFieldGetData(output_fields[i], &field_name, &size, &eval_mode));
     CeedCall(CeedQFunctionAddOutput(*qf_fallback, field_name, size, eval_mode));
   }
   CeedCall(CeedFree(&source_path_with_name));
@@ -152,10 +148,7 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
       CeedElemRestriction rstr;
       CeedBasis           basis;
 
-      CeedCall(CeedOperatorFieldGetName(input_fields[i], &field_name));
-      CeedCall(CeedOperatorFieldGetVector(input_fields[i], &vec));
-      CeedCall(CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr));
-      CeedCall(CeedOperatorFieldGetBasis(input_fields[i], &basis));
+      CeedCall(CeedOperatorFieldGetData(input_fields[i], &field_name, &rstr, &basis, &vec));
       CeedCall(CeedOperatorSetField(op_fallback, field_name, rstr, basis, vec));
     }
     for (CeedInt i = 0; i < num_output_fields; i++) {
@@ -164,10 +157,7 @@ static int CeedOperatorCreateFallback(CeedOperator op) {
       CeedElemRestriction rstr;
       CeedBasis           basis;
 
-      CeedCall(CeedOperatorFieldGetName(output_fields[i], &field_name));
-      CeedCall(CeedOperatorFieldGetVector(output_fields[i], &vec));
-      CeedCall(CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr));
-      CeedCall(CeedOperatorFieldGetBasis(output_fields[i], &basis));
+      CeedCall(CeedOperatorFieldGetData(output_fields[i], &field_name, &rstr, &basis, &vec));
       CeedCall(CeedOperatorSetField(op_fallback, field_name, rstr, basis, vec));
     }
     CeedCall(CeedQFunctionAssemblyDataReferenceCopy(op->qf_assembled, &op_fallback->qf_assembled));

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -129,9 +129,7 @@ static int CeedQFunctionFieldView(CeedQFunctionField field, CeedInt field_number
   CeedInt      size;
   CeedEvalMode eval_mode;
 
-  CeedCall(CeedQFunctionFieldGetName(field, &field_name));
-  CeedCall(CeedQFunctionFieldGetSize(field, &size));
-  CeedCall(CeedQFunctionFieldGetEvalMode(field, &eval_mode));
+  CeedCall(CeedQFunctionFieldGetData(field, &field_name, &size, &eval_mode));
   fprintf(stream,
           "    %s field %" CeedInt_FMT
           ":\n"
@@ -884,6 +882,27 @@ int CeedQFunctionFieldGetSize(CeedQFunctionField qf_field, CeedInt *size) {
 **/
 int CeedQFunctionFieldGetEvalMode(CeedQFunctionField qf_field, CeedEvalMode *eval_mode) {
   *eval_mode = qf_field->eval_mode;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get the data of a `CeedQFunctionField`.
+
+  Any arguments set as `NULL` are ignored.
+
+  @param[in]  qf_field   `CeedQFunctionField`
+  @param[out] field_name Variable to store the field name
+  @param[out] size       Variable to store the size of the field
+  @param[out] eval_mode  Variable to store the field evaluation mode
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Advanced
+**/
+int CeedQFunctionFieldGetData(CeedQFunctionField qf_field, char **field_name, CeedInt *size, CeedEvalMode *eval_mode) {
+  if (field_name) CeedCall(CeedQFunctionFieldGetName(qf_field, field_name));
+  if (size) CeedCall(CeedQFunctionFieldGetSize(qf_field, size));
+  if (eval_mode) CeedCall(CeedQFunctionFieldGetEvalMode(qf_field, eval_mode));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -59,10 +59,12 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx, const char *fi
                                         CeedContextFieldType field_type, size_t num_values) {
   size_t  field_size  = 0;
   CeedInt field_index = -1;
+  Ceed    ceed;
 
   // Check for duplicate
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
   CeedCall(CeedQFunctionContextGetFieldIndex(ctx, field_name, &field_index));
-  CeedCheck(field_index == -1, ctx->ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" already registered", field_name);
+  CeedCheck(field_index == -1, ceed, CEED_ERROR_UNSUPPORTED, "QFunctionContext field with name \"%s\" already registered", field_name);
 
   // Allocate space for field data
   if (ctx->num_fields == 0) {
@@ -266,9 +268,11 @@ int CeedQFunctionContextGetFieldLabel(CeedQFunctionContext ctx, const char *fiel
 int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type, void *values) {
   bool  is_different;
   char *data;
+  Ceed  ceed;
 
   // Check field type
-  CeedCheck(field_label->type == field_type, ctx->ceed, CEED_ERROR_UNSUPPORTED,
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label->type == field_type, ceed, CEED_ERROR_UNSUPPORTED,
             "QFunctionContext field with name \"%s\" registered as %s, not registered as %s", field_label->name,
             CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
 
@@ -299,9 +303,11 @@ int CeedQFunctionContextSetGeneric(CeedQFunctionContext ctx, CeedContextFieldLab
 int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type,
                                        size_t *num_values, void *values) {
   char *data;
+  Ceed  ceed;
 
   // Check field type
-  CeedCheck(field_label->type == field_type, ctx->ceed, CEED_ERROR_UNSUPPORTED,
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label->type == field_type, ceed, CEED_ERROR_UNSUPPORTED,
             "QFunctionContext field with name \"%s\" registered as %s, not registered as %s", field_label->name,
             CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
 
@@ -335,8 +341,11 @@ int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFiel
 **/
 int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type,
                                            void *values) {
+  Ceed ceed;
+
   // Check field type
-  CeedCheck(field_label->type == field_type, ctx->ceed, CEED_ERROR_UNSUPPORTED,
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label->type == field_type, ceed, CEED_ERROR_UNSUPPORTED,
             "QFunctionContext field with name \"%s\" registered as %s, not registered as %s", field_label->name,
             CeedContextFieldTypes[field_label->type], CeedContextFieldTypes[field_type]);
 
@@ -356,7 +365,10 @@ int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContext
   @ref Backend
 **/
 int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, double *values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -374,7 +386,10 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabe
   @ref Backend
 **/
 int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const double **values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, num_values, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -391,7 +406,10 @@ int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextField
   @ref Backend
 **/
 int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const double **values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -408,7 +426,10 @@ int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextF
   @ref Backend
 **/
 int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int32_t *values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_INT32, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -426,7 +447,10 @@ int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel
   @ref Backend
 **/
 int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT32, num_values, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -443,7 +467,10 @@ int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldL
   @ref Backend
 **/
 int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int32_t **values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT32, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -460,7 +487,10 @@ int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFi
   @ref Backend
 **/
 int CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, bool *values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_BOOL, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -478,7 +508,10 @@ int CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLab
   @ref Backend
 **/
 int CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const bool **values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_BOOL, num_values, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -495,7 +528,10 @@ int CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFiel
   @ref Backend
 **/
 int CeedQFunctionContextRestoreBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const bool **values) {
-  CeedCheck(field_label, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(field_label, ceed, CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_BOOL, values));
   return CEED_ERROR_SUCCESS;
 }
@@ -605,8 +641,11 @@ int CeedQFunctionContextReferenceCopy(CeedQFunctionContext ctx, CeedQFunctionCon
   @ref User
 **/
 int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, CeedCopyMode copy_mode, size_t size, void *data) {
-  CeedCheck(ctx->SetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextSetData");
-  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(ctx->SetData, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextSetData");
+  CeedCheck(ctx->state % 2 == 0, ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextDestroyData(ctx));
   ctx->ctx_size = size;
@@ -632,15 +671,17 @@ int CeedQFunctionContextSetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 int CeedQFunctionContextTakeData(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
   void *temp_data      = NULL;
   bool  has_valid_data = true, has_borrowed_data_of_type = true;
+  Ceed  ceed;
 
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
-  CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to take, must set data");
+  CeedCheck(has_valid_data, ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to take, must set data");
 
-  CeedCheck(ctx->TakeData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextTakeData");
-  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
+  CeedCheck(ctx->TakeData, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextTakeData");
+  CeedCheck(ctx->state % 2 == 0, ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextHasBorrowedDataOfType(ctx, mem_type, &has_borrowed_data_of_type));
-  CeedCheck(has_borrowed_data_of_type, ctx->ceed, CEED_ERROR_BACKEND,
+  CeedCheck(has_borrowed_data_of_type, ceed, CEED_ERROR_BACKEND,
             "CeedQFunctionContext has no borrowed %s data, must set data with CeedQFunctionContextSetData", CeedMemTypes[mem_type]);
 
   CeedCall(ctx->TakeData(ctx, mem_type, &temp_data));
@@ -667,13 +708,15 @@ int CeedQFunctionContextTakeData(CeedQFunctionContext ctx, CeedMemType mem_type,
 **/
 int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
   bool has_valid_data = true;
+  Ceed ceed;
 
-  CeedCheck(ctx->GetData, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextGetData");
-  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
-  CeedCheck(ctx->num_readers == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, a process has read access");
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(ctx->GetData, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextGetData");
+  CeedCheck(ctx->state % 2 == 0, ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
+  CeedCheck(ctx->num_readers == 0, ceed, 1, "Cannot grant CeedQFunctionContext data access, a process has read access");
 
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
-  CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
+  CeedCheck(has_valid_data, ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
 
   CeedCall(ctx->GetData(ctx, mem_type, data));
   ctx->state++;
@@ -699,12 +742,14 @@ int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemType mem_type, 
 **/
 int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_type, void *data) {
   bool has_valid_data = true;
+  Ceed ceed;
 
-  CeedCheck(ctx->GetDataRead, ctx->ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextGetDataRead");
-  CeedCheck(ctx->state % 2 == 0, ctx->ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(ctx->GetDataRead, ceed, CEED_ERROR_UNSUPPORTED, "Backend does not support CeedQFunctionContextGetDataRead");
+  CeedCheck(ctx->state % 2 == 0, ceed, 1, "Cannot grant CeedQFunctionContext data access, the access lock is already in use");
 
   CeedCall(CeedQFunctionContextHasValidData(ctx, &has_valid_data));
-  CeedCheck(has_valid_data, ctx->ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
+  CeedCheck(has_valid_data, ceed, CEED_ERROR_BACKEND, "CeedQFunctionContext has no valid data to get, must set data");
 
   CeedCall(ctx->GetDataRead(ctx, mem_type, data));
   ctx->num_readers++;
@@ -722,7 +767,10 @@ int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_ty
   @ref User
 **/
 int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
-  CeedCheck(ctx->state % 2 == 1, ctx->ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(ctx->state % 2 == 1, ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
 
   if (ctx->RestoreData) CeedCall(ctx->RestoreData(ctx));
   *(void **)data = NULL;
@@ -741,7 +789,10 @@ int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data) {
   @ref User
 **/
 int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data) {
-  CeedCheck(ctx->num_readers > 0, ctx->ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(ctx->num_readers > 0, ceed, 1, "Cannot restore CeedQFunctionContext array access, access was not granted");
 
   ctx->num_readers--;
   if (ctx->num_readers == 0 && ctx->RestoreDataRead) CeedCall(ctx->RestoreDataRead(ctx));
@@ -890,7 +941,10 @@ int CeedQFunctionContextView(CeedQFunctionContext ctx, FILE *stream) {
   @ref User
 **/
 int CeedQFunctionContextSetDataDestroy(CeedQFunctionContext ctx, CeedMemType f_mem_type, CeedQFunctionContextDataDestroyUser f) {
-  CeedCheck(f, ctx->ceed, 1, "Must provide valid callback function for destroying user data");
+  Ceed ceed;
+
+  CeedCall(CeedQFunctionContextGetCeed(ctx, &ceed));
+  CeedCheck(f, ceed, 1, "Must provide valid callback function for destroying user data");
   ctx->data_destroy_mem_type = f_mem_type;
   ctx->data_destroy_function = f;
   return CEED_ERROR_SUCCESS;


### PR DESCRIPTION
Zero functional changes. This uses getters in favor of reaching into private object data in most places. My hope is this helps better keep our data types consistent.