### PR TITLE
fix: Correct docstring, make parameter name consistent

### DIFF
--- a/include/ceed/jit-tools.h
+++ b/include/ceed/jit-tools.h
@@ -13,8 +13,10 @@
 
 CEED_EXTERN int CeedCheckFilePath(Ceed ceed, const char *source_file_path, bool *is_valid);
 CEED_EXTERN int CeedLoadSourceToBuffer(Ceed ceed, const char *source_file_path, char **buffer);
-CEED_EXTERN int CeedLoadSourceAndInitializeBuffer(Ceed ceed, const char *source_file_path, CeedInt *num_filepaths, char ***file_paths, char **buffer);
-CEED_EXTERN int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, CeedInt *num_filepaths, char ***file_paths, char **buffer);
+CEED_EXTERN int CeedLoadSourceAndInitializeBuffer(Ceed ceed, const char *source_file_path, CeedInt *num_file_paths, char ***file_paths,
+                                                  char **buffer);
+CEED_EXTERN int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, CeedInt *num_file_paths, char ***file_paths,
+                                                  char **buffer);
 CEED_EXTERN int CeedPathConcatenate(Ceed ceed, const char *base_file_path, const char *relative_file_path, char **new_file_path);
 CEED_EXTERN int CeedGetJitRelativePath(const char *absolute_file_path, const char **relative_file_path);
 CEED_EXTERN int CeedGetJitAbsolutePath(Ceed ceed, const char *relative_file_path, const char **absolute_file_path);

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -300,6 +300,7 @@ int CeedFree(void *p) {
   @param[in]     source_array          Source data provided by user
   @param[in]     copy_mode             Copy mode for the data
   @param[in]     num_values            Number of values to handle
+  @param[in]     size_unit             Size of array element in bytes
   @param[in,out] target_array_owned    Pointer to location to allocated or hold owned data, may be freed if already allocated
   @param[out]    target_array_borrowed Pointer to location to hold borrowed data
   @param[out]    target_array          Pointer to location for data


### PR DESCRIPTION
Caught these when I was running documentation locally. I'm still getting:
```
/home/jrwrigh/software/libCEED/interface/ceed-jit-tools.c:65: warning: end of comment block while expecting command </tt>
/home/jrwrigh/software/libCEED/interface/ceed-jit-tools.c:64: warning: found </tt> tag without matching <tt>
```

but I'm not sure how to address those.