### PR TITLE
Fluids: Add LogEvent for Differential Filter and Velocity Gradient Projection

### DIFF
--- a/examples/fluids/Makefile
+++ b/examples/fluids/Makefile
@@ -14,6 +14,8 @@
 # software, applications, hardware, advanced system engineering and early
 # testbed platforms, in support of the nation's exascale computing imperative.
 
+CONFIG ?= ../../config.mk
+-include $(CONFIG)
 COMMON ?= ../../common.mk
 -include $(COMMON)
 

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -101,6 +101,8 @@ extern PetscLogEvent FLUIDS_SmartRedis_Init;
 extern PetscLogEvent FLUIDS_SmartRedis_Meta;
 extern PetscLogEvent FLUIDS_SmartRedis_Train;
 extern PetscLogEvent FLUIDS_TrainDataCompute;
+extern PetscLogEvent FLUIDS_DifferentialFilter;
+extern PetscLogEvent FLUIDS_VelocityGradientProjection;
 PetscErrorCode       RegisterLogEvents();
 
 // -----------------------------------------------------------------------------

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -277,11 +277,13 @@ PetscErrorCode DifferentialFilterApply(User user, const PetscReal solution_time,
   DiffFilterData diff_filter = user->diff_filter;
 
   PetscFunctionBeginUser;
+  PetscCall(PetscLogEventBegin(FLUIDS_DifferentialFilter, Q, Filtered_Solution, 0, 0));
   PetscCall(UpdateBoundaryValues(user, diff_filter->op_rhs_ctx->X_loc, solution_time));
   ApplyCeedOperatorGlobalToGlobal(Q, Filtered_Solution, diff_filter->op_rhs_ctx);
   PetscCall(VecViewFromOptions(Filtered_Solution, NULL, "-diff_filter_rhs_view"));
 
   PetscCall(KSPSolve(diff_filter->ksp, Filtered_Solution, Filtered_Solution));
+  PetscCall(PetscLogEventEnd(FLUIDS_DifferentialFilter, Q, Filtered_Solution, 0, 0));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -345,7 +345,9 @@ PetscLogEvent       FLUIDS_SmartRedis_Init;
 PetscLogEvent       FLUIDS_SmartRedis_Meta;
 PetscLogEvent       FLUIDS_SmartRedis_Train;
 PetscLogEvent       FLUIDS_TrainDataCompute;
-static PetscClassId libCEED_classid, onlineTrain_classid;
+PetscLogEvent       FLUIDS_DifferentialFilter;
+PetscLogEvent       FLUIDS_VelocityGradientProjection;
+static PetscClassId libCEED_classid, onlineTrain_classid, misc_classid;
 
 PetscErrorCode RegisterLogEvents() {
   PetscFunctionBeginUser;
@@ -360,6 +362,10 @@ PetscErrorCode RegisterLogEvents() {
   PetscCall(PetscLogEventRegister("SmartRedis_Meta", onlineTrain_classid, &FLUIDS_SmartRedis_Meta));
   PetscCall(PetscLogEventRegister("SmartRedis_Train", onlineTrain_classid, &FLUIDS_SmartRedis_Train));
   PetscCall(PetscLogEventRegister("TrainDataCompute", onlineTrain_classid, &FLUIDS_TrainDataCompute));
+
+  PetscCall(PetscClassIdRegister("Miscellaneous", &misc_classid));
+  PetscCall(PetscLogEventRegister("DiffFilter", misc_classid, &FLUIDS_DifferentialFilter));
+  PetscCall(PetscLogEventRegister("VeloGradProj", misc_classid, &FLUIDS_VelocityGradientProjection));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/velocity_gradient_projection.c
+++ b/examples/fluids/src/velocity_gradient_projection.c
@@ -139,8 +139,10 @@ PetscErrorCode VelocityGradientProjectionApply(NodalProjectionData grad_velo_pro
   OperatorApplyContext l2_rhs_ctx = grad_velo_proj->l2_rhs_ctx;
 
   PetscFunctionBeginUser;
+  PetscCall(PetscLogEventBegin(FLUIDS_VelocityGradientProjection, Q_loc, VelocityGradient, 0, 0));
   PetscCall(ApplyCeedOperatorLocalToGlobal(Q_loc, VelocityGradient, l2_rhs_ctx));
 
   PetscCall(KSPSolve(grad_velo_proj->ksp, VelocityGradient, VelocityGradient));
+  PetscCall(PetscLogEventEnd(FLUIDS_VelocityGradientProjection, Q_loc, VelocityGradient, 0, 0));
   PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
Add `PetscLogEvent` differential filtering and velocity gradient projection. Also add `config.mk` capability to the fluids Makefile.

Stemming from conversation in https://github.com/CEED/libCEED/pull/1480#discussion_r1499951644

Now for the SGS training test we get (note the last two lines):
```
--- Event Stage 1: Fluids Solve

PetscBarrier           1 1.0 1.0500e-07 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
BuildTwoSided          3 1.0 8.5890e-06 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
CeedOpApply           60 1.0 1.7748e+00 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00 29  0  0  0  0  31  0  0  0  0     0
CeedOpAsm              6 1.0 1.9365e+00 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00 32  0  0  0  0  34  0  0  0  0     0
CeedOpAsmD             1 1.0 5.9659e-01 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00 10  0  0  0  0  10  0  0  0  0     0
SmartRedis_Meta        8 1.0 4.5910e-04 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SmartRedis_Train       3 1.0 1.5302e-03 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
TrainDataCompute       3 1.0 2.2904e+00 1.0 2.65e+07 1.0 0.0e+00 0.0e+00 0.0e+00 38  2  0  0  0  40  2  0  0  0    12
DiffFilter             3 1.0 2.2158e+00 1.0 2.63e+07 1.0 0.0e+00 0.0e+00 0.0e+00 37  2  0  0  0  39  2  0  0  0    12
VeloGradProj           3 1.0 4.1521e-02 1.0 1.35e+05 1.0 0.0e+00 0.0e+00 0.0e+00  1  0  0  0  0   1  0  0  0  0     3
```

`DiffFilter` and `VeloGradProj` are used in `TrainDataCompute`, so I've already learned that the differential filtering is _much_ more expensive than the velocity gradient projection. Which I kinda guessed before, but it's more substantial than I would've thought.