### PR TITLE
Reduce Code Duplication

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -372,7 +372,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
         CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
         code << "    // CompStride: " << comp_stride << "\n";
         CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-        data->indices.inputs[i] = rstr_data->d_ind;
+        data->indices.inputs[i] = rstr_data->d_offsets;
         code << "    readDofsOffset" << dim << "d<num_comp_in_" << i << ", " << comp_stride << ", P_in_" << i << ">(data, l_size_in_" << i
              << ", elem, indices.inputs[" << i << "], d_u_" << i << ", r_u_" << i << ");\n";
       } else {
@@ -486,7 +486,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
             CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
             code << "      // CompStride: " << comp_stride << "\n";
             CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-            data->indices.inputs[i] = rstr_data->d_ind;
+            data->indices.inputs[i] = rstr_data->d_offsets;
             code << "      readSliceQuadsOffset"
                  << "3d<num_comp_in_" << i << ", " << comp_stride << ", Q_1d>(data, l_size_in_" << i << ", elem, q, indices.inputs[" << i << "], d_u_"
                  << i << ", r_q_" << i << ");\n";
@@ -676,7 +676,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
       code << "    // CompStride: " << comp_stride << "\n";
       CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-      data->indices.outputs[i] = rstr_data->d_ind;
+      data->indices.outputs[i] = rstr_data->d_offsets;
       code << "    writeDofsOffset" << dim << "d<num_comp_out_" << i << ", " << comp_stride << ", P_out_" << i << ">(data, l_size_out_" << i
            << ", elem, indices.outputs[" << i << "], r_v_" << i << ", d_v_" << i << ");\n";
     } else {

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -372,7 +372,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
         CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
         code << "    // CompStride: " << comp_stride << "\n";
         CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-        data->indices.inputs[i] = rstr_data->d_offsets;
+        data->indices.inputs[i] = (CeedInt *)rstr_data->d_offsets;
         code << "    readDofsOffset" << dim << "d<num_comp_in_" << i << ", " << comp_stride << ", P_in_" << i << ">(data, l_size_in_" << i
              << ", elem, indices.inputs[" << i << "], d_u_" << i << ", r_u_" << i << ");\n";
       } else {
@@ -486,7 +486,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
             CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
             code << "      // CompStride: " << comp_stride << "\n";
             CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-            data->indices.inputs[i] = rstr_data->d_offsets;
+            data->indices.inputs[i] = (CeedInt *)rstr_data->d_offsets;
             code << "      readSliceQuadsOffset"
                  << "3d<num_comp_in_" << i << ", " << comp_stride << ", Q_1d>(data, l_size_in_" << i << ", elem, q, indices.inputs[" << i << "], d_u_"
                  << i << ", r_q_" << i << ");\n";
@@ -676,7 +676,7 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
       code << "    // CompStride: " << comp_stride << "\n";
       CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-      data->indices.outputs[i] = rstr_data->d_offsets;
+      data->indices.outputs[i] = (CeedInt *)rstr_data->d_offsets;
       code << "    writeDofsOffset" << dim << "d<num_comp_out_" << i << ", " << comp_stride << ", P_out_" << i << ">(data, l_size_out_" << i
            << ", elem, indices.outputs[" << i << "], r_v_" << i << ", d_v_" << i << ");\n";
     } else {

--- a/backends/cuda-ref/ceed-cuda-ref-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-restriction.c
@@ -166,32 +166,32 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
         CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyNoTranspose, grid, block_size, args));
       } break;
       case CEED_RESTRICTION_STANDARD: {
-        void *args[] = {&impl->d_ind, &d_u, &d_v};
+        void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
         CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyNoTranspose, grid, block_size, args));
       } break;
       case CEED_RESTRICTION_ORIENTED: {
         if (use_signs) {
-          void *args[] = {&impl->d_ind, &impl->d_orients, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &impl->d_orients, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyNoTranspose, grid, block_size, args));
         } else {
-          void *args[] = {&impl->d_ind, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyUnsignedNoTranspose, grid, block_size, args));
         }
       } break;
       case CEED_RESTRICTION_CURL_ORIENTED: {
         if (use_signs && use_orients) {
-          void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyNoTranspose, grid, block_size, args));
         } else if (use_orients) {
-          void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyUnsignedNoTranspose, grid, block_size, args));
         } else {
-          void *args[] = {&impl->d_ind, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyUnorientedNoTranspose, grid, block_size, args));
         }
@@ -216,7 +216,7 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
       } break;
       case CEED_RESTRICTION_STANDARD: {
         if (!is_deterministic) {
-          void *args[] = {&impl->d_ind, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyTranspose, grid, block_size, args));
         } else {
@@ -228,7 +228,7 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
       case CEED_RESTRICTION_ORIENTED: {
         if (use_signs) {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &impl->d_orients, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &impl->d_orients, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyTranspose, grid, block_size, args));
           } else {
@@ -238,7 +238,7 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
           }
         } else {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyUnsignedTranspose, grid, block_size, args));
           } else {
@@ -251,7 +251,7 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
       case CEED_RESTRICTION_CURL_ORIENTED: {
         if (use_signs && use_orients) {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyTranspose, grid, block_size, args));
           } else {
@@ -261,7 +261,7 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
           }
         } else if (use_orients) {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyUnsignedTranspose, grid, block_size, args));
           } else {
@@ -271,7 +271,7 @@ static inline int CeedElemRestrictionApply_Cuda_Core(CeedElemRestriction rstr, C
           }
         } else {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Cuda(ceed, impl->ApplyUnorientedTranspose, grid, block_size, args));
           } else {
@@ -329,10 +329,10 @@ static int CeedElemRestrictionGetOffsets_Cuda(CeedElemRestriction rstr, CeedMemT
   CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *offsets = impl->h_ind;
+      *offsets = impl->h_offsets;
       break;
     case CEED_MEM_DEVICE:
-      *offsets = impl->d_ind;
+      *offsets = impl->d_offsets;
       break;
   }
   return CEED_ERROR_SUCCESS;
@@ -386,15 +386,15 @@ static int CeedElemRestrictionDestroy_Cuda(CeedElemRestriction rstr) {
   if (impl->module) {
     CeedCallCuda(ceed, cuModuleUnload(impl->module));
   }
-  CeedCallBackend(CeedFree(&impl->h_ind_allocated));
-  CeedCallCuda(ceed, cudaFree(impl->d_ind_allocated));
+  CeedCallBackend(CeedFree(&impl->h_offsets_owned));
+  CeedCallCuda(ceed, cudaFree(impl->d_offsets_owned));
   CeedCallCuda(ceed, cudaFree(impl->d_t_offsets));
   CeedCallCuda(ceed, cudaFree(impl->d_t_indices));
   CeedCallCuda(ceed, cudaFree(impl->d_l_vec_indices));
-  CeedCallBackend(CeedFree(&impl->h_orients_allocated));
-  CeedCallCuda(ceed, cudaFree(impl->d_orients_allocated));
-  CeedCallBackend(CeedFree(&impl->h_curl_orients_allocated));
-  CeedCallCuda(ceed, cudaFree(impl->d_curl_orients_allocated));
+  CeedCallBackend(CeedFree(&impl->h_orients_owned));
+  CeedCallCuda(ceed, cudaFree(impl->d_orients_owned));
+  CeedCallBackend(CeedFree(&impl->h_curl_orients_owned));
+  CeedCallCuda(ceed, cudaFree(impl->d_curl_orients_owned));
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
 }
@@ -482,7 +482,7 @@ static int CeedElemRestrictionOffset_Cuda(const CeedElemRestriction rstr, const 
 //------------------------------------------------------------------------------
 // Create restriction
 //------------------------------------------------------------------------------
-int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
+int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *offsets, const bool *orients,
                                    const CeedInt8 *curl_orients, CeedElemRestriction rstr) {
   Ceed                      ceed, ceed_parent;
   bool                      is_deterministic;
@@ -499,21 +499,7 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode,
   const CeedInt size = num_elem * elem_size;
 
   CeedCallBackend(CeedCalloc(1, &impl));
-  impl->num_nodes                = size;
-  impl->h_ind                    = NULL;
-  impl->h_ind_allocated          = NULL;
-  impl->d_ind                    = NULL;
-  impl->d_ind_allocated          = NULL;
-  impl->d_t_indices              = NULL;
-  impl->d_t_offsets              = NULL;
-  impl->h_orients                = NULL;
-  impl->h_orients_allocated      = NULL;
-  impl->d_orients                = NULL;
-  impl->d_orients_allocated      = NULL;
-  impl->h_curl_orients           = NULL;
-  impl->h_curl_orients_allocated = NULL;
-  impl->d_curl_orients           = NULL;
-  impl->d_curl_orients_allocated = NULL;
+  impl->num_nodes = size;
   CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
 
   // Set layouts
@@ -535,43 +521,51 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode,
     switch (mem_type) {
       case CEED_MEM_HOST: {
         switch (copy_mode) {
+          case CEED_COPY_VALUES:
+            CeedCallBackend(CeedMalloc(size, &impl->h_offsets_owned));
+            memcpy(impl->h_offsets_owned, offsets, size * sizeof(CeedInt));
+            impl->h_offsets_borrowed = NULL;
+            impl->h_offsets          = impl->h_offsets_owned;
+            break;
           case CEED_OWN_POINTER:
-            impl->h_ind_allocated = (CeedInt *)indices;
-            impl->h_ind           = (CeedInt *)indices;
+            impl->h_offsets_owned    = (CeedInt *)offsets;
+            impl->h_offsets_borrowed = NULL;
+            impl->h_offsets          = impl->h_offsets_owned;
             break;
           case CEED_USE_POINTER:
-            impl->h_ind = (CeedInt *)indices;
-            break;
-          case CEED_COPY_VALUES:
-            CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
-            memcpy(impl->h_ind_allocated, indices, size * sizeof(CeedInt));
-            impl->h_ind = impl->h_ind_allocated;
+            impl->h_offsets_owned    = NULL;
+            impl->h_offsets_borrowed = (CeedInt *)offsets;
+            impl->h_offsets          = impl->h_offsets_borrowed;
             break;
         }
-        CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-        impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-        CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyHostToDevice));
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(rstr, indices));
+        CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_offsets_owned, size * sizeof(CeedInt)));
+        CeedCallCuda(ceed, cudaMemcpy(impl->d_offsets_owned, impl->h_offsets, size * sizeof(CeedInt), cudaMemcpyHostToDevice));
+        impl->d_offsets = impl->d_offsets_owned;
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(rstr, offsets));
       } break;
       case CEED_MEM_DEVICE: {
         switch (copy_mode) {
           case CEED_COPY_VALUES:
-            CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-            impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-            CeedCallCuda(ceed, cudaMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), cudaMemcpyDeviceToDevice));
+            CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_offsets_owned, size * sizeof(CeedInt)));
+            CeedCallCuda(ceed, cudaMemcpy(impl->d_offsets_owned, offsets, size * sizeof(CeedInt), cudaMemcpyDeviceToDevice));
+            impl->d_offsets_borrowed = NULL;
+            impl->d_offsets          = impl->d_offsets_owned;
             break;
           case CEED_OWN_POINTER:
-            impl->d_ind           = (CeedInt *)indices;
-            impl->d_ind_allocated = impl->d_ind;
+            impl->d_offsets_owned    = (CeedInt *)offsets;
+            impl->d_offsets_borrowed = NULL;
+            impl->d_offsets          = impl->d_offsets_owned;
             break;
           case CEED_USE_POINTER:
-            impl->d_ind = (CeedInt *)indices;
+            impl->d_offsets_owned    = NULL;
+            impl->d_offsets_borrowed = (CeedInt *)offsets;
+            impl->d_offsets          = impl->d_offsets_borrowed;
             break;
         }
