### PR TITLE
Drop JiT Guards in Most QF Source

### DIFF
--- a/backends/avx/ceed-avx.h
+++ b/backends/avx/ceed-avx.h
@@ -4,13 +4,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_AVX_H
-#define CEED_AVX_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
 
 CEED_INTERN int CeedTensorContractCreate_Avx(CeedTensorContract contract);
-
-#endif  // CEED_AVX_H

--- a/backends/blocked/ceed-blocked.h
+++ b/backends/blocked/ceed-blocked.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_BLOCKED_H
-#define CEED_BLOCKED_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -34,5 +32,3 @@ typedef struct {
 } CeedOperator_Blocked;
 
 CEED_INTERN int CeedOperatorCreate_Blocked(CeedOperator op);
-
-#endif  // CEED_BLOCKED_H

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.h
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.h
@@ -4,10 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_GEN_OPERATOR_BUILD_H
-#define CEED_CUDA_GEN_OPERATOR_BUILD_H
+#pragma once
 
 CEED_INTERN int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op);
-
-#endif  // CEED_CUDA_GEN_OPERATOR_BUILD_H

--- a/backends/cuda-gen/ceed-cuda-gen.h
+++ b/backends/cuda-gen/ceed-cuda-gen.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_GEN_H
-#define CEED_CUDA_GEN_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -35,5 +33,3 @@ typedef struct {
 CEED_INTERN int CeedQFunctionCreate_Cuda_gen(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Cuda_gen(CeedOperator op);
-
-#endif  // CEED_CUDA_GEN_H

--- a/backends/cuda-ref/ceed-cuda-ref-qfunction-load.h
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunction-load.h
@@ -4,10 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_QFUNCTION_LOAD_H
-#define CEED_CUDA_QFUNCTION_LOAD_H
+#pragma once
 
 CEED_INTERN int CeedQFunctionBuildKernel_Cuda_ref(CeedQFunction qf);
-
-#endif  // CEED_CUDA_QFUNCTION_LOAD_H

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_REF_H
-#define CEED_CUDA_REF_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -144,5 +142,3 @@ CEED_INTERN int CeedQFunctionCreate_Cuda(CeedQFunction qf);
 CEED_INTERN int CeedQFunctionContextCreate_Cuda(CeedQFunctionContext ctx);
 
 CEED_INTERN int CeedOperatorCreate_Cuda(CeedOperator op);
-
-#endif  // CEED_CUDA_REF_H

--- a/backends/cuda-shared/ceed-cuda-shared.h
+++ b/backends/cuda-shared/ceed-cuda-shared.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_SHARED_H
-#define CEED_CUDA_SHARED_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -29,5 +27,3 @@ typedef struct {
 
 CEED_INTERN int CeedBasisCreateTensorH1_Cuda_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
                                                     const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);
-
-#endif  // CEED_CUDA_SHARED_H

--- a/backends/cuda/ceed-cuda-common.h
+++ b/backends/cuda/ceed-cuda-common.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_COMMON_H
-#define CEED_CUDA_COMMON_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -87,5 +85,3 @@ CEED_INTERN int CeedSetDeviceCeedIntArray_Cuda(Ceed ceed, const CeedInt *source_
 CEED_INTERN int CeedSetDeviceCeedScalarArray_Cuda(Ceed ceed, const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
                                                   const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
                                                   const CeedScalar **target_array);
-
-#endif  // CEED_CUDA_COMMON_H

--- a/backends/cuda/ceed-cuda-compile.h
+++ b/backends/cuda/ceed-cuda-compile.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_CUDA_COMPILE_H
-#define CEED_CUDA_COMPILE_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -26,5 +24,3 @@ CEED_INTERN int CeedRunKernelDim_Cuda(Ceed ceed, CUfunction kernel, int grid_siz
 
 CEED_INTERN int CeedRunKernelDimShared_Cuda(Ceed ceed, CUfunction kernel, int grid_size, int block_size_x, int block_size_y, int block_size_z,
                                             int shared_mem_size, void **args);
-
-#endif  // CEED_CUDA_COMPILE_H

--- a/backends/hip-gen/ceed-hip-gen-operator-build.h
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.h
@@ -4,11 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_HIP_GEN_OPERATOR_BUILD_H
-#define CEED_HIP_GEN_OPERATOR_BUILD_H
+#pragma once
 
 CEED_INTERN int BlockGridCalculate_Hip_gen(CeedInt dim, CeedInt num_elem, CeedInt P_1d, CeedInt Q_1d, CeedInt *block_sizes);
 CEED_INTERN int CeedOperatorBuildKernel_Hip_gen(CeedOperator op);
-
-#endif  // CEED_HIP_GEN_OPERATOR_BUILD_H

--- a/backends/hip-gen/ceed-hip-gen.h
+++ b/backends/hip-gen/ceed-hip-gen.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_HIP_GEN_H
-#define CEED_HIP_GEN_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -35,5 +33,3 @@ typedef struct {
 CEED_INTERN int CeedQFunctionCreate_Hip_gen(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Hip_gen(CeedOperator op);
-
-#endif  // CEED_HIP_GEN_H

--- a/backends/hip-ref/ceed-hip-ref-qfunction-load.h
+++ b/backends/hip-ref/ceed-hip-ref-qfunction-load.h
@@ -4,10 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_HIP_QFUNCTION_LOAD_H
-#define CEED_HIP_QFUNCTION_LOAD_H
+#pragma once
 
 CEED_INTERN int CeedQFunctionBuildKernel_Hip_ref(CeedQFunction qf);
-
-#endif  // CEED_HIP_QFUNCTION_LOAD_H

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -41,8 +41,8 @@ static inline int CeedElemRestrictionSetupCompile_Hip(CeedElemRestriction rstr) 
   // Compile HIP kernels
   switch (rstr_type) {
     case CEED_RESTRICTION_STRIDED: {
-      CeedInt strides[3] = {1, num_elem * elem_size, elem_size};
       bool    has_backend_strides;
+      CeedInt strides[3] = {1, num_elem * elem_size, elem_size};
 
       CeedCallBackend(CeedElemRestrictionHasBackendStrides(rstr, &has_backend_strides));
       if (!has_backend_strides) {
@@ -72,12 +72,14 @@ static inline int CeedElemRestrictionSetupCompile_Hip(CeedElemRestriction rstr) 
     } break;
     case CEED_RESTRICTION_ORIENTED: {
       const char *offset_kernel_path;
+      char      **file_paths     = NULL;
+      CeedInt     num_file_paths = 0;
 
       CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-restriction-oriented.h", &restriction_kernel_path));
       CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
-      CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
+      CeedCallBackend(CeedLoadSourceAndInitializeBuffer(ceed, restriction_kernel_path, &num_file_paths, &file_paths, &restriction_kernel_source));
       CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-restriction-offset.h", &offset_kernel_path));
-      CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, offset_kernel_path, &restriction_kernel_source));
+      CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, offset_kernel_path, &num_file_paths, &file_paths, &restriction_kernel_source));
       CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
       CeedCallBackend(CeedCompile_Hip(ceed, restriction_kernel_source, &impl->module, 6, "RSTR_ELEM_SIZE", elem_size, "RSTR_NUM_ELEM", num_elem,
                                       "RSTR_NUM_COMP", num_comp, "RSTR_NUM_NODES", impl->num_nodes, "RSTR_COMP_STRIDE", comp_stride,
@@ -86,16 +88,21 @@ static inline int CeedElemRestrictionSetupCompile_Hip(CeedElemRestriction rstr) 
       CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetNoTranspose", &impl->ApplyUnsignedNoTranspose));
       CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OrientedTranspose", &impl->ApplyTranspose));
       CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTranspose", &impl->ApplyUnsignedTranspose));
+      // Cleanup
       CeedCallBackend(CeedFree(&offset_kernel_path));
+      for (CeedInt i = 0; i < num_file_paths; i++) CeedCall(CeedFree(&file_paths[i]));
+      CeedCall(CeedFree(&file_paths));
     } break;
     case CEED_RESTRICTION_CURL_ORIENTED: {
       const char *offset_kernel_path;
+      char      **file_paths     = NULL;
+      CeedInt     num_file_paths = 0;
 
       CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-restriction-curl-oriented.h", &restriction_kernel_path));
       CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source -----\n");
-      CeedCallBackend(CeedLoadSourceToBuffer(ceed, restriction_kernel_path, &restriction_kernel_source));
+      CeedCallBackend(CeedLoadSourceAndInitializeBuffer(ceed, restriction_kernel_path, &num_file_paths, &file_paths, &restriction_kernel_source));
       CeedCallBackend(CeedGetJitAbsolutePath(ceed, "ceed/jit-source/hip/hip-ref-restriction-offset.h", &offset_kernel_path));
-      CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, offset_kernel_path, &restriction_kernel_source));
+      CeedCallBackend(CeedLoadSourceToInitializedBuffer(ceed, offset_kernel_path, &num_file_paths, &file_paths, &restriction_kernel_source));
       CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS, "----- Loading Restriction Kernel Source Complete! -----\n");
       CeedCallBackend(CeedCompile_Hip(ceed, restriction_kernel_source, &impl->module, 6, "RSTR_ELEM_SIZE", elem_size, "RSTR_NUM_ELEM", num_elem,
                                       "RSTR_NUM_COMP", num_comp, "RSTR_NUM_NODES", impl->num_nodes, "RSTR_COMP_STRIDE", comp_stride,
@@ -106,7 +113,10 @@ static inline int CeedElemRestrictionSetupCompile_Hip(CeedElemRestriction rstr) 
       CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedTranspose", &impl->ApplyTranspose));
       CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "CurlOrientedUnsignedTranspose", &impl->ApplyUnsignedTranspose));
       CeedCallBackend(CeedGetKernel_Hip(ceed, impl->module, "OffsetTranspose", &impl->ApplyUnorientedTranspose));
+      // Cleanup
       CeedCallBackend(CeedFree(&offset_kernel_path));
+      for (CeedInt i = 0; i < num_file_paths; i++) CeedCall(CeedFree(&file_paths[i]));
+      CeedCall(CeedFree(&file_paths));
     } break;
     case CEED_RESTRICTION_POINTS: {
       // LCOV_EXCL_START

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_HIP_REF_H
-#define CEED_HIP_REF_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -148,5 +146,3 @@ CEED_INTERN int CeedQFunctionCreate_Hip(CeedQFunction qf);
 CEED_INTERN int CeedQFunctionContextCreate_Hip(CeedQFunctionContext ctx);
 
 CEED_INTERN int CeedOperatorCreate_Hip(CeedOperator op);
-
-#endif  // CEED_HIP_REF_H

--- a/backends/hip-shared/ceed-hip-shared.h
+++ b/backends/hip-shared/ceed-hip-shared.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_HIP_SHARED_H
-#define CEED_HIP_SHARED_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -28,5 +26,3 @@ typedef struct {
 
 CEED_INTERN int CeedBasisCreateTensorH1_Hip_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
                                                    const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);
-
-#endif  // CEED_HIP_SHARED_H

--- a/backends/hip/ceed-hip-common.h
+++ b/backends/hip/ceed-hip-common.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_COMMON_HIP_H
-#define CEED_COMMON_HIP_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -91,5 +89,3 @@ CEED_INTERN int CeedSetDeviceCeedIntArray_Hip(Ceed ceed, const CeedInt *source_a
 CEED_INTERN int CeedSetDeviceCeedScalarArray_Hip(Ceed ceed, const CeedScalar *source_array, CeedCopyMode copy_mode, CeedSize num_values,
                                                  const CeedScalar **target_array_owned, const CeedScalar **target_array_borrowed,
                                                  const CeedScalar **target_array);
-
-#endif  // CEED_COMMON_HIP_H

--- a/backends/hip/ceed-hip-compile.h
+++ b/backends/hip/ceed-hip-compile.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_HIP_COMPILE_H
-#define CEED_HIP_COMPILE_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -25,5 +23,3 @@ CEED_INTERN int CeedRunKernelDim_Hip(Ceed ceed, hipFunction_t kernel, int grid_s
 
 CEED_INTERN int CeedRunKernelDimShared_Hip(Ceed ceed, hipFunction_t kernel, int grid_size, int block_size_x, int block_size_y, int block_size_z,
                                            int shared_mem_size, void **args);
-
-#endif  // CEED_HIP_COMPILE_H

--- a/backends/magma/ceed-magma-common.h
+++ b/backends/magma/ceed-magma-common.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_MAGMA_COMMON_H
-#define CEED_MAGMA_COMMON_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -20,5 +18,3 @@ typedef struct {
 CEED_INTERN int CeedInit_Magma_common(Ceed ceed, const char *resource);
 
 CEED_INTERN int CeedDestroy_Magma(Ceed ceed);
-
-#endif  // CEED_MAGMA_COMMON_H

--- a/backends/magma/ceed-magma-gemm-nontensor.h
+++ b/backends/magma/ceed-magma-gemm-nontensor.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_MAGMA_GEMM_NONTENSOR_H
-#define CEED_MAGMA_GEMM_NONTENSOR_H
+#pragma once
 
 #include "ceed-magma.h"
 
