### PR TITLE
fluids: Remove ceed backend from advection.yaml

### DIFF
--- a/examples/fluids/advection.yaml
+++ b/examples/fluids/advection.yaml
@@ -1,4 +1,3 @@
-ceed: /cpu/self/memcheck/blocked
 problem: advection
 CtauS: .3
 stab: su


### PR DESCRIPTION
Due to ordering, this overides the regression tests. So all the new advection tests that used `advection.yaml` were actually running with the wrong ceed backend the entire time. Let's hope everything still passes...