### PR TITLE
Restriction CeedInt vs CeedSize

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
-Checks: "clang-diagnostic-*,clang-analyzer-*,readability-inconsistent-declaration-parameter-name"
+Checks: "clang-diagnostic-*,clang-analyzer-*,readability-inconsistent-declaration-parameter-name,bugprone-too-small-loop-variable"
 HeaderFilterRegex: .*
 WarningsAsErrors: "clang-diagnostic-*,clang-analyzer-*,readability-inconsistent-declaration-parameter-name"

--- a/backends/blocked/ceed-blocked-operator.c
+++ b/backends/blocked/ceed-blocked-operator.c
@@ -265,7 +265,7 @@ static inline int CeedOperatorInputBasis_Blocked(CeedInt e, CeedInt Q, CeedQFunc
     // Basis action
     switch (eval_mode) {
       case CEED_EVAL_NONE:
-        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][e * Q * size]));
+        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][(CeedSize)e * Q * size]));
         break;
       case CEED_EVAL_INTERP:
       case CEED_EVAL_GRAD:
@@ -273,7 +273,7 @@ static inline int CeedOperatorInputBasis_Blocked(CeedInt e, CeedInt Q, CeedQFunc
       case CEED_EVAL_CURL:
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
-        CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][e * elem_size * num_comp]));
+        CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][(CeedSize)e * elem_size * num_comp]));
         CeedCallBackend(CeedBasisApply(basis, block_size, CEED_NOTRANSPOSE, eval_mode, impl->e_vecs_in[i], impl->q_vecs_in[i]));
         break;
       case CEED_EVAL_WEIGHT:
@@ -309,8 +309,8 @@ static inline int CeedOperatorOutputBasis_Blocked(CeedInt e, CeedInt Q, CeedQFun
       case CEED_EVAL_CURL:
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
         CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
-        CeedCallBackend(
-            CeedVectorSetArray(impl->e_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i + num_input_fields][e * elem_size * num_comp]));
+        CeedCallBackend(CeedVectorSetArray(impl->e_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER,
+                                           &e_data_full[i + num_input_fields][(CeedSize)e * elem_size * num_comp]));
         CeedCallBackend(CeedBasisApply(basis, block_size, CEED_TRANSPOSE, eval_mode, impl->q_vecs_out[i], impl->e_vecs_out[i]));
         break;
       // LCOV_EXCL_START
@@ -393,7 +393,8 @@ static int CeedOperatorApplyAdd_Blocked(CeedOperator op, CeedVector in_vec, Ceed
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
       if (eval_mode == CEED_EVAL_NONE) {
         CeedCallBackend(CeedQFunctionFieldGetSize(qf_output_fields[i], &size));
-        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i + num_input_fields][e * Q * size]));
+        CeedCallBackend(
+            CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i + num_input_fields][(CeedSize)e * Q * size]));
       }
     }
 