@@ -14,5 +12,3 @@
 CEED_INTERN int magma_gemm_nontensor(magma_trans_t trans_A, magma_trans_t trans_B, magma_int_t m, magma_int_t n, magma_int_t k, CeedScalar alpha,
                                      const CeedScalar *d_A, magma_int_t ldda, const CeedScalar *d_B, magma_int_t lddb, CeedScalar beta,
                                      CeedScalar *d_C, magma_int_t lddc, magma_queue_t queue);
-
-#endif  // CEED_MAGMA_GEMM_NONTENSOR_H

--- a/backends/magma/ceed-magma-gemm-selector.h
+++ b/backends/magma/ceed-magma-gemm-selector.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_MAGMA_GEMM_SELECTOR_H
-#define CEED_MAGMA_GEMM_SELECTOR_H
+#pragma once
 
 #include "ceed-magma.h"
 
@@ -15,5 +13,3 @@ CEED_INTERN void gemm_selector(int gpu_arch, char precision, char trans_A, int m
 
 ////////////////////////////////////////////////////////////////////////////////
 CEED_INTERN CeedInt nontensor_rtc_get_nb(int gpu_arch, char trans_A, int q_comp, int P, int Q, int N);
-
-#endif  // CEED_MAGMA_GEMM_SELECTOR_H

--- a/backends/magma/ceed-magma.h
+++ b/backends/magma/ceed-magma.h
@@ -6,8 +6,7 @@
 // This file is part of CEED:  http://github.com/ceed
 
 // magma functions specific to ceed
-#ifndef CEED_MAGMA_H
-#define CEED_MAGMA_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -88,5 +87,3 @@ CEED_INTERN magma_int_t magma_isdevptr(const void *);
 
 // If magma and cuda/ref are using the null stream, then ceed_magma_queue_sync should do nothing
 #define ceed_magma_queue_sync(...)
-
-#endif  // CEED_MAGMA_H

--- a/backends/memcheck/ceed-memcheck.h
+++ b/backends/memcheck/ceed-memcheck.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_MEMCHECK_H
-#define CEED_MEMCHECK_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -55,5 +53,3 @@ CEED_INTERN int CeedElemRestrictionCreate_Memcheck(CeedMemType mem_type, CeedCop
 CEED_INTERN int CeedQFunctionCreate_Memcheck(CeedQFunction qf);
 
 CEED_INTERN int CeedQFunctionContextCreate_Memcheck(CeedQFunctionContext ctx);
-
-#endif  // CEED_MEMCHECK_H

--- a/backends/opt/ceed-opt.h
+++ b/backends/opt/ceed-opt.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_OPT_H
-#define CEED_OPT_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -40,5 +38,3 @@ typedef struct {
 CEED_INTERN int CeedTensorContractCreate_Opt(CeedTensorContract contract);
 
 CEED_INTERN int CeedOperatorCreate_Opt(CeedOperator op);
-
-#endif  // CEED_OPT_H

--- a/backends/ref/ceed-ref.h
+++ b/backends/ref/ceed-ref.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_REF_H
-#define CEED_REF_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
@@ -84,5 +82,3 @@ CEED_INTERN int CeedQFunctionContextCreate_Ref(CeedQFunctionContext ctx);
 
 CEED_INTERN int CeedOperatorCreate_Ref(CeedOperator op);
 CEED_INTERN int CeedOperatorCreateAtPoints_Ref(CeedOperator op);
-
-#endif  // CEED_REF_H

--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.hpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.hpp
@@ -4,11 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_GEN_OPERATOR_BUILD_HPP
-#define CEED_SYCL_GEN_OPERATOR_BUILD_HPP
+#pragma once
 
 CEED_INTERN int BlockGridCalculate_Sycl_gen(const CeedInt dim, const CeedInt P_1d, const CeedInt Q_1d, CeedInt *block_sizes);
 CEED_INTERN int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op);
-
-#endif  // CEED_SYCL_GEN_OPERATOR_BUILD_HPP

--- a/backends/sycl-gen/ceed-sycl-gen.hpp
+++ b/backends/sycl-gen/ceed-sycl-gen.hpp
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_GEN_HPP
-#define CEED_SYCL_GEN_HPP
+#pragma once
 
 #include <ceed/backend.h>
 #include <ceed/ceed.h>
@@ -37,5 +35,3 @@ typedef struct {
 CEED_INTERN int CeedQFunctionCreate_Sycl_gen(CeedQFunction qf);
 
 CEED_INTERN int CeedOperatorCreate_Sycl_gen(CeedOperator op);
-
-#endif  // CEED_SYCL_GEN_HPP

--- a/backends/sycl-ref/ceed-sycl-ref-qfunction-load.hpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunction-load.hpp
@@ -4,10 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_QFUNCTION_LOAD_HPP
-#define CEED_SYCL_QFUNCTION_LOAD_HPP
+#pragma once
 
 CEED_INTERN int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf);
-
-#endif  // CEED_SYCL_QFUNCTION_LOAD_HPP

--- a/backends/sycl-ref/ceed-sycl-ref.hpp
+++ b/backends/sycl-ref/ceed-sycl-ref.hpp
@@ -5,9 +5,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_REF_HPP
-#define CEED_SYCL_REF_HPP
+#pragma once
 
 #include <ceed/backend.h>
 #include <ceed/ceed.h>
@@ -131,5 +129,3 @@ CEED_INTERN int CeedQFunctionCreate_Sycl(CeedQFunction qf);
 CEED_INTERN int CeedQFunctionContextCreate_Sycl(CeedQFunctionContext ctx);
 
 CEED_INTERN int CeedOperatorCreate_Sycl(CeedOperator op);
-
-#endif  // CEED_SYCL_REF_HPP

--- a/backends/sycl-shared/ceed-sycl-shared.hpp
+++ b/backends/sycl-shared/ceed-sycl-shared.hpp
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_SHARED_HPP
-#define CEED_SYCL_SHARED_HPP
+#pragma once
 
 #include <ceed/backend.h>
 #include <ceed/ceed.h>
@@ -34,5 +32,3 @@ typedef struct {
 
 CEED_INTERN int CeedBasisCreateTensorH1_Sycl_shared(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const CeedScalar *interp_1d, const CeedScalar *grad_1d,
                                                     const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, CeedBasis basis);
-
-#endif  // CEED_SYCL_SHARED_HPP

--- a/backends/sycl/ceed-sycl-common.hpp
+++ b/backends/sycl/ceed-sycl-common.hpp
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_COMMON_HPP
-#define CEED_SYCL_COMMON_HPP
+#pragma once
 
 #include <ceed/backend.h>
 #include <ceed/jit-source/sycl/sycl-types.h>
@@ -44,5 +42,3 @@ CEED_INTERN int CeedInit_Sycl(Ceed ceed, const char *resource);
 CEED_INTERN int CeedDestroy_Sycl(Ceed ceed);
 
 CEED_INTERN int CeedSetStream_Sycl(Ceed ceed, void *handle);
-
-#endif  // CEED_SYCL_COMMON_HPP

--- a/backends/sycl/ceed-sycl-compile.hpp
+++ b/backends/sycl/ceed-sycl-compile.hpp
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_SYCL_COMPILE_HPP
-#define CEED_SYCL_COMPILE_HPP
+#pragma once
 
 #include <ceed/backend.h>
 #include <ceed/ceed.h>
@@ -22,5 +20,3 @@ CEED_INTERN int CeedGetKernel_Sycl(Ceed ceed, const SyclModule_t *sycl_module, c
 
 CEED_INTERN int CeedRunKernelDimSharedSycl(Ceed ceed, sycl::kernel *kernel, const int grid_size, const int block_size_x, const int block_size_y,
                                            const int block_size_z, const int shared_mem_size, void **args);
-
-#endif  // CEED_SYCL_COMPILE_HPP

--- a/backends/sycl/online_compiler.hpp
+++ b/backends/sycl/online_compiler.hpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
 #pragma once
 
 #include <sycl/sycl.hpp>

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -4,13 +4,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef CEED_XSMM_H
-#define CEED_XSMM_H
+#pragma once
 
 #include <ceed.h>
 #include <ceed/backend.h>
 
 CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedTensorContract contract);
-
-#endif  // CEED_XSMM_H

--- a/examples/ceed/ex1-volume.h
+++ b/examples/ceed/ex1-volume.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef ex1_volume_h
-#define ex1_volume_h
-
 #include <ceed.h>
 
 /// A structure used to pass additional data to f_build_mass
@@ -61,5 +58,3 @@ CEED_QFUNCTION(apply_mass)(void *ctx, const CeedInt Q, const CeedScalar *const *
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { v[i] = q_data[i] * u[i]; }  // End of Quadrature Point Loop
   return 0;
 }
-
-#endif  // ex1_volume_h

--- a/examples/ceed/ex2-surface.h
+++ b/examples/ceed/ex2-surface.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef ex2_surface_h
-#define ex2_surface_h
-
 #include <ceed.h>
 
 /// A structure used to pass additional data to f_build_diff
@@ -125,5 +122,3 @@ CEED_QFUNCTION(apply_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *
   }
   return 0;
 }
-
-#endif  // ex2_surface_h

--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Advection initial condition and operator for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/advection.h
+++ b/examples/fluids/qfunctions/advection.h
@@ -8,9 +8,6 @@
 /// @file
 /// Advection initial condition and operator for Navier-Stokes example using PETSc
 
-#ifndef advection_h
-#define advection_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -465,5 +462,3 @@ CEED_QFUNCTION(Advection2d_InOutFlow)(void *ctx, CeedInt Q, const CeedScalar *co
   Advection_InOutFlowGeneric(ctx, Q, in, out, 2);
   return 0;
 }
-
-#endif  // advection_h

--- a/examples/fluids/qfunctions/advection_types.h
+++ b/examples/fluids/qfunctions/advection_types.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef advection_types_h
-#define advection_types_h
+#pragma once
 
 #include <ceed.h>
 #include "stabilization_types.h"
@@ -57,5 +55,3 @@ struct SetupContextAdv_ {
   AdvectionICType      initial_condition_type;
   BubbleContinuityType bubble_continuity_type;
 };
-
-#endif /* ifndef advection_types_h */

--- a/examples/fluids/qfunctions/bc_freestream.h
+++ b/examples/fluids/qfunctions/bc_freestream.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// QFunctions for the `bc_freestream` and `bc_outflow` boundary conditions
-
 #include "bc_freestream_type.h"
 #include "newtonian_state.h"
 #include "newtonian_types.h"

--- a/examples/fluids/qfunctions/bc_freestream_type.h
+++ b/examples/fluids/qfunctions/bc_freestream_type.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef freestream_bc_type_h
-#define freestream_bc_type_h
+#pragma once
 
 #include "newtonian_state.h"
 #include "newtonian_types.h"
@@ -25,5 +23,3 @@ struct OutflowContext_ {
   CeedScalar                       pressure;
   CeedScalar                       temperature;
 };
-
-#endif

--- a/examples/fluids/qfunctions/bc_slip.h
+++ b/examples/fluids/qfunctions/bc_slip.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// QFunctions for the `bc_slip` boundary conditions
-
 #include "bc_freestream_type.h"
 #include "newtonian_state.h"
 #include "newtonian_types.h"

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -8,9 +8,6 @@
 /// @file
 /// Operator for Navier-Stokes example using PETSc
 
-#ifndef blasius_h
-#define blasius_h
-
 #include <ceed.h>
 
 #include "newtonian_state.h"
@@ -260,5 +257,3 @@ CEED_QFUNCTION(Blasius_Inflow_Jacobian)(void *ctx, CeedInt Q, const CeedScalar *
   }
   return 0;
 }
-
-#endif  // blasius_h

--- a/examples/fluids/qfunctions/blasius.h
+++ b/examples/fluids/qfunctions/blasius.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Operator for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 
 #include "newtonian_state.h"

--- a/examples/fluids/qfunctions/channel.h
+++ b/examples/fluids/qfunctions/channel.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Operator for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/channel.h
+++ b/examples/fluids/qfunctions/channel.h
@@ -8,9 +8,6 @@
 /// @file
 /// Operator for Navier-Stokes example using PETSc
 
-#ifndef channel_h
-#define channel_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -207,6 +204,3 @@ CEED_QFUNCTION(Channel_Outflow)(void *ctx, CeedInt Q, const CeedScalar *const *i
   }  // End Quadrature Point Loop
   return 0;
 }
-
-// *****************************************************************************
-#endif  // channel_h

--- a/examples/fluids/qfunctions/densitycurrent.h
+++ b/examples/fluids/qfunctions/densitycurrent.h
@@ -12,9 +12,6 @@
 //   Semi-Implicit Formulations of the Navier-Stokes Equations: Application to
 //   Nonhydrostatic Atmospheric Modeling, Giraldo, Restelli, and Lauter (2010).
 
-#ifndef densitycurrent_h
-#define densitycurrent_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -163,7 +160,3 @@ CEED_QFUNCTION(ICsDC)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSca
 
   return 0;
 }
