### PR TITLE
fix(fluids): Update to new isoperiodic API

### DIFF
--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -16,13 +16,8 @@
 #include "qfunctions/newtonian_types.h"
 #include "qfunctions/stabilization_types.h"
 
-#if PETSC_VERSION_LT(3, 20, 0)
-#error "PETSc v3.20 or later is required"
-#endif
-
 #if PETSC_VERSION_LT(3, 21, 0)
-#define DMSetCoordinateDisc(a, b, c) DMProjectCoordinates(a, b)
-#define DMPlexFilter(a, b, c, d, e, f, g) DMPlexFilter(a, b, c, g)
+#error "PETSc v3.21 or later is required"
 #endif
 
 // -----------------------------------------------------------------------------

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -43,19 +43,22 @@ PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree) {
   user->spanstats.span_width = domain_max[2] - domain_min[1];
 
   {  // Get DM from surface
-    DM          parent_distributed_dm;
-    PetscSF     isoperiodicface;
-    DMLabel     label;
-    PetscMPIInt size;
+    DM             parent_distributed_dm;
+    const PetscSF *isoperiodicface;
+    PetscInt       num_isoperiodicface;
+    DMLabel        label;
+    PetscMPIInt    size;
 
-    PetscCall(DMPlexGetIsoperiodicFaceSF(user->dm, &isoperiodicface));
+    PetscCall(DMPlexGetIsoperiodicFaceSF(user->dm, &num_isoperiodicface, &isoperiodicface));
 
     if (isoperiodicface) {
       PetscSF         inv_isoperiodicface;
-      PetscInt        nleaves;
+      PetscInt        nleaves, isoperiodicface_index = -1;
       const PetscInt *ilocal;
 
-      PetscCall(PetscSFCreateInverseSF(isoperiodicface, &inv_isoperiodicface));
+      PetscCall(PetscOptionsGetInt(NULL, NULL, "-ts_monitor_turbulence_spanstats_isoperiodic_facesf", &isoperiodicface_index, NULL));
+      isoperiodicface_index = isoperiodicface_index == -1 ? num_isoperiodicface - 1 : isoperiodicface_index;
+      PetscCall(PetscSFCreateInverseSF(isoperiodicface[isoperiodicface_index], &inv_isoperiodicface));
       PetscCall(PetscSFGetGraph(inv_isoperiodicface, NULL, &nleaves, &ilocal, NULL));
       PetscCall(DMCreateLabel(user->dm, "Periodic Face"));
       PetscCall(DMGetLabel(user->dm, "Periodic Face", &label));


### PR DESCRIPTION
[This (my) PETSc MR](https://gitlab.com/petsc/petsc/-/merge_requests/7305) changed the interface for the isoperiodic functions. This is not a "same, but new arguments" breakage as most previous Plex breakages have been, but actually requires a small change to the code itself. Thus, a simple macro overload isn't an option.

**How do we want to handle that transitions?**

I see a two main options:
1. Just say "must use PETSc version >= 3.21.0". We've done similar things in the past
2. Add in a macro code block. I'd love to keep these things out of the code, but beggars and choosers and such.

I prefer route 1 (especially since the PETSc version macros aren't effective for builds off of PETSc `main`), but am open to either. Thoughts?

Regardless of which way we go, this will require updating the PETSc version on Noether.