--- a/backends/memcheck/ceed-memcheck-restriction.c
+++ b/backends/memcheck/ceed-memcheck-restriction.c
@@ -45,7 +45,7 @@ static inline int CeedElemRestrictionGetBackendStrides_Memcheck(CeedElemRestrict
 //------------------------------------------------------------------------------
 static inline int CeedElemRestrictionApplyStridedNoTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                            CeedInt start, CeedInt stop, CeedInt num_elem, CeedInt elem_size,
-                                                                           CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                           CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                            CeedScalar *__restrict__ vv) {
   // Get strides
   bool    has_backend_strides;
@@ -60,7 +60,7 @@ static inline int CeedElemRestrictionApplyStridedNoTranspose_Memcheck_Core(CeedE
     CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
       CeedPragmaSIMD for (CeedInt n = 0; n < elem_size; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-          vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+          vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
               uu[n * strides[0] + k * strides[1] + CeedIntMin(e + j, num_elem - 1) * strides[2]];
         }
       }
@@ -71,7 +71,7 @@ static inline int CeedElemRestrictionApplyStridedNoTranspose_Memcheck_Core(CeedE
 
 static inline int CeedElemRestrictionApplyOffsetNoTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                           const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                          CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                          CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                           CeedScalar *__restrict__ vv) {
   // Default restriction with offsets
   CeedElemRestriction_Memcheck *impl;
@@ -80,7 +80,7 @@ static inline int CeedElemRestrictionApplyOffsetNoTranspose_Memcheck_Core(CeedEl
   for (CeedInt e = start * block_size; e < stop * block_size; e += block_size) {
     CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
       CeedPragmaSIMD for (CeedInt i = 0; i < elem_size * block_size; i++) {
-        vv[elem_size * (k * block_size + e * num_comp) + i - v_offset] = uu[impl->offsets[i + e * elem_size] + k * comp_stride];
+        vv[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + i - v_offset] = uu[impl->offsets[i + e * elem_size] + k * comp_stride];
       }
     }
   }
@@ -89,7 +89,7 @@ static inline int CeedElemRestrictionApplyOffsetNoTranspose_Memcheck_Core(CeedEl
 
 static inline int CeedElemRestrictionApplyOrientedNoTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp,
                                                                             const CeedInt block_size, const CeedInt comp_stride, CeedInt start,
-                                                                            CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedInt v_offset,
+                                                                            CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedSize v_offset,
                                                                             const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
   // Restriction with orientations
   CeedElemRestriction_Memcheck *impl;
@@ -98,7 +98,7 @@ static inline int CeedElemRestrictionApplyOrientedNoTranspose_Memcheck_Core(Ceed
   for (CeedInt e = start * block_size; e < stop * block_size; e += block_size) {
     CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
       CeedPragmaSIMD for (CeedInt i = 0; i < elem_size * block_size; i++) {
-        vv[elem_size * (k * block_size + e * num_comp) + i - v_offset] =
+        vv[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + i - v_offset] =
             uu[impl->offsets[i + e * elem_size] + k * comp_stride] * (impl->orients[i + e * elem_size] ? -1.0 : 1.0);
       }
     }
@@ -108,7 +108,7 @@ static inline int CeedElemRestrictionApplyOrientedNoTranspose_Memcheck_Core(Ceed
 
 static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp,
                                                                                 const CeedInt block_size, const CeedInt comp_stride, CeedInt start,
-                                                                                CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedInt v_offset,
+                                                                                CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedSize v_offset,
                                                                                 const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
   // Restriction with tridiagonal transformation
   CeedElemRestriction_Memcheck *impl;
@@ -119,7 +119,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Memcheck_Core(
       CeedInt n = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
                 impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size] +
             uu[impl->offsets[j + (n + 1) * block_size + e * elem_size] + k * comp_stride] *
@@ -127,7 +127,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Memcheck_Core(
       }
       CeedPragmaSIMD for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-          vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+          vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
               uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                   impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size] +
               uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -137,7 +137,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Memcheck_Core(
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                 impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size] +
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -150,7 +150,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Memcheck_Core(
 
 static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Memcheck_Core(
     CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size, const CeedInt comp_stride, CeedInt start, CeedInt stop,
-    CeedInt num_elem, CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
+    CeedInt num_elem, CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
   // Restriction with (unsigned) tridiagonal transformation
   CeedElemRestriction_Memcheck *impl;
 
@@ -160,7 +160,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Memche
       CeedInt n = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
                 abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]) +
             uu[impl->offsets[j + (n + 1) * block_size + e * elem_size] + k * comp_stride] *
@@ -168,7 +168,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Memche
       }
       CeedPragmaSIMD for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-          vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+          vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
               uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                   abs(impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size]) +
               uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -178,7 +178,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Memche
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                 abs(impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size]) +
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -191,7 +191,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Memche
 
 static inline int CeedElemRestrictionApplyStridedTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                          CeedInt start, CeedInt stop, CeedInt num_elem, CeedInt elem_size,
-                                                                         CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                         CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                          CeedScalar *__restrict__ vv) {
   // Get strides
   bool    has_backend_strides;
@@ -206,8 +206,8 @@ static inline int CeedElemRestrictionApplyStridedTranspose_Memcheck_Core(CeedEle
     CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
       CeedPragmaSIMD for (CeedInt n = 0; n < elem_size; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < CeedIntMin(block_size, num_elem - e); j++) {
-          vv[n * strides[0] + k * strides[1] + (e + j) * strides[2]] +=
-              uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset];
+          vv[n * (CeedSize)strides[0] + k * (CeedSize)strides[1] + (e + j) * (CeedSize)strides[2]] +=
+              uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset];
         }
       }
     }
@@ -217,7 +217,7 @@ static inline int CeedElemRestrictionApplyStridedTranspose_Memcheck_Core(CeedEle
 
 static inline int CeedElemRestrictionApplyOffsetTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                         const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                        CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                        CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                         CeedScalar *__restrict__ vv) {
   // Default restriction with offsets
   CeedElemRestriction_Memcheck *impl;
@@ -230,7 +230,7 @@ static inline int CeedElemRestrictionApplyOffsetTranspose_Memcheck_Core(CeedElem
         for (CeedInt j = i; j < i + CeedIntMin(block_size, num_elem - e); j++) {
           CeedScalar vv_loc;
 
-          vv_loc = uu[elem_size * (k * block_size + e * num_comp) + j - v_offset];
+          vv_loc = uu[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + j - v_offset];
           CeedPragmaAtomic vv[impl->offsets[j + e * elem_size] + k * comp_stride] += vv_loc;
         }
       }
@@ -241,7 +241,7 @@ static inline int CeedElemRestrictionApplyOffsetTranspose_Memcheck_Core(CeedElem
 
 static inline int CeedElemRestrictionApplyOrientedTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                           const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                          CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                          CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                           CeedScalar *__restrict__ vv) {
   // Restriction with orientations
   CeedElemRestriction_Memcheck *impl;
@@ -254,7 +254,8 @@ static inline int CeedElemRestrictionApplyOrientedTranspose_Memcheck_Core(CeedEl
         for (CeedInt j = i; j < i + CeedIntMin(block_size, num_elem - e); j++) {
           CeedScalar vv_loc;
 
-          vv_loc = uu[elem_size * (k * block_size + e * num_comp) + j - v_offset] * (impl->orients[j + e * elem_size] ? -1.0 : 1.0);
+          vv_loc =
+              uu[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + j - v_offset] * (impl->orients[j + e * elem_size] ? -1.0 : 1.0);
           CeedPragmaAtomic vv[impl->offsets[j + e * elem_size] + k * comp_stride] += vv_loc;
         }
       }
@@ -265,7 +266,7 @@ static inline int CeedElemRestrictionApplyOrientedTranspose_Memcheck_Core(CeedEl
 
 static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp,
                                                                               const CeedInt block_size, const CeedInt comp_stride, CeedInt start,
-                                                                              CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedInt v_offset,
+                                                                              CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedSize v_offset,
                                                                               const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
   // Restriction with tridiagonal transformation
   CeedElemRestriction_Memcheck *impl;
@@ -279,9 +280,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Memcheck_Core(Ce
       CeedInt       n         = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size] +
-                    uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size];
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -289,11 +290,11 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Memcheck_Core(Ce
       }
       for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-          vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+          vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                           impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size] +
-                      uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                           impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size] +
-                      uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                           impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size];
         }
         for (CeedInt j = 0; j < block_end; j++) {
@@ -301,9 +302,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Memcheck_Core(Ce
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size] +
-                    uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size];
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -316,7 +317,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Memcheck_Core(Ce
 
 static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Memcheck_Core(
     CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size, const CeedInt comp_stride, CeedInt start, CeedInt stop,
-    CeedInt num_elem, CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
+    CeedInt num_elem, CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
   // Restriction with (unsigned) tridiagonal transformation
   CeedElemRestriction_Memcheck *impl;
   CeedScalar                    vv_loc[block_size];
@@ -329,9 +330,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Memcheck
       CeedInt       n         = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]) +