-
-// *****************************************************************************
-
-#endif  // densitycurrent_h

--- a/examples/fluids/qfunctions/densitycurrent.h
+++ b/examples/fluids/qfunctions/densitycurrent.h
@@ -11,7 +11,6 @@
 // Model from:
 //   Semi-Implicit Formulations of the Navier-Stokes Equations: Application to
 //   Nonhydrostatic Atmospheric Modeling, Giraldo, Restelli, and Lauter (2010).
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/differential_filter.h
+++ b/examples/fluids/qfunctions/differential_filter.h
@@ -7,7 +7,6 @@
 //
 /// @file
 /// Implementation of differential filtering
-
 #include <ceed.h>
 
 #include "differential_filter_enums.h"

--- a/examples/fluids/qfunctions/eulervortex.h
+++ b/examples/fluids/qfunctions/eulervortex.h
@@ -12,9 +12,6 @@
 // Model from:
 //   On the Order of Accuracy and Numerical Performance of Two Classes of Finite Volume WENO Schemes, Zhang, Zhang, and Shu (2011).
 
-#ifndef eulervortex_h
-#define eulervortex_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -659,7 +656,3 @@ CEED_QFUNCTION(Euler_Outflow)(void *ctx, CeedInt Q, const CeedScalar *const *in,
   }  // End Quadrature Point Loop
   return 0;
 }
-
-// *****************************************************************************
-
-#endif  // eulervortex_h

--- a/examples/fluids/qfunctions/eulervortex.h
+++ b/examples/fluids/qfunctions/eulervortex.h
@@ -11,7 +11,6 @@
 
 // Model from:
 //   On the Order of Accuracy and Numerical Performance of Two Classes of Finite Volume WENO Schemes, Zhang, Zhang, and Shu (2011).
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/gaussianwave.h
+++ b/examples/fluids/qfunctions/gaussianwave.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Thermodynamic wave propogation for testing freestream/non-reflecting boundary conditions. Proposed in Mengaldo et. al. 2014
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/grid_anisotropy_tensor.h
+++ b/examples/fluids/qfunctions/grid_anisotropy_tensor.h
@@ -8,7 +8,6 @@
 /// @file
 /// Element anisotropy tensor, as defined in 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation'
 /// Prakash et al. 2022
-
 #include <ceed.h>
 
 #include "utils.h"

--- a/examples/fluids/qfunctions/grid_anisotropy_tensor.h
+++ b/examples/fluids/qfunctions/grid_anisotropy_tensor.h
@@ -9,9 +9,6 @@
 /// Element anisotropy tensor, as defined in 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation'
 /// Prakash et al. 2022
 
-#ifndef grid_anisotropy_tensor_h
-#define grid_anisotropy_tensor_h
-
 #include <ceed.h>
 
 #include "utils.h"
@@ -84,5 +81,3 @@ CEED_QFUNCTION(AnisotropyTensorCollocate)(void *ctx, CeedInt Q, const CeedScalar
   }
   return 0;
 }
-
-#endif /* ifndef grid_anisotropy_tensor_h */

--- a/examples/fluids/qfunctions/inverse_multiplicity.h
+++ b/examples/fluids/qfunctions/inverse_multiplicity.h
@@ -4,9 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-/// @file
-
 #include <ceed.h>
 
 // @brief Calculate the inverse of the multiplicity, reducing to a single component

--- a/examples/fluids/qfunctions/inverse_multiplicity.h
+++ b/examples/fluids/qfunctions/inverse_multiplicity.h
@@ -7,9 +7,6 @@
 
 /// @file
 
-#ifndef inverse_multiplicity_h
-#define inverse_multiplicity_h
-
 #include <ceed.h>
 
 // @brief Calculate the inverse of the multiplicity, reducing to a single component
@@ -20,5 +17,3 @@ CEED_QFUNCTION(InverseMultiplicity)(void *ctx, CeedInt Q, const CeedScalar *cons
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) inv_multiplicity[i] = 1.0 / multiplicity[0][i];
   return 0;
 }
-
-#endif  // sgs_dd_utils_h

--- a/examples/fluids/qfunctions/mass.h
+++ b/examples/fluids/qfunctions/mass.h
@@ -8,9 +8,6 @@
 /// @file
 /// Mass operator for Navier-Stokes example using PETSc
 
-#ifndef mass_h
-#define mass_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -48,6 +45,3 @@ CEED_QFUNCTION(Mass_7)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSc
 CEED_QFUNCTION(Mass_9)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) { return Mass_N(ctx, Q, in, out, 9); }
 
 CEED_QFUNCTION(Mass_22)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) { return Mass_N(ctx, Q, in, out, 22); }
-// *****************************************************************************
-
-#endif  // mass_h

--- a/examples/fluids/qfunctions/mass.h
+++ b/examples/fluids/qfunctions/mass.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Mass operator for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/newtonian.h
+++ b/examples/fluids/qfunctions/newtonian.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Operator for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 #include <math.h>
 #include <stdlib.h>

--- a/examples/fluids/qfunctions/newtonian.h
+++ b/examples/fluids/qfunctions/newtonian.h
@@ -8,9 +8,6 @@
 /// @file
 /// Operator for Navier-Stokes example using PETSc
 
-#ifndef newtonian_h
-#define newtonian_h
-
 #include <ceed.h>
 #include <math.h>
 #include <stdlib.h>
@@ -462,5 +459,3 @@ CEED_QFUNCTION(BoundaryIntegral_Jacobian_Conserv)(void *ctx, CeedInt Q, const Ce
 CEED_QFUNCTION(BoundaryIntegral_Jacobian_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   return BoundaryIntegral_Jacobian(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
-
-#endif  // newtonian_h

--- a/examples/fluids/qfunctions/newtonian_state.h
+++ b/examples/fluids/qfunctions/newtonian_state.h
@@ -7,9 +7,7 @@
 
 /// @file
 /// Structs and helper functions regarding the state of a newtonian simulation
-
-#ifndef newtonian_state_h
-#define newtonian_state_h
+#pragma once
 
 #include <ceed.h>
 #include <math.h>
@@ -416,5 +414,3 @@ CEED_QFUNCTION_HELPER void StatePhysicalGradientFromReference_Boundary(CeedInt Q
     grad_s[k] = StateFromQ_fwd(gas, s, dqi, state_var);
   }
 }
-
-#endif  // newtonian_state_h

--- a/examples/fluids/qfunctions/newtonian_types.h
+++ b/examples/fluids/qfunctions/newtonian_types.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef newtonian_types_h
-#define newtonian_types_h
+#pragma once
 
 #include <ceed.h>
 
@@ -59,5 +57,3 @@ struct SetupContext_ {
   CeedScalar                       lz;
   CeedScalar                       time;
 };
-
-#endif  // newtonian_types_h

--- a/examples/fluids/qfunctions/riemann_solver.h
+++ b/examples/fluids/qfunctions/riemann_solver.h
@@ -19,7 +19,6 @@
 //
 // The right state is exterior to the domain and the left state is the interior to the domain.
 // Much of the work references Eleuterio F. Toro's "Riemann Solvers and Numerical Methods for Fluid Dynamics", 2009
-
 #include "newtonian_state.h"
 #include "newtonian_types.h"
 

--- a/examples/fluids/qfunctions/riemann_solver.h
+++ b/examples/fluids/qfunctions/riemann_solver.h
@@ -20,9 +20,6 @@
 // The right state is exterior to the domain and the left state is the interior to the domain.
 // Much of the work references Eleuterio F. Toro's "Riemann Solvers and Numerical Methods for Fluid Dynamics", 2009
 
-#ifndef riemann_solver_h
-#define riemann_solver_h
-
 #include "newtonian_state.h"
 #include "newtonian_types.h"
 
@@ -346,5 +343,3 @@ CEED_QFUNCTION_HELPER StateConservative RiemannFlux_HLLC_fwd(NewtonianIdealGasCo
     return dflux_right;
   }
 }
-
-#endif  // riemann_solver_h

--- a/examples/fluids/qfunctions/setupgeo.h
+++ b/examples/fluids/qfunctions/setupgeo.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Geometric factors (3D) for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/setupgeo.h
+++ b/examples/fluids/qfunctions/setupgeo.h
@@ -8,9 +8,6 @@
 /// @file
 /// Geometric factors (3D) for Navier-Stokes example using PETSc
 
-#ifndef setup_geo_h
-#define setup_geo_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -124,7 +121,3 @@ CEED_QFUNCTION(SetupBoundary)(void *ctx, CeedInt Q, const CeedScalar *const *in,
   }
   return 0;
 }
-
-// *****************************************************************************
-
-#endif  // setup_geo_h

--- a/examples/fluids/qfunctions/setupgeo2d.h
+++ b/examples/fluids/qfunctions/setupgeo2d.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Geometric factors (2D) for Navier-Stokes example using PETSc
-
 #include <ceed.h>
 #include <math.h>
 #include "setupgeo_helpers.h"

--- a/examples/fluids/qfunctions/setupgeo2d.h
+++ b/examples/fluids/qfunctions/setupgeo2d.h
@@ -8,9 +8,6 @@
 /// @file
 /// Geometric factors (2D) for Navier-Stokes example using PETSc
 
-#ifndef setup_geo_2d_h
-#define setup_geo_2d_h
-
 #include <ceed.h>
 #include <math.h>
 #include "setupgeo_helpers.h"
@@ -102,7 +99,3 @@ CEED_QFUNCTION(SetupBoundary2d)(void *ctx, CeedInt Q, const CeedScalar *const *i
   }
   return 0;
 }
-
-// *****************************************************************************
-
-#endif  // setup_geo_2d_h

--- a/examples/fluids/qfunctions/setupgeo_helpers.h
+++ b/examples/fluids/qfunctions/setupgeo_helpers.h
@@ -7,9 +7,7 @@
 
 /// @file
 /// Geometric factors (3D) for Navier-Stokes example using PETSc
-
-#ifndef setupgeo_helpers_h
-#define setupgeo_helpers_h
+#pragma once
 
 #include <ceed.h>
 #include <math.h>
@@ -235,5 +233,3 @@ CEED_QFUNCTION_HELPER void InvertBoundaryMappingJacobian_3D(CeedInt Q, CeedInt i
     }
   }
 }
-
-#endif  // setupgeo_helpers_h

--- a/examples/fluids/qfunctions/sgs_dd_model.h
+++ b/examples/fluids/qfunctions/sgs_dd_model.h
@@ -9,7 +9,6 @@
 /// Structs and helper functions to evaluate data-driven subgrid-stress modeling
 /// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
 /// correction models for data-informed Reynolds stress closure' 2022
-
 #include <ceed.h>
 
 #include "newtonian_state.h"

--- a/examples/fluids/qfunctions/sgs_dd_model.h
+++ b/examples/fluids/qfunctions/sgs_dd_model.h
@@ -10,9 +10,6 @@
 /// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
 /// correction models for data-informed Reynolds stress closure' 2022
 
-#ifndef sgs_dd_model_h
-#define sgs_dd_model_h
-
 #include <ceed.h>
 
 #include "newtonian_state.h"