-        CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
-        CeedCallCuda(ceed, cudaMemcpy(impl->h_ind_allocated, impl->d_ind, size * sizeof(CeedInt), cudaMemcpyDeviceToHost));
-        impl->h_ind = impl->h_ind_allocated;
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(rstr, indices));
+        CeedCallBackend(CeedMalloc(size, &impl->h_offsets_owned));
+        CeedCallCuda(ceed, cudaMemcpy(impl->h_offsets_owned, impl->d_offsets, size * sizeof(CeedInt), cudaMemcpyDeviceToHost));
+        impl->h_offsets = impl->h_offsets_owned;
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Cuda(rstr, offsets));
       } break;
     }
 
@@ -580,82 +574,98 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode,
       switch (mem_type) {
         case CEED_MEM_HOST: {
           switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(size, &impl->h_orients_owned));
+              memcpy(impl->h_orients_owned, orients, size * sizeof(bool));
+              impl->h_orients_borrowed = NULL;
+              impl->h_orients          = impl->h_orients_owned;
+              break;
             case CEED_OWN_POINTER:
-              impl->h_orients_allocated = (bool *)orients;
-              impl->h_orients           = (bool *)orients;
+              impl->h_orients_owned    = (bool *)orients;
+              impl->h_orients_borrowed = NULL;
+              impl->h_orients          = impl->h_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->h_orients = (bool *)orients;
-              break;
-            case CEED_COPY_VALUES:
-              CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
-              memcpy(impl->h_orients_allocated, orients, size * sizeof(bool));
-              impl->h_orients = impl->h_orients_allocated;
+              impl->h_orients_owned    = NULL;
+              impl->h_orients_borrowed = (bool *)orients;
+              impl->h_orients          = impl->h_orients_borrowed;
               break;
           }
-          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_orients, size * sizeof(bool)));
-          impl->d_orients_allocated = impl->d_orients;  // We own the device memory
-          CeedCallCuda(ceed, cudaMemcpy(impl->d_orients, orients, size * sizeof(bool), cudaMemcpyHostToDevice));
+          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_orients_owned, size * sizeof(bool)));
+          CeedCallCuda(ceed, cudaMemcpy(impl->d_orients_owned, impl->h_orients, size * sizeof(bool), cudaMemcpyHostToDevice));
+          impl->d_orients = impl->d_orients_owned;
         } break;
         case CEED_MEM_DEVICE: {
           switch (copy_mode) {
             case CEED_COPY_VALUES:
-              CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_orients, size * sizeof(bool)));
-              impl->d_orients_allocated = impl->d_orients;  // We own the device memory
-              CeedCallCuda(ceed, cudaMemcpy(impl->d_orients, orients, size * sizeof(bool), cudaMemcpyDeviceToDevice));
+              CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_orients_owned, size * sizeof(bool)));
+              CeedCallCuda(ceed, cudaMemcpy(impl->d_orients_owned, orients, size * sizeof(bool), cudaMemcpyDeviceToDevice));
+              impl->d_orients_borrowed = NULL;
+              impl->d_orients          = impl->d_orients_owned;
               break;
             case CEED_OWN_POINTER:
-              impl->d_orients           = (bool *)orients;
-              impl->d_orients_allocated = impl->d_orients;
+              impl->d_orients_owned    = (bool *)orients;
+              impl->d_orients_borrowed = NULL;
+              impl->d_orients          = impl->d_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->d_orients = (bool *)orients;
+              impl->d_orients_owned    = NULL;
+              impl->d_orients_borrowed = (bool *)orients;
+              impl->d_orients          = impl->d_orients_borrowed;
               break;
           }
-          CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
-          CeedCallCuda(ceed, cudaMemcpy(impl->h_orients_allocated, impl->d_orients, size * sizeof(bool), cudaMemcpyDeviceToHost));
-          impl->h_orients = impl->h_orients_allocated;
+          CeedCallBackend(CeedMalloc(size, &impl->h_orients_owned));
+          CeedCallCuda(ceed, cudaMemcpy(impl->h_orients_owned, impl->d_orients, size * sizeof(bool), cudaMemcpyDeviceToHost));
+          impl->h_orients = impl->h_orients_owned;
         } break;
       }
     } else if (rstr_type == CEED_RESTRICTION_CURL_ORIENTED) {
       switch (mem_type) {
         case CEED_MEM_HOST: {
           switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_owned));
+              memcpy(impl->h_curl_orients_owned, curl_orients, 3 * size * sizeof(CeedInt8));
+              impl->h_curl_orients_borrowed = NULL;
+              impl->h_curl_orients          = impl->h_curl_orients_owned;
+              break;
             case CEED_OWN_POINTER:
-              impl->h_curl_orients_allocated = (CeedInt8 *)curl_orients;
-              impl->h_curl_orients           = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients_owned    = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients_borrowed = NULL;
+              impl->h_curl_orients          = impl->h_curl_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->h_curl_orients = (CeedInt8 *)curl_orients;
-              break;
-            case CEED_COPY_VALUES:
-              CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
-              memcpy(impl->h_curl_orients_allocated, curl_orients, 3 * size * sizeof(CeedInt8));
-              impl->h_curl_orients = impl->h_curl_orients_allocated;
+              impl->h_curl_orients_owned    = NULL;
+              impl->h_curl_orients_borrowed = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients          = impl->h_curl_orients_borrowed;
               break;
           }
-          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
-          impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
-          CeedCallCuda(ceed, cudaMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyHostToDevice));
+          CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_curl_orients_owned, 3 * size * sizeof(CeedInt8)));
+          CeedCallCuda(ceed, cudaMemcpy(impl->d_curl_orients_owned, impl->h_curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyHostToDevice));
+          impl->d_curl_orients = impl->d_curl_orients_owned;
         } break;
         case CEED_MEM_DEVICE: {
           switch (copy_mode) {
             case CEED_COPY_VALUES:
-              CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
-              impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
-              CeedCallCuda(ceed, cudaMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyDeviceToDevice));
+              CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_curl_orients_owned, 3 * size * sizeof(CeedInt8)));
+              CeedCallCuda(ceed, cudaMemcpy(impl->d_curl_orients_owned, curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyDeviceToDevice));
+              impl->d_curl_orients_borrowed = NULL;
+              impl->d_curl_orients          = impl->d_curl_orients_owned;
               break;
             case CEED_OWN_POINTER:
-              impl->d_curl_orients           = (CeedInt8 *)curl_orients;
-              impl->d_curl_orients_allocated = impl->d_curl_orients;
+              impl->d_curl_orients_owned    = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients_borrowed = NULL;
+              impl->d_curl_orients          = impl->d_curl_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->d_curl_orients = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients_owned    = NULL;
+              impl->d_curl_orients_borrowed = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients          = impl->d_curl_orients_borrowed;
               break;
           }
-          CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
-          CeedCallCuda(ceed, cudaMemcpy(impl->h_curl_orients_allocated, impl->d_curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyDeviceToHost));
-          impl->h_curl_orients = impl->h_curl_orients_allocated;
+          CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_owned));
+          CeedCallCuda(ceed, cudaMemcpy(impl->h_curl_orients_owned, impl->d_curl_orients, 3 * size * sizeof(CeedInt8), cudaMemcpyDeviceToHost));
+          impl->h_curl_orients = impl->h_curl_orients_owned;
         } break;
       }
     }

--- a/backends/cuda-ref/ceed-cuda-ref-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-restriction.c
@@ -388,9 +388,9 @@ static int CeedElemRestrictionDestroy_Cuda(CeedElemRestriction rstr) {
   }
   CeedCallBackend(CeedFree(&impl->h_offsets_owned));
   CeedCallCuda(ceed, cudaFree((CeedInt *)impl->d_offsets_owned));
-  CeedCallCuda(ceed, cudaFree(impl->d_t_offsets));
-  CeedCallCuda(ceed, cudaFree(impl->d_t_indices));
-  CeedCallCuda(ceed, cudaFree(impl->d_l_vec_indices));
+  CeedCallCuda(ceed, cudaFree((CeedInt *)impl->d_t_offsets));
+  CeedCallCuda(ceed, cudaFree((CeedInt *)impl->d_t_indices));
+  CeedCallCuda(ceed, cudaFree((CeedInt *)impl->d_l_vec_indices));
   CeedCallBackend(CeedFree(&impl->h_orients_owned));
   CeedCallCuda(ceed, cudaFree((bool *)impl->d_orients_owned));
   CeedCallBackend(CeedFree(&impl->h_curl_orients_owned));
@@ -463,13 +463,13 @@ static int CeedElemRestrictionOffset_Cuda(const CeedElemRestriction rstr, const 
   // Copy data to device
   // -- L-vector indices
   CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_l_vec_indices, num_nodes * sizeof(CeedInt)));
-  CeedCallCuda(ceed, cudaMemcpy(impl->d_l_vec_indices, l_vec_indices, num_nodes * sizeof(CeedInt), cudaMemcpyHostToDevice));
+  CeedCallCuda(ceed, cudaMemcpy((CeedInt *)impl->d_l_vec_indices, l_vec_indices, num_nodes * sizeof(CeedInt), cudaMemcpyHostToDevice));
   // -- Transpose offsets
   CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_t_offsets, size_offsets * sizeof(CeedInt)));
-  CeedCallCuda(ceed, cudaMemcpy(impl->d_t_offsets, t_offsets, size_offsets * sizeof(CeedInt), cudaMemcpyHostToDevice));
+  CeedCallCuda(ceed, cudaMemcpy((CeedInt *)impl->d_t_offsets, t_offsets, size_offsets * sizeof(CeedInt), cudaMemcpyHostToDevice));
   // -- Transpose indices
   CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_t_indices, size_indices * sizeof(CeedInt)));
-  CeedCallCuda(ceed, cudaMemcpy(impl->d_t_indices, t_indices, size_indices * sizeof(CeedInt), cudaMemcpyHostToDevice));
+  CeedCallCuda(ceed, cudaMemcpy((CeedInt *)impl->d_t_indices, t_indices, size_indices * sizeof(CeedInt), cudaMemcpyHostToDevice));
 
   // Cleanup
   CeedCallBackend(CeedFree(&ind_to_offset));