-                    uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size]);
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -339,11 +340,11 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Memcheck
       }
       for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-          vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+          vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                           abs(impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size]) +
-                      uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                           abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]) +
-                      uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                           abs(impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size]);
         }
         for (CeedInt j = 0; j < block_end; j++) {
@@ -351,9 +352,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Memcheck
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size]) +
-                    uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]);
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -367,7 +368,8 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Memcheck
 static inline int CeedElemRestrictionApplyAtPointsInElement_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, CeedInt start,
                                                                           CeedInt stop, CeedTransposeMode t_mode, const CeedScalar *__restrict__ uu,
                                                                           CeedScalar *__restrict__ vv) {
-  CeedInt                       num_points, l_vec_offset, e_vec_offset = 0;
+  CeedInt                       num_points, l_vec_offset;
+  CeedSize                      e_vec_offset = 0;
   CeedElemRestriction_Memcheck *impl;
 
   CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
@@ -376,14 +378,14 @@ static inline int CeedElemRestrictionApplyAtPointsInElement_Memcheck_Core(CeedEl
     CeedCallBackend(CeedElemRestrictionGetNumPointsInElement(rstr, e, &num_points));
     if (t_mode == CEED_NOTRANSPOSE) {
       for (CeedInt i = 0; i < num_points; i++) {
-        for (CeedInt j = 0; j < num_comp; j++) vv[j * num_points + i + e_vec_offset] = uu[impl->offsets[i + l_vec_offset] * num_comp + j];
+        for (CeedInt j = 0; j < num_comp; j++) vv[j * (CeedSize)num_points + i + e_vec_offset] = uu[impl->offsets[i + l_vec_offset] * num_comp + j];
       }
     } else {
       for (CeedInt i = 0; i < num_points; i++) {
-        for (CeedInt j = 0; j < num_comp; j++) vv[impl->offsets[i + l_vec_offset] * num_comp + j] = uu[j * num_points + i + e_vec_offset];
+        for (CeedInt j = 0; j < num_comp; j++) vv[impl->offsets[i + l_vec_offset] * num_comp + j] = uu[j * (CeedSize)num_points + i + e_vec_offset];
       }
     }
-    e_vec_offset += num_points * num_comp;
+    e_vec_offset += num_points * (CeedSize)num_comp;
   }
   return CEED_ERROR_SUCCESS;
 }
@@ -391,14 +393,15 @@ static inline int CeedElemRestrictionApplyAtPointsInElement_Memcheck_Core(CeedEl
 static inline int CeedElemRestrictionApply_Memcheck_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                          const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedTransposeMode t_mode,
                                                          bool use_signs, bool use_orients, CeedVector u, CeedVector v, CeedRequest *request) {
-  CeedInt             num_elem, elem_size, v_offset;
+  CeedInt             num_elem, elem_size;
+  CeedSize            v_offset;
   CeedRestrictionType rstr_type;
   const CeedScalar   *uu;
   CeedScalar         *vv;
 
   CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
   CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
-  v_offset = start * block_size * elem_size * num_comp;
+  v_offset = start * block_size * elem_size * (CeedSize)num_comp;
   CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
   CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_HOST, &uu));
 

