### PR TITLE
Enable int64 testing for PETSc examples

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ noether-cpu:
     - make -k -j$((NPROC_CPU / NPROC_POOL)) BACKENDS="$BACKENDS_CPU" JUNIT_BATCH="cpu" junit realsearch=%
 # Libraries for examples
 # -- PETSc with HIP (minimal)
-    - export PETSC_DIR=/projects/petsc PETSC_ARCH=mpich-hip && git -C $PETSC_DIR -c safe.directory=$PETSC_DIR describe
+    - export PETSC_DIR=/projects/petsc PETSC_ARCH=mpich-hip-int64 && git -C $PETSC_DIR -c safe.directory=$PETSC_DIR describe
     - source /home/jawr8143/SmartSimTestingSoftware/bin/activate && export SMARTREDIS_DIR=/home/jawr8143/SmartSimTestingSoftware/smartredis/install
     - echo "-------------- PETSc ---------------" && make -C $PETSC_DIR info
     - make -k -j$((NPROC_CPU / NPROC_POOL)) BACKENDS="$BACKENDS_CPU" JUNIT_BATCH="cpu" junit search="petsc fluids solids"

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ ifneq ($(wildcard ../petsc/lib/libpetsc.*),)
   PETSC_DIR ?= ../petsc
 endif
 
+# SmartSim testing
+SMARTREDIS_DIR ?=
+
 # Warning: SANTIZ options still don't run with /gpu/occa
 AFLAGS ?= -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
@@ -649,7 +652,7 @@ NPROC_POOL ?= 1
 export NPROC_POOL
 
 run-% : $(OBJDIR)/%
-	@$(PYTHON) tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) $(<:$(OBJDIR)/%=%)
+	@$(PYTHON) tests/junit.py --mode tap --ceed-backends $(BACKENDS) $(if $(SMARTREDIS_DIR),--smartredis_dir $(SMARTREDIS_DIR) )--nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) $(<:$(OBJDIR)/%=%)
 
 external_examples := \
 	$(if $(MFEM_DIR),$(mfemexamples)) \
@@ -683,7 +686,7 @@ ctc-% : $(ctests);@$(foreach tst,$(ctests),$(tst) /cpu/$*;)
 
 prove : $(matched)
 	$(info Testing backends: $(BACKENDS))
-	$(PROVE) $(PROVE_OPTS) --exec 'tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL)' $(matched:$(OBJDIR)/%=%)
+	$(PROVE) $(PROVE_OPTS) --exec 'tests/junit.py --mode tap --ceed-backends $(BACKENDS) $(if $(SMARTREDIS_DIR),--smartredis_dir $(SMARTREDIS_DIR) )--nproc $(NPROC_TEST) --pool-size $(NPROC_POOL)' $(matched:$(OBJDIR)/%=%)
 # Run prove target in parallel
 prv : ;@$(MAKE) $(MFLAGS) V=$(V) prove
 
@@ -691,7 +694,7 @@ prove-all :
 	+$(MAKE) prove realsearch=%
 
 junit-% : $(OBJDIR)/%
-	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) --junit-batch $(JUNIT_BATCH) $(<:$(OBJDIR)/%=%)
+	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) $(if $(SMARTREDIS_DIR),--smartredis_dir $(SMARTREDIS_DIR) )--nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) --junit-batch $(JUNIT_BATCH) $(<:$(OBJDIR)/%=%)
 
 junit : $(matched:$(OBJDIR)/%=junit-%)
 