--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -177,38 +177,29 @@ static inline int CeedVectorHasBorrowedArrayOfType_Cuda(const CeedVector vec, Ce
 // Set array from host
 //------------------------------------------------------------------------------
 static int CeedVectorSetArrayHost_Cuda(const CeedVector vec, const CeedCopyMode copy_mode, CeedScalar *array) {
+  CeedSize         length;
   CeedVector_Cuda *impl;
 
   CeedCallBackend(CeedVectorGetData(vec, &impl));
-  switch (copy_mode) {
-    case CEED_COPY_VALUES: {
-      if (!impl->h_array_owned) {
-        CeedSize length;
+  CeedCallBackend(CeedVectorGetLength(vec, &length));
 
-        CeedCallBackend(CeedVectorGetLength(vec, &length));
-        CeedCallBackend(CeedMalloc(length, &impl->h_array_owned));
-      }
+  switch (copy_mode) {
+    case CEED_COPY_VALUES:
+      if (!impl->h_array_owned) CeedCallBackend(CeedMalloc(length, &impl->h_array_owned));
+      if (array) memcpy(impl->h_array_owned, array, length * sizeof(array[0]));
       impl->h_array_borrowed = NULL;
       impl->h_array          = impl->h_array_owned;
-      if (array) {
-        CeedSize length;
-        size_t   bytes;
-
-        CeedCallBackend(CeedVectorGetLength(vec, &length));
-        bytes = length * sizeof(CeedScalar);
-        memcpy(impl->h_array, array, bytes);
-      }
-    } break;
+      break;
     case CEED_OWN_POINTER:
       CeedCallBackend(CeedFree(&impl->h_array_owned));
       impl->h_array_owned    = array;
       impl->h_array_borrowed = NULL;
-      impl->h_array          = array;
+      impl->h_array          = impl->h_array_owned;
       break;
     case CEED_USE_POINTER:
       CeedCallBackend(CeedFree(&impl->h_array_owned));
       impl->h_array_borrowed = array;
-      impl->h_array          = array;
+      impl->h_array          = impl->h_array_borrowed;
       break;
   }
   return CEED_ERROR_SUCCESS;
@@ -218,36 +209,32 @@ static int CeedVectorSetArrayHost_Cuda(const CeedVector vec, const CeedCopyMode 
 // Set array from device
 //------------------------------------------------------------------------------
 static int CeedVectorSetArrayDevice_Cuda(const CeedVector vec, const CeedCopyMode copy_mode, CeedScalar *array) {
+  CeedSize         length;
   Ceed             ceed;
   CeedVector_Cuda *impl;
 
   CeedCallBackend(CeedVectorGetCeed(vec, &ceed));
   CeedCallBackend(CeedVectorGetData(vec, &impl));
-  switch (copy_mode) {
-    case CEED_COPY_VALUES: {
-      CeedSize length;
-      size_t   bytes;
+  CeedCallBackend(CeedVectorGetLength(vec, &length));
 
-      CeedCallBackend(CeedVectorGetLength(vec, &length));
-      bytes = length * sizeof(CeedScalar);
-      if (!impl->d_array_owned) {
-        CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_array_owned, bytes));
-      }
+  switch (copy_mode) {
+    case CEED_COPY_VALUES:
+      if (!impl->d_array_owned) CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_array_owned, length * sizeof(array[0])));
+      if (array) CeedCallCuda(ceed, cudaMemcpy(impl->d_array_owned, array, length * sizeof(array[0]), cudaMemcpyDeviceToDevice));
       impl->d_array_borrowed = NULL;
       impl->d_array          = impl->d_array_owned;
-      if (array) CeedCallCuda(ceed, cudaMemcpy(impl->d_array, array, bytes, cudaMemcpyDeviceToDevice));
-    } break;
+      break;
     case CEED_OWN_POINTER:
       CeedCallCuda(ceed, cudaFree(impl->d_array_owned));
       impl->d_array_owned    = array;
       impl->d_array_borrowed = NULL;
-      impl->d_array          = array;
+      impl->d_array          = impl->d_array_owned;
       break;
     case CEED_USE_POINTER:
       CeedCallCuda(ceed, cudaFree(impl->d_array_owned));
       impl->d_array_owned    = NULL;
       impl->d_array_borrowed = array;
-      impl->d_array          = array;
+      impl->d_array          = impl->d_array_borrowed;
       break;
   }
   return CEED_ERROR_SUCCESS;

--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -183,25 +183,8 @@ static int CeedVectorSetArrayHost_Cuda(const CeedVector vec, const CeedCopyMode 
   CeedCallBackend(CeedVectorGetData(vec, &impl));
   CeedCallBackend(CeedVectorGetLength(vec, &length));
 
-  switch (copy_mode) {
-    case CEED_COPY_VALUES:
-      if (!impl->h_array_owned) CeedCallBackend(CeedMalloc(length, &impl->h_array_owned));
-      if (array) memcpy(impl->h_array_owned, array, length * sizeof(array[0]));
-      impl->h_array_borrowed = NULL;
-      impl->h_array          = impl->h_array_owned;
-      break;
-    case CEED_OWN_POINTER:
-      CeedCallBackend(CeedFree(&impl->h_array_owned));
-      impl->h_array_owned    = array;
-      impl->h_array_borrowed = NULL;
-      impl->h_array          = impl->h_array_owned;
-      break;
-    case CEED_USE_POINTER:
-      CeedCallBackend(CeedFree(&impl->h_array_owned));
-      impl->h_array_borrowed = array;
-      impl->h_array          = impl->h_array_borrowed;
-      break;
-  }
+  CeedCallBackend(CeedSetHostCeedScalarArray(array, copy_mode, length, (const CeedScalar **)&impl->h_array_owned,
+                                             (const CeedScalar **)&impl->h_array_borrowed, (const CeedScalar **)&impl->h_array));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -217,26 +200,8 @@ static int CeedVectorSetArrayDevice_Cuda(const CeedVector vec, const CeedCopyMod
   CeedCallBackend(CeedVectorGetData(vec, &impl));
   CeedCallBackend(CeedVectorGetLength(vec, &length));
 
-  switch (copy_mode) {
-    case CEED_COPY_VALUES:
-      if (!impl->d_array_owned) CeedCallCuda(ceed, cudaMalloc((void **)&impl->d_array_owned, length * sizeof(array[0])));
-      if (array) CeedCallCuda(ceed, cudaMemcpy(impl->d_array_owned, array, length * sizeof(array[0]), cudaMemcpyDeviceToDevice));
-      impl->d_array_borrowed = NULL;
-      impl->d_array          = impl->d_array_owned;
-      break;
-    case CEED_OWN_POINTER:
-      CeedCallCuda(ceed, cudaFree(impl->d_array_owned));
-      impl->d_array_owned    = array;
-      impl->d_array_borrowed = NULL;
-      impl->d_array          = impl->d_array_owned;
-      break;
-    case CEED_USE_POINTER:
-      CeedCallCuda(ceed, cudaFree(impl->d_array_owned));
-      impl->d_array_owned    = NULL;
-      impl->d_array_borrowed = array;
-      impl->d_array          = impl->d_array_borrowed;
-      break;
-  }
+  CeedCallBackend(CeedSetDeviceCeedScalarArray_Cuda(ceed, array, copy_mode, length, (const CeedScalar **)&impl->d_array_owned,
+                                                    (const CeedScalar **)&impl->d_array_borrowed, (const CeedScalar **)&impl->d_array));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -32,12 +32,12 @@ typedef struct {
   const CeedInt  *h_offsets;
   const CeedInt  *h_offsets_borrowed;
   const CeedInt  *h_offsets_owned;
-  CeedInt        *d_offsets;
+  const CeedInt  *d_offsets;
   const CeedInt  *d_offsets_borrowed;
   const CeedInt  *d_offsets_owned;
-  CeedInt        *d_t_offsets;
-  CeedInt        *d_t_indices;
-  CeedInt        *d_l_vec_indices;
+  const CeedInt  *d_t_offsets;
+  const CeedInt  *d_t_indices;
+  const CeedInt  *d_l_vec_indices;
   const bool     *h_orients;
   const bool     *h_orients_borrowed;
   const bool     *h_orients_owned;

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -29,21 +29,27 @@ typedef struct {
   CUfunction ApplyUnsignedNoTranspose, ApplyUnsignedTranspose;
   CUfunction ApplyUnorientedNoTranspose, ApplyUnorientedTranspose;
   CeedInt    num_nodes;
-  CeedInt   *h_ind;
-  CeedInt   *h_ind_allocated;
-  CeedInt   *d_ind;
-  CeedInt   *d_ind_allocated;
+  CeedInt   *h_offsets;
+  CeedInt   *h_offsets_borrowed;
+  CeedInt   *h_offsets_owned;
+  CeedInt   *d_offsets;
+  CeedInt   *d_offsets_borrowed;
+  CeedInt   *d_offsets_owned;
   CeedInt   *d_t_offsets;
   CeedInt   *d_t_indices;
   CeedInt   *d_l_vec_indices;
   bool      *h_orients;
-  bool      *h_orients_allocated;
+  bool      *h_orients_borrowed;
+  bool      *h_orients_owned;
   bool      *d_orients;
-  bool      *d_orients_allocated;
+  bool      *d_orients_borrowed;
+  bool      *d_orients_owned;
   CeedInt8  *h_curl_orients;
-  CeedInt8  *h_curl_orients_allocated;
+  CeedInt8  *h_curl_orients_borrowed;
+  CeedInt8  *h_curl_orients_owned;
   CeedInt8  *d_curl_orients;
-  CeedInt8  *d_curl_orients_allocated;
+  CeedInt8  *d_curl_orients_borrowed;
+  CeedInt8  *d_curl_orients_owned;
 } CeedElemRestriction_Cuda;
 
 typedef struct {

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -24,32 +24,32 @@ typedef struct {
 } CeedVector_Cuda;
 
 typedef struct {
-  CUmodule   module;
-  CUfunction ApplyNoTranspose, ApplyTranspose;
-  CUfunction ApplyUnsignedNoTranspose, ApplyUnsignedTranspose;
-  CUfunction ApplyUnorientedNoTranspose, ApplyUnorientedTranspose;
-  CeedInt    num_nodes;
-  CeedInt   *h_offsets;
-  CeedInt   *h_offsets_borrowed;
-  CeedInt   *h_offsets_owned;
-  CeedInt   *d_offsets;
-  CeedInt   *d_offsets_borrowed;
-  CeedInt   *d_offsets_owned;
-  CeedInt   *d_t_offsets;
-  CeedInt   *d_t_indices;
-  CeedInt   *d_l_vec_indices;
-  bool      *h_orients;
-  bool      *h_orients_borrowed;
-  bool      *h_orients_owned;
-  bool      *d_orients;
-  bool      *d_orients_borrowed;
-  bool      *d_orients_owned;
-  CeedInt8  *h_curl_orients;
-  CeedInt8  *h_curl_orients_borrowed;
-  CeedInt8  *h_curl_orients_owned;
-  CeedInt8  *d_curl_orients;
-  CeedInt8  *d_curl_orients_borrowed;
-  CeedInt8  *d_curl_orients_owned;
+  CUmodule        module;
+  CUfunction      ApplyNoTranspose, ApplyTranspose;
+  CUfunction      ApplyUnsignedNoTranspose, ApplyUnsignedTranspose;
+  CUfunction      ApplyUnorientedNoTranspose, ApplyUnorientedTranspose;
+  CeedInt         num_nodes;
+  const CeedInt  *h_offsets;
+  const CeedInt  *h_offsets_borrowed;
+  const CeedInt  *h_offsets_owned;
+  CeedInt        *d_offsets;
+  const CeedInt  *d_offsets_borrowed;
+  const CeedInt  *d_offsets_owned;
+  CeedInt        *d_t_offsets;
+  CeedInt        *d_t_indices;
+  CeedInt        *d_l_vec_indices;
+  const bool     *h_orients;
+  const bool     *h_orients_borrowed;
+  const bool     *h_orients_owned;
+  const bool     *d_orients;
+  const bool     *d_orients_borrowed;
+  const bool     *d_orients_owned;
+  const CeedInt8 *h_curl_orients;
+  const CeedInt8 *h_curl_orients_borrowed;
+  const CeedInt8 *h_curl_orients_owned;
+  const CeedInt8 *d_curl_orients;
+  const CeedInt8 *d_curl_orients_borrowed;
+  const CeedInt8 *d_curl_orients_owned;
 } CeedElemRestriction_Cuda;
 
 typedef struct {

--- a/backends/cuda/ceed-cuda-common.c
+++ b/backends/cuda/ceed-cuda-common.c
@@ -47,3 +47,59 @@ int CeedDestroy_Cuda(Ceed ceed) {
 }
 
 //------------------------------------------------------------------------------
+// Memory transfer utilities
+//------------------------------------------------------------------------------
+static inline int CeedSetDeviceGenericArray_Cuda(Ceed ceed, const void *source_array, CeedCopyMode copy_mode, size_t size_unit, CeedSize num_values,
+                                                 void *target_array_owned, void *target_array_borrowed, void *target_array) {
+  switch (copy_mode) {
+    case CEED_COPY_VALUES:
+      if (!*(void **)target_array_owned) CeedCallCuda(ceed, cudaMalloc(target_array_owned, size_unit * num_values));
+      if (source_array) CeedCallCuda(ceed, cudaMemcpy(*(void **)target_array_owned, source_array, size_unit * num_values, cudaMemcpyDeviceToDevice));
+      *(void **)target_array_borrowed = NULL;
+      *(void **)target_array          = *(void **)target_array_owned;
+      break;
+    case CEED_OWN_POINTER:
+      CeedCallCuda(ceed, cudaFree(*(void **)target_array_borrowed));
+      *(void **)target_array_owned    = (void *)source_array;
+      *(void **)target_array_borrowed = NULL;
+      *(void **)target_array          = *(void **)target_array_owned;
+      break;
+    case CEED_USE_POINTER:
+      CeedCallCuda(ceed, cudaFree(*(void **)target_array_borrowed));
+      *(void **)target_array_owned    = NULL;
+      *(void **)target_array_borrowed = (void *)source_array;
+      *(void **)target_array          = *(void **)target_array_borrowed;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceBoolArray_Cuda(Ceed ceed, const bool *source_array, CeedCopyMode copy_mode, CeedSize num_values, const bool **target_array_owned,
+                                const bool **target_array_borrowed, const bool **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Cuda(ceed, source_array, copy_mode, sizeof(bool), num_values, target_array_owned, target_array_borrowed,
+                                                 target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceCeedInt8Array_Cuda(Ceed ceed, const CeedInt8 *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                    const CeedInt8 **target_array_owned, const CeedInt8 **target_array_borrowed, const CeedInt8 **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Cuda(ceed, source_array, copy_mode, sizeof(CeedInt8), num_values, target_array_owned,
+                                                 target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceCeedIntArray_Cuda(Ceed ceed, const CeedInt *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                   const CeedInt **target_array_owned, const CeedInt **target_array_borrowed, const CeedInt **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Cuda(ceed, source_array, copy_mode, sizeof(CeedInt), num_values, target_array_owned,
+                                                 target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceCeedScalarArray_Cuda(Ceed ceed, const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                      const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
+                                      const CeedScalar **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Cuda(ceed, source_array, copy_mode, sizeof(CeedScalar), num_values, target_array_owned,
+                                                 target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------

--- a/backends/cuda/ceed-cuda-common.c
+++ b/backends/cuda/ceed-cuda-common.c
@@ -59,13 +59,13 @@ static inline int CeedSetDeviceGenericArray_Cuda(Ceed ceed, const void *source_a
       *(void **)target_array          = *(void **)target_array_owned;
       break;
     case CEED_OWN_POINTER:
-      CeedCallCuda(ceed, cudaFree(*(void **)target_array_borrowed));
+      CeedCallCuda(ceed, cudaFree(*(void **)target_array_owned));
       *(void **)target_array_owned    = (void *)source_array;
       *(void **)target_array_borrowed = NULL;
       *(void **)target_array          = *(void **)target_array_owned;
       break;
     case CEED_USE_POINTER:
-      CeedCallCuda(ceed, cudaFree(*(void **)target_array_borrowed));
+      CeedCallCuda(ceed, cudaFree(*(void **)target_array_owned));
       *(void **)target_array_owned    = NULL;
       *(void **)target_array_borrowed = (void *)source_array;
       *(void **)target_array          = *(void **)target_array_borrowed;

--- a/backends/cuda/ceed-cuda-common.h
+++ b/backends/cuda/ceed-cuda-common.h
@@ -76,4 +76,16 @@ CEED_INTERN int CeedInit_Cuda(Ceed ceed, const char *resource);
 
 CEED_INTERN int CeedDestroy_Cuda(Ceed ceed);
 
+CEED_INTERN int CeedSetDeviceBoolArray_Cuda(Ceed ceed, const bool *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                            const bool **target_array_owned, const bool **target_array_borrowed, const bool **target_array);
+CEED_INTERN int CeedSetDeviceCeedInt8Array_Cuda(Ceed ceed, const CeedInt8 *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                                const CeedInt8 **target_array_owned, const CeedInt8 **target_array_borrowed,
+                                                const CeedInt8 **target_array);
+CEED_INTERN int CeedSetDeviceCeedIntArray_Cuda(Ceed ceed, const CeedInt *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                               const CeedInt **target_array_owned, const CeedInt **target_array_borrowed,
+                                               const CeedInt **target_array);
+CEED_INTERN int CeedSetDeviceCeedScalarArray_Cuda(Ceed ceed, const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                                  const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
+                                                  const CeedScalar **target_array);
+
 #endif  // CEED_CUDA_COMMON_H

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -381,7 +381,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
         CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
         code << "    // CompStride: " << comp_stride << "\n";
         CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-        data->indices.inputs[i] = rstr_data->d_ind;
+        data->indices.inputs[i] = rstr_data->d_offsets;
         code << "    readDofsOffset" << dim << "d<num_comp_in_" << i << ", " << comp_stride << ", P_in_" << i << ">(data, l_size_in_" << i
              << ", elem, indices.inputs[" << i << "], d_u_" << i << ", r_u_" << i << ");\n";
       } else {
@@ -494,7 +494,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
             CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
             code << "      // CompStride: " << comp_stride << "\n";
             CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-            data->indices.inputs[i] = rstr_data->d_ind;
+            data->indices.inputs[i] = rstr_data->d_offsets;
             code << "      readSliceQuadsOffset"
                  << "3d<num_comp_in_" << i << ", " << comp_stride << ", Q_1d>(data, l_size_in_" << i << ", elem, q, indices.inputs[" << i << "], d_u_"
                  << i << ", r_q_" << i << ");\n";
@@ -685,7 +685,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
       code << "    // CompStride: " << comp_stride << "\n";
       CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-      data->indices.outputs[i] = rstr_data->d_ind;
+      data->indices.outputs[i] = rstr_data->d_offsets;
       code << "    writeDofsOffset" << dim << "d<num_comp_out_" << i << ", " << comp_stride << ", P_out_" << i << ">(data, l_size_out_" << i
            << ", elem, indices.outputs[" << i << "], r_v_" << i << ", d_v_" << i << ");\n";
     } else {

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -381,7 +381,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
         CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
         code << "    // CompStride: " << comp_stride << "\n";
         CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-        data->indices.inputs[i] = rstr_data->d_offsets;
+        data->indices.inputs[i] = (CeedInt *)rstr_data->d_offsets;
         code << "    readDofsOffset" << dim << "d<num_comp_in_" << i << ", " << comp_stride << ", P_in_" << i << ">(data, l_size_in_" << i
              << ", elem, indices.inputs[" << i << "], d_u_" << i << ", r_u_" << i << ");\n";
       } else {
@@ -494,7 +494,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
             CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
             code << "      // CompStride: " << comp_stride << "\n";
             CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-            data->indices.inputs[i] = rstr_data->d_offsets;
+            data->indices.inputs[i] = (CeedInt *)rstr_data->d_offsets;
             code << "      readSliceQuadsOffset"
                  << "3d<num_comp_in_" << i << ", " << comp_stride << ", Q_1d>(data, l_size_in_" << i << ", elem, q, indices.inputs[" << i << "], d_u_"
                  << i << ", r_q_" << i << ");\n";
@@ -685,7 +685,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
       code << "    // CompStride: " << comp_stride << "\n";
       CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_data));
-      data->indices.outputs[i] = rstr_data->d_offsets;
+      data->indices.outputs[i] = (CeedInt *)rstr_data->d_offsets;
       code << "    writeDofsOffset" << dim << "d<num_comp_out_" << i << ", " << comp_stride << ", P_out_" << i << ">(data, l_size_out_" << i
            << ", elem, indices.outputs[" << i << "], r_v_" << i << ", d_v_" << i << ");\n";
     } else {

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -387,9 +387,9 @@ static int CeedElemRestrictionDestroy_Hip(CeedElemRestriction rstr) {
   }
   CeedCallBackend(CeedFree(&impl->h_offsets_owned));
   CeedCallHip(ceed, hipFree((CeedInt *)impl->d_offsets_owned));
-  CeedCallHip(ceed, hipFree(impl->d_t_offsets));
-  CeedCallHip(ceed, hipFree(impl->d_t_indices));
-  CeedCallHip(ceed, hipFree(impl->d_l_vec_indices));
+  CeedCallHip(ceed, hipFree((CeedInt *)impl->d_t_offsets));
+  CeedCallHip(ceed, hipFree((CeedInt *)impl->d_t_indices));
+  CeedCallHip(ceed, hipFree((CeedInt *)impl->d_l_vec_indices));
   CeedCallBackend(CeedFree(&impl->h_orients_owned));
   CeedCallHip(ceed, hipFree((bool *)impl->d_orients_owned));
   CeedCallBackend(CeedFree(&impl->h_curl_orients_owned));
@@ -462,13 +462,13 @@ static int CeedElemRestrictionOffset_Hip(const CeedElemRestriction rstr, const C
   // Copy data to device
   // -- L-vector indices
   CeedCallHip(ceed, hipMalloc((void **)&impl->d_l_vec_indices, num_nodes * sizeof(CeedInt)));
-  CeedCallHip(ceed, hipMemcpy(impl->d_l_vec_indices, l_vec_indices, num_nodes * sizeof(CeedInt), hipMemcpyHostToDevice));
+  CeedCallHip(ceed, hipMemcpy((CeedInt *)impl->d_l_vec_indices, l_vec_indices, num_nodes * sizeof(CeedInt), hipMemcpyHostToDevice));
   // -- Transpose offsets
   CeedCallHip(ceed, hipMalloc((void **)&impl->d_t_offsets, size_offsets * sizeof(CeedInt)));
-  CeedCallHip(ceed, hipMemcpy(impl->d_t_offsets, t_offsets, size_offsets * sizeof(CeedInt), hipMemcpyHostToDevice));
+  CeedCallHip(ceed, hipMemcpy((CeedInt *)impl->d_t_offsets, t_offsets, size_offsets * sizeof(CeedInt), hipMemcpyHostToDevice));
   // -- Transpose indices
   CeedCallHip(ceed, hipMalloc((void **)&impl->d_t_indices, size_indices * sizeof(CeedInt)));
-  CeedCallHip(ceed, hipMemcpy(impl->d_t_indices, t_indices, size_indices * sizeof(CeedInt), hipMemcpyHostToDevice));
+  CeedCallHip(ceed, hipMemcpy((CeedInt *)impl->d_t_indices, t_indices, size_indices * sizeof(CeedInt), hipMemcpyHostToDevice));
 
   // Cleanup
   CeedCallBackend(CeedFree(&ind_to_offset));

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -165,32 +165,32 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
         CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyNoTranspose, grid, block_size, args));
       } break;
       case CEED_RESTRICTION_STANDARD: {
-        void *args[] = {&impl->d_ind, &d_u, &d_v};
+        void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
         CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyNoTranspose, grid, block_size, args));
       } break;
       case CEED_RESTRICTION_ORIENTED: {
         if (use_signs) {
-          void *args[] = {&impl->d_ind, &impl->d_orients, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &impl->d_orients, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyNoTranspose, grid, block_size, args));
         } else {
-          void *args[] = {&impl->d_ind, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyUnsignedNoTranspose, grid, block_size, args));
         }
       } break;
       case CEED_RESTRICTION_CURL_ORIENTED: {
         if (use_signs && use_orients) {
-          void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyNoTranspose, grid, block_size, args));
         } else if (use_orients) {
-          void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyUnsignedNoTranspose, grid, block_size, args));
         } else {
-          void *args[] = {&impl->d_ind, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyUnorientedNoTranspose, grid, block_size, args));
         }
@@ -215,7 +215,7 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
       } break;
       case CEED_RESTRICTION_STANDARD: {
         if (!is_deterministic) {
-          void *args[] = {&impl->d_ind, &d_u, &d_v};
+          void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
           CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyTranspose, grid, block_size, args));
         } else {
@@ -227,7 +227,7 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
       case CEED_RESTRICTION_ORIENTED: {
         if (use_signs) {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &impl->d_orients, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &impl->d_orients, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyTranspose, grid, block_size, args));
           } else {
@@ -237,7 +237,7 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
           }
         } else {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyUnsignedTranspose, grid, block_size, args));
           } else {
@@ -250,7 +250,7 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
       case CEED_RESTRICTION_CURL_ORIENTED: {
         if (use_signs && use_orients) {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyTranspose, grid, block_size, args));
           } else {
@@ -260,7 +260,7 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
           }
         } else if (use_orients) {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &impl->d_curl_orients, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &impl->d_curl_orients, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyUnsignedTranspose, grid, block_size, args));
           } else {
@@ -270,7 +270,7 @@ static inline int CeedElemRestrictionApply_Hip_Core(CeedElemRestriction rstr, Ce
           }
         } else {
           if (!is_deterministic) {
-            void *args[] = {&impl->d_ind, &d_u, &d_v};
+            void *args[] = {&impl->d_offsets, &d_u, &d_v};
 
             CeedCallBackend(CeedRunKernel_Hip(ceed, impl->ApplyUnorientedTranspose, grid, block_size, args));
           } else {
@@ -328,10 +328,10 @@ static int CeedElemRestrictionGetOffsets_Hip(CeedElemRestriction rstr, CeedMemTy
   CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
   switch (mem_type) {
     case CEED_MEM_HOST:
-      *offsets = impl->h_ind;
+      *offsets = impl->h_offsets;
       break;
     case CEED_MEM_DEVICE:
-      *offsets = impl->d_ind;
+      *offsets = impl->d_offsets;
       break;
   }
   return CEED_ERROR_SUCCESS;
@@ -385,15 +385,15 @@ static int CeedElemRestrictionDestroy_Hip(CeedElemRestriction rstr) {
   if (impl->module) {
     CeedCallHip(ceed, hipModuleUnload(impl->module));
   }
-  CeedCallBackend(CeedFree(&impl->h_ind_allocated));
-  CeedCallHip(ceed, hipFree(impl->d_ind_allocated));
+  CeedCallBackend(CeedFree(&impl->h_offsets_owned));
+  CeedCallHip(ceed, hipFree(impl->d_offsets_owned));
   CeedCallHip(ceed, hipFree(impl->d_t_offsets));
   CeedCallHip(ceed, hipFree(impl->d_t_indices));
   CeedCallHip(ceed, hipFree(impl->d_l_vec_indices));
-  CeedCallBackend(CeedFree(&impl->h_orients_allocated));
-  CeedCallHip(ceed, hipFree(impl->d_orients_allocated));
-  CeedCallBackend(CeedFree(&impl->h_curl_orients_allocated));
-  CeedCallHip(ceed, hipFree(impl->d_curl_orients_allocated));
+  CeedCallBackend(CeedFree(&impl->h_orients_owned));
+  CeedCallHip(ceed, hipFree(impl->d_orients_owned));
+  CeedCallBackend(CeedFree(&impl->h_curl_orients_owned));
+  CeedCallHip(ceed, hipFree(impl->d_curl_orients_owned));
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
 }
@@ -481,7 +481,7 @@ static int CeedElemRestrictionOffset_Hip(const CeedElemRestriction rstr, const C
 //------------------------------------------------------------------------------
 // Create restriction
 //------------------------------------------------------------------------------
-int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
+int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *offsets, const bool *orients,
                                   const CeedInt8 *curl_orients, CeedElemRestriction rstr) {
   Ceed                     ceed, ceed_parent;
   bool                     is_deterministic;
@@ -498,21 +498,7 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
   const CeedInt size = num_elem * elem_size;
 
   CeedCallBackend(CeedCalloc(1, &impl));
-  impl->num_nodes                = size;
-  impl->h_ind                    = NULL;
-  impl->h_ind_allocated          = NULL;
-  impl->d_ind                    = NULL;
-  impl->d_ind_allocated          = NULL;
-  impl->d_t_indices              = NULL;
-  impl->d_t_offsets              = NULL;
-  impl->h_orients                = NULL;
-  impl->h_orients_allocated      = NULL;
-  impl->d_orients                = NULL;
-  impl->d_orients_allocated      = NULL;
-  impl->h_curl_orients           = NULL;
-  impl->h_curl_orients_allocated = NULL;
-  impl->d_curl_orients           = NULL;
-  impl->d_curl_orients_allocated = NULL;
+  impl->num_nodes = size;
   CeedCallBackend(CeedElemRestrictionSetData(rstr, impl));
 
   // Set layouts
@@ -534,43 +520,51 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
     switch (mem_type) {
       case CEED_MEM_HOST: {
         switch (copy_mode) {
+          case CEED_COPY_VALUES:
+            CeedCallBackend(CeedMalloc(size, &impl->h_offsets_owned));
+            memcpy(impl->h_offsets_owned, offsets, size * sizeof(CeedInt));
+            impl->h_offsets_borrowed = NULL;
+            impl->h_offsets          = impl->h_offsets_owned;
+            break;
           case CEED_OWN_POINTER:
-            impl->h_ind_allocated = (CeedInt *)indices;
-            impl->h_ind           = (CeedInt *)indices;
+            impl->h_offsets_owned    = (CeedInt *)offsets;
+            impl->h_offsets_borrowed = NULL;
+            impl->h_offsets          = impl->h_offsets_owned;
             break;
           case CEED_USE_POINTER:
-            impl->h_ind = (CeedInt *)indices;
-            break;
-          case CEED_COPY_VALUES:
-            CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
-            memcpy(impl->h_ind_allocated, indices, size * sizeof(CeedInt));
-            impl->h_ind = impl->h_ind_allocated;
+            impl->h_offsets_owned    = NULL;
+            impl->h_offsets_borrowed = (CeedInt *)offsets;
+            impl->h_offsets          = impl->h_offsets_borrowed;
             break;
         }
-        CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-        impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-        CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyHostToDevice));
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(rstr, indices));
+        CeedCallHip(ceed, hipMalloc((void **)&impl->d_offsets_owned, size * sizeof(CeedInt)));
+        CeedCallHip(ceed, hipMemcpy(impl->d_offsets_owned, impl->h_offsets, size * sizeof(CeedInt), hipMemcpyHostToDevice));
+        impl->d_offsets = impl->d_offsets_owned;
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(rstr, offsets));
       } break;
       case CEED_MEM_DEVICE: {
         switch (copy_mode) {
           case CEED_COPY_VALUES:
-            CeedCallHip(ceed, hipMalloc((void **)&impl->d_ind, size * sizeof(CeedInt)));
-            impl->d_ind_allocated = impl->d_ind;  // We own the device memory
-            CeedCallHip(ceed, hipMemcpy(impl->d_ind, indices, size * sizeof(CeedInt), hipMemcpyDeviceToDevice));
+            CeedCallHip(ceed, hipMalloc((void **)&impl->d_offsets_owned, size * sizeof(CeedInt)));
+            CeedCallHip(ceed, hipMemcpy(impl->d_offsets_owned, offsets, size * sizeof(CeedInt), hipMemcpyDeviceToDevice));
+            impl->d_offsets_borrowed = NULL;
+            impl->d_offsets          = impl->d_offsets_owned;
             break;
           case CEED_OWN_POINTER:
-            impl->d_ind           = (CeedInt *)indices;
-            impl->d_ind_allocated = impl->d_ind;
+            impl->d_offsets_owned    = (CeedInt *)offsets;
+            impl->d_offsets_borrowed = NULL;
+            impl->d_offsets          = impl->d_offsets_owned;
             break;
           case CEED_USE_POINTER:
-            impl->d_ind = (CeedInt *)indices;
+            impl->d_offsets_owned    = NULL;
+            impl->d_offsets_borrowed = (CeedInt *)offsets;
+            impl->d_offsets          = impl->d_offsets_borrowed;
             break;
         }
-        CeedCallBackend(CeedMalloc(size, &impl->h_ind_allocated));
-        CeedCallHip(ceed, hipMemcpy(impl->h_ind_allocated, impl->d_ind, size * sizeof(CeedInt), hipMemcpyDeviceToHost));
-        impl->h_ind = impl->h_ind_allocated;
-        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(rstr, indices));
+        CeedCallBackend(CeedMalloc(size, &impl->h_offsets_owned));
+        CeedCallHip(ceed, hipMemcpy(impl->h_offsets_owned, impl->d_offsets, size * sizeof(CeedInt), hipMemcpyDeviceToHost));
+        impl->h_offsets = impl->h_offsets_owned;
+        if (is_deterministic) CeedCallBackend(CeedElemRestrictionOffset_Hip(rstr, offsets));
       } break;
     }
 