--- a/backends/memcheck/ceed-memcheck-restriction.c
+++ b/backends/memcheck/ceed-memcheck-restriction.c
@@ -675,21 +675,8 @@ int CeedElemRestrictionCreate_Memcheck(CeedMemType mem_type, CeedCopyMode copy_m
 
   // Offsets data
   if (rstr_type != CEED_RESTRICTION_STRIDED) {
-    const char *resource;
-
-    // Check indices for ref or memcheck backends
+    // Check indices
     {
-      Ceed current = ceed, parent = NULL;
-
-      CeedCallBackend(CeedGetParent(current, &parent));
-      while (current != parent) {
-        current = parent;
-        CeedCallBackend(CeedGetParent(current, &parent));
-      }
-      CeedCallBackend(CeedGetResource(parent, &resource));
-    }
-    if (!strcmp(resource, "/cpu/self/ref/serial") || !strcmp(resource, "/cpu/self/ref/blocked") || !strcmp(resource, "/cpu/self/memcheck/serial") ||
-        !strcmp(resource, "/cpu/self/memcheck/blocked")) {
       CeedSize l_size;
 
       CeedCallBackend(CeedElemRestrictionGetLVectorSize(rstr, &l_size));

--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -279,7 +279,7 @@ static inline int CeedOperatorInputBasis_Opt(CeedInt e, CeedInt Q, CeedQFunction
     switch (eval_mode) {
       case CEED_EVAL_NONE:
         if (!is_active_input) {
-          CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data[i][e * Q * size]));
+          CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data[i][(CeedSize)e * Q * size]));
         }
         break;
       case CEED_EVAL_INTERP:
@@ -289,7 +289,7 @@ static inline int CeedOperatorInputBasis_Opt(CeedInt e, CeedInt Q, CeedQFunction
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         if (!is_active_input) {
           CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
-          CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data[i][e * elem_size * num_comp]));
+          CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data[i][(CeedSize)e * elem_size * num_comp]));
         }
         CeedCallBackend(CeedBasisApply(basis, block_size, CEED_NOTRANSPOSE, eval_mode, impl->e_vecs_in[i], impl->q_vecs_in[i]));
         break;

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -206,7 +206,7 @@ static inline int CeedOperatorInputBasis_Ref(CeedInt e, CeedInt Q, CeedQFunction
     // Basis action
     switch (eval_mode) {
       case CEED_EVAL_NONE:
-        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][e * Q * size]));
+        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][(CeedSize)e * Q * size]));
         break;
       case CEED_EVAL_INTERP:
       case CEED_EVAL_GRAD:
@@ -214,7 +214,7 @@ static inline int CeedOperatorInputBasis_Ref(CeedInt e, CeedInt Q, CeedQFunction
       case CEED_EVAL_CURL:
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
-        CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][e * elem_size * num_comp]));
+        CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i][(CeedSize)e * elem_size * num_comp]));
         CeedCallBackend(CeedBasisApply(basis, 1, CEED_NOTRANSPOSE, eval_mode, impl->e_vecs_in[i], impl->q_vecs_in[i]));
         break;
       case CEED_EVAL_WEIGHT:
@@ -250,8 +250,8 @@ static inline int CeedOperatorOutputBasis_Ref(CeedInt e, CeedInt Q, CeedQFunctio
       case CEED_EVAL_CURL:
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
         CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
-        CeedCallBackend(
-            CeedVectorSetArray(impl->e_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i + num_input_fields][e * elem_size * num_comp]));
+        CeedCallBackend(CeedVectorSetArray(impl->e_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER,
+                                           &e_data_full[i + num_input_fields][(CeedSize)e * elem_size * num_comp]));
         CeedCallBackend(CeedBasisApply(basis, 1, CEED_TRANSPOSE, eval_mode, impl->q_vecs_out[i], impl->e_vecs_out[i]));
         break;
       // LCOV_EXCL_START
@@ -337,7 +337,8 @@ static int CeedOperatorApplyAdd_Ref(CeedOperator op, CeedVector in_vec, CeedVect
       CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
       if (eval_mode == CEED_EVAL_NONE) {
         CeedCallBackend(CeedQFunctionFieldGetSize(qf_output_fields[i], &size));
-        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i + num_input_fields][e * Q * size]));
+        CeedCallBackend(
+            CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data_full[i + num_input_fields][(CeedSize)e * Q * size]));
       }
     }
 
@@ -765,7 +766,7 @@ static inline int CeedOperatorInputBasisAtPoints_Ref(CeedInt e, CeedInt num_poin
         if (!is_active_input) {
           CeedCallBackend(CeedBasisGetNumComponents(basis, &num_comp));
           CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-          CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data[i][e * elem_size * num_comp]));
+          CeedCallBackend(CeedVectorSetArray(impl->e_vecs_in[i], CEED_MEM_HOST, CEED_USE_POINTER, &e_data[i][(CeedSize)e * elem_size * num_comp]));
         }
         CeedCallBackend(
             CeedBasisApplyAtPoints(basis, num_points, CEED_NOTRANSPOSE, eval_mode, point_coords_elem, impl->e_vecs_in[i], impl->q_vecs_in[i]));

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -18,7 +18,7 @@
 //------------------------------------------------------------------------------
 static inline int CeedElemRestrictionApplyStridedNoTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                       CeedInt start, CeedInt stop, CeedInt num_elem, CeedInt elem_size,
-                                                                      CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                      CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                       CeedScalar *__restrict__ vv) {
   // No offsets provided, identity restriction
   bool has_backend_strides;
@@ -31,8 +31,8 @@ static inline int CeedElemRestrictionApplyStridedNoTranspose_Ref_Core(CeedElemRe
       CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
         CeedPragmaSIMD for (CeedInt n = 0; n < elem_size; n++) {
           CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-            vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
-                uu[n + k * elem_size + CeedIntMin(e + j, num_elem - 1) * elem_size * num_comp];
+            vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
+                uu[n + k * (CeedSize)elem_size + CeedIntMin(e + j, num_elem - 1) * elem_size * (CeedSize)num_comp];
           }
         }
       }
