### PR TITLE
Remove obsolete LSAN_OPTIONS and .asanignore

### DIFF
--- a/.asanignore
+++ b/.asanignore
@@ -1,3 +1,0 @@
-leak:libcuda
-leak:libocca
-leak:basic_string.tcc

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,6 @@ ifneq ($(wildcard ../petsc/lib/libpetsc.*),)
 endif
 
 # Warning: SANTIZ options still don't run with /gpu/occa
-# export LSAN_OPTIONS=suppressions=.asanignore
 AFLAGS ?= -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
 # Note: Intel oneAPI C/C++ compiler is now icx/icpx


### PR DESCRIPTION
Removes dead code in the Makefile to set `LSAN_OPTIONS`.

Any platform needing to suppress leaks should set `LSAN_OPTIONS` in its particular CI script, rather than being set globally.