@@ -579,82 +573,98 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
       switch (mem_type) {
         case CEED_MEM_HOST: {
           switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(size, &impl->h_orients_owned));
+              memcpy(impl->h_orients_owned, orients, size * sizeof(bool));
+              impl->h_orients_borrowed = NULL;
+              impl->h_orients          = impl->h_orients_owned;
+              break;
             case CEED_OWN_POINTER:
-              impl->h_orients_allocated = (bool *)orients;
-              impl->h_orients           = (bool *)orients;
+              impl->h_orients_owned    = (bool *)orients;
+              impl->h_orients_borrowed = NULL;
+              impl->h_orients          = impl->h_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->h_orients = (bool *)orients;
-              break;
-            case CEED_COPY_VALUES:
-              CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
-              memcpy(impl->h_orients_allocated, orients, size * sizeof(bool));
-              impl->h_orients = impl->h_orients_allocated;
+              impl->h_orients_owned    = NULL;
+              impl->h_orients_borrowed = (bool *)orients;
+              impl->h_orients          = impl->h_orients_borrowed;
               break;
           }
-          CeedCallHip(ceed, hipMalloc((void **)&impl->d_orients, size * sizeof(bool)));
-          impl->d_orients_allocated = impl->d_orients;  // We own the device memory
-          CeedCallHip(ceed, hipMemcpy(impl->d_orients, orients, size * sizeof(bool), hipMemcpyHostToDevice));
+          CeedCallHip(ceed, hipMalloc((void **)&impl->d_orients_owned, size * sizeof(bool)));
+          CeedCallHip(ceed, hipMemcpy(impl->d_orients_owned, impl->h_orients, size * sizeof(bool), hipMemcpyHostToDevice));
+          impl->d_orients = impl->d_orients_owned;
         } break;
         case CEED_MEM_DEVICE: {
           switch (copy_mode) {
             case CEED_COPY_VALUES:
-              CeedCallHip(ceed, hipMalloc((void **)&impl->d_orients, size * sizeof(bool)));
-              impl->d_orients_allocated = impl->d_orients;  // We own the device memory
-              CeedCallHip(ceed, hipMemcpy(impl->d_orients, orients, size * sizeof(bool), hipMemcpyDeviceToDevice));
+              CeedCallHip(ceed, hipMalloc((void **)&impl->d_orients_owned, size * sizeof(bool)));
+              CeedCallHip(ceed, hipMemcpy(impl->d_orients_owned, orients, size * sizeof(bool), hipMemcpyDeviceToDevice));
+              impl->d_orients_borrowed = NULL;
+              impl->d_orients          = impl->d_orients_owned;
               break;
             case CEED_OWN_POINTER:
-              impl->d_orients           = (bool *)orients;
-              impl->d_orients_allocated = impl->d_orients;
+              impl->d_orients_owned    = (bool *)orients;
+              impl->d_orients_borrowed = NULL;
+              impl->d_orients          = impl->d_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->d_orients = (bool *)orients;
+              impl->d_orients_owned    = NULL;
+              impl->d_orients_borrowed = (bool *)orients;
+              impl->d_orients          = impl->d_orients_borrowed;
               break;
           }
-          CeedCallBackend(CeedMalloc(size, &impl->h_orients_allocated));
-          CeedCallHip(ceed, hipMemcpy(impl->h_orients_allocated, impl->d_orients, size * sizeof(bool), hipMemcpyDeviceToHost));
-          impl->h_orients = impl->h_orients_allocated;
+          CeedCallBackend(CeedMalloc(size, &impl->h_orients_owned));
+          CeedCallHip(ceed, hipMemcpy(impl->h_orients_owned, impl->d_orients, size * sizeof(bool), hipMemcpyDeviceToHost));
+          impl->h_orients = impl->h_orients_owned;
         } break;
       }
     } else if (rstr_type == CEED_RESTRICTION_CURL_ORIENTED) {
       switch (mem_type) {
         case CEED_MEM_HOST: {
           switch (copy_mode) {
+            case CEED_COPY_VALUES:
+              CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_owned));
+              memcpy(impl->h_curl_orients_owned, curl_orients, 3 * size * sizeof(CeedInt8));
+              impl->h_curl_orients_borrowed = NULL;
+              impl->h_curl_orients          = impl->h_curl_orients_owned;
+              break;
             case CEED_OWN_POINTER:
-              impl->h_curl_orients_allocated = (CeedInt8 *)curl_orients;
-              impl->h_curl_orients           = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients_owned    = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients_borrowed = NULL;
+              impl->h_curl_orients          = impl->h_curl_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->h_curl_orients = (CeedInt8 *)curl_orients;
-              break;
-            case CEED_COPY_VALUES:
-              CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
-              memcpy(impl->h_curl_orients_allocated, curl_orients, 3 * size * sizeof(CeedInt8));
-              impl->h_curl_orients = impl->h_curl_orients_allocated;
+              impl->h_curl_orients_owned    = NULL;
+              impl->h_curl_orients_borrowed = (CeedInt8 *)curl_orients;
+              impl->h_curl_orients          = impl->h_curl_orients_borrowed;
               break;
           }
-          CeedCallHip(ceed, hipMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
-          impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
-          CeedCallHip(ceed, hipMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyHostToDevice));
+          CeedCallHip(ceed, hipMalloc((void **)&impl->d_curl_orients_owned, 3 * size * sizeof(CeedInt8)));
+          CeedCallHip(ceed, hipMemcpy(impl->d_curl_orients_owned, impl->h_curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyHostToDevice));
+          impl->d_curl_orients = impl->d_curl_orients_owned;
         } break;
         case CEED_MEM_DEVICE: {
           switch (copy_mode) {
             case CEED_COPY_VALUES:
-              CeedCallHip(ceed, hipMalloc((void **)&impl->d_curl_orients, 3 * size * sizeof(CeedInt8)));
-              impl->d_curl_orients_allocated = impl->d_curl_orients;  // We own the device memory
-              CeedCallHip(ceed, hipMemcpy(impl->d_curl_orients, curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyDeviceToDevice));
+              CeedCallHip(ceed, hipMalloc((void **)&impl->d_curl_orients_owned, 3 * size * sizeof(CeedInt8)));
+              CeedCallHip(ceed, hipMemcpy(impl->d_curl_orients_owned, curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyDeviceToDevice));
+              impl->d_curl_orients_borrowed = NULL;
+              impl->d_curl_orients          = impl->d_curl_orients_owned;
               break;
             case CEED_OWN_POINTER:
-              impl->d_curl_orients           = (CeedInt8 *)curl_orients;
-              impl->d_curl_orients_allocated = impl->d_curl_orients;
+              impl->d_curl_orients_owned    = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients_borrowed = NULL;
+              impl->d_curl_orients          = impl->d_curl_orients_owned;
               break;
             case CEED_USE_POINTER:
-              impl->d_curl_orients = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients_owned    = NULL;
+              impl->d_curl_orients_borrowed = (CeedInt8 *)curl_orients;
+              impl->d_curl_orients          = impl->d_curl_orients_borrowed;
               break;
           }
-          CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_allocated));
-          CeedCallHip(ceed, hipMemcpy(impl->h_curl_orients_allocated, impl->d_curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyDeviceToHost));
-          impl->h_curl_orients = impl->h_curl_orients_allocated;
+          CeedCallBackend(CeedMalloc(3 * size, &impl->h_curl_orients_owned));
+          CeedCallHip(ceed, hipMemcpy(impl->h_curl_orients_owned, impl->d_curl_orients, 3 * size * sizeof(CeedInt8), hipMemcpyDeviceToHost));
+          impl->h_curl_orients = impl->h_curl_orients_owned;
         } break;
       }
     }

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -28,32 +28,32 @@ typedef struct {
 } CeedVector_Hip;
 
 typedef struct {
-  hipModule_t   module;
-  hipFunction_t ApplyNoTranspose, ApplyTranspose;
-  hipFunction_t ApplyUnsignedNoTranspose, ApplyUnsignedTranspose;
-  hipFunction_t ApplyUnorientedNoTranspose, ApplyUnorientedTranspose;
-  CeedInt       num_nodes;
-  CeedInt      *h_offsets;
-  CeedInt      *h_offsets_borrowed;
-  CeedInt      *h_offsets_owned;
-  CeedInt      *d_offsets;
-  CeedInt      *d_offsets_borrowed;
-  CeedInt      *d_offsets_owned;
-  CeedInt      *d_t_offsets;
-  CeedInt      *d_t_indices;
-  CeedInt      *d_l_vec_indices;
-  bool         *h_orients;
-  bool         *h_orients_borrowed;
-  bool         *h_orients_owned;
-  bool         *d_orients;
-  bool         *d_orients_borrowed;
-  bool         *d_orients_owned;
-  CeedInt8     *h_curl_orients;
-  CeedInt8     *h_curl_orients_borrowed;
-  CeedInt8     *h_curl_orients_owned;
-  CeedInt8     *d_curl_orients;
-  CeedInt8     *d_curl_orients_borrowed;
-  CeedInt8     *d_curl_orients_owned;
+  hipModule_t     module;
+  hipFunction_t   ApplyNoTranspose, ApplyTranspose;
+  hipFunction_t   ApplyUnsignedNoTranspose, ApplyUnsignedTranspose;
+  hipFunction_t   ApplyUnorientedNoTranspose, ApplyUnorientedTranspose;
+  CeedInt         num_nodes;
+  const CeedInt  *h_offsets;
+  const CeedInt  *h_offsets_borrowed;
+  const CeedInt  *h_offsets_owned;
+  CeedInt        *d_offsets;
+  const CeedInt  *d_offsets_borrowed;
+  const CeedInt  *d_offsets_owned;
+  CeedInt        *d_t_offsets;
+  CeedInt        *d_t_indices;
+  CeedInt        *d_l_vec_indices;
+  const bool     *h_orients;
+  const bool     *h_orients_borrowed;
+  const bool     *h_orients_owned;
+  const bool     *d_orients;
+  const bool     *d_orients_borrowed;
+  const bool     *d_orients_owned;
+  const CeedInt8 *h_curl_orients;
+  const CeedInt8 *h_curl_orients_borrowed;
+  const CeedInt8 *h_curl_orients_owned;
+  const CeedInt8 *d_curl_orients;
+  const CeedInt8 *d_curl_orients_borrowed;
+  const CeedInt8 *d_curl_orients_owned;
 } CeedElemRestriction_Hip;
 
 typedef struct {

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -36,12 +36,12 @@ typedef struct {
   const CeedInt  *h_offsets;
   const CeedInt  *h_offsets_borrowed;
   const CeedInt  *h_offsets_owned;
-  CeedInt        *d_offsets;
+  const CeedInt  *d_offsets;
   const CeedInt  *d_offsets_borrowed;
   const CeedInt  *d_offsets_owned;
-  CeedInt        *d_t_offsets;
-  CeedInt        *d_t_indices;
-  CeedInt        *d_l_vec_indices;
+  const CeedInt  *d_t_offsets;
+  const CeedInt  *d_t_indices;
+  const CeedInt  *d_l_vec_indices;
   const bool     *h_orients;
   const bool     *h_orients_borrowed;
   const bool     *h_orients_owned;

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -33,21 +33,27 @@ typedef struct {
   hipFunction_t ApplyUnsignedNoTranspose, ApplyUnsignedTranspose;
   hipFunction_t ApplyUnorientedNoTranspose, ApplyUnorientedTranspose;
   CeedInt       num_nodes;
-  CeedInt      *h_ind;
-  CeedInt      *h_ind_allocated;
-  CeedInt      *d_ind;
-  CeedInt      *d_ind_allocated;
+  CeedInt      *h_offsets;
+  CeedInt      *h_offsets_borrowed;
+  CeedInt      *h_offsets_owned;
+  CeedInt      *d_offsets;
+  CeedInt      *d_offsets_borrowed;
+  CeedInt      *d_offsets_owned;
   CeedInt      *d_t_offsets;
   CeedInt      *d_t_indices;
   CeedInt      *d_l_vec_indices;
   bool         *h_orients;
-  bool         *h_orients_allocated;
+  bool         *h_orients_borrowed;
+  bool         *h_orients_owned;
   bool         *d_orients;
-  bool         *d_orients_allocated;
+  bool         *d_orients_borrowed;
+  bool         *d_orients_owned;
   CeedInt8     *h_curl_orients;
-  CeedInt8     *h_curl_orients_allocated;
+  CeedInt8     *h_curl_orients_borrowed;
+  CeedInt8     *h_curl_orients_owned;
   CeedInt8     *d_curl_orients;
-  CeedInt8     *d_curl_orients_allocated;
+  CeedInt8     *d_curl_orients_borrowed;
+  CeedInt8     *d_curl_orients_owned;
 } CeedElemRestriction_Hip;
 
 typedef struct {
@@ -125,8 +131,8 @@ CEED_INTERN int CeedGetHipblasHandle_Hip(Ceed ceed, hipblasHandle_t *handle);
 
 CEED_INTERN int CeedVectorCreate_Hip(CeedSize n, CeedVector vec);
 
-CEED_INTERN int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
-                                              const CeedInt8 *curl_orients, CeedElemRestriction r);
+CEED_INTERN int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *offsets, const bool *orients,
+                                              const CeedInt8 *curl_orients, CeedElemRestriction rstr);
 
 CEED_INTERN int CeedBasisCreateTensorH1_Hip(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
                                             const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);

--- a/backends/hip/ceed-hip-common.c
+++ b/backends/hip/ceed-hip-common.c
@@ -59,13 +59,13 @@ static inline int CeedSetDeviceGenericArray_Hip(Ceed ceed, const void *source_ar
       *(void **)target_array          = *(void **)target_array_owned;
       break;
     case CEED_OWN_POINTER:
-      CeedCallHip(ceed, hipFree(*(void **)target_array_borrowed));
+      CeedCallHip(ceed, hipFree(*(void **)target_array_owned));
       *(void **)target_array_owned    = (void *)source_array;
       *(void **)target_array_borrowed = NULL;
       *(void **)target_array          = *(void **)target_array_owned;
       break;
     case CEED_USE_POINTER:
-      CeedCallHip(ceed, hipFree(*(void **)target_array_borrowed));
+      CeedCallHip(ceed, hipFree(*(void **)target_array_owned));
       *(void **)target_array_owned    = NULL;
       *(void **)target_array_borrowed = (void *)source_array;
       *(void **)target_array          = *(void **)target_array_borrowed;

--- a/backends/hip/ceed-hip-common.c
+++ b/backends/hip/ceed-hip-common.c
@@ -47,3 +47,59 @@ int CeedDestroy_Hip(Ceed ceed) {
 }
 
 //------------------------------------------------------------------------------
+// Memory transfer utilities
+//------------------------------------------------------------------------------
+static inline int CeedSetDeviceGenericArray_Hip(Ceed ceed, const void *source_array, CeedCopyMode copy_mode, size_t size_unit, CeedSize num_values,
+                                                void *target_array_owned, void *target_array_borrowed, void *target_array) {
+  switch (copy_mode) {
+    case CEED_COPY_VALUES:
+      if (!*(void **)target_array_owned) CeedCallHip(ceed, hipMalloc(target_array_owned, size_unit * num_values));
+      if (source_array) CeedCallHip(ceed, hipMemcpy(*(void **)target_array_owned, source_array, size_unit * num_values, hipMemcpyDeviceToDevice));
+      *(void **)target_array_borrowed = NULL;
+      *(void **)target_array          = *(void **)target_array_owned;
+      break;
+    case CEED_OWN_POINTER:
+      CeedCallHip(ceed, hipFree(*(void **)target_array_borrowed));
+      *(void **)target_array_owned    = (void *)source_array;
+      *(void **)target_array_borrowed = NULL;
+      *(void **)target_array          = *(void **)target_array_owned;
+      break;
+    case CEED_USE_POINTER:
+      CeedCallHip(ceed, hipFree(*(void **)target_array_borrowed));
+      *(void **)target_array_owned    = NULL;
+      *(void **)target_array_borrowed = (void *)source_array;
+      *(void **)target_array          = *(void **)target_array_borrowed;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceBoolArray_Hip(Ceed ceed, const bool *source_array, CeedCopyMode copy_mode, CeedSize num_values, const bool **target_array_owned,
+                               const bool **target_array_borrowed, const bool **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Hip(ceed, source_array, copy_mode, sizeof(bool), num_values, target_array_owned, target_array_borrowed,
+                                                target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceCeedInt8Array_Hip(Ceed ceed, const CeedInt8 *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                   const CeedInt8 **target_array_owned, const CeedInt8 **target_array_borrowed, const CeedInt8 **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Hip(ceed, source_array, copy_mode, sizeof(CeedInt8), num_values, target_array_owned,
+                                                target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceCeedIntArray_Hip(Ceed ceed, const CeedInt *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                  const CeedInt **target_array_owned, const CeedInt **target_array_borrowed, const CeedInt **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Hip(ceed, source_array, copy_mode, sizeof(CeedInt), num_values, target_array_owned, target_array_borrowed,
+                                                target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+int CeedSetDeviceCeedScalarArray_Hip(Ceed ceed, const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                     const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
+                                     const CeedScalar **target_array) {
+  CeedCallBackend(CeedSetDeviceGenericArray_Hip(ceed, source_array, copy_mode, sizeof(CeedScalar), num_values, target_array_owned,
+                                                target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------

--- a/backends/hip/ceed-hip-common.h
+++ b/backends/hip/ceed-hip-common.h
@@ -80,4 +80,16 @@ CEED_INTERN int CeedInit_Hip(Ceed ceed, const char *resource);
 
 CEED_INTERN int CeedDestroy_Hip(Ceed ceed);
 
+CEED_INTERN int CeedSetDeviceBoolArray_Hip(Ceed ceed, const bool *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                           const bool **target_array_owned, const bool **target_array_borrowed, const bool **target_array);
+CEED_INTERN int CeedSetDeviceCeedInt8Array_Hip(Ceed ceed, const CeedInt8 *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                               const CeedInt8 **target_array_owned, const CeedInt8 **target_array_borrowed,
+                                               const CeedInt8 **target_array);
+CEED_INTERN int CeedSetDeviceCeedIntArray_Hip(Ceed ceed, const CeedInt *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                              const CeedInt **target_array_owned, const CeedInt **target_array_borrowed,
+                                              const CeedInt **target_array);
+CEED_INTERN int CeedSetDeviceCeedScalarArray_Hip(Ceed ceed, const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                                 const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
+                                                 const CeedScalar **target_array);
+
 #endif  // CEED_COMMON_HIP_H

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -781,63 +781,16 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
     // Copy data
     if (rstr_type == CEED_RESTRICTION_POINTS) CeedCallBackend(CeedElemRestrictionGetNumPoints(rstr, &num_points));
     num_offsets = rstr_type == CEED_RESTRICTION_POINTS ? (num_elem + 1 + num_points) : (num_elem * elem_size);
-    switch (copy_mode) {
-      case CEED_COPY_VALUES:
-        CeedCallBackend(CeedMalloc(num_offsets, &impl->offsets_owned));
-        memcpy(impl->offsets_owned, offsets, num_offsets * sizeof(offsets[0]));
-        impl->offsets_borrowed = NULL;
-        impl->offsets          = impl->offsets_owned;
-        break;
-      case CEED_OWN_POINTER:
-        impl->offsets_owned    = (CeedInt *)offsets;
-        impl->offsets_borrowed = NULL;
-        impl->offsets          = impl->offsets_owned;
-        break;
-      case CEED_USE_POINTER:
-        impl->offsets_owned    = NULL;
-        impl->offsets_borrowed = offsets;
-        impl->offsets          = impl->offsets_borrowed;
-    }
+    CeedCallBackend(CeedSetHostCeedIntArray(offsets, copy_mode, num_offsets, &impl->offsets_owned, &impl->offsets_borrowed, &impl->offsets));
 
     // Orientation data
     if (rstr_type == CEED_RESTRICTION_ORIENTED) {
       CeedCheck(orients != NULL, ceed, CEED_ERROR_BACKEND, "No orients array provided for oriented restriction");
-      switch (copy_mode) {
-        case CEED_COPY_VALUES:
-          CeedCallBackend(CeedMalloc(num_offsets, &impl->orients_owned));
-          memcpy(impl->orients_owned, orients, num_offsets * sizeof(orients[0]));
-          impl->orients_borrowed = NULL;
-          impl->orients          = impl->orients_owned;
-          break;
-        case CEED_OWN_POINTER:
-          impl->orients_owned    = (bool *)orients;
-          impl->orients_borrowed = NULL;
-          impl->orients          = impl->orients_owned;
-          break;
-        case CEED_USE_POINTER:
-          impl->orients_owned    = NULL;
-          impl->orients_borrowed = orients;
-          impl->orients          = impl->orients_borrowed;
-      }
+      CeedCallBackend(CeedSetHostBoolArray(orients, copy_mode, num_offsets, &impl->orients_owned, &impl->orients_borrowed, &impl->orients));
     } else if (rstr_type == CEED_RESTRICTION_CURL_ORIENTED) {
       CeedCheck(curl_orients != NULL, ceed, CEED_ERROR_BACKEND, "No curl_orients array provided for oriented restriction");
-      switch (copy_mode) {
-        case CEED_COPY_VALUES:
-          CeedCallBackend(CeedMalloc(3 * num_offsets, &impl->curl_orients_owned));
-          memcpy(impl->curl_orients_owned, curl_orients, 3 * num_offsets * sizeof(curl_orients[0]));
-          impl->curl_orients_borrowed = NULL;
-          impl->curl_orients          = impl->curl_orients_owned;
-          break;
-        case CEED_OWN_POINTER:
-          impl->curl_orients_owned    = (CeedInt8 *)curl_orients;
-          impl->curl_orients_borrowed = NULL;
-          impl->curl_orients          = impl->curl_orients_owned;
-          break;
-        case CEED_USE_POINTER:
-          impl->curl_orients_owned    = NULL;
-          impl->curl_orients_borrowed = (CeedInt8 *)curl_orients;
-          impl->curl_orients          = impl->curl_orients_borrowed;
-      }
+      CeedCallBackend(CeedSetHostCeedInt8Array(curl_orients, copy_mode, 3 * num_offsets, &impl->curl_orients_owned, &impl->curl_orients_borrowed,
+                                               &impl->curl_orients));
     }
   }
 

--- a/backends/ref/ceed-ref-vector.c
+++ b/backends/ref/ceed-ref-vector.c
@@ -48,24 +48,8 @@ static int CeedVectorSetArray_Ref(CeedVector vec, CeedMemType mem_type, CeedCopy
 
   CeedCheck(mem_type == CEED_MEM_HOST, CeedVectorReturnCeed(vec), CEED_ERROR_BACKEND, "Can only set HOST memory for this backend");
 
-  switch (copy_mode) {
-    case CEED_COPY_VALUES:
-      if (!impl->array_owned) CeedCallBackend(CeedCalloc(length, &impl->array_owned));
-      if (array) memcpy(impl->array_owned, array, length * sizeof(array[0]));
-      impl->array_borrowed = NULL;
-      impl->array          = impl->array_owned;
-      break;
-    case CEED_OWN_POINTER:
-      CeedCallBackend(CeedFree(&impl->array_owned));
-      impl->array_owned    = array;
-      impl->array_borrowed = NULL;
-      impl->array          = array;
-      break;
-    case CEED_USE_POINTER:
-      CeedCallBackend(CeedFree(&impl->array_owned));
-      impl->array_borrowed = array;
-      impl->array          = array;
-  }
+  CeedCallBackend(CeedSetHostCeedScalarArray(array, copy_mode, length, (const CeedScalar **)&impl->array_owned,
+                                             (const CeedScalar **)&impl->array_borrowed, (const CeedScalar **)&impl->array));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/ref/ceed-ref-vector.c
+++ b/backends/ref/ceed-ref-vector.c
@@ -50,12 +50,10 @@ static int CeedVectorSetArray_Ref(CeedVector vec, CeedMemType mem_type, CeedCopy
 
   switch (copy_mode) {
     case CEED_COPY_VALUES:
-      if (!impl->array_owned) {
-        CeedCallBackend(CeedCalloc(length, &impl->array_owned));
-      }
+      if (!impl->array_owned) CeedCallBackend(CeedCalloc(length, &impl->array_owned));
+      if (array) memcpy(impl->array_owned, array, length * sizeof(array[0]));
       impl->array_borrowed = NULL;
       impl->array          = impl->array_owned;
-      if (array) memcpy(impl->array, array, length * sizeof(array[0]));
       break;
     case CEED_OWN_POINTER:
       CeedCallBackend(CeedFree(&impl->array_owned));

--- a/backends/ref/ceed-ref-vector.c
+++ b/backends/ref/ceed-ref-vector.c
@@ -123,16 +123,7 @@ static int CeedVectorGetArrayWrite_Ref(CeedVector vec, CeedMemType mem_type, Cee
 
   CeedCallBackend(CeedVectorGetData(vec, &impl));
 
-  if (!impl->array) {
-    if (!impl->array_owned && !impl->array_borrowed) {
-      // Allocate if array is not yet allocated
-      CeedCallBackend(CeedVectorSetArray(vec, CEED_MEM_HOST, CEED_COPY_VALUES, NULL));
-    } else {
-      // Select dirty array for GetArrayWrite
-      if (impl->array_borrowed) impl->array = impl->array_borrowed;
-      else impl->array = impl->array_owned;
-    }
-  }
+  if (!impl->array) CeedCallBackend(CeedVectorSetArray(vec, CEED_MEM_HOST, CEED_COPY_VALUES, NULL));
   return CeedVectorGetArrayCore_Ref(vec, mem_type, (CeedScalar **)array);
 }
 

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -27,13 +27,13 @@ typedef struct {
 typedef struct {
   const CeedInt  *offsets;
   const CeedInt  *offsets_borrowed;
-  CeedInt        *offsets_owned;
+  const CeedInt  *offsets_owned;
   const bool     *orients; /* Orientation, if it exists, is true when the dof must be flipped */
   const bool     *orients_borrowed;
-  bool           *orients_owned;
+  const bool     *orients_owned;
   const CeedInt8 *curl_orients; /* Tridiagonal matrix (row-major) for a general transformation during restriction */
   const CeedInt8 *curl_orients_borrowed;
-  CeedInt8       *curl_orients_owned;
+  const CeedInt8 *curl_orients_owned;
   int (*Apply)(CeedElemRestriction, CeedInt, CeedInt, CeedInt, CeedInt, CeedInt, CeedTransposeMode, bool, bool, CeedVector, CeedVector,
                CeedRequest *);
 } CeedElemRestriction_Ref;

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -26,11 +26,14 @@ typedef struct {
 
 typedef struct {
   const CeedInt  *offsets;
-  CeedInt        *offsets_allocated;
+  const CeedInt  *offsets_borrowed;
+  CeedInt        *offsets_owned;
   const bool     *orients; /* Orientation, if it exists, is true when the dof must be flipped */
-  bool           *orients_allocated;
+  const bool     *orients_borrowed;
+  bool           *orients_owned;
   const CeedInt8 *curl_orients; /* Tridiagonal matrix (row-major) for a general transformation during restriction */
-  CeedInt8       *curl_orients_allocated;
+  const CeedInt8 *curl_orients_borrowed;
+  CeedInt8       *curl_orients_owned;
   int (*Apply)(CeedElemRestriction, CeedInt, CeedInt, CeedInt, CeedInt, CeedInt, CeedTransposeMode, bool, bool, CeedVector, CeedVector,
                CeedRequest *);
 } CeedElemRestriction_Ref;

--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
@@ -412,7 +412,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
         CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
         code << "    // CompStride: " << comp_stride << "\n";
         CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_impl));
-        h_indices.inputs[i] = rstr_impl->d_ind;
+        h_indices.inputs[i] = rstr_impl->d_offsets;
         code << "    readDofsOffset" << dim << "d(num_comp_in_" << i << ", " << comp_stride << ", P_in_" << i << ", num_elem, indices->inputs[" << i
              << "], d_u_" << i << ", r_u_" << i << ");\n";
       } else {
@@ -523,7 +523,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
             CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
             code << "      // CompStride: " << comp_stride << "\n";
             CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_impl));
-            h_indices.inputs[i] = rstr_impl->d_ind;
+            h_indices.inputs[i] = rstr_impl->d_offsets;
             code << "      readSliceQuadsOffset"
                  << "3d(num_comp_in_" << i << ", " << comp_stride << ", Q_1D, l_size_in_" << i << ", num_elem, q, indices->inputs[" << i << "], d_u_"
                  << i << ", r_q_" << i << ");\n";
@@ -716,7 +716,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionGetCompStride(elem_rstr, &comp_stride));
       code << "    // CompStride: " << comp_stride << "\n";
       CeedCallBackend(CeedElemRestrictionGetData(elem_rstr, &rstr_impl));
-      h_indices.outputs[i] = rstr_impl->d_ind;
+      h_indices.outputs[i] = rstr_impl->d_offsets;
       code << "    writeDofsOffset" << dim << "d(num_comp_out_" << i << ", " << comp_stride << ", P_out_" << i << ", num_elem, indices->outputs[" << i
            << "], r_v_" << i << ", d_v_" << i << ");\n";
     } else {

--- a/backends/sycl-ref/ceed-sycl-ref.hpp
+++ b/backends/sycl-ref/ceed-sycl-ref.hpp
@@ -34,10 +34,12 @@ typedef struct {
   CeedInt  elem_size;
   CeedInt  comp_stride;
   CeedInt  strides[3];
-  CeedInt *h_ind;
-  CeedInt *h_ind_allocated;
-  CeedInt *d_ind;
-  CeedInt *d_ind_allocated;
+  CeedInt *h_offsets;
+  CeedInt *h_offsets_borrowed;
+  CeedInt *h_offsets_owned;
+  CeedInt *d_offsets;
+  CeedInt *d_offsets_borrowed;
+  CeedInt *d_offsets_owned;
   CeedInt *d_t_offsets;
   CeedInt *d_t_indices;
   CeedInt *d_l_vec_indices;
@@ -121,7 +123,7 @@ CEED_INTERN int CeedBasisCreateTensorH1_Sycl(CeedInt dim, CeedInt P_1d, CeedInt 
 CEED_INTERN int CeedBasisCreateH1_Sycl(CeedElemTopology topo, CeedInt dim, CeedInt num_dof, CeedInt num_qpts, const CeedScalar *interp,
                                        const CeedScalar *grad, const CeedScalar *q_ref, const CeedScalar *q_weight, CeedBasis basis);
 
-CEED_INTERN int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *indices, const bool *orients,
+CEED_INTERN int CeedElemRestrictionCreate_Sycl(CeedMemType mem_type, CeedCopyMode copy_mode, const CeedInt *offsets, const bool *orients,
                                                const CeedInt8 *curl_orients, CeedElemRestriction r);
 
 CEED_INTERN int CeedQFunctionCreate_Sycl(CeedQFunction qf);

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -188,26 +188,8 @@ static int CeedVectorSetArrayHost_Sycl(const CeedVector vec, const CeedCopyMode 
   CeedCallBackend(CeedVectorGetData(vec, &impl));
   CeedCallBackend(CeedVectorGetLength(vec, &length));
 
-  switch (copy_mode) {
-    case CEED_COPY_VALUES: {
-      if (!impl->h_array_owned) CeedCallBackend(CeedMalloc(length, &impl->h_array_owned));
-      if (array) memcpy(impl->h_array_owned, array, length * sizeof(array[0]));
-      impl->h_array_borrowed = NULL;
-      impl->h_array          = impl->h_array_owned;
-    } break;
-    case CEED_OWN_POINTER:
-      CeedCallBackend(CeedFree(&impl->h_array_owned));
-      impl->h_array_owned    = array;
-      impl->h_array_borrowed = NULL;
-      impl->h_array          = impl->h_array_owned;
-      break;
-    case CEED_USE_POINTER:
-      CeedCallBackend(CeedFree(&impl->h_array_owned));
-      impl->h_array_owned    = NULL;
-      impl->h_array_borrowed = array;
-      impl->h_array          = impl->h_array_borrowed;
-      break;
-  }
+  CeedCallBackend(CeedSetHostCeedScalarArray(array, copy_mode, length, (const CeedScalar **)&impl->h_array_owned,
+                                             (const CeedScalar **)&impl->h_array_borrowed, (const CeedScalar **)&impl->h_array));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -181,6 +181,16 @@ CEED_INTERN int CeedReallocArray(size_t n, size_t unit, void *p);
 CEED_INTERN int CeedStringAllocCopy(const char *source, char **copy);
 CEED_INTERN int CeedFree(void *p);
 
+CEED_INTERN int CeedSetHostBoolArray(const bool *source_array, CeedCopyMode copy_mode, CeedSize num_values, const bool **target_array_owned,
+                                     const bool **target_array_borrowed, const bool **target_array);
+CEED_INTERN int CeedSetHostCeedInt8Array(const CeedInt8 *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                         const CeedInt8 **target_array_owned, const CeedInt8 **target_array_borrowed, const CeedInt8 **target_array);
+CEED_INTERN int CeedSetHostCeedIntArray(const CeedInt *source_array, CeedCopyMode copy_mode, CeedSize num_values, const CeedInt **target_array_owned,
+                                        const CeedInt **target_array_borrowed, const CeedInt **target_array);
+CEED_INTERN int CeedSetHostCeedScalarArray(const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
+                                           const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
+                                           const CeedScalar **target_array);
+
 /**
   @brief Calls a libCEED function and then checks the resulting error code.
   If the error code is non-zero, then the error handler is called and the call from the current function with the error code.

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -295,6 +295,119 @@ int CeedFree(void *p) {
   return CEED_ERROR_SUCCESS;
 }
 
+/** Internal helper to manage handoff of user `source_array` to backend with proper @ref CeedCopyMode behavior.
+
+  @param[in]     source_array          Source data provided by user
+  @param[in]     copy_mode             Copy mode for the data
+  @param[in]     num_values            Number of values to handle
+  @param[in,out] target_array_owned    Pointer to location to allocated or hold owned data, may be freed if already allocated
+  @param[out]    target_array_borrowed Pointer to location to hold borrowed data
+  @param[out]    target_array          Pointer to location for data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+static inline int CeedSetHostGenericArray(const void *source_array, CeedCopyMode copy_mode, size_t size_unit, CeedSize num_values,
+                                          void *target_array_owned, void *target_array_borrowed, void *target_array) {
+  switch (copy_mode) {
+    case CEED_COPY_VALUES:
+      if (!*(void **)target_array_owned) CeedCall(CeedCallocArray(num_values, size_unit, target_array_owned));
+      if (source_array) memcpy(*(void **)target_array_owned, source_array, size_unit * num_values);
+      *(void **)target_array_borrowed = NULL;
+      *(void **)target_array          = *(void **)target_array_owned;
+      break;
+    case CEED_OWN_POINTER:
+      CeedCall(CeedFree(target_array_owned));
+      *(void **)target_array_owned    = (void *)source_array;
+      *(void **)target_array_borrowed = NULL;
+      *(void **)target_array          = *(void **)target_array_owned;
+      break;
+    case CEED_USE_POINTER:
+      CeedCall(CeedFree(target_array_owned));
+      *(void **)target_array_owned    = NULL;
+      *(void **)target_array_borrowed = (void *)source_array;
+      *(void **)target_array          = *(void **)target_array_borrowed;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/** Manage handoff of user `bool` `source_array` to backend with proper @ref CeedCopyMode behavior.
+
+  @param[in]     source_array          Source data provided by user
+  @param[in]     copy_mode             Copy mode for the data
+  @param[in]     num_values            Number of values to handle
+  @param[in,out] target_array_owned    Pointer to location to allocated or hold owned data, may be freed if already allocated
+  @param[out]    target_array_borrowed Pointer to location to hold borrowed data
+  @param[out]    target_array          Pointer to location for data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedSetHostBoolArray(const bool *source_array, CeedCopyMode copy_mode, CeedSize num_values, const bool **target_array_owned,
+                         const bool **target_array_borrowed, const bool **target_array) {
+  CeedCall(CeedSetHostGenericArray(source_array, copy_mode, sizeof(bool), num_values, target_array_owned, target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+/** Manage handoff of user `CeedInt8` `source_array` to backend with proper @ref CeedCopyMode behavior.
+
+  @param[in]     source_array          Source data provided by user
+  @param[in]     copy_mode             Copy mode for the data
+  @param[in]     num_values            Number of values to handle
+  @param[in,out] target_array_owned    Pointer to location to allocated or hold owned data, may be freed if already allocated
+  @param[out]    target_array_borrowed Pointer to location to hold borrowed data
+  @param[out]    target_array          Pointer to location for data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedSetHostCeedInt8Array(const CeedInt8 *source_array, CeedCopyMode copy_mode, CeedSize num_values, const CeedInt8 **target_array_owned,
+                             const CeedInt8 **target_array_borrowed, const CeedInt8 **target_array) {
+  CeedCall(CeedSetHostGenericArray(source_array, copy_mode, sizeof(CeedInt8), num_values, target_array_owned, target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+/** Manage handoff of user `CeedInt` `source_array` to backend with proper @ref CeedCopyMode behavior.
+
+  @param[in]     source_array          Source data provided by user
+  @param[in]     copy_mode             Copy mode for the data
+  @param[in]     num_values            Number of values to handle
+  @param[in,out] target_array_owned    Pointer to location to allocated or hold owned data, may be freed if already allocated
+  @param[out]    target_array_borrowed Pointer to location to hold borrowed data
+  @param[out]    target_array          Pointer to location for data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedSetHostCeedIntArray(const CeedInt *source_array, CeedCopyMode copy_mode, CeedSize num_values, const CeedInt **target_array_owned,
+                            const CeedInt **target_array_borrowed, const CeedInt **target_array) {
+  CeedCall(CeedSetHostGenericArray(source_array, copy_mode, sizeof(CeedInt), num_values, target_array_owned, target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
+/** Manage handoff of user `CeedScalar` `source_array` to backend with proper @ref CeedCopyMode behavior.
+
+  @param[in]     source_array          Source data provided by user
+  @param[in]     copy_mode             Copy mode for the data
+  @param[in]     num_values            Number of values to handle
+  @param[in,out] target_array_owned    Pointer to location to allocated or hold owned data, may be freed if already allocated
+  @param[out]    target_array_borrowed Pointer to location to hold borrowed data
+  @param[out]    target_array          Pointer to location for data
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedSetHostCeedScalarArray(const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values, const CeedScalar **target_array_owned,
+                               const CeedScalar **target_array_borrowed, const CeedScalar **target_array) {
+  CeedCall(CeedSetHostGenericArray(source_array, copy_mode, sizeof(CeedScalar), num_values, target_array_owned, target_array_borrowed, target_array));
+  return CEED_ERROR_SUCCESS;
+}
+
 /**
   @brief Register a `Ceed` backend
 


### PR DESCRIPTION
Fixes #1441, I'm trying to unify duplicated logic around coping/holding user provided pointers and their contents.

Basically, we had this pattern strewn all over the place with minor variation, so I consolidated
```C
  switch (copy_mode) {
    case CEED_COPY_VALUES: {
      if (!impl->h_array_owned) CeedCallBackend(CeedMalloc(length, &impl->h_array_owned));
      if (array) memcpy(impl->h_array_owned, array, array * sizeof(array[0]));
      impl->h_array_borrowed = NULL;
      impl->h_array          = impl->h_array_owned;
    } break;
    case CEED_OWN_POINTER:
      CeedCallBackend(CeedFree(&impl->h_array_owned));
      impl->h_array_owned    = array;
      impl->h_array_borrowed = NULL;
      impl->h_array          = array;
      break;
    case CEED_USE_POINTER:
      CeedCallBackend(CeedFree(&impl->h_array_owned));
      impl->h_array_owned    = NULL;
      impl->h_array_borrowed = array;
      impl->h_array          = array;
      break;
  }
```

now
```C
  CeedCallBackend(CeedSetHostCeedScalarArray(array, copy_mode, length, (const CeedScalar **)&impl->h_array_owned,
                                             (const CeedScalar **)&impl->h_array_borrowed, (const CeedScalar **)&impl->h_array));
```