@@ -46,8 +46,8 @@ static inline int CeedElemRestrictionApplyStridedNoTranspose_Ref_Core(CeedElemRe
       CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
         CeedPragmaSIMD for (CeedInt n = 0; n < elem_size; n++) {
           CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-            vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
-                uu[n * strides[0] + k * strides[1] + CeedIntMin(e + j, num_elem - 1) * strides[2]];
+            vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
+                uu[n * (CeedSize)strides[0] + k * (CeedSize)strides[1] + CeedIntMin(e + j, num_elem - 1) * (CeedSize)strides[2]];
           }
         }
       }
@@ -58,7 +58,7 @@ static inline int CeedElemRestrictionApplyStridedNoTranspose_Ref_Core(CeedElemRe
 
 static inline int CeedElemRestrictionApplyOffsetNoTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                      const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                     CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                     CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                      CeedScalar *__restrict__ vv) {
   // Default restriction with offsets
   CeedElemRestriction_Ref *impl;
@@ -67,7 +67,7 @@ static inline int CeedElemRestrictionApplyOffsetNoTranspose_Ref_Core(CeedElemRes
   for (CeedInt e = start * block_size; e < stop * block_size; e += block_size) {
     CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
       CeedPragmaSIMD for (CeedInt i = 0; i < elem_size * block_size; i++) {
-        vv[elem_size * (k * block_size + e * num_comp) + i - v_offset] = uu[impl->offsets[i + e * elem_size] + k * comp_stride];
+        vv[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + i - v_offset] = uu[impl->offsets[i + e * elem_size] + k * comp_stride];
       }
     }
   }
@@ -76,7 +76,7 @@ static inline int CeedElemRestrictionApplyOffsetNoTranspose_Ref_Core(CeedElemRes
 
 static inline int CeedElemRestrictionApplyOrientedNoTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                        const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                       CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                       CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                        CeedScalar *__restrict__ vv) {
   // Restriction with orientations
   CeedElemRestriction_Ref *impl;
@@ -85,7 +85,7 @@ static inline int CeedElemRestrictionApplyOrientedNoTranspose_Ref_Core(CeedElemR
   for (CeedInt e = start * block_size; e < stop * block_size; e += block_size) {
     CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
       CeedPragmaSIMD for (CeedInt i = 0; i < elem_size * block_size; i++) {
-        vv[elem_size * (k * block_size + e * num_comp) + i - v_offset] =
+        vv[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + i - v_offset] =
             uu[impl->offsets[i + e * elem_size] + k * comp_stride] * (impl->orients[i + e * elem_size] ? -1.0 : 1.0);
       }
     }
@@ -95,7 +95,7 @@ static inline int CeedElemRestrictionApplyOrientedNoTranspose_Ref_Core(CeedElemR
 
 static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                            const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                           CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                           CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                            CeedScalar *__restrict__ vv) {
   // Restriction with tridiagonal transformation
   CeedElemRestriction_Ref *impl;
@@ -106,7 +106,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Ref_Core(CeedE
       CeedInt n = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
                 impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size] +
             uu[impl->offsets[j + (n + 1) * block_size + e * elem_size] + k * comp_stride] *
@@ -114,7 +114,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Ref_Core(CeedE
       }
       CeedPragmaSIMD for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-          vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+          vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
               uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                   impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size] +
               uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -124,7 +124,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Ref_Core(CeedE
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                 impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size] +
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -138,7 +138,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedNoTranspose_Ref_Core(CeedE
 static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp,
                                                                                    const CeedInt block_size, const CeedInt comp_stride, CeedInt start,
                                                                                    CeedInt stop, CeedInt num_elem, CeedInt elem_size,
-                                                                                   CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                                   CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                                    CeedScalar *__restrict__ vv) {
   // Restriction with (unsigned) tridiagonal transformation
   CeedElemRestriction_Ref *impl;
@@ -149,7 +149,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Ref_Co
       CeedInt n = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
                 abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]) +
             uu[impl->offsets[j + (n + 1) * block_size + e * elem_size] + k * comp_stride] *
@@ -157,7 +157,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Ref_Co
       }
       CeedPragmaSIMD for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-          vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+          vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
               uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                   abs(impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size]) +
               uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -167,7 +167,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Ref_Co
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_size; j++) {
-        vv[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] =
+        vv[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] =
             uu[impl->offsets[j + (n - 1) * block_size + e * elem_size] + k * comp_stride] *
                 abs(impl->curl_orients[j + (3 * n + 0) * block_size + e * 3 * elem_size]) +
             uu[impl->offsets[j + n * block_size + e * elem_size] + k * comp_stride] *
@@ -180,7 +180,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedNoTranspose_Ref_Co
 
 static inline int CeedElemRestrictionApplyStridedTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                     CeedInt start, CeedInt stop, CeedInt num_elem, CeedInt elem_size,
-                                                                    CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                    CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                     CeedScalar *__restrict__ vv) {
   // No offsets provided, identity restriction
   bool has_backend_strides;
@@ -193,7 +193,8 @@ static inline int CeedElemRestrictionApplyStridedTranspose_Ref_Core(CeedElemRest
       CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
         CeedPragmaSIMD for (CeedInt n = 0; n < elem_size; n++) {
           CeedPragmaSIMD for (CeedInt j = 0; j < CeedIntMin(block_size, num_elem - e); j++) {
-            vv[n + k * elem_size + (e + j) * elem_size * num_comp] += uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset];
+            vv[n + k * (CeedSize)elem_size + (e + j) * elem_size * (CeedSize)num_comp] +=
+                uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset];
           }
         }
       }