@@ -247,5 +244,3 @@ CEED_QFUNCTION(IFunction_NodalSgs_Conserv)(void *ctx, CeedInt Q, const CeedScala
 CEED_QFUNCTION(IFunction_NodalSgs_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   return IFunction_NodalSgs(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
-
-#endif  // sgs_dd_model_h

--- a/examples/fluids/qfunctions/sgs_dd_training.h
+++ b/examples/fluids/qfunctions/sgs_dd_training.h
@@ -10,9 +10,6 @@
 /// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
 /// correction models for data-informed Reynolds stress closure' 2022
 
-#ifndef sgs_dd_training_h
-#define sgs_dd_training_h
-
 #include <ceed.h>
 
 #include "differential_filter_enums.h"
@@ -72,5 +69,3 @@ CEED_QFUNCTION_HELPER int ComputeSGS_DDAnisotropicTrainingDataNodal(void *ctx, C
 CEED_QFUNCTION(ComputeSGS_DDAnisotropicTrainingDataNodal_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   return ComputeSGS_DDAnisotropicTrainingDataNodal(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
-
-#endif  // sgs_dd_training_h

--- a/examples/fluids/qfunctions/sgs_dd_training.h
+++ b/examples/fluids/qfunctions/sgs_dd_training.h
@@ -9,7 +9,6 @@
 /// Structs and helper functions for training data-driven subgrid-stress models
 /// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
 /// correction models for data-informed Reynolds stress closure' 2022
-
 #include <ceed.h>
 
 #include "differential_filter_enums.h"

--- a/examples/fluids/qfunctions/sgs_dd_utils.h
+++ b/examples/fluids/qfunctions/sgs_dd_utils.h
@@ -9,9 +9,7 @@
 /// Structs and helper functions for data-driven subgrid-stress modeling
 /// See 'Invariant data-driven subgrid stress modeling in the strain-rate eigenframe for large eddy simulation' 2022 and 'S-frame discrepancy
 /// correction models for data-informed Reynolds stress closure' 2022
-
-#ifndef sgs_dd_utils_h
-#define sgs_dd_utils_h
+#pragma once
 
 #include <ceed.h>
 
@@ -131,5 +129,3 @@ CEED_QFUNCTION_HELPER void ComputeSgsDDOutputs(CeedScalar outputs[6], const Ceed
 
   KMPack(sgs_stress, kmsgs_stress);
 }
-
-#endif  // sgs_dd_utils_h

--- a/examples/fluids/qfunctions/shocktube.h
+++ b/examples/fluids/qfunctions/shocktube.h
@@ -11,9 +11,6 @@
 // Model from:
 //   On the Order of Accuracy and Numerical Performance of Two Classes of Finite Volume WENO Schemes, Zhang, Zhang, and Shu (2011).
 
-#ifndef shocktube_h
-#define shocktube_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -387,5 +384,3 @@ CEED_QFUNCTION(EulerShockTube)(void *ctx, CeedInt Q, const CeedScalar *const *in
   // Return
   return 0;
 }
-
-#endif  // shocktube_h

--- a/examples/fluids/qfunctions/shocktube.h
+++ b/examples/fluids/qfunctions/shocktube.h
@@ -10,7 +10,6 @@
 
 // Model from:
 //   On the Order of Accuracy and Numerical Performance of Two Classes of Finite Volume WENO Schemes, Zhang, Zhang, and Shu (2011).
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/stabilization.h
+++ b/examples/fluids/qfunctions/stabilization.h
@@ -8,9 +8,6 @@
 /// @file
 /// Helper functions for computing stabilization terms of a newtonian simulation
 
-#ifndef stabilization_h
-#define stabilization_h
-
 #include <ceed.h>
 
 #include "newtonian_state.h"
@@ -113,7 +110,3 @@ CEED_QFUNCTION_HELPER void Tau_diagPrim(NewtonianIdealGasContext gas, State s, c
   // OR we could absorb cv into Ctau_E but this puts more burden on user to know how to change constants with a change of fluid or units.  Same for
   // Ctau_v * mu * mu IF AND ONLY IF we don't add viscosity law =f(T)
 }
-
-// *****************************************************************************
-
-#endif  // stabilization_h

--- a/examples/fluids/qfunctions/stabilization.h
+++ b/examples/fluids/qfunctions/stabilization.h
@@ -7,7 +7,6 @@
 
 /// @file
 /// Helper functions for computing stabilization terms of a newtonian simulation
-
 #include <ceed.h>
 
 #include "newtonian_state.h"

--- a/examples/fluids/qfunctions/stabilization_types.h
+++ b/examples/fluids/qfunctions/stabilization_types.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef stabilization_types_h
-#define stabilization_types_h
+#pragma once
 
 typedef enum {
   STAB_NONE = 0,
@@ -18,5 +16,3 @@ typedef enum {
   STAB_TAU_CTAU           = 0,
   STAB_TAU_ADVDIFF_SHAKIB = 1,  // Approximation from Shakib's Thesis
 } StabilizationTauType;
-
-#endif  // stabilization_types_h

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -13,9 +13,6 @@
 /// Then STGShur14_CalcQF is run over quadrature points.
 /// Before the program exits, TearDownSTG is run to free the memory of the allocated arrays.
 
-#ifndef stg_shur14_h
-#define stg_shur14_h
-
 #include <ceed.h>
 #include <math.h>
 #include <stdlib.h>
@@ -543,5 +540,3 @@ CEED_QFUNCTION(StgShur14InflowStrongQF)(void *ctx, CeedInt Q, const CeedScalar *
   }
   return 0;
 }
-
-#endif  // stg_shur14_h

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -12,7 +12,6 @@
 /// SetupSTG_Rand reads in the input files and fills in STGShur14Context.
 /// Then STGShur14_CalcQF is run over quadrature points.
 /// Before the program exits, TearDownSTG is run to free the memory of the allocated arrays.
-
 #include <ceed.h>
 #include <math.h>
 #include <stdlib.h>

--- a/examples/fluids/qfunctions/stg_shur14_type.h
+++ b/examples/fluids/qfunctions/stg_shur14_type.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef stg_shur14_type_h
-#define stg_shur14_type_h
+#pragma once
 
 #include <ceed.h>
 
@@ -43,5 +41,3 @@ struct STGShur14Context_ {
   size_t     total_bytes;  // !< Total size of struct plus array
   CeedScalar data[1];      // !< Holds concatenated scalar array data
 };
-
-#endif

--- a/examples/fluids/qfunctions/strong_boundary_conditions.h
+++ b/examples/fluids/qfunctions/strong_boundary_conditions.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef strong_boundary_conditions_h
-#define strong_boundary_conditions_h
-
 #include <ceed.h>
 
 #include "setupgeo_helpers.h"
@@ -37,5 +34,3 @@ CEED_QFUNCTION(SetupStrongBC)(void *ctx, CeedInt Q, const CeedScalar *const *in,
   }
   return 0;
 }
-
-#endif  // strong_boundary_conditions_h

--- a/examples/fluids/qfunctions/strong_boundary_conditions.h
+++ b/examples/fluids/qfunctions/strong_boundary_conditions.h
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
 #include <ceed.h>
 
 #include "setupgeo_helpers.h"

--- a/examples/fluids/qfunctions/taylorgreen.h
+++ b/examples/fluids/qfunctions/taylorgreen.h
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
 #include <ceed.h>
 #include <math.h>
 

--- a/examples/fluids/qfunctions/taylorgreen.h
+++ b/examples/fluids/qfunctions/taylorgreen.h
@@ -5,12 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-/// @file
-///
-
-#ifndef taylorgreen_h
-#define taylorgreen_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -56,5 +50,3 @@ CEED_QFUNCTION(ICsTaylorGreen)(void *ctx, CeedInt Q, const CeedScalar *const *in
   }
   return 0;
 }
-
-#endif  // taylorgreen_h

--- a/examples/fluids/qfunctions/turb_spanstats.h
+++ b/examples/fluids/qfunctions/turb_spanstats.h
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
 #include <ceed.h>
 
 #include "newtonian_state.h"

--- a/examples/fluids/qfunctions/turb_stats_types.h
+++ b/examples/fluids/qfunctions/turb_stats_types.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef turb_stats_types_h
-#define turb_stats_types_h
+#pragma once
 
 #include "./newtonian_types.h"
 
@@ -42,5 +40,3 @@ struct Turbulence_SpanStatsContext_ {
   CeedScalar                       previous_time;
   struct NewtonianIdealGasContext_ gas;
 };
-
-#endif  // turb_stats_types_h

--- a/examples/fluids/qfunctions/turb_stats_types.h
+++ b/examples/fluids/qfunctions/turb_stats_types.h
@@ -6,7 +6,7 @@
 // This file is part of CEED:  http://github.com/ceed
 #pragma once
 
-#include "./newtonian_types.h"
+#include "newtonian_types.h"
 
 enum TurbComponent {
   TURB_MEAN_DENSITY,

--- a/examples/fluids/qfunctions/utils.h
+++ b/examples/fluids/qfunctions/utils.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef utils_h
-#define utils_h
+#pragma once
 
 #include <ceed.h>
 #include <math.h>
@@ -301,5 +299,3 @@ CEED_QFUNCTION_HELPER int QdataBoundaryUnpack_2D(CeedInt Q, CeedInt i, const Cee
   if (normal) StoredValuesUnpack(Q, i, 1, 2, q_data, normal);
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // utils_h

--- a/examples/fluids/qfunctions/utils_eigensolver_jacobi.h
+++ b/examples/fluids/qfunctions/utils_eigensolver_jacobi.h
@@ -7,9 +7,7 @@
 
 /// @file
 /// Eigen system solver for symmetric NxN matrices. Modified from the CC0 code provided at https://github.com/jewettaij/jacobi_pd
-
-#ifndef utils_eigensolver_jacobi_h
-#define utils_eigensolver_jacobi_h
+#pragma once
 
 #include <ceed.h>
 #include <math.h>
@@ -323,5 +321,3 @@ CEED_QFUNCTION_HELPER CeedInt Diagonalize3(CeedScalar A[3][3], CeedScalar eval[3
                                            SortCriteria sort_criteria, bool calc_evec, const CeedInt max_num_sweeps) {
   return Diagonalize((CeedScalar *)A, 3, (CeedScalar *)eval, (CeedScalar *)evec, (CeedInt *)max_idx_row, sort_criteria, calc_evec, max_num_sweeps);
 }
-
-#endif  // utils_eigensolver_jacobi_h

--- a/examples/fluids/qfunctions/velocity_gradient_projection.h
+++ b/examples/fluids/qfunctions/velocity_gradient_projection.h
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
 #include <ceed.h>
 
 #include "newtonian_state.h"

--- a/examples/fluids/qfunctions/velocity_gradient_projection.h
+++ b/examples/fluids/qfunctions/velocity_gradient_projection.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef velocity_gradient_projection_h
-#define velocity_gradient_projection_h
-
 #include <ceed.h>
 
 #include "newtonian_state.h"
@@ -51,4 +48,3 @@ CEED_QFUNCTION(VelocityGradientProjectionRHS_Conserv)(void *ctx, CeedInt Q, cons
 CEED_QFUNCTION(VelocityGradientProjectionRHS_Prim)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   return VelocityGradientProjectionRHS(ctx, Q, in, out, STATEVAR_PRIMITIVE);
 }
-#endif  // velocity_gradient_projection_h

--- a/examples/mfem/bp1.h
+++ b/examples/mfem/bp1.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef bp1_h
-#define bp1_h
-
 #include <ceed.h>
 
 /// A structure used to pass additional data to f_build_mass
@@ -61,5 +58,3 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, const CeedInt Q, const CeedScalar *const
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { v[i] = qdata[i] * u[i]; }
   return 0;
 }
-
-#endif  // bp1_h

--- a/examples/mfem/bp3.h
+++ b/examples/mfem/bp3.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef bp3_h
-#define bp3_h
-
 #include <ceed.h>
 
 /// A structure used to pass additional data to f_build_diff and f_apply_diff
@@ -117,5 +114,3 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, const CeedInt Q, const CeedScalar *const
   }
   return 0;
 }
-
-#endif  // bp3_h

--- a/examples/petsc/qfunctions/area/areacube.h
+++ b/examples/petsc/qfunctions/area/areacube.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example for a scalar field on the sphere using PETSc
 
-#ifndef areacube_h
-#define areacube_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -105,5 +102,3 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, Ce
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // areacube_h

--- a/examples/petsc/qfunctions/area/areasphere.h
+++ b/examples/petsc/qfunctions/area/areasphere.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example for a scalar field on the sphere using PETSc
 
-#ifndef areasphere_h
-#define areasphere_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -99,5 +96,3 @@ CEED_QFUNCTION(SetupMassGeoSphere)(void *ctx, const CeedInt Q, const CeedScalar 
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // areasphere_h

--- a/examples/petsc/qfunctions/bps/bp1.h
+++ b/examples/petsc/qfunctions/bps/bp1.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example using PETSc
 
-#ifndef bp1_h
-#define bp1_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -85,5 +82,3 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, Ce
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp1_h

--- a/examples/petsc/qfunctions/bps/bp1sphere.h
+++ b/examples/petsc/qfunctions/bps/bp1sphere.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example for a scalar field on the sphere using PETSc
 
-#ifndef bp1sphere_h
-#define bp1sphere_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -150,5 +147,3 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, Ce
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp1sphere_h

--- a/examples/petsc/qfunctions/bps/bp2.h
+++ b/examples/petsc/qfunctions/bps/bp2.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example using PETSc
 
-#ifndef bp2_h
-#define bp2_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -66,5 +63,3 @@ CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q, const CeedScalar *const *in, C
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp2_h

--- a/examples/petsc/qfunctions/bps/bp2sphere.h
+++ b/examples/petsc/qfunctions/bps/bp2sphere.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example for a vector field on the sphere using PETSc
 
-#ifndef bp2sphere_h
-#define bp2sphere_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -78,5 +75,3 @@ CEED_QFUNCTION(Mass3)(void *ctx, const CeedInt Q, const CeedScalar *const *in, C
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp2sphere_h

--- a/examples/petsc/qfunctions/bps/bp3.h
+++ b/examples/petsc/qfunctions/bps/bp3.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example using PETSc
 
-#ifndef bp3_h
-#define bp3_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -126,5 +123,3 @@ CEED_QFUNCTION(Diff)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScal
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp3_h

--- a/examples/petsc/qfunctions/bps/bp3sphere.h
+++ b/examples/petsc/qfunctions/bps/bp3sphere.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example for a scalar field on the sphere using PETSc
 
-#ifndef bp3sphere_h
-#define bp3sphere_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -208,5 +205,3 @@ CEED_QFUNCTION(Diff)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedScal
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp3sphere_h

--- a/examples/petsc/qfunctions/bps/bp4.h
+++ b/examples/petsc/qfunctions/bps/bp4.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for diffusion operator example using PETSc
 
-#ifndef bp4_h
-#define bp4_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -87,5 +84,3 @@ CEED_QFUNCTION(Diff3)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSca
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp4_h

--- a/examples/petsc/qfunctions/bps/bp4sphere.h
+++ b/examples/petsc/qfunctions/bps/bp4sphere.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for mass operator example for a vector field on the sphere using PETSc
 
-#ifndef bp4sphere_h
-#define bp4sphere_h
-
 #include <ceed.h>
 #include <math.h>
 
@@ -100,5 +97,3 @@ CEED_QFUNCTION(Diff3)(void *ctx, const CeedInt Q, const CeedScalar *const *in, C
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // bp4sphere_h

--- a/examples/petsc/qfunctions/bps/common.h
+++ b/examples/petsc/qfunctions/bps/common.h
@@ -8,9 +8,6 @@
 /// @file
 /// libCEED QFunctions for BP examples using PETSc
 
-#ifndef common_h
-#define common_h
-
 #include <ceed.h>
 
 // -----------------------------------------------------------------------------
@@ -35,5 +32,3 @@ CEED_QFUNCTION(Error3)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSc
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // common_h

--- a/examples/petsc/qfunctions/swarm/swarmmass.h
+++ b/examples/petsc/qfunctions/swarm/swarmmass.h
@@ -5,9 +5,6 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef SWARM_MASS_H
-#define SWARM_MASS_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(SetupMass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -38,5 +35,3 @@ CEED_QFUNCTION(Mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, Ce
   }
   return 0;
 }
-
-#endif  // SWARM_MASS_H

--- a/examples/solids/problems/cl-problems.h
+++ b/examples/solids/problems/cl-problems.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef cl_problems_h
-#define cl_problems_h
+#pragma once
 
 // Problem options
 typedef enum {
@@ -28,5 +26,3 @@ static const char *const problemTypesForDisp[] = {
     "Hyperelasticity finite strain Current configuration Neo-Hookean w/ dXref_dxinit, Grad(u) storage",
     "Hyperelasticity finite strain Current configuration Neo-Hookean w/ dXref_dxcurr, tau, constant storage",
     "Hyperelasticity finite strain Initial configuration Moony-Rivlin w/ dXref_dxinit, Grad(u) storage"};
-
-#endif  // cl_problems_h

--- a/examples/solids/problems/mooney-rivlin.h
+++ b/examples/solids/problems/mooney-rivlin.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef mooney_rivlin_h
-#define mooney_rivlin_h
+#pragma once
 
 #include <ceed.h>
 #include <petsc.h>
@@ -30,5 +28,3 @@ PetscErrorCode PhysicsSmootherContext_MR(MPI_Comm comm, Ceed ceed, CeedQFunction
 
 // Process physics options - Mooney-Rivlin
 PetscErrorCode ProcessPhysics_MR(MPI_Comm comm, Physics_MR phys, Units units);
-
-#endif  // mooney_rivlin_h

--- a/examples/solids/problems/neo-hookean.h
+++ b/examples/solids/problems/neo-hookean.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef neo_hookean_h
-#define neo_hookean_h
+#pragma once
 
 #include <ceed.h>
 #include <petsc.h>
@@ -28,5 +26,3 @@ PetscErrorCode PhysicsSmootherContext_NH(MPI_Comm comm, Ceed ceed, CeedQFunction
 
 // Process physics options
 PetscErrorCode ProcessPhysics_NH(MPI_Comm comm, Physics_NH phys, Units units);
-
-#endif  // neo_hookean_h

--- a/examples/solids/problems/problems.h
+++ b/examples/solids/problems/problems.h
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 // This file is part of CEED:  http://github.com/ceed
-
-#ifndef problems_h
-#define problems_h
+#pragma once
 
 #include <ceed.h>
 #include <petsc.h>
@@ -43,5 +41,3 @@ SOLIDS_PROBLEM(ElasFSCurrentNH2);
 SOLIDS_PROBLEM(ElasFSInitialNH1);
 SOLIDS_PROBLEM(ElasFSInitialNH2);
 SOLIDS_PROBLEM(ElasFSInitialMR1);
-
-#endif  // problems_h

--- a/examples/solids/qfunctions/common.h
+++ b/examples/solids/qfunctions/common.h
@@ -8,9 +8,6 @@
 /// @file
 /// Geometric factors for solid mechanics example using PETSc
 
-#ifndef COMMON_H
-#define COMMON_H
-
 #include <ceed.h>
 
 // -----------------------------------------------------------------------------
@@ -86,5 +83,3 @@ CEED_QFUNCTION(SetupGeo)(void *ctx, CeedInt Q, const CeedScalar *const *in, Ceed
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of COMMON_H

--- a/examples/solids/qfunctions/constant-force.h
+++ b/examples/solids/qfunctions/constant-force.h
@@ -8,9 +8,6 @@
 /// @file
 /// Constant forcing term for solid mechanics example using PETSc
 
-#ifndef CONSTANT_H
-#define CONSTANT_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -55,5 +52,3 @@ CEED_QFUNCTION(SetupConstantForce)(void *ctx, const CeedInt Q, const CeedScalar 
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of CONSTANT_H

--- a/examples/solids/qfunctions/finite-strain-mooney-rivlin-initial-1.h
+++ b/examples/solids/qfunctions/finite-strain-mooney-rivlin-initial-1.h
@@ -8,9 +8,6 @@
 /// @file
 /// Hyperelasticity, finite strain for solid mechanics example using PETSc
 
-#ifndef ELAS_FSInitialMR1_H
-#define ELAS_FSInitialMR1_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -611,5 +608,3 @@ CEED_QFUNCTION(ElasFSInitialMR1Diagnostic)(void *ctx, CeedInt Q, const CeedScala
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_FSInitialMR1_H

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-current-1.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-current-1.h
@@ -8,9 +8,6 @@
 /// @file
 /// Hyperelasticity, finite strain for solid mechanics example using PETSc
 
-#ifndef ELAS_FSCurrentNH1_H
-#define ELAS_FSCurrentNH1_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -536,5 +533,3 @@ CEED_QFUNCTION(ElasFSCurrentNH1Diagnostic)(void *ctx, CeedInt Q, const CeedScala
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_FSCurrentNH1_H

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-current-2.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-current-2.h
@@ -8,9 +8,6 @@
 /// @file
 /// Hyperelasticity, finite strain for solid mechanics example using PETSc
 
-#ifndef ELAS_FSCurrentNH2_H
-#define ELAS_FSCurrentNH2_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -483,5 +480,3 @@ CEED_QFUNCTION(ElasFSCurrentNH2Diagnostic)(void *ctx, CeedInt Q, const CeedScala
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_FSCurrentNH2_H

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-initial-1.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-initial-1.h
@@ -8,9 +8,6 @@
 /// @file
 /// Hyperelasticity, finite strain for solid mechanics example using PETSc
 
-#ifndef ELAS_FSInitialNH1_H
-#define ELAS_FSInitialNH1_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -548,5 +545,3 @@ CEED_QFUNCTION(ElasFSInitialNH1Diagnostic)(void *ctx, CeedInt Q, const CeedScala
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_FSInitialNH1_H

--- a/examples/solids/qfunctions/finite-strain-neo-hookean-initial-2.h
+++ b/examples/solids/qfunctions/finite-strain-neo-hookean-initial-2.h
@@ -8,9 +8,6 @@
 /// @file
 /// Hyperelasticity, finite strain for solid mechanics example using PETSc
 
-#ifndef ELAS_FSInitialNH2_H
-#define ELAS_FSInitialNH2_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -560,5 +557,3 @@ CEED_QFUNCTION(ElasFSInitialNH2Diagnostic)(void *ctx, CeedInt Q, const CeedScala
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_FSInitialNH2_H

--- a/examples/solids/qfunctions/linear.h
+++ b/examples/solids/qfunctions/linear.h
@@ -8,9 +8,6 @@
 /// @file
 /// Linear elasticity for solid mechanics example using PETSc
 
-#ifndef ELAS_LINEAR_H
-#define ELAS_LINEAR_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -363,5 +360,3 @@ CEED_QFUNCTION(ElasLinearDiagnostic)(void *ctx, CeedInt Q, const CeedScalar *con
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_LINEAR_H

--- a/examples/solids/qfunctions/manufactured-force.h
+++ b/examples/solids/qfunctions/manufactured-force.h
@@ -8,9 +8,6 @@
 /// @file
 /// Linear elasticity manufactured solution forcing term for solid mechanics example using PETSc
 
-#ifndef MANUFACTURED_H
-#define MANUFACTURED_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -80,5 +77,3 @@ CEED_QFUNCTION(SetupMMSForce)(void *ctx, const CeedInt Q, const CeedScalar *cons
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End MANUFACTURED_H

--- a/examples/solids/qfunctions/manufactured-true.h
+++ b/examples/solids/qfunctions/manufactured-true.h
@@ -8,9 +8,6 @@
 /// @file
 /// Linear elasticity manufactured solution true solution for solid mechanics example using PETSc
 
-#ifndef MANUFACTURED_TRUE_H
-#define MANUFACTURED_TRUE_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -44,5 +41,3 @@ CEED_QFUNCTION(MMSTrueSoln)(void *ctx, const CeedInt Q, const CeedScalar *const 
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End MANUFACTURED_TRUE_H

--- a/examples/solids/qfunctions/small-strain-neo-hookean.h
+++ b/examples/solids/qfunctions/small-strain-neo-hookean.h
@@ -8,9 +8,6 @@
 /// @file
 /// Hyperelasticity, small strain for solid mechanics example using PETSc
 
-#ifndef ELAS_SS_NH_H
-#define ELAS_SS_NH_H
-
 #include <ceed.h>
 #include <math.h>
 
@@ -411,5 +408,3 @@ CEED_QFUNCTION(ElasSSNHDiagnostic)(void *ctx, CeedInt Q, const CeedScalar *const
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of ELAS_SS_NH_H

--- a/examples/solids/qfunctions/traction-boundary.h
+++ b/examples/solids/qfunctions/traction-boundary.h
@@ -8,9 +8,6 @@
 /// @file
 /// Geometric factors for solid mechanics example using PETSc
 
-#ifndef TRACTION_BOUNDARY_H
-#define TRACTION_BOUNDARY_H
-
 #include <ceed.h>
 
 // -----------------------------------------------------------------------------
@@ -64,5 +61,3 @@ CEED_QFUNCTION(SetupTractionBCs)(void *ctx, CeedInt Q, const CeedScalar *const *
   return 0;
 }
 // -----------------------------------------------------------------------------
-
-#endif  // End of TRACTION_BOUNDARY_H

--- a/include/ceed/jit-source/cuda/cuda-atomic-add-fallback.h
+++ b/include/ceed/jit-source/cuda/cuda-atomic-add-fallback.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA atomic add fallback definition
-#ifndef CEED_CUDA_ATOMIC_ADD_FALLBACK_H
-#define CEED_CUDA_ATOMIC_ADD_FALLBACK_H
 
 #include <ceed.h>
 
@@ -26,7 +24,3 @@ __device__ CeedScalar atomicAdd(CeedScalar *address, CeedScalar val) {
   } while (assumed != old);
   return __longlong_as_double(old);
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_ATOMIC_ADD_FALLBACK_H

--- a/include/ceed/jit-source/cuda/cuda-gen-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-gen-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA backend macro and type definitions for JiT source
-#ifndef CEED_CUDA_GEN_TEMPLATES_H
-#define CEED_CUDA_GEN_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -291,5 +289,3 @@ inline __device__ void gradColloTranspose3d(SharedData_Cuda &data, const CeedInt
     }
   }
 }
-
-#endif  // CEED_CUDA_GEN_TEMPLATES_H

--- a/include/ceed/jit-source/cuda/cuda-jit.h
+++ b/include/ceed/jit-source/cuda/cuda-jit.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA backend macro and type definitions for JiT source
-#ifndef CEED_CUDA_JIT_H
-#define CEED_CUDA_JIT_H
 
 #define CEED_QFUNCTION(name) inline __device__ int name
 #define CEED_QFUNCTION_HELPER inline __device__
@@ -16,5 +14,3 @@
 #define CEED_Q_VLA 1
 
 #include "cuda-types.h"
-
-#endif  // CEED_CUDA_JIT_H

--- a/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA non-tensor product basis templates
-#ifndef CEED_CUDA_REF_BASIS_NONTENSOR_TEMPLATES_H
-#define CEED_CUDA_REF_BASIS_NONTENSOR_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -61,7 +59,3 @@ inline __device__ void ContractTranspose(const CeedInt elem, const CeedInt strid
     d_V[elem * strides_elem_V + comp * strides_comp_V + t_id] = r_V;
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_BASIS_NONTENSOR_TEMPLATES_H

--- a/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-basis-nontensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA non-tensor product basis
-#ifndef CEED_CUDA_REF_BASIS_NONTENSOR_H
-#define CEED_CUDA_REF_BASIS_NONTENSOR_H
 
 #include <ceed.h>
 
@@ -67,7 +65,3 @@ extern "C" __global__ void Weight(const CeedInt num_elem, const CeedScalar *__re
     d_V[elem * BASIS_Q + t_id] = q_weight[t_id];
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_BASIS_NONTENSOR_H

--- a/include/ceed/jit-source/cuda/cuda-ref-basis-tensor.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-basis-tensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA tensor product basis
-#ifndef CEED_CUDA_REF_BASIS_TENSOR_H
-#define CEED_CUDA_REF_BASIS_TENSOR_H
 
 #include <ceed.h>
 
@@ -200,7 +198,3 @@ extern "C" __global__ void Weight(const CeedInt num_elem, const CeedScalar *__re
   else if (BASIS_DIM == 2) Weight2d(num_elem, q_weight_1d, v);
   else if (BASIS_DIM == 3) Weight3d(num_elem, q_weight_1d, v);
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_BASIS_TENSOR_H

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-diagonal.h
@@ -7,9 +7,6 @@
 
 /// @file
 /// Internal header for CUDA operator diagonal assembly
-#ifndef CEED_CUDA_REF_OPERATOR_ASSEMBLE_DIAGONAL_H
-#define CEED_CUDA_REF_OPERATOR_ASSEMBLE_DIAGONAL_H
-
 #include <ceed.h>
 
 #if USE_CEEDSIZE
@@ -117,7 +114,3 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_OPERATOR_ASSEMBLE_DIAGONAL_H

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA operator full assembly
-#ifndef CEED_CUDA_REF_OPERATOR_ASSEMBLE_H
-#define CEED_CUDA_REF_OPERATOR_ASSEMBLE_H
 
 #include <ceed.h>
 
@@ -106,7 +104,3 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
     }    // end of in component
   }      // end of element loop
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_OPERATOR_ASSEMBLE_H

--- a/include/ceed/jit-source/cuda/cuda-ref-qfunction.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-qfunction.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA backend QFunction read/write kernels
-#ifndef CEED_CUDA_REF_QFUNCTION_H
-#define CEED_CUDA_REF_QFUNCTION_H
 
 #include <ceed.h>
 
@@ -31,7 +29,3 @@ inline __device__ void writeQuads(const CeedInt quad, const CeedInt num_qpts, co
     d_v[quad + num_qpts * comp] = r_v[comp];
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_QFUNCTION_H

--- a/include/ceed/jit-source/cuda/cuda-ref-restriction-curl-oriented.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-restriction-curl-oriented.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA curl-oriented element restriction kernels
-#ifndef CEED_CUDA_REF_RESTRICTION_CURL_ORIENTED_H
-#define CEED_CUDA_REF_RESTRICTION_CURL_ORIENTED_H
 
 #include <ceed.h>
 
@@ -177,7 +175,3 @@ extern "C" __global__ void CurlOrientedUnsignedTranspose(const CeedInt *__restri
   }
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_RESTRICTION_CURL_ORIENTED_H

--- a/include/ceed/jit-source/cuda/cuda-ref-restriction-offset.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-restriction-offset.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA offset element restriction kernels
-#ifndef CEED_CUDA_REF_RESTRICTION_OFFSET_H
-#define CEED_CUDA_REF_RESTRICTION_OFFSET_H
 
 #include <ceed.h>
 
@@ -68,7 +66,3 @@ extern "C" __global__ void OffsetTranspose(const CeedInt *__restrict__ l_vec_ind
   }
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_RESTRICTION_OFFSET_H

--- a/include/ceed/jit-source/cuda/cuda-ref-restriction-oriented.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-restriction-oriented.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA oriented element restriction kernels
-#ifndef CEED_CUDA_REF_RESTRICTION_ORIENTED_H
-#define CEED_CUDA_REF_RESTRICTION_ORIENTED_H
 
 #include <ceed.h>
 
@@ -75,7 +73,3 @@ extern "C" __global__ void OrientedTranspose(const CeedInt *__restrict__ l_vec_i
   }
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_RESTRICTION_ORIENTED_H

--- a/include/ceed/jit-source/cuda/cuda-ref-restriction-strided.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-restriction-strided.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA strided element restriction kernels
-#ifndef CEED_CUDA_REF_RESTRICTION_STRIDED_H
-#define CEED_CUDA_REF_RESTRICTION_STRIDED_H
 
 #include <ceed.h>
 
@@ -41,7 +39,3 @@ extern "C" __global__ void StridedTranspose(const CeedScalar *__restrict__ u, Ce
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_REF_RESTRICTION_STRIDED_H

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-read-write-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-read-write-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA shared memory basis read/write templates
-#ifndef CEED_CUDA_SHARED_BASIS_READ_WRITE_TEMPLATES_H
-#define CEED_CUDA_SHARED_BASIS_READ_WRITE_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -123,7 +121,3 @@ inline __device__ void WriteElementStrided3d(SharedData_Cuda &data, const CeedIn
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_SHARED_BASIS_READ_WRITE_TEMPLATES_H

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA shared memory tensor product basis templates
-#ifndef CEED_CUDA_SHARED_BASIS_TENSOR_TEMPLATES_H
-#define CEED_CUDA_SHARED_BASIS_TENSOR_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -535,7 +533,3 @@ inline __device__ void WeightTensor3d(SharedData_Cuda &data, const CeedScalar *_
     w[q] = quad ? pw * q_weight_1d[q] : 0.0;
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_SHARED_BASIS_TENSOR_TEMPLATES_H

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for CUDA shared memory tensor product basis
-#ifndef CEED_CUDA_SHARED_BASIS_TENSOR_H
-#define CEED_CUDA_SHARED_BASIS_TENSOR_H
 
 #include <ceed.h>
 
@@ -185,7 +183,3 @@ extern "C" __global__ void Weight(const CeedInt num_elem, const CeedScalar *__re
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_CUDA_SHARED_BASIS_TENSOR_H

--- a/include/ceed/jit-source/gallery/ceed-identity.h
+++ b/include/ceed/jit-source/gallery/ceed-identity.h
@@ -9,9 +9,6 @@
   @brief  Identity QFunction that copies inputs directly into outputs
 **/
 
-#ifndef CEED_IDENTITY_H
-#define CEED_IDENTITY_H
-
 #include <ceed.h>
 
 typedef struct {
@@ -33,5 +30,3 @@ CEED_QFUNCTION(Identity)(void *ctx, const CeedInt Q, const CeedScalar *const *in
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_IDENTITY_H

--- a/include/ceed/jit-source/gallery/ceed-mass1dbuild.h
+++ b/include/ceed/jit-source/gallery/ceed-mass1dbuild.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for building the geometric data for the 1D mass matrix
 **/
 
-#ifndef CEED_MASS1DBUILD_H
-#define CEED_MASS1DBUILD_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Mass1DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -26,5 +23,3 @@ CEED_QFUNCTION(Mass1DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const 
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_MASS1DBUILD_H

--- a/include/ceed/jit-source/gallery/ceed-mass2dbuild.h
+++ b/include/ceed/jit-source/gallery/ceed-mass2dbuild.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for building the geometric data for the 2D mass matrix
 **/
 
-#ifndef CEED_MASS2DBUILD_H
-#define CEED_MASS2DBUILD_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Mass2DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -28,5 +25,3 @@ CEED_QFUNCTION(Mass2DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const 
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_MASS2DBUILD_H

--- a/include/ceed/jit-source/gallery/ceed-mass3dbuild.h
+++ b/include/ceed/jit-source/gallery/ceed-mass3dbuild.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for building the geometric data for the 3D mass matrix
 **/
 
-#ifndef CEED_MASS3DBUILD_H
-#define CEED_MASS3DBUILD_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Mass3DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -30,5 +27,3 @@ CEED_QFUNCTION(Mass3DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const 
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_MASS3DBUILD_H

--- a/include/ceed/jit-source/gallery/ceed-massapply.h
+++ b/include/ceed/jit-source/gallery/ceed-massapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the mass matrix
 **/
 
-#ifndef CEED_MASSAPPLY_H
-#define CEED_MASSAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(MassApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -26,5 +23,3 @@ CEED_QFUNCTION(MassApply)(void *ctx, const CeedInt Q, const CeedScalar *const *i
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_MASSAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-poisson1dapply.h
+++ b/include/ceed/jit-source/gallery/ceed-poisson1dapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the 1D Poisson operator
 **/
 
-#ifndef CEED_POISSON1DAPPLY_H
-#define CEED_POISSON1DAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Poisson1DApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -27,5 +24,3 @@ CEED_QFUNCTION(Poisson1DApply)(void *ctx, const CeedInt Q, const CeedScalar *con
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_POISSON1DAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-poisson1dbuild.h
+++ b/include/ceed/jit-source/gallery/ceed-poisson1dbuild.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for building the geometric data for the 1D Poisson operator
 **/
 
-#ifndef CEED_POISSON1DBUILD_H
-#define CEED_POISSON1DBUILD_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Poisson1DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -30,5 +27,3 @@ CEED_QFUNCTION(Poisson1DBuild)(void *ctx, const CeedInt Q, const CeedScalar *con
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_POISSON1DBUILD_H

--- a/include/ceed/jit-source/gallery/ceed-poisson2dapply.h
+++ b/include/ceed/jit-source/gallery/ceed-poisson2dapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the 2D Poisson operator
 **/
 
-#ifndef CEED_POISSON2DAPPLY_H
-#define CEED_POISSON2DAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Poisson2DApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -41,5 +38,3 @@ CEED_QFUNCTION(Poisson2DApply)(void *ctx, const CeedInt Q, const CeedScalar *con
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_POISSON2DAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-poisson2dbuild.h
+++ b/include/ceed/jit-source/gallery/ceed-poisson2dbuild.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for building the geometric data for the 2D Poisson operator
 **/
 
-#ifndef CEED_POISSON2DBUILD_H
-#define CEED_POISSON2DBUILD_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Poisson2DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -40,5 +37,3 @@ CEED_QFUNCTION(Poisson2DBuild)(void *ctx, const CeedInt Q, const CeedScalar *con
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_POISSON2DBUILD_H

--- a/include/ceed/jit-source/gallery/ceed-poisson3dapply.h
+++ b/include/ceed/jit-source/gallery/ceed-poisson3dapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the geometric data for the 3D Poisson operator
 **/
 
-#ifndef CEED_POISSON3DAPPLY_H
-#define CEED_POISSON3DAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Poisson3DApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -43,5 +40,3 @@ CEED_QFUNCTION(Poisson3DApply)(void *ctx, const CeedInt Q, const CeedScalar *con
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_POISSON3DAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-poisson3dbuild.h
+++ b/include/ceed/jit-source/gallery/ceed-poisson3dbuild.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for building the geometric data for the 3D Poisson operator
 **/
 
-#ifndef CEED_POISSON3DBUILD_H
-#define CEED_POISSON3DBUILD_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Poisson3DBuild)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -53,5 +50,3 @@ CEED_QFUNCTION(Poisson3DBuild)(void *ctx, const CeedInt Q, const CeedScalar *con
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_POISSON3DBUILD_H

--- a/include/ceed/jit-source/gallery/ceed-scale.h
+++ b/include/ceed/jit-source/gallery/ceed-scale.h
@@ -9,9 +9,6 @@
   @brief  Scaling QFunction that scales inputs
 **/
 
-#ifndef CEED_SCALE_H
-#define CEED_SCALE_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Scale)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -29,5 +26,3 @@ CEED_QFUNCTION(Scale)(void *ctx, const CeedInt Q, const CeedScalar *const *in, C
   CeedPragmaSIMD for (CeedInt i = 0; i < Q * size; i++) { output[i] = input[i] * scale[i]; }  // End of Quadrature Point Loop
   return 0;
 }
-
-#endif  // CEED_SCALE_H

--- a/include/ceed/jit-source/gallery/ceed-vectormassapply.h
+++ b/include/ceed/jit-source/gallery/ceed-vectormassapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the mass matrix on a vector system with three components
 **/
 
-#ifndef CEED_VECTORMASSAPPLY_H
-#define CEED_VECTORMASSAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Vector3MassApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -32,5 +29,3 @@ CEED_QFUNCTION(Vector3MassApply)(void *ctx, const CeedInt Q, const CeedScalar *c
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_VECTORMASSAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-vectorpoisson1dapply.h
+++ b/include/ceed/jit-source/gallery/ceed-vectorpoisson1dapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the 1D Poisson operator on a vector system with three components
 **/
 
-#ifndef CEED_VECTORPOISSON1DAPPLY_H
-#define CEED_VECTORPOISSON1DAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Vector3Poisson1DApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -32,5 +29,3 @@ CEED_QFUNCTION(Vector3Poisson1DApply)(void *ctx, const CeedInt Q, const CeedScal
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_VECTORPOISSON1DAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-vectorpoisson2dapply.h
+++ b/include/ceed/jit-source/gallery/ceed-vectorpoisson2dapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the 2D Poisson operator on a vector system with three components
 **/
 
-#ifndef CEED_VECTORPOISSON2DAPPLY_H
-#define CEED_VECTORPOISSON2DAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Vector3Poisson2DApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -42,5 +39,3 @@ CEED_QFUNCTION(Vector3Poisson2DApply)(void *ctx, const CeedInt Q, const CeedScal
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_VECTORPOISSON2DAPPLY_H

--- a/include/ceed/jit-source/gallery/ceed-vectorpoisson3dapply.h
+++ b/include/ceed/jit-source/gallery/ceed-vectorpoisson3dapply.h
@@ -9,9 +9,6 @@
   @brief Ceed QFunction for applying the geometric data for the 3D Poisson on a vector system with three components operator
 **/
 
-#ifndef CEED_VECTORPOISSON3DAPPLY_H
-#define CEED_VECTORPOISSON3DAPPLY_H
-
 #include <ceed.h>
 
 CEED_QFUNCTION(Vector3Poisson3DApply)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
@@ -45,5 +42,3 @@ CEED_QFUNCTION(Vector3Poisson3DApply)(void *ctx, const CeedInt Q, const CeedScal
 
   return CEED_ERROR_SUCCESS;
 }
-
-#endif  // CEED_VECTORPOISSON3DAPPLY_H

--- a/include/ceed/jit-source/hip/hip-gen-templates.h
+++ b/include/ceed/jit-source/hip/hip-gen-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP backend macro and type definitions for JiT source
-#ifndef CEED_HIP_GEN_TEMPLATES_H
-#define CEED_HIP_GEN_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -288,5 +286,3 @@ inline __device__ void gradColloTranspose3d(SharedData_Hip &data, const CeedInt 
     }
   }
 }
-
-#endif  // CEED_HIP_GEN_TEMPLATES_H

--- a/include/ceed/jit-source/hip/hip-jit.h
+++ b/include/ceed/jit-source/hip/hip-jit.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP backend macro and type definitions for JiT source
-#ifndef CEED_HIP_JIT_H
-#define CEED_HIP_JIT_H
 
 #define CEED_QFUNCTION(name) inline __device__ int name
 #define CEED_QFUNCTION_HELPER inline __device__
@@ -16,5 +14,3 @@
 #define CEED_Q_VLA 1
 
 #include "hip-types.h"
-
-#endif  // CEED_HIP_JIT_H

--- a/include/ceed/jit-source/hip/hip-ref-basis-nontensor-templates.h
+++ b/include/ceed/jit-source/hip/hip-ref-basis-nontensor-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP non-tensor product basis templates
-#ifndef CEED_HIP_REF_BASIS_NONTENSOR_TEMPLATES_H
-#define CEED_HIP_REF_BASIS_NONTENSOR_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -61,7 +59,3 @@ inline __device__ void ContractTranspose(const CeedInt elem, const CeedInt strid
     d_V[elem * strides_elem_V + comp * strides_comp_V + t_id] = r_V;
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_BASIS_NONTENSOR_TEMPLATES_H

--- a/include/ceed/jit-source/hip/hip-ref-basis-nontensor.h
+++ b/include/ceed/jit-source/hip/hip-ref-basis-nontensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP non-tensor product basis
-#ifndef CEED_HIP_REF_BASIS_NONTENSOR_H
-#define CEED_HIP_REF_BASIS_NONTENSOR_H
 
 #include <ceed.h>
 
@@ -67,7 +65,3 @@ extern "C" __global__ void Weight(const CeedInt num_elem, const CeedScalar *__re
     d_V[elem * BASIS_Q + t_id] = q_weight[t_id];
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_BASIS_NONTENSOR_H

--- a/include/ceed/jit-source/hip/hip-ref-basis-tensor.h
+++ b/include/ceed/jit-source/hip/hip-ref-basis-tensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP tensor product basis
-#ifndef CEED_HIP_REF_BASIS_TENSOR_H
-#define CEED_HIP_REF_BASIS_TENSOR_H
 
 #include <ceed.h>
 
@@ -200,7 +198,3 @@ extern "C" __global__ void Weight(const CeedInt num_elem, const CeedScalar *__re
   else if (BASIS_DIM == 2) Weight2d(num_elem, q_weight_1d, v);
   else if (BASIS_DIM == 3) Weight3d(num_elem, q_weight_1d, v);
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_BASIS_TENSOR_H

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble-diagonal.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP operator diagonal assembly
-#ifndef CEED_HIP_REF_OPERATOR_ASSEMBLE_DIAGONAL_H
-#define CEED_HIP_REF_OPERATOR_ASSEMBLE_DIAGONAL_H
 
 #include <ceed.h>
 
@@ -117,7 +115,3 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_OPERATOR_ASSEMBLE_DIAGONAL_H

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP operator full assembly
-#ifndef CEED_HIP_REF_OPERATOR_ASSEMBLE_H
-#define CEED_HIP_REF_OPERATOR_ASSEMBLE_H
 
 #include <ceed.h>
 
@@ -106,7 +104,3 @@ extern "C" __launch_bounds__(BLOCK_SIZE) __global__
     }    // end of in component
   }      // end of element loop
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_OPERATOR_ASSEMBLE_H

--- a/include/ceed/jit-source/hip/hip-ref-qfunction.h
+++ b/include/ceed/jit-source/hip/hip-ref-qfunction.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP backend QFunction read/write kernels
-#ifndef CEED_HIP_REF_QFUNCTION_H
-#define CEED_HIP_REF_QFUNCTION_H
 
 #include <ceed.h>
 
@@ -31,7 +29,3 @@ inline __device__ void writeQuads(const CeedInt quad, const CeedInt num_qpts, co
     d_v[quad + num_qpts * comp] = r_v[comp];
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_QFUNCTION_H

--- a/include/ceed/jit-source/hip/hip-ref-restriction-curl-oriented.h
+++ b/include/ceed/jit-source/hip/hip-ref-restriction-curl-oriented.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP curl-oriented element restriction kernels
-#ifndef CEED_HIP_REF_RESTRICTION_CURL_ORIENTED_H
-#define CEED_HIP_REF_RESTRICTION_CURL_ORIENTED_H
 
 #include <ceed.h>
 
@@ -177,7 +175,3 @@ extern "C" __global__ void CurlOrientedUnsignedTranspose(const CeedInt *__restri
   }
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_RESTRICTION_CURL_ORIENTED_H

--- a/include/ceed/jit-source/hip/hip-ref-restriction-offset.h
+++ b/include/ceed/jit-source/hip/hip-ref-restriction-offset.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP offset element restriction kernels
-#ifndef CEED_HIP_REF_RESTRICTION_OFFSET_H
-#define CEED_HIP_REF_RESTRICTION_OFFSET_H
 
 #include <ceed.h>
 
@@ -68,7 +66,3 @@ extern "C" __global__ void OffsetTranspose(const CeedInt *__restrict__ l_vec_ind
   }
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_RESTRICTION_OFFSET_H

--- a/include/ceed/jit-source/hip/hip-ref-restriction-oriented.h
+++ b/include/ceed/jit-source/hip/hip-ref-restriction-oriented.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP oriented element restriction kernels
-#ifndef CEED_HIP_REF_RESTRICTION_ORIENTED_H
-#define CEED_HIP_REF_RESTRICTION_ORIENTED_H
 
 #include <ceed.h>
 
@@ -75,7 +73,3 @@ extern "C" __global__ void OrientedTranspose(const CeedInt *__restrict__ l_vec_i
   }
 }
 #endif
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_RESTRICTION_ORIENTED_H

--- a/include/ceed/jit-source/hip/hip-ref-restriction-strided.h
+++ b/include/ceed/jit-source/hip/hip-ref-restriction-strided.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP strided element restriction kernels
-#ifndef CEED_HIP_REF_RESTRICTION_STRIDED_H
-#define CEED_HIP_REF_RESTRICTION_STRIDED_H
 
 #include <ceed.h>
 
@@ -41,7 +39,3 @@ extern "C" __global__ void StridedTranspose(const CeedScalar *__restrict__ u, Ce
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_REF_RESTRICTION_STRIDED_H

--- a/include/ceed/jit-source/hip/hip-shared-basis-read-write-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-read-write-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP shared memory basis read/write templates
-#ifndef CEED_HIP_SHARED_BASIS_READ_WRITE_TEMPLATES_H
-#define CEED_HIP_SHARED_BASIS_READ_WRITE_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -133,7 +131,3 @@ inline __device__ void WriteElementStrided3d(SharedData_Hip &data, const CeedInt
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_SHARED_BASIS_READ_WRITE_TEMPLATES_H

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP shared memory tensor product basis templates
-#ifndef CEED_HIP_SHARED_BASIS_TENSOR_TEMPLATES_H
-#define CEED_HIP_SHARED_BASIS_TENSOR_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -533,7 +531,3 @@ inline __device__ void WeightTensor3d(SharedData_Hip &data, const CeedScalar *__
     w[q] = quad ? pw * q_weight_1d[q] : 0.0;
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_SHARED_BASIS_TENSOR_TEMPLATES_H

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for HIP shared memory tensor product basis
-#ifndef CEED_HIP_SHARED_BASIS_TENSOR_H
-#define CEED_HIP_SHARED_BASIS_TENSOR_H
 
 #include <ceed.h>
 
@@ -213,7 +211,3 @@ extern "C" __launch_bounds__(BASIS_WEIGHT_BLOCK_SIZE) __global__
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_HIP_SHARED_BASIS_TENSOR_H

--- a/include/ceed/jit-source/magma/magma-basis-grad-1d.h
+++ b/include/ceed/jit-source/magma/magma-basis-grad-1d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis gradient in 1D
-#ifndef CEED_MAGMA_BASIS_GRAD_1D_H
-#define CEED_MAGMA_BASIS_GRAD_1D_H
 
 #include "magma-common-tensor.h"
 
@@ -128,5 +126,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_MAX_P_Q, MAGMA_MAXTHREADS_
   // write V
   write_1d<CeedScalar, BASIS_P, BASIS_NUM_COMP>(sV, dV, cstrdV, tx);
 }
-
-#endif  // CEED_MAGMA_BASIS_GRAD_1D_H

--- a/include/ceed/jit-source/magma/magma-basis-grad-2d.h
+++ b/include/ceed/jit-source/magma/magma-basis-grad-2d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis gradient in 2D
-#ifndef CEED_MAGMA_BASIS_GRAD_2D_H
-#define CEED_MAGMA_BASIS_GRAD_2D_H
 
 #include "magma-common-tensor.h"
 
@@ -190,5 +188,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_MAX_P_Q, MAGMA_MAXTHREADS_
   // write V
   write_V_2d<CeedScalar, BASIS_P, 1, BASIS_NUM_COMP, BASIS_P, 0>(dV + (0 * dstrdV), cstrdV, rV, tx);
 }
-
-#endif  // CEED_MAGMA_BASIS_GRAD_2D_H

--- a/include/ceed/jit-source/magma/magma-basis-grad-3d.h
+++ b/include/ceed/jit-source/magma/magma-basis-grad-3d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis gradient in 3D
-#ifndef CEED_MAGMA_BASIS_GRAD_3D_H
-#define CEED_MAGMA_BASIS_GRAD_3D_H
 
 #include "magma-common-tensor.h"
 
@@ -227,5 +225,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_MAX_P_Q *BASIS_MAX_P_Q, MA
   // write V
   write_V_3d<CeedScalar, BASIS_P, 1, BASIS_NUM_COMP, BASIS_P, 0>(dV + (0 * dstrdV), cstrdV, rV, tx);
 }
-
-#endif  // CEED_MAGMA_BASIS_GRAD_3D_H

--- a/include/ceed/jit-source/magma/magma-basis-interp-1d.h
+++ b/include/ceed/jit-source/magma/magma-basis-interp-1d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis interpolation in 1D
-#ifndef CEED_MAGMA_BASIS_INTERP_1D_H
-#define CEED_MAGMA_BASIS_INTERP_1D_H
 
 #include "magma-common-tensor.h"
 
@@ -128,5 +126,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_MAX_P_Q, MAGMA_MAXTHREADS_
   // write V
   write_1d<CeedScalar, BASIS_P, BASIS_NUM_COMP>(sV, dV, cstrdV, tx);
 }
-
-#endif  // CEED_MAGMA_BASIS_INTERP_1D_H

--- a/include/ceed/jit-source/magma/magma-basis-interp-2d.h
+++ b/include/ceed/jit-source/magma/magma-basis-interp-2d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis interpolation in 1D
-#ifndef CEED_MAGMA_BASIS_INTERP_2D_H
-#define CEED_MAGMA_BASIS_INTERP_2D_H
 
 #include "magma-common-tensor.h"
 
@@ -146,5 +144,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_MAX_P_Q, MAGMA_MAXTHREADS_
   // write V
   write_V_2d<CeedScalar, BASIS_P, 1, BASIS_NUM_COMP, BASIS_P, 0>(dV, cstrdV, rV, tx);
 }
