### PR TITLE
Avoid integer conversion warnings for fields in SgsDDData

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -15,7 +15,7 @@
 //
 // Sample runs:
 //
-//     ./navierstokes -ceed /cpu/self -problem density_current -degree 1
+//     ./navierstokes -ceed /cpu/self -options_file gaussianwave.yml
 //     ./navierstokes -ceed /gpu/cuda -problem advection -degree 1
 //
 //TESTARGS(name="Advection 2D, rotation, explicit, su, consistent mass") -ceed {ceed_resource} -test_type solver -problem advection -degree 3 -dm_plex_box_faces 2,2 -dm_plex_box_lower 0,0 -dm_plex_box_upper 125,125 -bc_wall 1,2,3,4 -wall_comps 4 -units_kilogram 1e-9 -rc 100. -ts_dt 1e-3 -ts_max_steps 10 -stab su -Ctaus 0.5 -mass_ksp_type cg -mass_pc_jacobi_type diagonal -compare_final_state_atol 1e-10 -compare_final_state_filename examples/fluids/tests-output/fluids-navierstokes-adv2d-rotation-explicit-stab-su-consistent-mass.bin

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -202,8 +202,7 @@ typedef PetscErrorCode (*SgsDDNodalStressEval)(User user, Vec Q_loc, Vec Velocit
 typedef PetscErrorCode (*SgsDDNodalStressInference)(Vec DD_Inputs_loc, Vec DD_Outputs_loc, void *ctx);
 typedef struct {
   DM                        dm_sgs, dm_dd_inputs, dm_dd_outputs;
-  PetscInt                  num_comp_sgs;
-  CeedInt                   num_comp_inputs, num_comp_outputs;
+  PetscInt                  num_comp_sgs, num_comp_inputs, num_comp_outputs;
   OperatorApplyContext      op_nodal_evaluation_ctx, op_nodal_dd_inputs_ctx, op_nodal_dd_outputs_ctx, op_sgs_apply_ctx;
   CeedVector                sgs_nodal_ceed, grad_velo_ceed;
   SgsDDNodalStressEval      sgs_nodal_eval;


### PR DESCRIPTION
And also edit sample command-lines for the navierstokes example