@@ -207,8 +208,8 @@ static inline int CeedElemRestrictionApplyStridedTranspose_Ref_Core(CeedElemRest
       CeedPragmaSIMD for (CeedInt k = 0; k < num_comp; k++) {
         CeedPragmaSIMD for (CeedInt n = 0; n < elem_size; n++) {
           CeedPragmaSIMD for (CeedInt j = 0; j < CeedIntMin(block_size, num_elem - e); j++) {
-            vv[n * strides[0] + k * strides[1] + (e + j) * strides[2]] +=
-                uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset];
+            vv[n * (CeedSize)strides[0] + k * (CeedSize)strides[1] + (e + j) * (CeedSize)strides[2]] +=
+                uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset];
           }
         }
       }
@@ -219,7 +220,7 @@ static inline int CeedElemRestrictionApplyStridedTranspose_Ref_Core(CeedElemRest
 
 static inline int CeedElemRestrictionApplyOffsetTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                    const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                   CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                   CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                    CeedScalar *__restrict__ vv) {
   // Default restriction with offsets
   CeedElemRestriction_Ref *impl;
@@ -232,7 +233,7 @@ static inline int CeedElemRestrictionApplyOffsetTranspose_Ref_Core(CeedElemRestr
         for (CeedInt j = i; j < i + CeedIntMin(block_size, num_elem - e); j++) {
           CeedScalar vv_loc;
 
-          vv_loc = uu[elem_size * (k * block_size + e * num_comp) + j - v_offset];
+          vv_loc = uu[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + j - v_offset];
           CeedPragmaAtomic vv[impl->offsets[j + e * elem_size] + k * comp_stride] += vv_loc;
         }
       }
@@ -243,7 +244,7 @@ static inline int CeedElemRestrictionApplyOffsetTranspose_Ref_Core(CeedElemRestr
 
 static inline int CeedElemRestrictionApplyOrientedTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                      const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                     CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                     CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                      CeedScalar *__restrict__ vv) {
   // Restriction with orientations
   CeedElemRestriction_Ref *impl;
@@ -256,7 +257,8 @@ static inline int CeedElemRestrictionApplyOrientedTranspose_Ref_Core(CeedElemRes
         for (CeedInt j = i; j < i + CeedIntMin(block_size, num_elem - e); j++) {
           CeedScalar vv_loc;
 
-          vv_loc = uu[elem_size * (k * block_size + e * num_comp) + j - v_offset] * (impl->orients[j + e * elem_size] ? -1.0 : 1.0);
+          vv_loc =
+              uu[elem_size * (k * (CeedSize)block_size + e * (CeedSize)num_comp) + j - v_offset] * (impl->orients[j + e * elem_size] ? -1.0 : 1.0);
           CeedPragmaAtomic vv[impl->offsets[j + e * elem_size] + k * comp_stride] += vv_loc;
         }
       }
@@ -267,7 +269,7 @@ static inline int CeedElemRestrictionApplyOrientedTranspose_Ref_Core(CeedElemRes
 
 static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                                          const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedInt num_elem,
-                                                                         CeedInt elem_size, CeedInt v_offset, const CeedScalar *__restrict__ uu,
+                                                                         CeedInt elem_size, CeedSize v_offset, const CeedScalar *__restrict__ uu,
                                                                          CeedScalar *__restrict__ vv) {
   // Restriction with tridiagonal transformation
   CeedElemRestriction_Ref *impl;
@@ -281,9 +283,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Ref_Core(CeedEle
       CeedInt       n         = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size] +
-                    uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size];
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -291,11 +293,11 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Ref_Core(CeedEle
       }
       for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-          vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+          vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                           impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size] +
-                      uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                           impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size] +
-                      uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                           impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size];
         }
         for (CeedInt j = 0; j < block_end; j++) {
@@ -303,9 +305,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Ref_Core(CeedEle
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size] +
-                    uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size];
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -318,7 +320,7 @@ static inline int CeedElemRestrictionApplyCurlOrientedTranspose_Ref_Core(CeedEle
 
 static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp,
                                                                                  const CeedInt block_size, const CeedInt comp_stride, CeedInt start,
-                                                                                 CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedInt v_offset,
+                                                                                 CeedInt stop, CeedInt num_elem, CeedInt elem_size, CeedSize v_offset,
                                                                                  const CeedScalar *__restrict__ uu, CeedScalar *__restrict__ vv) {
   // Restriction with (unsigned) tridiagonal transformation
   CeedElemRestriction_Ref *impl;
@@ -332,9 +334,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Ref_Core
       CeedInt       n         = 0;
 
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]) +
-                    uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size]);
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -342,11 +344,11 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Ref_Core
       }
       for (n = 1; n < elem_size - 1; n++) {
         CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-          vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+          vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                           abs(impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size]) +