-
-#endif  // CEED_MAGMA_BASIS_INTERP_2D_H

--- a/include/ceed/jit-source/magma/magma-basis-interp-3d.h
+++ b/include/ceed/jit-source/magma/magma-basis-interp-3d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis interpolation in 3D
-#ifndef CEED_MAGMA_BASIS_INTERP_3D_H
-#define CEED_MAGMA_BASIS_INTERP_3D_H
 
 #include "magma-common-tensor.h"
 
@@ -174,5 +172,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_MAX_P_Q *BASIS_MAX_P_Q, MA
   // write V
   write_V_3d<CeedScalar, BASIS_P, 1, BASIS_NUM_COMP, BASIS_P, 0>(dV, cstrdV, rV, tx);
 }
-
-#endif  // CEED_MAGMA_BASIS_INTERP_3D_H

--- a/include/ceed/jit-source/magma/magma-basis-interp-deriv-nontensor.h
+++ b/include/ceed/jit-source/magma/magma-basis-interp-deriv-nontensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA non-tensor basis interpolation
-#ifndef CEED_MAGMA_BASIS_INTERP_DERIV_NONTENSOR_H
-#define CEED_MAGMA_BASIS_INTERP_DERIV_NONTENSOR_H
 
 #include "magma-common-nontensor.h"
 