--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -156,9 +156,9 @@ int main(int argc, char **argv) {
                           "    libCEED Backend                         : %s\n"
                           "    libCEED Backend MemType                 : %s\n"
                           "  Mesh:\n"
-                          "    Solution Order (P)                      : %" CeedInt_FMT "\n"
-                          "    Quadrature Order (Q)                    : %" CeedInt_FMT "\n"
-                          "    Additional quadrature points (q_extra)  : %" CeedInt_FMT "\n"
+                          "    Solution Order (P)                      : %" PetscInt_FMT "\n"
+                          "    Quadrature Order (Q)                    : %" PetscInt_FMT "\n"
+                          "    Additional quadrature points (q_extra)  : %" PetscInt_FMT "\n"
                           "    Global nodes                            : %" PetscInt_FMT "\n"
                           "    DoF per node                            : %" PetscInt_FMT "\n"
                           "    Global DoFs                             : %" PetscInt_FMT "\n",

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -134,9 +134,9 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm, const char *ceed_resource) 
                           "    libCEED Backend                         : %s\n"
                           "    libCEED Backend MemType                 : %s\n"
                           "  Mesh:\n"
-                          "    Solution Order (P)                      : %" CeedInt_FMT "\n"
-                          "    Quadrature  Order (Q)                   : %" CeedInt_FMT "\n"
-                          "    Additional quadrature points (q_extra)  : %" CeedInt_FMT "\n"
+                          "    Solution Order (P)                      : %" PetscInt_FMT "\n"
+                          "    Quadrature  Order (Q)                   : %" PetscInt_FMT "\n"
+                          "    Additional quadrature points (q_extra)  : %" PetscInt_FMT "\n"
                           "    Global nodes                            : %" PetscInt_FMT "\n"
                           "    Local Elements                          : %" PetscInt_FMT "\n"
                           "    Element topology                        : %s\n"