-                      uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                           abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]) +
-                      uu[e * elem_size * num_comp + (k * elem_size + n + 1) * block_size + j - v_offset] *
+                      uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n + 1) * block_size + j - v_offset] *
                           abs(impl->curl_orients[j + (3 * n + 3) * block_size + e * 3 * elem_size]);
         }
         for (CeedInt j = 0; j < block_end; j++) {
@@ -354,9 +356,9 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Ref_Core
         }
       }
       CeedPragmaSIMD for (CeedInt j = 0; j < block_end; j++) {
-        vv_loc[j] = uu[e * elem_size * num_comp + (k * elem_size + n - 1) * block_size + j - v_offset] *
+        vv_loc[j] = uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n - 1) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n - 1) * block_size + e * 3 * elem_size]) +
-                    uu[e * elem_size * num_comp + (k * elem_size + n) * block_size + j - v_offset] *
+                    uu[e * elem_size * (CeedSize)num_comp + (k * (CeedSize)elem_size + n) * block_size + j - v_offset] *
                         abs(impl->curl_orients[j + (3 * n + 1) * block_size + e * 3 * elem_size]);
       }
       for (CeedInt j = 0; j < block_end; j++) {
@@ -370,7 +372,8 @@ static inline int CeedElemRestrictionApplyCurlOrientedUnsignedTranspose_Ref_Core
 static inline int CeedElemRestrictionApplyAtPointsInElement_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, CeedInt start, CeedInt stop,
                                                                      CeedTransposeMode t_mode, const CeedScalar *__restrict__ uu,
                                                                      CeedScalar *__restrict__ vv) {
-  CeedInt                  num_points, l_vec_offset, e_vec_offset = 0;
+  CeedInt                  num_points, l_vec_offset;
+  CeedSize                 e_vec_offset = 0;
   CeedElemRestriction_Ref *impl;
 
   CeedCallBackend(CeedElemRestrictionGetData(rstr, &impl));
@@ -379,14 +382,14 @@ static inline int CeedElemRestrictionApplyAtPointsInElement_Ref_Core(CeedElemRes
     CeedCallBackend(CeedElemRestrictionGetNumPointsInElement(rstr, e, &num_points));
     if (t_mode == CEED_NOTRANSPOSE) {
       for (CeedInt i = 0; i < num_points; i++) {
-        for (CeedInt j = 0; j < num_comp; j++) vv[j * num_points + i + e_vec_offset] = uu[impl->offsets[i + l_vec_offset] * num_comp + j];
+        for (CeedInt j = 0; j < num_comp; j++) vv[j * (CeedSize)num_points + i + e_vec_offset] = uu[impl->offsets[i + l_vec_offset] * num_comp + j];
       }
     } else {
       for (CeedInt i = 0; i < num_points; i++) {
-        for (CeedInt j = 0; j < num_comp; j++) vv[impl->offsets[i + l_vec_offset] * num_comp + j] = uu[j * num_points + i + e_vec_offset];
+        for (CeedInt j = 0; j < num_comp; j++) vv[impl->offsets[i + l_vec_offset] * num_comp + j] = uu[j * (CeedSize)num_points + i + e_vec_offset];
       }
     }
-    e_vec_offset += num_points * num_comp;
+    e_vec_offset += num_points * (CeedSize)num_comp;
   }
   return CEED_ERROR_SUCCESS;
 }