@@ -220,5 +218,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_P, MAGMA_MAXTHREADS_1D)) _
   magma_basis_nontensor_device_t<CeedScalar, BASIS_Q_COMP_DERIV, BASIS_P, BASIS_Q, BASIS_NB_DERIV_T>(n, dA, dB, dC, (CeedScalar *)shared_data);
 #endif
 }
-
-#endif  // CEED_MAGMA_BASIS_INTERP_DERIV_NONTENSOR_H

--- a/include/ceed/jit-source/magma/magma-basis-weight-1d.h
+++ b/include/ceed/jit-source/magma/magma-basis-weight-1d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis weight in 1D
-#ifndef CEED_MAGMA_BASIS_WEIGHT_1D_H
-#define CEED_MAGMA_BASIS_WEIGHT_1D_H
 
 #include "magma-common-tensor.h"
 
@@ -55,5 +53,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_Q, MAGMA_MAXTHREADS_1D)) _
   // write V
   dV[tx] = sV[tx];
 }
-
-#endif  // CEED_MAGMA_BASIS_WEIGHT_1D_H

--- a/include/ceed/jit-source/magma/magma-basis-weight-2d.h
+++ b/include/ceed/jit-source/magma/magma-basis-weight-2d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis weight in 2D
-#ifndef CEED_MAGMA_BASIS_WEIGHT_2D_H
-#define CEED_MAGMA_BASIS_WEIGHT_2D_H
 
 #include "magma-common-tensor.h"
 