@@ -334,13 +334,13 @@ static PetscErrorCode Run(RunParams rp, PetscInt num_resources, char *const *cee
 }
 
 int main(int argc, char **argv) {
-  PetscInt  comm_size;
-  RunParams rp;
-  MPI_Comm  comm;
-  char      filename[PETSC_MAX_PATH_LEN];
-  char     *ceed_resources[30];
-  PetscInt  num_ceed_resources = 30;
-  char      hostname[PETSC_MAX_PATH_LEN];
+  PetscMPIInt comm_size;
+  RunParams   rp;
+  MPI_Comm    comm;
+  char        filename[PETSC_MAX_PATH_LEN];
+  char       *ceed_resources[30];
+  PetscInt    num_ceed_resources = 30;
+  char        hostname[PETSC_MAX_PATH_LEN];
 
   PetscInt    dim = 3, mesh_elem[3] = {3, 3, 3};
   PetscInt    num_degrees = 30, degree[30] = {0}, num_local_nodes = 2, local_nodes[2] = {0};
@@ -356,6 +356,7 @@ int main(int argc, char **argv) {
 #if defined(PETSC_HAVE_MPI_PROCESS_SHARED_MEMORY)
   {
     MPI_Comm splitcomm;
+
     PetscCall(MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &splitcomm));
     PetscCall(MPI_Comm_size(splitcomm, &ranks_per_node));
     PetscCall(MPI_Comm_free(&splitcomm));

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -74,9 +74,9 @@ static PetscInt GlobalStart(const PetscInt p[3], const PetscInt i_rank[3], Petsc
   }
   return -1;
 }
-static PetscErrorCode CreateRestriction(Ceed ceed, const CeedInt mesh_elem[3], CeedInt P, CeedInt num_comp, CeedElemRestriction *elem_restr) {
+static PetscErrorCode CreateRestriction(Ceed ceed, const PetscInt mesh_elem[3], CeedInt P, CeedInt num_comp, CeedElemRestriction *elem_restr) {
   const PetscInt num_elem = mesh_elem[0] * mesh_elem[1] * mesh_elem[2];
-  PetscInt       m_nodes[3], *idx, *idx_p;
+  CeedInt        m_nodes[3], *idx, *idx_p;
 
   PetscFunctionBeginUser;
   // Get indicies
@@ -442,7 +442,8 @@ int main(int argc, char **argv) {
   CeedInit(ceed_resource, &ceed);
 
   // Print summary
-  CeedInt gsize;
+  PetscInt gsize;
+
   PetscCall(VecGetSize(X, &gsize));
   if (!test_mode) {
     const char *used_resource;
@@ -554,12 +555,14 @@ int main(int argc, char **argv) {
   PetscCall(CreateRestriction(ceed, mesh_elem, P, num_comp_u, &elem_restr_u));
   PetscCall(CreateRestriction(ceed, mesh_elem, 2, dim, &elem_restr_x));
   CeedInt num_elem = mesh_elem[0] * mesh_elem[1] * mesh_elem[2];
+
   CeedElemRestrictionCreateStrided(ceed, num_elem, Q * Q * Q, num_comp_u, num_comp_u * num_elem * Q * Q * Q, CEED_STRIDES_BACKEND, &elem_restr_u_i);
   CeedElemRestrictionCreateStrided(ceed, num_elem, Q * Q * Q, bp_options[bp_choice].q_data_size,
                                    bp_options[bp_choice].q_data_size * num_elem * Q * Q * Q, CEED_STRIDES_BACKEND, &elem_restr_qd_i);
   {
     CeedScalar *x_loc;
     CeedInt     shape[3] = {mesh_elem[0] + 1, mesh_elem[1] + 1, mesh_elem[2] + 1}, len = shape[0] * shape[1] * shape[2];
+
     x_loc = malloc(len * num_comp_x * sizeof x_loc[0]);
     for (CeedInt i = 0; i < shape[0]; i++) {
       for (CeedInt j = 0; j < shape[1]; j++) {

--- a/examples/petsc/bpssphere.c
+++ b/examples/petsc/bpssphere.c
@@ -159,9 +159,9 @@ int main(int argc, char **argv) {
                           "    libCEED Backend                         : %s\n"
                           "    libCEED Backend MemType                 : %s\n"
                           "  Mesh:\n"
-                          "    Solution Order (P)                      : %" CeedInt_FMT "\n"
-                          "    Quadrature  Order (Q)                   : %" CeedInt_FMT "\n"
-                          "    Additional quadrature points (q_extra)  : %" CeedInt_FMT "\n"
+                          "    Solution Order (P)                      : %" PetscInt_FMT "\n"
+                          "    Quadrature  Order (Q)                   : %" PetscInt_FMT "\n"
+                          "    Additional quadrature points (q_extra)  : %" PetscInt_FMT "\n"
                           "    Global nodes                            : %" PetscInt_FMT "\n",
                           bp_choice + 1, ceed_resource, CeedMemTypes[mem_type_backend], P, Q, q_extra, g_size / num_comp_u));
   }

--- a/examples/petsc/bpsswarm.c
+++ b/examples/petsc/bpsswarm.c
@@ -52,7 +52,8 @@ int main(int argc, char **argv) {
   char                 ceed_resource[PETSC_MAX_PATH_LEN] = "/cpu/self", filename[PETSC_MAX_PATH_LEN];
   double               my_rt_start, my_rt, rt_min, rt_max;
   PetscScalar          tolerance;
-  PetscInt             comm_size, degree, q_extra, l_size, g_size, dim = 3, num_comp_u = 1, xl_size, num_points = 1728, num_points_per_cell = 64;
+  PetscMPIInt          comm_size;
+  PetscInt             degree, q_extra, l_size, g_size, dim = 3, num_comp_u = 1, xl_size, num_points = 1728, num_points_per_cell = 64;
   PetscBool            test_mode, benchmark_mode, read_mesh, write_solution, write_true_solution_swarm;
   PetscLogStage        solve_stage;
   Vec                  X, X_loc, rhs;
@@ -266,9 +267,9 @@ int main(int argc, char **argv) {
                           "    libCEED Backend                         : %s\n"
                           "    libCEED Backend MemType                 : %s\n"
                           "  Mesh:\n"
-                          "    Solution Order (P)                      : %" CeedInt_FMT "\n"
-                          "    Quadrature  Order (Q)                   : %" CeedInt_FMT "\n"
-                          "    Additional quadrature points (q_extra)  : %" CeedInt_FMT "\n"
+                          "    Solution Order (P)                      : %" PetscInt_FMT "\n"
+                          "    Quadrature  Order (Q)                   : %" PetscInt_FMT "\n"
+                          "    Additional quadrature points (q_extra)  : %" PetscInt_FMT "\n"
                           "    Global nodes                            : %" PetscInt_FMT "\n"
                           "    Local Elements                          : %" PetscInt_FMT "\n"
                           "    Owned nodes                             : %" PetscInt_FMT "\n"

--- a/examples/petsc/include/petscutils.h
+++ b/examples/petsc/include/petscutils.h
@@ -32,3 +32,61 @@ PetscErrorCode   BasisCreateFromTabulation(Ceed ceed, DM dm, DMLabel domain_labe
 PetscErrorCode   CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedInt label_value, CeedInt height, CeedInt dm_field, BPData bp_data,
                                      CeedBasis *basis);
 PetscErrorCode   CreateDistributedDM(RunParams rp, DM *dm);
+
+/**
+  @brief Translate array of `PetscInt` to `CeedInt`.
+    If the types differ, `array_petsc` is freed with `PetscFree()` and `array_ceed` is allocated with `PetscMalloc1()`.
+    Caller is responsible for freeing `array_ceed` with `PetscFree()`.
+
+  Not collective across MPI processes.
+
+  @param[in]      num_entries  Number of array entries
+  @param[in,out]  array_petsc  Array of `PetscInt`
+  @param[out]     array_ceed   Array of `CeedInt`
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static inline PetscErrorCode IntArrayCeedToPetsc(PetscInt num_entries, CeedInt **array_ceed, PetscInt **array_petsc) {
+  const CeedInt  int_c = 0;
+  const PetscInt int_p = 0;
+
+  PetscFunctionBeginUser;
+  if (sizeof(int_c) == sizeof(int_p)) {
+    *array_petsc = (PetscInt *)*array_ceed;
+  } else {
+    *array_petsc = malloc(num_entries * sizeof(PetscInt));
+    for (PetscInt i = 0; i < num_entries; i++) (*array_petsc)[i] = (*array_ceed)[i];
+    free(*array_ceed);
+  }
+  *array_ceed = NULL;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Translate array of `PetscInt` to `CeedInt`.
+    If the types differ, `array_petsc` is freed with `PetscFree()` and `array_ceed` is allocated with `PetscMalloc1()`.
+    Caller is responsible for freeing `array_ceed` with `PetscFree()`.
+
+  Not collective across MPI processes.
+
+  @param[in]      num_entries  Number of array entries
+  @param[in,out]  array_petsc  Array of `PetscInt`
+  @param[out]     array_ceed   Array of `CeedInt`
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static inline PetscErrorCode IntArrayPetscToCeed(PetscInt num_entries, PetscInt **array_petsc, CeedInt **array_ceed) {
+  const CeedInt  int_c = 0;
+  const PetscInt int_p = 0;
+
+  PetscFunctionBeginUser;
+  if (sizeof(int_c) == sizeof(int_p)) {
+    *array_ceed = (CeedInt *)*array_petsc;
+  } else {
+    PetscCall(PetscMalloc1(num_entries, array_ceed));
+    for (PetscInt i = 0; i < num_entries; i++) (*array_ceed)[i] = (*array_petsc)[i];
+    PetscCall(PetscFree(*array_petsc));
+  }
+  *array_petsc = NULL;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/examples/petsc/src/libceedsetup.c
+++ b/examples/petsc/src/libceedsetup.c
@@ -50,7 +50,8 @@ PetscErrorCode SetupLibceedByDegree(DM dm, Ceed ceed, CeedInt degree, CeedInt to
   CeedQFunction       qf_setup_geo, qf_apply;
   CeedOperator        op_setup_geo, op_apply;
   CeedVector          x_coord, q_data, x_ceed, y_ceed;
-  CeedInt             num_qpts, c_start, c_end, num_elem, q_data_size = bp_data.q_data_size;
+  PetscInt            c_start, c_end, num_elem;
+  CeedInt             num_qpts, q_data_size = bp_data.q_data_size;
   CeedScalar          R = 1;                         // radius of the sphere
   CeedScalar          l = 1.0 / PetscSqrtReal(3.0);  // half edge of the inscribed cube
 
@@ -222,7 +223,8 @@ PetscErrorCode SetupErrorOperator(DM dm, Ceed ceed, BPData bp_data, CeedInt topo
   CeedQFunction       qf_setup_geo, qf_setup_rhs, qf_error;
   CeedOperator        op_setup_geo, op_setup_rhs;
   CeedVector          x_coord, q_data, target, rhs;
-  CeedInt             num_qpts, c_start, c_end, num_elem, q_data_size = bp_data.q_data_size;
+  PetscInt            c_start, c_end, num_elem;
+  CeedInt             num_qpts, q_data_size = bp_data.q_data_size;
   CeedScalar          R = 1;                         // radius of the sphere
   CeedScalar          l = 1.0 / PetscSqrtReal(3.0);  // half edge of the inscribed cube
 

--- a/examples/petsc/src/petscutils.c
+++ b/examples/petsc/src/petscutils.c
@@ -188,13 +188,15 @@ PetscErrorCode SetupDMByDegree(DM dm, PetscInt p_degree, PetscInt q_extra, Petsc
 // Get CEED restriction data from DMPlex
 // -----------------------------------------------------------------------------
 PetscErrorCode CreateRestrictionFromPlex(Ceed ceed, DM dm, CeedInt height, DMLabel domain_label, CeedInt value, CeedElemRestriction *elem_restr) {
-  PetscInt num_elem, elem_size, num_dof, num_comp, *elem_restr_offsets;
+  PetscInt num_elem, elem_size, num_dof, num_comp, *elem_restr_offsets_petsc;
+  CeedInt *elem_restr_offsets_ceed;
 
   PetscFunctionBeginUser;
-  PetscCall(DMPlexGetLocalOffsets(dm, domain_label, value, height, 0, &num_elem, &elem_size, &num_comp, &num_dof, &elem_restr_offsets));
+  PetscCall(DMPlexGetLocalOffsets(dm, domain_label, value, height, 0, &num_elem, &elem_size, &num_comp, &num_dof, &elem_restr_offsets_petsc));
 
-  CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp, 1, num_dof, CEED_MEM_HOST, CEED_COPY_VALUES, elem_restr_offsets, elem_restr);
-  PetscCall(PetscFree(elem_restr_offsets));
+  PetscCall(IntArrayPetscToCeed(num_elem * elem_size, &elem_restr_offsets_petsc, &elem_restr_offsets_ceed));
+  CeedElemRestrictionCreate(ceed, num_elem, elem_size, num_comp, 1, num_dof, CEED_MEM_HOST, CEED_COPY_VALUES, elem_restr_offsets_ceed, elem_restr);
+  PetscCall(PetscFree(elem_restr_offsets_ceed));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/petsc/src/swarmutils.c
+++ b/examples/petsc/src/swarmutils.c
@@ -91,7 +91,7 @@ PetscErrorCode DMSwarmCeedContextCreate(DM dm_swarm, const char *ceed_resource, 
 
       {
         Vec                X_loc;
-        CeedInt            len;
+        PetscInt           len;
         const PetscScalar *x;
 
         PetscCall(DMGetCoordinatesLocal(dm_mesh, &X_loc));
@@ -588,7 +588,8 @@ PetscErrorCode SetupProblemSwarm(DM dm_swarm, Ceed ceed, BPData bp_data, CeedDat
   CeedElemRestriction elem_restr_u_mesh, elem_restr_x_mesh, elem_restr_x_points, elem_restr_u_points, elem_restr_q_data_points;
   CeedBasis           basis_u, basis_x;
   CeedVector          x_coord, x_ref_points, q_data_points;
-  CeedInt             num_comp, q_data_size = bp_data.q_data_size, dim, X_loc_len;
+  PetscInt            X_loc_len, dim;
+  CeedInt             num_comp, q_data_size = bp_data.q_data_size;
   CeedScalar          R = 1;                         // radius of the sphere
   CeedScalar          l = 1.0 / PetscSqrtReal(3.0);  // half edge of the inscribed cube
   Vec                 X_loc;

--- a/examples/solids/include/utils.h
+++ b/examples/solids/include/utils.h
@@ -11,3 +11,61 @@
 
 // Translate PetscMemType to CeedMemType
 static inline CeedMemType MemTypeP2C(PetscMemType mem_type) { return PetscMemTypeDevice(mem_type) ? CEED_MEM_DEVICE : CEED_MEM_HOST; }
+
+/**
+  @brief Translate array of `PetscInt` to `CeedInt`.
+    If the types differ, `array_petsc` is freed with `PetscFree()` and `array_ceed` is allocated with `PetscMalloc1()`.
+    Caller is responsible for freeing `array_ceed` with `PetscFree()`.
+
+  Not collective across MPI processes.
+
+  @param[in]      num_entries  Number of array entries
+  @param[in,out]  array_petsc  Array of `PetscInt`
+  @param[out]     array_ceed   Array of `CeedInt`
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static inline PetscErrorCode IntArrayCeedToPetsc(PetscInt num_entries, CeedInt **array_ceed, PetscInt **array_petsc) {
+  const CeedInt  int_c = 0;
+  const PetscInt int_p = 0;
+
+  PetscFunctionBeginUser;
+  if (sizeof(int_c) == sizeof(int_p)) {
+    *array_petsc = (PetscInt *)*array_ceed;
+  } else {
+    *array_petsc = malloc(num_entries * sizeof(PetscInt));
+    for (PetscInt i = 0; i < num_entries; i++) (*array_petsc)[i] = (*array_ceed)[i];
+    free(*array_ceed);
+  }
+  *array_ceed = NULL;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Translate array of `PetscInt` to `CeedInt`.
+    If the types differ, `array_petsc` is freed with `PetscFree()` and `array_ceed` is allocated with `PetscMalloc1()`.
+    Caller is responsible for freeing `array_ceed` with `PetscFree()`.
+
+  Not collective across MPI processes.
+
+  @param[in]      num_entries  Number of array entries
+  @param[in,out]  array_petsc  Array of `PetscInt`
+  @param[out]     array_ceed   Array of `CeedInt`
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static inline PetscErrorCode IntArrayPetscToCeed(PetscInt num_entries, PetscInt **array_petsc, CeedInt **array_ceed) {
+  const CeedInt  int_c = 0;
+  const PetscInt int_p = 0;
+
+  PetscFunctionBeginUser;
+  if (sizeof(int_c) == sizeof(int_p)) {
+    *array_ceed = (CeedInt *)*array_petsc;
+  } else {
+    PetscCall(PetscMalloc1(num_entries, array_ceed));
+    for (PetscInt i = 0; i < num_entries; i++) (*array_ceed)[i] = (*array_petsc)[i];
+    PetscCall(PetscFree(*array_petsc));
+  }
+  *array_petsc = NULL;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/examples/solids/src/matops.c
+++ b/examples/solids/src/matops.c
@@ -219,7 +219,7 @@ PetscErrorCode GetDiag_Ceed(Mat A, Vec D) {
 PetscErrorCode ComputeStrainEnergy(DM dmEnergy, UserMult user, CeedOperator op_energy, Vec X, PetscReal *energy) {
   PetscScalar *x;
   PetscMemType x_mem_type;
-  CeedInt      length;
+  PetscInt     length;
 
   PetscFunctionBeginUser;
 
@@ -235,6 +235,7 @@ PetscErrorCode ComputeStrainEnergy(DM dmEnergy, UserMult user, CeedOperator op_e
   // Setup libCEED output vector
   Vec        E_loc;
   CeedVector e_loc;
+
   PetscCall(DMCreateLocalVector(dmEnergy, &E_loc));
   PetscCall(VecGetSize(E_loc, &length));
   PetscCall(VecDestroy(&E_loc));

--- a/tests/junit.py
+++ b/tests/junit.py
@@ -27,6 +27,7 @@ def create_argparser() -> argparse.ArgumentParser:
     parser.add_argument('-o', '--output', type=Optional[Path], default=None, help='Output file to write test')
     parser.add_argument('-b', '--junit-batch', type=str, default='', help='Name of JUnit batch for output file')
     parser.add_argument('-np', '--pool-size', type=int, default=1, help='Number of test cases to run in parallel')
+    parser.add_argument('-s', '--smartredis_dir', type=str, default='', help='path to SmartSim library, if present')
     parser.add_argument('test', help='Test executable', nargs='?')
 
     return parser
@@ -194,25 +195,32 @@ if __name__ == '__main__':
 
     # run tests
     if 'smartsim' in args.test:
-        sys.path.insert(0, str(Path(__file__).parents[1] / "examples" / "fluids"))
-        from smartsim_regression_framework import SmartSimTest
-
-        test_framework = SmartSimTest(Path(__file__).parent / 'test_dir')
-        test_framework.setup()
+        has_smartsim: bool = args.smartredis_dir and Path(args.smartredis_dir).is_file()
         test_cases = []
-        print(f'1..1')
-        is_new_subtest = True
-        subtest_ok = True
-        for i, backend in enumerate(args.ceed_backends):
-            test_cases.append(test_framework.test_junit(backend))
-            if is_new_subtest and args.mode == RunMode.TAP:
-                is_new_subtest = False
-                print(f'# Subtest: {test_cases[0].category}')
-                print(f'    1..{len(args.ceed_backends)}')
-            print(test_case_output_string(test_cases[i], TestSpec("SmartSim Tests"), args.mode, backend, '', i))
-        if args.mode == RunMode.TAP:
-            print(f'{"" if subtest_ok else "not "}ok 1 - {test_cases[0].category}')
-        test_framework.teardown()
+
+        if args.mode is RunMode.TAP:
+            print(f'1..1')
+        if has_smartsim:
+            sys.path.insert(0, str(Path(__file__).parents[1] / "examples" / "fluids"))
+            from smartsim_regression_framework import SmartSimTest
+
+            test_framework = SmartSimTest(Path(__file__).parent / 'test_dir')
+            test_framework.setup()
+
+            is_new_subtest = True
+            subtest_ok = True
+            for i, backend in enumerate(args.ceed_backends):
+                test_cases.append(test_framework.test_junit(backend))
+                if is_new_subtest and args.mode == RunMode.TAP:
+                    is_new_subtest = False
+                    print(f'# Subtest: {test_cases[0].category}')
+                    print(f'    1..{len(args.ceed_backends)}')
+                print(test_case_output_string(test_cases[i], TestSpec("SmartSim Tests"), args.mode, backend, '', i))
+            if args.mode == RunMode.TAP:
+                print(f'{"" if subtest_ok else "not "}ok 1 - {test_cases[0].category}')
+            test_framework.teardown()
+        elif args.mode is RunMode.TAP:
+            print(f'ok 1 - # SKIP SmartSim not installed')
         result: TestSuite = TestSuite('SmartSim Tests', test_cases)
     else:
         result: TestSuite = run_tests(


### PR DESCRIPTION
The examples in `petsc/` and `solids/` needed minor fixes, but this should do a fast `int64` job to make sure everything compiles and runs

Closes #1523 