@@ -394,14 +397,15 @@ static inline int CeedElemRestrictionApplyAtPointsInElement_Ref_Core(CeedElemRes
 static inline int CeedElemRestrictionApply_Ref_Core(CeedElemRestriction rstr, const CeedInt num_comp, const CeedInt block_size,
                                                     const CeedInt comp_stride, CeedInt start, CeedInt stop, CeedTransposeMode t_mode, bool use_signs,
                                                     bool use_orients, CeedVector u, CeedVector v, CeedRequest *request) {
-  CeedInt             num_elem, elem_size, v_offset;
+  CeedInt             num_elem, elem_size;
+  CeedSize            v_offset = 0;
   CeedRestrictionType rstr_type;
   const CeedScalar   *uu;
   CeedScalar         *vv;
 
   CeedCallBackend(CeedElemRestrictionGetNumElements(rstr, &num_elem));
   CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
-  v_offset = start * block_size * elem_size * num_comp;
+  v_offset = start * block_size * elem_size * (CeedSize)num_comp;
   CeedCallBackend(CeedElemRestrictionGetType(rstr, &rstr_type));
   CeedCallBackend(CeedVectorGetArrayRead(u, CEED_MEM_HOST, &uu));
 

--- a/backends/ref/ceed-ref-restriction.c
+++ b/backends/ref/ceed-ref-restriction.c
@@ -768,8 +768,7 @@ int CeedElemRestrictionCreate_Ref(CeedMemType mem_type, CeedCopyMode copy_mode, 
       }
       CeedCallBackend(CeedGetResource(parent, &resource));
     }
-    if (!strcmp(resource, "/cpu/self/ref/serial") || !strcmp(resource, "/cpu/self/ref/blocked") || !strcmp(resource, "/cpu/self/memcheck/serial") ||
-        !strcmp(resource, "/cpu/self/memcheck/blocked")) {
+    if (!strcmp(resource, "/cpu/self/ref/serial") || !strcmp(resource, "/cpu/self/ref/blocked")) {
       CeedSize l_size;
 
       CeedCallBackend(CeedElemRestrictionGetLVectorSize(rstr, &l_size));

--- a/interface/ceed-elemrestriction.c
+++ b/interface/ceed-elemrestriction.c
@@ -744,7 +744,8 @@ int CeedElemRestrictionCreateStrided(Ceed ceed, CeedInt num_elem, CeedInt elem_s
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
   CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
-  CeedCheck(l_size >= num_elem * elem_size * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector size must be at least num_elem * elem_size * num_comp");
+  CeedCheck(l_size >= (CeedSize)num_elem * elem_size * num_comp, ceed, CEED_ERROR_DIMENSION,
+            "L-vector size must be at least num_elem * elem_size * num_comp");
 
   CeedCall(CeedCalloc(1, rstr));
   CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
@@ -809,7 +810,7 @@ int CeedElemRestrictionCreateAtPoints(Ceed ceed, CeedInt num_elem, CeedInt num_p
   CeedCheck(num_elem >= 0, ceed, CEED_ERROR_DIMENSION, "Number of elements must be non-negative");
   CeedCheck(num_points >= 0, ceed, CEED_ERROR_DIMENSION, "Number of points must be non-negative");
   CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
-  CeedCheck(l_size >= num_points * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector must be at least num_points * num_comp");
+  CeedCheck(l_size >= (CeedSize)num_points * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector must be at least num_points * num_comp");
 
   CeedCall(CeedCalloc(1, rstr));
   CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));
@@ -1072,7 +1073,8 @@ int CeedElemRestrictionCreateBlockedStrided(Ceed ceed, CeedInt num_elem, CeedInt
   CeedCheck(elem_size > 0, ceed, CEED_ERROR_DIMENSION, "Element size must be at least 1");
   CeedCheck(block_size > 0, ceed, CEED_ERROR_DIMENSION, "Block size must be at least 1");
   CeedCheck(num_comp > 0, ceed, CEED_ERROR_DIMENSION, "CeedElemRestriction must have at least 1 component");
-  CeedCheck(l_size >= num_elem * elem_size * num_comp, ceed, CEED_ERROR_DIMENSION, "L-vector size must be at least num_elem * elem_size * num_comp");
+  CeedCheck(l_size >= (CeedSize)num_elem * elem_size * num_comp, ceed, CEED_ERROR_DIMENSION,
+            "L-vector size must be at least num_elem * elem_size * num_comp");
 
   CeedCall(CeedCalloc(1, rstr));
   CeedCall(CeedReferenceCopy(ceed, &(*rstr)->ceed));

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -407,9 +407,9 @@ static inline int CeedCompositeOperatorLinearAssembleAddDiagonal(CeedOperator op
 static int CeedSingleOperatorAssembleSymbolic(CeedOperator op, CeedInt offset, CeedInt *rows, CeedInt *cols) {
   Ceed                ceed;
   bool                is_composite;
-  CeedSize            num_nodes_in, num_nodes_out, count = 0;
+  CeedSize            num_nodes_in, num_nodes_out, local_num_entries, count = 0;
   CeedInt             num_elem_in, elem_size_in, num_comp_in, layout_er_in[3];
-  CeedInt             num_elem_out, elem_size_out, num_comp_out, layout_er_out[3], local_num_entries;
+  CeedInt             num_elem_out, elem_size_out, num_comp_out, layout_er_out[3];
   CeedScalar         *array;
   const CeedScalar   *elem_dof_a_in, *elem_dof_a_out;
   CeedVector          index_vec_in, index_vec_out, elem_dof_in, elem_dof_out;
@@ -556,7 +556,8 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset, CeedVecto
 
   // Get assembly data
   CeedInt                  num_elem_in, elem_size_in, num_comp_in, num_qpts_in;
-  CeedInt                  num_elem_out, elem_size_out, num_comp_out, num_qpts_out, local_num_entries;
+  CeedInt                  num_elem_out, elem_size_out, num_comp_out, num_qpts_out;
+  CeedSize                 local_num_entries, count = 0;
   const CeedEvalMode     **eval_modes_in, **eval_modes_out;
   CeedInt                  num_active_bases_in, *num_eval_modes_in, num_active_bases_out, *num_eval_modes_out;
   CeedBasis               *active_bases_in, *active_bases_out, basis_in, basis_out;
@@ -626,7 +627,6 @@ static int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset, CeedVecto
   // Loop over elements and put in data structure
   // We store B_mat_in, B_mat_out, BTD, elem_mat in row-major order
   CeedTensorContract contract;
-  CeedSize           count = 0;
   CeedScalar        *vals, *BTD_mat = NULL, *elem_mat = NULL, *elem_mat_b = NULL;
 
   CeedCall(CeedBasisGetTensorContract(basis_in, &contract));


### PR DESCRIPTION
I promoted the `CeedInt` to `CeedSize` in the ref and memcheck backends while indexing into the e-vecs.

@sebastiangrimberg I'm not sure if this is sufficient for your use case?

The first two commits do pure promotion, while the 3rd commit swaps the loop iterator variable to `CeedSize`. Which do we prefer? I think the 3rd commit is easier to read