### PR TITLE
fluids: Make ProblemData a pointer to struct

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   AppCtx app_ctx;
   PetscCall(PetscCalloc1(1, &app_ctx));
 
-  ProblemData *problem = NULL;
+  ProblemData problem;
   PetscCall(PetscCalloc1(1, &problem));
 
   User user;
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
   // Choose the problem from the list of registered problems
   // ---------------------------------------------------------------------------
   {
-    PetscErrorCode (*p)(ProblemData *, DM, void *, SimpleBC);
+    PetscErrorCode (*p)(ProblemData, DM, void *, SimpleBC);
     PetscCall(PetscFunctionListFind(app_ctx->problems, app_ctx->problem_name, &p));
     PetscCheck(p, PETSC_COMM_SELF, 1, "Problem '%s' not found", app_ctx->problem_name);
     PetscCall((*p)(problem, dm, &user, bc));
@@ -362,6 +362,7 @@ int main(int argc, char **argv) {
   PetscCall(PetscFree(phys_ctx));
   PetscCall(PetscFree(app_ctx));
   PetscCall(PetscFree(ceed_data));
+  PetscCall(PetscFree(problem));
 
   return PetscFinalize();
 }

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -14,7 +14,6 @@
 
 #include "./include/petsc_ops.h"
 #include "qfunctions/newtonian_types.h"
-#include "qfunctions/stabilization_types.h"
 
 #if PETSC_VERSION_LT(3, 21, 0)
 #error "PETSc v3.21 or later is required"
@@ -290,7 +289,7 @@ typedef struct {
 } ProblemQFunctionSpec;
 
 // Problem specific data
-typedef struct ProblemData_private ProblemData;
+typedef struct ProblemData_private *ProblemData;
 struct ProblemData_private {
   CeedInt              dim, q_data_size_vol, q_data_size_sur, jac_data_size_sur;
   CeedScalar           dm_scale;
@@ -298,7 +297,7 @@ struct ProblemData_private {
       apply_freestream, apply_slip, apply_inflow_jacobian, apply_outflow_jacobian, apply_freestream_jacobian, apply_slip_jacobian;
   bool      non_zero_time;
   PetscBool bc_from_ics, use_strong_bc_ceed, uses_newtonian;
-  PetscErrorCode (*print_info)(User, ProblemData *, AppCtx);
+  PetscErrorCode (*print_info)(User, ProblemData, AppCtx);
   PetscErrorCode (*create_mass_operator)(User, CeedOperator *);
 };
 
@@ -308,29 +307,29 @@ extern int FreeContextPetsc(void *);
 // Set up problems
 // -----------------------------------------------------------------------------
 // Set up function for each problem
-extern PetscErrorCode NS_TAYLOR_GREEN(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_GAUSSIAN_WAVE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_CHANNEL(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
-extern PetscErrorCode NS_ADVECTION2D(ProblemData *problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_TAYLOR_GREEN(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_GAUSSIAN_WAVE(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_CHANNEL(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_BLASIUS(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_NEWTONIAN_IG(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_DENSITY_CURRENT(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_EULER_VORTEX(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_SHOCKTUBE(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_ADVECTION(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
+extern PetscErrorCode NS_ADVECTION2D(ProblemData problem, DM dm, void *ctx, SimpleBC bc);
 
 // Print function for each problem
-extern PetscErrorCode PRINT_NEWTONIAN(User user, ProblemData *problem, AppCtx app_ctx);
+extern PetscErrorCode PRINT_NEWTONIAN(User user, ProblemData problem, AppCtx app_ctx);
 
-extern PetscErrorCode PRINT_EULER_VORTEX(User user, ProblemData *problem, AppCtx app_ctx);
+extern PetscErrorCode PRINT_EULER_VORTEX(User user, ProblemData problem, AppCtx app_ctx);
 
-extern PetscErrorCode PRINT_SHOCKTUBE(User user, ProblemData *problem, AppCtx app_ctx);
+extern PetscErrorCode PRINT_SHOCKTUBE(User user, ProblemData problem, AppCtx app_ctx);
 
-extern PetscErrorCode PRINT_ADVECTION(User user, ProblemData *problem, AppCtx app_ctx);
+extern PetscErrorCode PRINT_ADVECTION(User user, ProblemData problem, AppCtx app_ctx);
 
-extern PetscErrorCode PRINT_ADVECTION2D(User user, ProblemData *problem, AppCtx app_ctx);
+extern PetscErrorCode PRINT_ADVECTION2D(User user, ProblemData problem, AppCtx app_ctx);
 
-PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData *problem, MPI_Comm comm);
+PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData problem, MPI_Comm comm);
 
 // -----------------------------------------------------------------------------
 // libCEED functions
@@ -355,7 +354,7 @@ PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc, CeedData c
                                        CeedOperator op_apply_ijacobian_vol, CeedInt height, CeedInt P_sur, CeedInt Q_sur, CeedInt q_data_size_sur,
                                        CeedInt jac_data_size_sur, CeedOperator *op_apply, CeedOperator *op_apply_ijacobian);
 
-PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData *problem, SimpleBC bc);
+PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData problem, SimpleBC bc);
 
 // -----------------------------------------------------------------------------
 // Time-stepping functions
@@ -379,10 +378,10 @@ PetscErrorCode UpdateBoundaryValues(User user, Vec Q_loc, PetscReal t);
 // Setup DM
 // -----------------------------------------------------------------------------
 // Create mesh
-PetscErrorCode CreateDM(MPI_Comm comm, ProblemData *problem, MatType, VecType, DM *dm);
+PetscErrorCode CreateDM(MPI_Comm comm, ProblemData problem, MatType, VecType, DM *dm);
 
 // Set up DM
-PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_extra, SimpleBC bc, Physics phys);
+PetscErrorCode SetUpDM(DM dm, ProblemData problem, PetscInt degree, PetscInt q_extra, SimpleBC bc, Physics phys);
 PetscErrorCode DMSetupByOrderBegin_FEM(PetscBool setup_faces, PetscBool setup_coords, PetscInt degree, PetscInt coord_order, PetscInt q_extra,
                                        PetscInt num_fields, const PetscInt *field_sizes, DM dm);
 PetscErrorCode DMSetupByOrderEnd_FEM(PetscBool setup_coords, DM dm);
@@ -390,7 +389,7 @@ PetscErrorCode DMSetupByOrder_FEM(PetscBool setup_faces, PetscBool setup_coords,
                                   PetscInt num_fields, const PetscInt *field_sizes, DM dm);
 
 // Refine DM for high-order viz
-PetscErrorCode VizRefineDM(DM dm, User user, ProblemData *problem, SimpleBC bc, Physics phys);
+PetscErrorCode VizRefineDM(DM dm, User user, ProblemData problem, SimpleBC bc, Physics phys);
 
 // -----------------------------------------------------------------------------
 // Process command line options
@@ -419,7 +418,7 @@ PetscErrorCode RegressionTest(AppCtx app_ctx, Vec Q);
 PetscErrorCode PrintError(CeedData ceed_data, DM dm, User user, Vec Q, PetscScalar final_time);
 
 // Post-processing
-PetscErrorCode PostProcess(TS ts, CeedData ceed_data, DM dm, ProblemData *problem, User user, Vec Q, PetscScalar final_time);
+PetscErrorCode PostProcess(TS ts, CeedData ceed_data, DM dm, ProblemData problem, User user, Vec Q, PetscScalar final_time);
 
 // -- Gather initial Q values in case of continuation of simulation
 PetscErrorCode SetupICsFromBinary(MPI_Comm comm, AppCtx app_ctx, Vec Q);
@@ -448,7 +447,7 @@ PetscErrorCode PhastaDatFileReadToArrayReal(const MPI_Comm comm, const char path
 // Turbulence Statistics Collection Functions
 // -----------------------------------------------------------------------------
 
-PetscErrorCode TurbulenceStatisticsSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
+PetscErrorCode TurbulenceStatisticsSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem);
 PetscErrorCode TSMonitor_TurbulenceStatistics(TS ts, PetscInt steps, PetscReal solution_time, Vec Q, void *ctx);
 PetscErrorCode TurbulenceStatisticsDestroy(User user, CeedData ceed_data);
 
@@ -456,10 +455,10 @@ PetscErrorCode TurbulenceStatisticsDestroy(User user, CeedData ceed_data);
 // Data-Driven Subgrid Stress (DD-SGS) Modeling Functions
 // -----------------------------------------------------------------------------
 
-PetscErrorCode SgsDDSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
+PetscErrorCode SgsDDSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem);
 PetscErrorCode SgsDDDataDestroy(SgsDDData sgs_dd_data);
 PetscErrorCode SgsDDApplyIFunction(User user, const Vec Q_loc, Vec G_loc);
-PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem, StateVariable state_var_input,
+PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem, StateVariable state_var_input,
                                                CeedElemRestriction elem_restr_input, CeedBasis basis_input, NodalProjectionData *pgrad_velo_proj);
 PetscErrorCode VelocityGradientProjectionApply(NodalProjectionData grad_velo_proj, Vec Q_loc, Vec VelocityGradient);
 PetscErrorCode GridAnisotropyTensorProjectionSetupApply(Ceed ceed, User user, CeedData ceed_data, CeedElemRestriction *elem_restr_grid_aniso,
@@ -472,28 +471,28 @@ PetscErrorCode GridAnisotropyTensorCalculateCollocatedVector(Ceed ceed, User use
 // -----------------------------------------------------------------------------
 
 // Setup StrongBCs that use QFunctions
-PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData *problem, SimpleBC bc);
+PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData problem, SimpleBC bc);
 
-PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
-PetscErrorCode OutflowBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
-PetscErrorCode SlipBCSetup(ProblemData *problem, DM dm, void *ctx, CeedQFunctionContext newtonian_ig_qfctx);
+PetscErrorCode FreestreamBCSetup(ProblemData problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
+PetscErrorCode OutflowBCSetup(ProblemData problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
+PetscErrorCode SlipBCSetup(ProblemData problem, DM dm, void *ctx, CeedQFunctionContext newtonian_ig_qfctx);
 
 // -----------------------------------------------------------------------------
 // Differential Filtering Functions
 // -----------------------------------------------------------------------------
 
-PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
+PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem);
 PetscErrorCode DifferentialFilterDataDestroy(DiffFilterData diff_filter);
 PetscErrorCode TSMonitor_DifferentialFilter(TS ts, PetscInt steps, PetscReal solution_time, Vec Q, void *ctx);
 PetscErrorCode DifferentialFilterApply(User user, const PetscReal solution_time, const Vec Q, Vec Filtered_Solution);
-PetscErrorCode DifferentialFilterMmsICSetup(ProblemData *problem);
+PetscErrorCode DifferentialFilterMmsICSetup(ProblemData problem);
 
 // -----------------------------------------------------------------------------
 // SGS Data-Driven Training via SmartSim
 // -----------------------------------------------------------------------------
 PetscErrorCode SmartSimSetup(User user);
 PetscErrorCode SmartSimDataDestroy(SmartSimData smartsim);
-PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem);
+PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem);
 PetscErrorCode TSMonitor_SGS_DD_Training(TS ts, PetscInt step_num, PetscReal solution_time, Vec Q, void *ctx);
 PetscErrorCode TSPostStep_SGS_DD_Training(TS ts);
 PetscErrorCode SGS_DD_TrainingDataDestroy(SGS_DD_TrainingData sgs_dd_train);

--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -80,7 +80,7 @@ PetscErrorCode CreateKSPMassOperator_AdvectionStabilized(User user, CeedOperator
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_ADVECTION(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   WindType             wind_type;
   AdvectionICType      advectionic_type;
   BubbleContinuityType bubble_continuity_type;
@@ -284,7 +284,7 @@ PetscErrorCode NS_ADVECTION(ProblemData *problem, DM dm, void *ctx, SimpleBC bc)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode PRINT_ADVECTION(User user, ProblemData *problem, AppCtx app_ctx) {
+PetscErrorCode PRINT_ADVECTION(User user, ProblemData problem, AppCtx app_ctx) {
   MPI_Comm         comm = user->comm;
   Ceed             ceed = user->ceed;
   SetupContextAdv  setup_ctx;

--- a/examples/fluids/problems/bc_freestream.c
+++ b/examples/fluids/problems/bc_freestream.c
@@ -18,7 +18,7 @@
 
 static const char *const RiemannSolverTypes[] = {"hll", "hllc", "RiemannSolverTypes", "RIEMANN_", NULL};
 
-PetscErrorCode FreestreamBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference) {
+PetscErrorCode FreestreamBCSetup(ProblemData problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference) {
   User                 user = *(User *)ctx;
   MPI_Comm             comm = user->comm;
   Ceed                 ceed = user->ceed;
@@ -105,7 +105,7 @@ typedef enum {
   OUTFLOW_PRESSURE,
 } OutflowType;
 
-PetscErrorCode OutflowBCSetup(ProblemData *problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference) {
+PetscErrorCode OutflowBCSetup(ProblemData problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference) {
   User                 user = *(User *)ctx;
   Ceed                 ceed = user->ceed;
   OutflowContext       outflow_ctx;

--- a/examples/fluids/problems/bc_slip.c
+++ b/examples/fluids/problems/bc_slip.c
@@ -16,7 +16,7 @@
 #include "../navierstokes.h"
 #include "../qfunctions/newtonian_types.h"
 
-PetscErrorCode SlipBCSetup(ProblemData *problem, DM dm, void *ctx, CeedQFunctionContext newtonian_ig_qfctx) {
+PetscErrorCode SlipBCSetup(ProblemData problem, DM dm, void *ctx, CeedQFunctionContext newtonian_ig_qfctx) {
   User user = *(User *)ctx;
   Ceed ceed = user->ceed;
 

--- a/examples/fluids/problems/blasius.c
+++ b/examples/fluids/problems/blasius.c
@@ -229,7 +229,7 @@ static PetscErrorCode ModifyMesh(MPI_Comm comm, DM dm, PetscInt dim, PetscReal g
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode NS_BLASIUS(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_BLASIUS(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   User                     user    = *(User *)ctx;
   MPI_Comm                 comm    = user->comm;
   Ceed                     ceed    = user->ceed;

--- a/examples/fluids/problems/channel.c
+++ b/examples/fluids/problems/channel.c
@@ -15,7 +15,7 @@
 
 #include "../navierstokes.h"
 
-PetscErrorCode NS_CHANNEL(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_CHANNEL(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   User                     user = *(User *)ctx;
   MPI_Comm                 comm = user->comm;
   Ceed                     ceed = user->ceed;

--- a/examples/fluids/problems/densitycurrent.c
+++ b/examples/fluids/problems/densitycurrent.c
@@ -15,7 +15,7 @@
 
 #include "../navierstokes.h"
 
-PetscErrorCode NS_DENSITY_CURRENT(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_DENSITY_CURRENT(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   User                     user = *(User *)ctx;
   MPI_Comm                 comm = user->comm;
   Ceed                     ceed = user->ceed;

--- a/examples/fluids/problems/eulervortex.c
+++ b/examples/fluids/problems/eulervortex.c
@@ -16,7 +16,7 @@
 #include "../navierstokes.h"
 #include "../qfunctions/setupgeo.h"
 
-PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_EULER_VORTEX(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   EulerTestType        euler_test;
   User                 user = *(User *)ctx;
   StabilizationType    stab;
@@ -148,7 +148,7 @@ PetscErrorCode NS_EULER_VORTEX(ProblemData *problem, DM dm, void *ctx, SimpleBC 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode PRINT_EULER_VORTEX(User user, ProblemData *problem, AppCtx app_ctx) {
+PetscErrorCode PRINT_EULER_VORTEX(User user, ProblemData problem, AppCtx app_ctx) {
   MPI_Comm     comm = user->comm;
   Ceed         ceed = user->ceed;
   EulerContext euler_ctx;

--- a/examples/fluids/problems/gaussianwave.c
+++ b/examples/fluids/problems/gaussianwave.c
@@ -16,7 +16,7 @@
 #include "../navierstokes.h"
 #include "../qfunctions/bc_freestream_type.h"
 
-PetscErrorCode NS_GAUSSIAN_WAVE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_GAUSSIAN_WAVE(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   User                     user = *(User *)ctx;
   MPI_Comm                 comm = user->comm;
   Ceed                     ceed = user->ceed;

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -116,7 +116,7 @@ PetscErrorCode CreateKSPMassOperator_NewtonianStabilized(User user, CeedOperator
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_mass));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
-PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_NEWTONIAN_IG(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   SetupContext             setup_context;
   User                     user   = *(User *)ctx;
   CeedInt                  degree = user->app_ctx->degree;
@@ -376,7 +376,7 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData *problem, DM dm, void *ctx, SimpleBC 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode PRINT_NEWTONIAN(User user, ProblemData *problem, AppCtx app_ctx) {
+PetscErrorCode PRINT_NEWTONIAN(User user, ProblemData problem, AppCtx app_ctx) {
   MPI_Comm                 comm = user->comm;
   Ceed                     ceed = user->ceed;
   NewtonianIdealGasContext newtonian_ctx;

--- a/examples/fluids/problems/sgs_dd_model.c
+++ b/examples/fluids/problems/sgs_dd_model.c
@@ -509,7 +509,7 @@ static PetscErrorCode SgsDDContextFill(MPI_Comm comm, char data_dir[PETSC_MAX_PA
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SgsDDSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
+PetscErrorCode SgsDDSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem) {
   PetscReal                alpha = 0;
   SgsDDContext             sgsdd_ctx;
   MPI_Comm                 comm                           = user->comm;

--- a/examples/fluids/problems/shocktube.c
+++ b/examples/fluids/problems/shocktube.c
@@ -16,7 +16,7 @@
 #include "../navierstokes.h"
 #include "../qfunctions/setupgeo.h"
 
-PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_SHOCKTUBE(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   SetupContextShock    setup_context;
   User                 user = *(User *)ctx;
   MPI_Comm             comm = user->comm;
@@ -148,7 +148,7 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData *problem, DM dm, void *ctx, SimpleBC bc)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode PRINT_SHOCKTUBE(User user, ProblemData *problem, AppCtx app_ctx) {
+PetscErrorCode PRINT_SHOCKTUBE(User user, ProblemData problem, AppCtx app_ctx) {
   MPI_Comm comm = user->comm;
 
   PetscFunctionBeginUser;

--- a/examples/fluids/problems/stg_shur14.c
+++ b/examples/fluids/problems/stg_shur14.c
@@ -215,7 +215,7 @@ PetscErrorCode GetStgContextData(const MPI_Comm comm, const DM dm, char stg_infl
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupStg(const MPI_Comm comm, const DM dm, ProblemData *problem, User user, const bool prescribe_T, const CeedScalar theta0,
+PetscErrorCode SetupStg(const MPI_Comm comm, const DM dm, ProblemData problem, User user, const bool prescribe_T, const CeedScalar theta0,
                         const CeedScalar P0) {
   Ceed                     ceed                                = user->ceed;
   char                     stg_inflow_path[PETSC_MAX_PATH_LEN] = "./STGInflow.dat";
@@ -292,7 +292,7 @@ PetscErrorCode SetupStg(const MPI_Comm comm, const DM dm, ProblemData *problem, 
 }
 
 // @brief Set STG strongly enforce components using DMAddBoundary
-PetscErrorCode SetupStrongStg(DM dm, SimpleBC bc, ProblemData *problem, Physics phys) {
+PetscErrorCode SetupStrongStg(DM dm, SimpleBC bc, ProblemData problem, Physics phys) {
   DMLabel  label;
   PetscInt comps[5], num_comps = 4;
 
@@ -316,7 +316,7 @@ PetscErrorCode SetupStrongStg(DM dm, SimpleBC bc, ProblemData *problem, Physics 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupStrongStg_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size, CeedInt dXdx_size,
+PetscErrorCode SetupStrongStg_QF(Ceed ceed, ProblemData problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size, CeedInt dXdx_size,
                                  CeedQFunction *qf_strongbc) {
   PetscFunctionBeginUser;
   PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, StgShur14InflowStrongQF, StgShur14InflowStrongQF_loc, qf_strongbc));
@@ -330,7 +330,7 @@ PetscErrorCode SetupStrongStg_QF(Ceed ceed, ProblemData *problem, CeedInt num_co
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupStrongStg_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
+PetscErrorCode SetupStrongStg_PreProcessing(Ceed ceed, ProblemData problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
                                             CeedQFunction *qf_strongbc) {
   PetscFunctionBeginUser;
   PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, StgShur14Preprocess, StgShur14Preprocess_loc, qf_strongbc));

--- a/examples/fluids/problems/stg_shur14.h
+++ b/examples/fluids/problems/stg_shur14.h
@@ -11,13 +11,13 @@
 #include "../navierstokes.h"
 #include "../qfunctions/stg_shur14_type.h"
 
-extern PetscErrorCode SetupStg(const MPI_Comm comm, const DM dm, ProblemData *problem, User user, const bool prescribe_T, const CeedScalar theta0,
+extern PetscErrorCode SetupStg(const MPI_Comm comm, const DM dm, ProblemData problem, User user, const bool prescribe_T, const CeedScalar theta0,
                                const CeedScalar P0);
 
-extern PetscErrorCode SetupStrongStg(DM dm, SimpleBC bc, ProblemData *problem, Physics phys);
+extern PetscErrorCode SetupStrongStg(DM dm, SimpleBC bc, ProblemData problem, Physics phys);
 
-extern PetscErrorCode SetupStrongStg_QF(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size,
+extern PetscErrorCode SetupStrongStg_QF(Ceed ceed, ProblemData problem, CeedInt num_comp_x, CeedInt num_comp_q, CeedInt stg_data_size,
                                         CeedInt dXdx_size, CeedQFunction *qf_strongbc);
 
-extern PetscErrorCode SetupStrongStg_PreProcessing(Ceed ceed, ProblemData *problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
+extern PetscErrorCode SetupStrongStg_PreProcessing(Ceed ceed, ProblemData problem, CeedInt num_comp_x, CeedInt stg_data_size, CeedInt dXdx_size,
                                                    CeedQFunction *pqf_strongbc);

--- a/examples/fluids/problems/taylorgreen.c
+++ b/examples/fluids/problems/taylorgreen.c
@@ -12,7 +12,7 @@
 
 #include "../navierstokes.h"
 
-PetscErrorCode NS_TAYLOR_GREEN(ProblemData *problem, DM dm, void *ctx, SimpleBC bc) {
+PetscErrorCode NS_TAYLOR_GREEN(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   PetscFunctionBeginUser;
   PetscCall(NS_NEWTONIAN_IG(problem, dm, ctx, bc));
 

--- a/examples/fluids/src/cloptions.c
+++ b/examples/fluids/src/cloptions.c
@@ -172,7 +172,7 @@ PetscErrorCode ProcessCommandLineOptions(MPI_Comm comm, AppCtx app_ctx, SimpleBC
     }
   }
   app_ctx->wall_forces.num_wall = bc->num_wall;
-  PetscMalloc1(bc->num_wall, &app_ctx->wall_forces.walls);
+  PetscCall(PetscMalloc1(bc->num_wall, &app_ctx->wall_forces.walls));
   PetscCall(PetscArraycpy(app_ctx->wall_forces.walls, bc->walls, bc->num_wall));
 
   // Inflow BCs

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -173,7 +173,7 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
 }
 
 // @brief Setup DM, operators, contexts, etc. for performing differential filtering
-PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
+PetscErrorCode DifferentialFilterSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem) {
   MPI_Comm                  comm = user->comm;
   NewtonianIdealGasContext  gas;
   DifferentialFilterContext diff_filter_ctx;
@@ -331,7 +331,7 @@ PetscErrorCode DifferentialFilterDataDestroy(DiffFilterData diff_filter) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode DifferentialFilterMmsICSetup(ProblemData *problem) {
+PetscErrorCode DifferentialFilterMmsICSetup(ProblemData problem) {
   PetscFunctionBeginUser;
   problem->ics.qfunction     = DifferentialFilter_MMS_IC;
   problem->ics.qfunction_loc = DifferentialFilter_MMS_IC_loc;

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -194,7 +194,7 @@ PetscErrorCode PrintError(CeedData ceed_data, DM dm, User user, Vec Q, PetscScal
 }
 
 // Post-processing
-PetscErrorCode PostProcess(TS ts, CeedData ceed_data, DM dm, ProblemData *problem, User user, Vec Q, PetscScalar final_time) {
+PetscErrorCode PostProcess(TS ts, CeedData ceed_data, DM dm, ProblemData problem, User user, Vec Q, PetscScalar final_time) {
   PetscInt          steps;
   TSConvergedReason reason;
 
@@ -397,7 +397,7 @@ PetscErrorCode RegisterLogEvents() {
 }
 
 // Print information about the given simulation run
-PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData *problem, MPI_Comm comm) {
+PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData problem, MPI_Comm comm) {
   Ceed ceed = user->ceed;
   PetscFunctionBeginUser;
   // Header and rank

--- a/examples/fluids/src/setupdm.c
+++ b/examples/fluids/src/setupdm.c
@@ -16,7 +16,7 @@
 #include "../problems/stg_shur14.h"
 
 // Create mesh
-PetscErrorCode CreateDM(MPI_Comm comm, ProblemData *problem, MatType mat_type, VecType vec_type, DM *dm) {
+PetscErrorCode CreateDM(MPI_Comm comm, ProblemData problem, MatType mat_type, VecType vec_type, DM *dm) {
   PetscFunctionBeginUser;
   // Create DMPLEX
   PetscCall(DMCreate(comm, dm));
@@ -42,7 +42,7 @@ PetscErrorCode CreateDM(MPI_Comm comm, ProblemData *problem, MatType mat_type, V
 }
 
 // Setup DM
-PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_extra, SimpleBC bc, Physics phys) {
+PetscErrorCode SetUpDM(DM dm, ProblemData problem, PetscInt degree, PetscInt q_extra, SimpleBC bc, Physics phys) {
   PetscInt num_comp_q = 5;
   PetscFunctionBeginUser;
 
@@ -105,7 +105,7 @@ PetscErrorCode SetUpDM(DM dm, ProblemData *problem, PetscInt degree, PetscInt q_
 }
 
 // Refine DM for high-order viz
-PetscErrorCode VizRefineDM(DM dm, User user, ProblemData *problem, SimpleBC bc, Physics phys) {
+PetscErrorCode VizRefineDM(DM dm, User user, ProblemData problem, SimpleBC bc, Physics phys) {
   DM      dm_hierarchy[user->app_ctx->viz_refine + 1];
   VecType vec_type;
 

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -52,7 +52,7 @@ static PetscErrorCode CreateKSPMassOperator_Unstabilized(User user, CeedOperator
 }
 
 // @brief Create KSP to solve the inverse mass operator for explicit time stepping schemes
-static PetscErrorCode CreateKSPMass(User user, ProblemData *problem) {
+static PetscErrorCode CreateKSPMass(User user, ProblemData problem) {
   Ceed         ceed = user->ceed;
   DM           dm   = user->dm;
   CeedOperator op_mass;
@@ -238,7 +238,7 @@ PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData *problem, SimpleBC bc) {
+PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData problem, SimpleBC bc) {
   PetscFunctionBeginUser;
   // *****************************************************************************
   // Set up CEED objects for the interior domain (volume)

--- a/examples/fluids/src/smartsim/sgs_dd_training.c
+++ b/examples/fluids/src/smartsim/sgs_dd_training.c
@@ -61,7 +61,7 @@ static PetscErrorCode SGS_DD_TrainingCreateDM(DM dm_source, DM *dm_dd_training, 
 };
 
 // @brief Create CeedOperator to calculate training data for data-drive SGS model at nodes
-static PetscErrorCode SetupTrainingDataCalculation(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem,
+static PetscErrorCode SetupTrainingDataCalculation(Ceed ceed, User user, CeedData ceed_data, ProblemData problem,
                                                    SGS_DD_TrainingSetupData sgs_dd_train_setup_data) {
   SGS_DD_TrainingData sgs_dd_train = user->sgs_dd_train;
   CeedQFunction       qf_sgs_dd_train;
@@ -139,7 +139,7 @@ static PetscErrorCode SetupTrainingDataCalculation(Ceed ceed, User user, CeedDat
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
+PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem) {
   SGS_DDTrainingContext    sgsdd_train_qfctx;
   SGS_DD_TrainingSetupData sgs_dd_train_setup_data;
 

--- a/examples/fluids/src/smartsim_weak.c
+++ b/examples/fluids/src/smartsim_weak.c
@@ -10,8 +10,8 @@
 
 #include "../navierstokes.h"
 
-PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) __attribute__((weak));
-PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
+PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem) __attribute__((weak));
+PetscErrorCode SGS_DD_TrainingSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem) {
   PetscFunctionBeginUser;
   SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "Must build with SMARTREDIS_DIR set to run %s", __func__);
 };

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -13,7 +13,7 @@
 #include "../navierstokes.h"
 #include "../problems/stg_shur14.h"
 
-PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, ProblemData *problem, SimpleBC bc, Physics phys, CeedOperator op_strong_bc) {
+PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, ProblemData problem, SimpleBC bc, Physics phys, CeedOperator op_strong_bc) {
   CeedInt             num_comp_x = problem->dim, num_comp_q = 5, stg_data_size = 1, dim_boundary = 2, dXdx_size = num_comp_x * dim_boundary;
   CeedVector          multiplicity, x_stored, scale_stored, stg_data, dXdx;
   CeedBasis           basis_x_to_q_sur;
@@ -139,7 +139,7 @@ PetscErrorCode DMPlexInsertBoundaryValues_StrongBCCeed(DM dm, PetscBool insert_e
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData *problem, SimpleBC bc) {
+PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData problem, SimpleBC bc) {
   CeedOperator op_strong_bc;
 
   PetscFunctionBeginUser;

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -26,7 +26,7 @@ typedef struct {
   CeedVector          x_coord, q_data;
 } *SpanStatsSetupData;
 
-PetscErrorCode CreateStatsDM(User user, ProblemData *problem, PetscInt degree) {
+PetscErrorCode CreateStatsDM(User user, ProblemData problem, PetscInt degree) {
   user->spanstats.num_comp_stats = TURB_NUM_COMPONENTS;
   PetscReal     domain_min[3], domain_max[3];
   PetscSection  section;
@@ -181,7 +181,7 @@ PetscErrorCode GetQuadratureCoords(Ceed ceed, DM dm, CeedElemRestriction elem_re
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem, SpanStatsSetupData *stats_data) {
+PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data, ProblemData problem, SpanStatsSetupData *stats_data) {
   DM       dm = user->spanstats.dm;
   PetscInt dim;
   CeedInt  num_comp_x, num_comp_stats = user->spanstats.num_comp_stats;
@@ -366,7 +366,7 @@ PetscErrorCode SetupL2ProjectionStats(Ceed ceed, User user, CeedData ceed_data, 
 }
 
 // Create CeedOperator for statistics collection
-PetscErrorCode CreateStatisticCollectionOperator(Ceed ceed, User user, CeedData ceed_data, SpanStatsSetupData stats_data, ProblemData *problem) {
+PetscErrorCode CreateStatisticCollectionOperator(Ceed ceed, User user, CeedData ceed_data, SpanStatsSetupData stats_data, ProblemData problem) {
   CeedInt                     num_comp_stats = user->spanstats.num_comp_stats, num_comp_x = problem->dim, num_comp_q;
   Turbulence_SpanStatsContext collect_ctx;
   NewtonianIdealGasContext    newtonian_ig_ctx;
@@ -476,7 +476,7 @@ PetscErrorCode SetupMMSErrorChecking(Ceed ceed, User user, CeedData ceed_data, S
 }
 
 // Setup for statistics collection
-PetscErrorCode TurbulenceStatisticsSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem) {
+PetscErrorCode TurbulenceStatisticsSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem) {
   SpanStatsSetupData stats_data;
   PetscLogStage      stage_stats_setup;
 

--- a/examples/fluids/src/velocity_gradient_projection.c
+++ b/examples/fluids/src/velocity_gradient_projection.c
@@ -39,7 +39,7 @@ PetscErrorCode VelocityGradientProjectionCreateDM(NodalProjectionData grad_velo_
   PetscFunctionReturn(PETSC_SUCCESS);
 };
 
-PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData *problem, StateVariable state_var_input,
+PetscErrorCode VelocityGradientProjectionSetup(Ceed ceed, User user, CeedData ceed_data, ProblemData problem, StateVariable state_var_input,
                                                CeedElemRestriction elem_restr_input, CeedBasis basis_input, NodalProjectionData *pgrad_velo_proj) {
   NodalProjectionData grad_velo_proj;
   CeedOperator        op_rhs_assemble, op_mass;


### PR DESCRIPTION
We basically use `problem` as a pointer-to-struct type everywhere, so might as well make it consistent with the other structs.