### PR TITLE
Fixed SSDB issue with SmartSim Regression Test

### DIFF
--- a/examples/fluids/smartsim_regression_framework.py
+++ b/examples/fluids/smartsim_regression_framework.py
@@ -93,7 +93,7 @@ class SmartSimTest(object):
             # Start the client model
             self.exp.start(client_exp, summary=False, block=True)
 
-            client = Client(cluster=False)
+            client = Client(cluster=False, address=self.database.get_address()[0])
 
             assert client.poll_tensor("sizeInfo", 250, 5)
             assert np.all(client.get_tensor("sizeInfo") == np.array([35, 12, 6, 1, 1, 0]))


### PR DESCRIPTION
Initializing the Python client in `examples/fluids/smartsim_regression_framework.py` would sometimes fail when the SSDB environment variable with the database address was not correctly exported. This PR fixes the issue by pasisng the database address when initializing the client.