### PR TITLE
chore: Add tests/test_dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ config.mk
 # Debugging
 vgcore*
 *.json
+tests/test_dir
 
 # Python
 dist


### PR DESCRIPTION
This directory is created by the fluids smartsim regression test. If the test is successful, then the directory is deleted. If it is not, this is left over, for debugging purposes.