### PR TITLE
fluids: Refactor boundary condition handling

### DIFF
--- a/examples/fluids/include/bc_definition.h
+++ b/examples/fluids/include/bc_definition.h
@@ -9,6 +9,23 @@
 #include <ceed.h>
 #include <petsc.h>
 
+typedef struct {
+  CeedQFunctionUser    qfunction;
+  const char          *qfunction_loc;
+  CeedQFunctionContext qfunction_context;
+} ProblemQFunctionSpec;
+
+typedef enum {
+  BCTYPE_INFLOW_PROBLEM,
+  BCTYPE_OUTFLOW_PROBLEM,
+  BCTYPE_INFLOW_STG,
+  BCTYPE_FREESTREAM,
+  BCTYPE_OUTFLOW,
+  BCTYPE_SLIP,
+  BCTYPE_WALL,
+  BCTYPE_SYMMETRY,
+} BCType;
+
 typedef struct _p_BCDefinition *BCDefinition;
 struct _p_BCDefinition {
   char *name;
@@ -18,6 +35,10 @@ struct _p_BCDefinition {
 
   // Essential Boundary information
   PetscInt num_essential_comps, *essential_comps;
+
+  // Natural Boundary Information
+  BCType               bc_type;
+  ProblemQFunctionSpec ifunction_spec, ijacobian_spec;
 };
 
 /**
@@ -25,19 +46,20 @@ struct _p_BCDefinition {
 
    Must be between `PetscOptionsBegin()` and `PetscOptionsEnd()`.
 
-   @param[in]  opt    The option one is seeking
-   @param[in]  text   Short string describing option
-   @param[in]  man    Manual page for the option
-   @param[in]  name   String that sets the name of the `BCDefinition`
-   @param[out] bc_def Resulting `BCDefinition`, `NULL` if option is not set
-   @param[out] set    `PETSC_TRUE` if found, else `PETSC_FALSE`
+   @param[in]  opt     The option one is seeking
+   @param[in]  text    Short string describing option
+   @param[in]  man     Manual page for the option
+   @param[in]  name    String that sets the name of the `BCDefinition`
+   @param[in]  bc_type `BCType` of the boundary condition
+   @param[out] bc_def  Resulting `BCDefinition`, `NULL` if option is not set
+   @param[out] set     `PETSC_TRUE` if found, else `PETSC_FALSE`
 **/
-#define PetscOptionsBCDefinition(opt, text, man, name, bc_def, set) \
-  PetscOptionsBCDefinition_Private(PetscOptionsObject, opt, text, man, name, bc_def, set)
+#define PetscOptionsBCDefinition(opt, text, man, name, bc_type, bc_def, set) \
+  PetscOptionsBCDefinition_Private(PetscOptionsObject, opt, text, man, name, bc_type, bc_def, set)
 PetscErrorCode PetscOptionsBCDefinition_Private(PetscOptionItems *PetscOptionsObject, const char opt[], const char text[], const char man[],
-                                                const char name[], BCDefinition *bc_def, PetscBool *set);
+                                                const char name[], BCType bc_type, BCDefinition *bc_def, PetscBool *set);
 
-PetscErrorCode BCDefinitionCreate(const char *name, PetscInt num_label_values, PetscInt label_values[], BCDefinition *bc_def);
+PetscErrorCode BCDefinitionCreate(const char *name, BCType bc_type, PetscInt num_label_values, PetscInt label_values[], BCDefinition *bc_def);
 PetscErrorCode BCDefinitionGetInfo(BCDefinition bc_def, const char *name[], PetscInt *num_label_values, const PetscInt *label_values[]);
 PetscErrorCode BCDefinitionDestroy(BCDefinition *bc_def);
 

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
   MPI_Comm comm = PETSC_COMM_WORLD;
   user->comm    = comm;
   PetscCall(ProcessCommandLineOptions(comm, app_ctx, bc));
