### PR TITLE
fluids: Update topological periodicity localization

### DIFF
--- a/examples/fluids/src/dm_utils.c
+++ b/examples/fluids/src/dm_utils.c
@@ -457,7 +457,6 @@ PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_co
     PetscCall(PetscFECreateLagrange(comm, dim, num_comp_coord, is_simplex, fe_coord_order, q_order, &fe_coord_new));
     if (setup_faces) PetscCall(PetscFEGetHeightSubspace(fe_coord_new, 1, &fe_coord_face_new));
     PetscCall(DMSetCoordinateDisc(dm, fe_coord_new, PETSC_TRUE));
-    PetscCall(DMLocalizeCoordinates(dm));  // Update CellCoordinateDM with projected coordinates
     PetscCall(PetscFEDestroy(&fe_coord_new));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -486,10 +485,9 @@ PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm) {
 
       PetscCall(DMGetCoordinateDM(dm, &dm_coord));
       PetscCall(DMPlexSetClosurePermutationTensor(dm_coord, PETSC_DETERMINE, NULL));
-      PetscCall(DMGetCellCoordinateDM(dm, &dm_coord));
-      if (dm_coord) PetscCall(DMPlexSetClosurePermutationTensor(dm_coord, PETSC_DETERMINE, NULL));
     }
   }
+  PetscCall(DMLocalizeCoordinates(dm));  // Must localize after tensor closure setting
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -32,6 +32,7 @@ PetscErrorCode CreateDM(MPI_Comm comm, ProblemData *problem, MatType mat_type, V
   // Set Tensor elements
   PetscCall(PetscOptionsSetValue(NULL, "-dm_plex_simplex", "0"));
   PetscCall(PetscOptionsSetValue(NULL, "-dm_sparse_localize", "0"));
+  PetscCall(PetscOptionsSetValue(NULL, "-dm_localize", "0"));  // Localization done in DMSetupByOrderEnd_FEM
   PetscCall(PetscOptionsSetValue(NULL, "-dm_blocking_type", "field_node"));
 
   // Set CL options


### PR DESCRIPTION
See https://github.com/CEED/libCEED/issues/1470 for details. Relies on PETSc MR in https://gitlab.com/petsc/petsc/-/merge_requests/7438

tl;dr is that the localization of the continuous coordinate DM to the discontinuous coordinate DM (i.e. the cell DM) must be done *after* the coordinate DM is set to the tensor product ordering.

Fixes #1470 