@@ -65,5 +63,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_Q, MAGMA_MAXTHREADS_2D)) _
     }
   }
 }
-
-#endif  // CEED_MAGMA_BASIS_WEIGHT_2D_H

--- a/include/ceed/jit-source/magma/magma-basis-weight-3d.h
+++ b/include/ceed/jit-source/magma/magma-basis-weight-3d.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA tensor basis weight in 3D
-#ifndef CEED_MAGMA_BASIS_WEIGHT_3D_H
-#define CEED_MAGMA_BASIS_WEIGHT_3D_H
 
 #include "magma-common-tensor.h"
 
@@ -66,5 +64,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_Q *BASIS_Q, MAGMA_MAXTHREA
     }
   }
 }
-
-#endif  // CEED_MAGMA_BASIS_WEIGHT_3D_H

--- a/include/ceed/jit-source/magma/magma-basis-weight-nontensor.h
+++ b/include/ceed/jit-source/magma/magma-basis-weight-nontensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for MAGMA non-tensor basis weight
-#ifndef CEED_MAGMA_BASIS_WEIGHT_NONTENSOR_H
-#define CEED_MAGMA_BASIS_WEIGHT_NONTENSOR_H
 
 #include "magma-common-nontensor.h"
 
@@ -44,5 +42,3 @@ extern "C" __launch_bounds__(MAGMA_BASIS_BOUNDS(BASIS_Q, MAGMA_MAXTHREADS_1D)) _
   // write V
   dV[tx] = sV[tx];
 }