-  PetscCall(BoundaryConditionSetUp(user, problem, app_ctx, bc));
+  PetscCall(BoundaryConditionInitialize(user, problem, app_ctx, bc));
 
   // ---------------------------------------------------------------------------
   // Initialize libCEED
@@ -174,6 +174,8 @@ int main(int argc, char **argv) {
 
   // -- Set up DM
   PetscCall(SetUpDM(dm, problem, app_ctx->degree, app_ctx->q_extra, bc, phys_ctx));
+
+  PetscCall(BoundaryConditionSetUp(user, problem, dm, problem->num_bc_defs, problem->bc_defs));
 
   // -- Refine DM for high-order viz
   if (app_ctx->viz_refine) PetscCall(VizRefineDM(dm, user, problem, bc, phys_ctx));

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -285,10 +285,11 @@ struct ProblemData_private {
   CeedScalar           dm_scale;
   ProblemQFunctionSpec ics, apply_vol_rhs, apply_vol_ifunction, apply_vol_ijacobian, apply_inflow, apply_outflow, apply_freestream, apply_slip,
       apply_inflow_jacobian, apply_outflow_jacobian, apply_freestream_jacobian, apply_slip_jacobian;
-  bool          compute_exact_solution_error;
-  PetscBool     set_bc_from_ics, use_strong_bc_ceed, uses_newtonian;
-  size_t        num_bc_defs;
-  BCDefinition *bc_defs;
+  bool                     compute_exact_solution_error;
+  PetscBool                set_bc_from_ics, use_strong_bc_ceed, uses_newtonian;
+  NewtonianIdealGasContext newtonian_ig_ctx;
+  size_t                   num_bc_defs;
+  BCDefinition            *bc_defs;
   PetscErrorCode (*print_info)(User, ProblemData, AppCtx);
   PetscErrorCode (*create_mass_operator)(User, CeedOperator *);
 };
@@ -466,9 +467,9 @@ PetscErrorCode GridAnisotropyTensorCalculateCollocatedVector(Ceed ceed, User use
 // Setup StrongBCs that use QFunctions
 PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User user, ProblemData problem, SimpleBC bc);
 
-PetscErrorCode FreestreamBCSetup(ProblemData problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
-PetscErrorCode OutflowBCSetup(ProblemData problem, DM dm, void *ctx, NewtonianIdealGasContext newtonian_ig_ctx, const StatePrimitive *reference);
-PetscErrorCode SlipBCSetup(ProblemData problem, DM dm, void *ctx, CeedQFunctionContext newtonian_ig_qfctx);
+PetscErrorCode FreestreamBCSetup(User user, ProblemData problem, DM dm);
+PetscErrorCode OutflowBCSetup(User user, ProblemData problem, DM dm);
+PetscErrorCode SlipBCSetup(User user, ProblemData problem, DM dm);
 
 // -----------------------------------------------------------------------------
 // Differential Filtering Functions

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -271,13 +271,8 @@ struct Physics_private {
   CeedContextFieldLabel ics_time_label;
 };
 
-PetscErrorCode BoundaryConditionSetUp(User user, ProblemData problem, AppCtx app_ctx, SimpleBC bc);
-
-typedef struct {
-  CeedQFunctionUser    qfunction;
-  const char          *qfunction_loc;
-  CeedQFunctionContext qfunction_context;
-} ProblemQFunctionSpec;
+PetscErrorCode BoundaryConditionInitialize(User user, ProblemData problem, AppCtx app_ctx, SimpleBC bc);
+PetscErrorCode BoundaryConditionSetUp(User user, ProblemData problem, DM dm, PetscInt num_bc_defs, BCDefinition *bc_defs);
 
 // Problem specific data
 struct ProblemData_private {
@@ -470,6 +465,7 @@ PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User use
 PetscErrorCode FreestreamBCSetup(User user, ProblemData problem, DM dm);
 PetscErrorCode OutflowBCSetup(User user, ProblemData problem, DM dm);
 PetscErrorCode SlipBCSetup(User user, ProblemData problem, DM dm);
+PetscErrorCode FreestreamBCSetup_BCDefinition(User user, ProblemData problem, DM dm, BCDefinition bc_def);
 
 // -----------------------------------------------------------------------------
 // Differential Filtering Functions

--- a/examples/fluids/problems/bc_slip.c
+++ b/examples/fluids/problems/bc_slip.c
@@ -16,9 +16,9 @@
 #include "../navierstokes.h"
 #include "../qfunctions/newtonian_types.h"
 
-PetscErrorCode SlipBCSetup(ProblemData problem, DM dm, void *ctx, CeedQFunctionContext newtonian_ig_qfctx) {
-  User user = *(User *)ctx;
-  Ceed ceed = user->ceed;
+PetscErrorCode SlipBCSetup(User user, ProblemData problem, DM dm) {
+  Ceed                 ceed               = user->ceed;
+  CeedQFunctionContext newtonian_ig_qfctx = problem->apply_vol_rhs.qfunction_context;
 
   PetscFunctionBeginUser;
   switch (user->phys->state_var) {

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -317,6 +317,7 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData problem, DM dm, void *ctx, SimpleBC b
   newtonian_ig_ctx->Ctau_C        = Ctau_C;
   newtonian_ig_ctx->Ctau_M        = Ctau_M;
   newtonian_ig_ctx->Ctau_E        = Ctau_E;
+  newtonian_ig_ctx->reference     = reference;
   newtonian_ig_ctx->stabilization = stab;
   newtonian_ig_ctx->is_implicit   = implicit;
   newtonian_ig_ctx->state_var     = state_var;
@@ -326,6 +327,7 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData problem, DM dm, void *ctx, SimpleBC b
   newtonian_ig_ctx->idl_length    = idl_length * meter;
   newtonian_ig_ctx->idl_pressure  = idl_pressure;
   PetscCall(PetscArraycpy(newtonian_ig_ctx->g, g, 3));
+  problem->newtonian_ig_ctx = newtonian_ig_ctx;
 
   // -- Setup Context
   setup_context->reference = reference;
@@ -360,9 +362,9 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData problem, DM dm, void *ctx, SimpleBC b
   PetscCallCeed(ceed, CeedQFunctionContextReferenceCopy(newtonian_ig_context, &problem->apply_inflow.qfunction_context));
   PetscCallCeed(ceed, CeedQFunctionContextReferenceCopy(newtonian_ig_context, &problem->apply_inflow_jacobian.qfunction_context));
 
-  if (bc->num_freestream > 0) PetscCall(FreestreamBCSetup(problem, dm, ctx, newtonian_ig_ctx, &reference));
-  if (bc->num_outflow > 0) PetscCall(OutflowBCSetup(problem, dm, ctx, newtonian_ig_ctx, &reference));
-  if (bc->num_slip > 0) PetscCall(SlipBCSetup(problem, dm, ctx, newtonian_ig_context));
+  if (bc->num_freestream > 0) PetscCall(FreestreamBCSetup(user, problem, dm));
+  if (bc->num_outflow > 0) PetscCall(OutflowBCSetup(user, problem, dm));
+  if (bc->num_slip > 0) PetscCall(SlipBCSetup(user, problem, dm));
 
   if (unit_tests) {
     PetscCall(UnitTests_Newtonian(user, newtonian_ig_ctx));

--- a/examples/fluids/qfunctions/newtonian_types.h
+++ b/examples/fluids/qfunctions/newtonian_types.h
@@ -15,6 +15,12 @@ typedef enum {
   STATEVAR_PRIMITIVE    = 1,
 } StateVariable;
 
+typedef struct {
+  CeedScalar pressure;
+  CeedScalar velocity[3];
+  CeedScalar temperature;
+} StatePrimitive;
+
 typedef struct NewtonianIdealGasContext_ *NewtonianIdealGasContext;
 struct NewtonianIdealGasContext_ {
   CeedScalar        lambda;
@@ -34,6 +40,7 @@ struct NewtonianIdealGasContext_ {
   CeedScalar        ijacobian_time_shift;
   bool              is_implicit;
   StateVariable     state_var;
+  StatePrimitive    reference;
   StabilizationType stabilization;
   bool              idl_enable;
   CeedScalar        idl_pressure;
@@ -41,12 +48,6 @@ struct NewtonianIdealGasContext_ {
   CeedScalar        idl_start;
   CeedScalar        idl_length;
 };
-
-typedef struct {
-  CeedScalar pressure;
-  CeedScalar velocity[3];
-  CeedScalar temperature;
-} StatePrimitive;
 
 typedef struct SetupContext_ *SetupContext;
 struct SetupContext_ {

--- a/examples/fluids/src/bc_definition.c
+++ b/examples/fluids/src/bc_definition.c
@@ -11,15 +11,17 @@
    @brief Create `BCDefinition`
 
    @param[in]  name             Name of the boundary condition
+   @param[in]  bc_type          `BCType` for the boundary condition
    @param[in]  num_label_values Number of `DMLabel` values
    @param[in]  label_values     Array of label values that define the boundaries controlled by the `BCDefinition`, size `num_label_values`
    @param[out] bc_def           The new `BCDefinition`
 **/
-PetscErrorCode BCDefinitionCreate(const char *name, PetscInt num_label_values, PetscInt label_values[], BCDefinition *bc_def) {
+PetscErrorCode BCDefinitionCreate(const char *name, BCType bc_type, PetscInt num_label_values, PetscInt label_values[], BCDefinition *bc_def) {
   PetscFunctionBeginUser;
   PetscCall(PetscNew(bc_def));
 
   PetscCall(PetscStrallocpy(name, &(*bc_def)->name));
+  (*bc_def)->bc_type          = bc_type;
   (*bc_def)->num_label_values = num_label_values;
   PetscCall(PetscMalloc1(num_label_values, &(*bc_def)->label_values));
   for (PetscInt i = 0; i < num_label_values; i++) (*bc_def)->label_values[i] = label_values[i];
@@ -92,13 +94,13 @@ PetscErrorCode BCDefinitionGetEssential(BCDefinition bc_def, PetscInt *num_essen
 
 // @brief See `PetscOptionsBCDefinition`
 PetscErrorCode PetscOptionsBCDefinition_Private(PetscOptionItems *PetscOptionsObject, const char opt[], const char text[], const char man[],
-                                                const char name[], BCDefinition *bc_def, PetscBool *set) {
+                                                const char name[], BCType bc_type, BCDefinition *bc_def, PetscBool *set) {
   PetscInt num_label_values = LABEL_ARRAY_SIZE, label_values[LABEL_ARRAY_SIZE] = {0};
 
   PetscFunctionBeginUser;
   PetscCall(PetscOptionsIntArray(opt, text, man, label_values, &num_label_values, set));
   if (num_label_values > 0) {
-    PetscCall(BCDefinitionCreate(name, num_label_values, label_values, bc_def));
+    PetscCall(BCDefinitionCreate(name, bc_type, num_label_values, label_values, bc_def));
   } else {
     *bc_def = NULL;
   }


### PR DESCRIPTION
Currently in progress, but open to feedback. Currently, only the wall and symmetry BCs are converted over to the new `BCDefinition` format. Still deciding exactly how I want to handle the boundary integrals and Ceed-based essential BCs.


TODOs:
- [ ] Make a unified essential BC mask and values vector (for handling time-varying and initial-condition based essential BCs)
- [x] Add in a setup function for creating IFunction and IJacobian definitions
- [ ] Figure out integration with strong Ceed-based BCs

Addresses the backend parts of #1090 