### PR TITLE
Write source to debug when CUDA/HIP fails to compile

### DIFF
--- a/backends/cuda/ceed-cuda-compile.cpp
+++ b/backends/cuda/ceed-cuda-compile.cpp
@@ -73,8 +73,6 @@ int CeedCompile_Cuda(Ceed ceed, const char *source, CUmodule *module, const Ceed
   }
   code << jit_defs_source;
   code << "\n\n";
-  CeedCallBackend(CeedFree(&jit_defs_path));
-  CeedCallBackend(CeedFree(&jit_defs_source));
 
   // Non-macro options
   opts[0] = "-default-device";
@@ -97,11 +95,19 @@ int CeedCompile_Cuda(Ceed ceed, const char *source, CUmodule *module, const Ceed
     char  *log;
     size_t log_size;
 
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_ERROR, "---------- CEED JIT SOURCE FAILED TO COMPILE ----------\n");
+    CeedDebug(ceed, "File: %s\n", jit_defs_path);
+    CeedDebug(ceed, "Source:\n%s\n", jit_defs_source);
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_ERROR, "---------- CEED JIT SOURCE FAILED TO COMPILE ----------\n");
+    CeedCallBackend(CeedFree(&jit_defs_path));
+    CeedCallBackend(CeedFree(&jit_defs_source));
     CeedCallNvrtc(ceed, nvrtcGetProgramLogSize(prog, &log_size));
     CeedCallBackend(CeedMalloc(log_size, &log));
     CeedCallNvrtc(ceed, nvrtcGetProgramLog(prog, log));
     return CeedError(ceed, CEED_ERROR_BACKEND, "%s\n%s", nvrtcGetErrorString(result), log);
   }
+  CeedCallBackend(CeedFree(&jit_defs_path));
+  CeedCallBackend(CeedFree(&jit_defs_source));
 
   CeedCallNvrtc(ceed, nvrtcGetPTXSize(prog, &ptx_size));
   CeedCallBackend(CeedMalloc(ptx_size, &ptx));

--- a/backends/hip/ceed-hip-compile.cpp
+++ b/backends/hip/ceed-hip-compile.cpp
@@ -80,8 +80,6 @@ int CeedCompile_Hip(Ceed ceed, const char *source, hipModule_t *module, const Ce
   CeedCallBackend(CeedLoadSourceToBuffer(ceed, jit_defs_path, &jit_defs_source));
   code << jit_defs_source;
   code << "\n\n";
-  CeedCallBackend(CeedFree(&jit_defs_path));
-  CeedCallBackend(CeedFree(&jit_defs_source));
 
   // Non-macro options
   opts[0] = "-default-device";
@@ -104,11 +102,19 @@ int CeedCompile_Hip(Ceed ceed, const char *source, hipModule_t *module, const Ce
     size_t log_size;
     char  *log;
 
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_ERROR, "---------- CEED JIT SOURCE FAILED TO COMPILE ----------\n");
+    CeedDebug(ceed, "File: %s\n", jit_defs_path);
+    CeedDebug(ceed, "Source:\n%s\n", jit_defs_source);
+    CeedDebug256(ceed, CEED_DEBUG_COLOR_ERROR, "---------- CEED JIT SOURCE FAILED TO COMPILE ----------\n");
+    CeedCallBackend(CeedFree(&jit_defs_path));
+    CeedCallBackend(CeedFree(&jit_defs_source));
     CeedChk_hiprtc(ceed, hiprtcGetProgramLogSize(prog, &log_size));
     CeedCallBackend(CeedMalloc(log_size, &log));
     CeedCallHiprtc(ceed, hiprtcGetProgramLog(prog, log));
     return CeedError(ceed, CEED_ERROR_BACKEND, "%s\n%s", hiprtcGetErrorString(result), log);
   }
+  CeedCallBackend(CeedFree(&jit_defs_path));
+  CeedCallBackend(CeedFree(&jit_defs_source));
 
   CeedCallHiprtc(ceed, hiprtcGetCodeSize(prog, &ptx_size));
   CeedCallBackend(CeedMalloc(ptx_size, &ptx));


### PR DESCRIPTION
This change, suggested by @jrwrigh, dumps the last JiT source to stdout when CUDA/HIP fails to compile.