-
-#endif  // CEED_MAGMA_BASIS_WEIGHT_NONTENSOR_H

--- a/include/ceed/jit-source/magma/magma-common-nontensor.h
+++ b/include/ceed/jit-source/magma/magma-common-nontensor.h
@@ -7,8 +7,7 @@
 
 /// @file
 /// Internal header for MAGMA backend common non-tensor basis definitions
-#ifndef CEED_MAGMA_COMMON_NONTENSOR_H
-#define CEED_MAGMA_COMMON_NONTENSOR_H
+#pragma once
 
 #include "magma-common-defs.h"
 
@@ -151,5 +150,3 @@ static __device__ __inline__ void addmul_rAsBrC_1D_nosync(T rA[Q], T *sB, T rC[N
     }
   }
 }
-
-#endif  // CEED_MAGMA_COMMON_NONTENSOR_H

--- a/include/ceed/jit-source/magma/magma-common-tensor.h
+++ b/include/ceed/jit-source/magma/magma-common-tensor.h
@@ -7,8 +7,7 @@
 
 /// @file
 /// Internal header for MAGMA backend common tensor basis definitions
-#ifndef CEED_MAGMA_COMMON_TENSOR_H
-#define CEED_MAGMA_COMMON_TENSOR_H
+#pragma once
 
 #include "magma-common-defs.h"
 
@@ -206,5 +205,3 @@ static __device__ __inline__ void read_T_trans_gm2sm(const int tx, const CeedSca
   }
   // must sync after call
 }
-
-#endif  // CEED_MAGMA_COMMON_TENSOR_H

--- a/include/ceed/jit-source/sycl/sycl-gen-templates.h
+++ b/include/ceed/jit-source/sycl/sycl-gen-templates.h
@@ -7,9 +7,6 @@
 
 /// @file
 /// Internal header for SYCL backend macro and type definitions for JiT source
-#ifndef CEED_SYCL_GEN_TEMPLATES_H
-#define CEED_SYCL_GEN_TEMPLATES_H
-
 #include <ceed.h>
 
 #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
@@ -356,7 +353,3 @@ inline void gradColloTranspose3d(const CeedInt num_comp, const CeedInt Q_1D, con
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_SYCL_GEN_TEMPLATES_H

--- a/include/ceed/jit-source/sycl/sycl-jit.h
+++ b/include/ceed/jit-source/sycl/sycl-jit.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for SYCL backend macro and type definitions for JiT source
-#ifndef CEED_SYCL_JIT_H
-#define CEED_SYCL_JIT_H
 
 #define CEED_QFUNCTION(name) inline static int name
 #define CEED_QFUNCTION_HELPER inline static
@@ -17,5 +15,3 @@
 
 // Need quotes for recursive header inclusion
 #include "sycl-types.h"
-
-#endif  // CEED_SYCL_JIT_H

--- a/include/ceed/jit-source/sycl/sycl-ref-qfunction.h
+++ b/include/ceed/jit-source/sycl/sycl-ref-qfunction.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for SYCL backend QFunction read/write kernels
-#ifndef CEED_SYCL_REF_QFUNCTION_H
-#define CEED_SYCL_REF_QFUNCTION_H
 
 #include <ceed.h>
 
@@ -25,7 +23,3 @@ inline void readQuads(CeedInt N, CeedInt stride, CeedInt offset, const CeedScala
 inline void writeQuads(CeedInt N, CeedInt stride, CeedInt offset, const CeedScalar *src, CeedScalar *dest) {
   for (CeedInt i = 0; i < N; ++i) dest[stride * i + offset] = src[i];
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_SYCL_REF_QFUNCTION_H

--- a/include/ceed/jit-source/sycl/sycl-shared-basis-read-write-templates.h
+++ b/include/ceed/jit-source/sycl/sycl-shared-basis-read-write-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for SYCL shared memory basis read/write templates
-#ifndef CEED_SYCL_SHARED_BASIS_READ_WRITE_TEMPLATES_H
-#define CEED_SYCL_SHARED_BASIS_READ_WRITE_TEMPLATES_H
 
 #include <ceed.h>
 #include "sycl-types.h"
@@ -149,7 +147,3 @@ inline void WriteElementStrided3d(const CeedInt NUM_COMP, const CeedInt P_1D, co
     }
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_SYCL_SHARED_BASIS_READ_WRITE_TEMPLATES_H

--- a/include/ceed/jit-source/sycl/sycl-shared-basis-tensor-templates.h
+++ b/include/ceed/jit-source/sycl/sycl-shared-basis-tensor-templates.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for SYCL shared memory tensor product basis templates
-#ifndef CEED_SYCL_SHARED_BASIS_TENSOR_TEMPLATES_H
-#define CEED_SYCL_SHARED_BASIS_TENSOR_TEMPLATES_H
 
 #include <ceed.h>
 
@@ -598,7 +596,3 @@ inline void WeightTensor3d(const CeedInt Q_1D, const CeedScalar *restrict q_weig
     for (CeedInt q = 0; q < Q_1D; q++) w[q] = 0.0;
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_SYCL_SHARED_BASIS_TENSOR_TEMPLATES_H

--- a/include/ceed/jit-source/sycl/sycl-shared-basis-tensor.h
+++ b/include/ceed/jit-source/sycl/sycl-shared-basis-tensor.h
@@ -7,8 +7,6 @@
 
 /// @file
 /// Internal header for SYCL shared memory tensor product basis
-#ifndef CEED_SYCL_SHARED_BASIS_TENSOR_H
-#define CEED_SYCL_SHARED_BASIS_TENSOR_H
 
 #include <ceed.h>
 
@@ -182,7 +180,3 @@ kernel void Weight(const CeedInt num_elem, global const CeedScalar *restrict q_w
     WriteElementStrided3d(1, BASIS_Q_1D, num_elem, 1, BASIS_NUM_QPTS * num_elem, BASIS_NUM_QPTS, r_W, d_W);
   }
 }
-
-//------------------------------------------------------------------------------
-
-#endif  // CEED_SYCL_SHARED_BASIS_TENSOR_H

--- a/include/ceed/jit-tools.h
+++ b/include/ceed/jit-tools.h
@@ -13,7 +13,8 @@
 
 CEED_EXTERN int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid);
 CEED_EXTERN int CeedLoadSourceToBuffer(Ceed ceed, const char *source_file_path, char **buffer);
-CEED_EXTERN int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, char **buffer);
+CEED_EXTERN int CeedLoadSourceAndInitializeBuffer(Ceed ceed, const char *source_file_path, CeedInt *num_filepaths, char ***file_paths, char **buffer);
+CEED_EXTERN int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, CeedInt *num_filepaths, char ***file_paths, char **buffer);
 CEED_EXTERN int CeedPathConcatenate(Ceed ceed, const char *base_file_path, const char *relative_file_path, char **new_file_path);
 CEED_EXTERN int CeedGetJitRelativePath(const char *absolute_file_path, const char **relative_file_path);
 CEED_EXTERN int CeedGetJitAbsolutePath(Ceed ceed, const char *relative_file_path, const char **absolute_file_path);

--- a/tests/t406-qfunction-helper.h
+++ b/tests/t406-qfunction-helper.h
@@ -6,7 +6,8 @@
 // This file is part of CEED:  http://github.com/ceed
 
 // Note: testing 'pragma once'
-#pragma once
+// clang-format off
+# pragma  once
 // clang-format on
 
 #include <ceed.h>

--- a/tests/t406-qfunction-helper.h
+++ b/tests/t406-qfunction-helper.h
@@ -5,8 +5,9 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-#ifndef _helper_h
-#define _helper_h
+// Note: testing 'pragma once'
+#pragma once
+// clang-format on
 
 #include <ceed.h>
 
@@ -15,5 +16,3 @@
 CEED_QFUNCTION_HELPER CeedScalar times_two(CeedScalar x) { return SCALE_TWO * x; }
 
 CEED_QFUNCTION_HELPER CeedScalar times_three(CeedScalar x) { return SCALE_THREE * x; }
-
-#endif

--- a/tests/t406-qfunction-scales.h
+++ b/tests/t406-qfunction-scales.h
@@ -1,6 +1,7 @@
 #ifndef SCALES_H
 #define SCALES_H
 // Testing # on first line
+// Note: #ifndef and #pragma once header guards both work
 
 // Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and other CEED contributors.
 // All Rights Reserved. See the top-level LICENSE and NOTICE files for details.

--- a/tests/t406-qfunction.h
+++ b/tests/t406-qfunction.h
@@ -6,11 +6,13 @@
 // This file is part of CEED:  http://github.com/ceed
 
 // Note: intentionally testing strange spacing in '#include's
+// clang-format off
 #include <ceed.h>
-#include <math.h>
+#  include  <math.h>
 
 #include "t406-qfunction-helper.h"
-#include "t406-qfunction-scales.h"
+#  include "t406-qfunction-scales.h"
+// clang-format on
 
 CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   const CeedScalar *w      = in[0];

--- a/tests/t406-qfunction.h
+++ b/tests/t406-qfunction.h
@@ -11,6 +11,8 @@
 #  include  <math.h>
 
 #include "t406-qfunction-helper.h"
+// test duplicate includes of guarded files
+#include "t406-qfunction-helper.h"
 #  include "t406-qfunction-scales.h"
 // clang-format on
 


### PR DESCRIPTION
Follow-up on #1534 and #1537, dropping QF source header guards where able