### PR TITLE
fluids: Refactor primary Ceed Object creation routines

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -297,10 +297,6 @@ int main(int argc, char **argv) {
   }
 
   // -- QFunctions
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_setup_vol));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_ics));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_rhs_vol));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_ifunction_vol));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_setup_sur));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_inflow));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_inflow_jacobian));
@@ -308,7 +304,6 @@ int main(int argc, char **argv) {
   PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_freestream_jacobian));
 
   // -- Operators
-  PetscCallCeed(ceed, CeedOperatorDestroy(&ceed_data->op_setup_vol));
   PetscCall(OperatorApplyContextDestroy(ceed_data->op_ics_ctx));
   PetscCallCeed(ceed, CeedOperatorDestroy(&user->op_rhs_vol));
   PetscCallCeed(ceed, CeedOperatorDestroy(&user->op_ifunction_vol));

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -268,9 +268,6 @@ int main(int argc, char **argv) {
   // -- Bases
   PetscCallCeed(ceed, CeedBasisDestroy(&ceed_data->basis_q));
   PetscCallCeed(ceed, CeedBasisDestroy(&ceed_data->basis_x));
-  PetscCallCeed(ceed, CeedBasisDestroy(&ceed_data->basis_xc));
-  PetscCallCeed(ceed, CeedBasisDestroy(&ceed_data->basis_q_sur));
-  PetscCallCeed(ceed, CeedBasisDestroy(&ceed_data->basis_x_sur));
 
   // -- Restrictions
   PetscCallCeed(ceed, CeedElemRestrictionDestroy(&ceed_data->elem_restr_q));
@@ -298,10 +295,6 @@ int main(int argc, char **argv) {
 
   // -- QFunctions
   PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_setup_sur));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_inflow));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_inflow_jacobian));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_freestream));
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_apply_freestream_jacobian));
 
   // -- Operators
   PetscCall(OperatorApplyContextDestroy(ceed_data->op_ics_ctx));

--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -298,8 +298,6 @@ int main(int argc, char **argv) {
 
   // -- Operators
   PetscCall(OperatorApplyContextDestroy(ceed_data->op_ics_ctx));
-  PetscCallCeed(ceed, CeedOperatorDestroy(&user->op_rhs_vol));
-  PetscCallCeed(ceed, CeedOperatorDestroy(&user->op_ifunction_vol));
   PetscCall(OperatorApplyContextDestroy(user->op_rhs_ctx));
   PetscCall(OperatorApplyContextDestroy(user->op_strong_bc_ctx));
   PetscCallCeed(ceed, CeedOperatorDestroy(&user->op_ifunction));

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -231,7 +231,7 @@ struct User_private {
   Physics              phys;
   AppCtx               app_ctx;
   CeedVector           q_ceed, q_dot_ceed, g_ceed, x_ceed;
-  CeedOperator         op_rhs_vol, op_ifunction_vol, op_ifunction;
+  CeedOperator         op_ifunction;
   Mat                  mat_ijacobian;
   KSP                  mass_ksp;
   OperatorApplyContext op_rhs_ctx, op_strong_bc_ctx;

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -152,11 +152,10 @@ struct AppCtx_private {
 // libCEED data struct
 struct CeedData_private {
   CeedVector           x_coord, q_data;
-  CeedBasis            basis_x, basis_xc, basis_q, basis_x_sur, basis_q_sur;
+  CeedBasis            basis_x, basis_q;
   CeedElemRestriction  elem_restr_x, elem_restr_q, elem_restr_qd_i;
   OperatorApplyContext op_ics_ctx;
-  CeedQFunction        qf_setup_sur, qf_apply_inflow, qf_apply_inflow_jacobian, qf_apply_outflow, qf_apply_outflow_jacobian, qf_apply_freestream,
-      qf_apply_freestream_jacobian, qf_apply_slip, qf_apply_slip_jacobian;
+  CeedQFunction        qf_setup_sur;
 };
 
 typedef struct {
@@ -347,11 +346,6 @@ PetscErrorCode DMPlexCeedElemRestrictionCollocatedCreate(Ceed ceed, DM dm, DMLab
                                                          PetscInt q_data_size, CeedElemRestriction *restriction);
 
 PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedInt label_value, CeedInt height, CeedInt dm_field, CeedBasis *basis);
-
-// Utility function to create CEED Composite Operator for the entire domain
-PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc, CeedData ceed_data, Physics phys, CeedOperator op_apply_vol,
-                                       CeedOperator op_apply_ijacobian_vol, CeedInt height, CeedInt P_sur, CeedInt Q_sur, CeedInt q_data_size_sur,
-                                       CeedInt jac_data_size_sur, CeedOperator *op_apply, CeedOperator *op_apply_ijacobian);
 
 PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData problem, SimpleBC bc);
 

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -154,10 +154,9 @@ struct CeedData_private {
   CeedVector           x_coord, q_data;
   CeedBasis            basis_x, basis_xc, basis_q, basis_x_sur, basis_q_sur;
   CeedElemRestriction  elem_restr_x, elem_restr_q, elem_restr_qd_i;
-  CeedOperator         op_setup_vol;
   OperatorApplyContext op_ics_ctx;
-  CeedQFunction        qf_setup_vol, qf_ics, qf_rhs_vol, qf_ifunction_vol, qf_setup_sur, qf_apply_inflow, qf_apply_inflow_jacobian, qf_apply_outflow,
-      qf_apply_outflow_jacobian, qf_apply_freestream, qf_apply_freestream_jacobian, qf_apply_slip, qf_apply_slip_jacobian;
+  CeedQFunction        qf_setup_sur, qf_apply_inflow, qf_apply_inflow_jacobian, qf_apply_outflow, qf_apply_outflow_jacobian, qf_apply_freestream,
+      qf_apply_freestream_jacobian, qf_apply_slip, qf_apply_slip_jacobian;
 };
 
 typedef struct {

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -90,17 +90,16 @@ static PetscErrorCode CreateKSPMass(User user, ProblemData problem) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DMLabel domain_label, PetscInt label_value, CeedInt height, CeedInt Q_sur,
-                                CeedInt q_data_size_sur, CeedInt jac_data_size_sur, CeedQFunction qf_apply_bc, CeedQFunction qf_apply_bc_jacobian,
-                                CeedOperator *op_apply, CeedOperator *op_apply_ijacobian) {
-  CeedVector          q_data_sur, jac_data_sur = NULL;
-  CeedOperator        op_setup_sur, op_apply_bc, op_apply_bc_jacobian = NULL;
+static PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DMLabel domain_label, PetscInt label_value, CeedInt height,
+                                       CeedInt Q_sur, CeedInt q_data_size_sur, CeedInt jac_data_size_sur, CeedBasis basis_q_sur,
+                                       CeedBasis basis_x_sur, CeedQFunction qf_apply_bc, CeedQFunction qf_apply_bc_jacobian, CeedOperator op_apply,
+                                       CeedOperator op_apply_ijacobian) {
+  CeedVector          q_data_sur, jac_data_sur          = NULL;
+  CeedOperator        op_apply_bc, op_apply_bc_jacobian = NULL;
   CeedElemRestriction elem_restr_x_sur, elem_restr_q_sur, elem_restr_qd_i_sur, elem_restr_jd_i_sur = NULL;
-  CeedInt             num_qpts_sur, dm_field = 0;
+  PetscInt            dm_field = 0;
 
   PetscFunctionBeginUser;
-  // --- Get number of quadrature points for the boundaries
-  PetscCallCeed(ceed, CeedBasisGetNumQuadraturePoints(ceed_data->basis_q_sur, &num_qpts_sur));
 
   // ---- CEED Restriction
   PetscCall(DMPlexCeedElemRestrictionCreate(ceed, dm, domain_label, label_value, height, dm_field, &elem_restr_q_sur));
@@ -112,44 +111,43 @@ PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DMLabel do
     PetscCallCeed(ceed, CeedElemRestrictionCreateVector(elem_restr_jd_i_sur, &jac_data_sur, NULL));
   }
 
-  // ---- CEED Vector
-  CeedInt loc_num_elem_sur;
-  PetscCallCeed(ceed, CeedElemRestrictionGetNumElements(elem_restr_q_sur, &loc_num_elem_sur));
-  PetscCallCeed(ceed, CeedVectorCreate(ceed, q_data_size_sur * loc_num_elem_sur * num_qpts_sur, &q_data_sur));
+  {  // Create q_data_sur vector
+    CeedOperator op_setup_sur;
 
-  // ---- CEED Operator
-  // ----- CEED Operator for Setup (geometric factors)
-  PetscCallCeed(ceed, CeedOperatorCreate(ceed, ceed_data->qf_setup_sur, NULL, NULL, &op_setup_sur));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "dx", elem_restr_x_sur, ceed_data->basis_x_sur, CEED_VECTOR_ACTIVE));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "weight", CEED_ELEMRESTRICTION_NONE, ceed_data->basis_x_sur, CEED_VECTOR_NONE));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "surface qdata", elem_restr_qd_i_sur, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedElemRestrictionCreateVector(elem_restr_qd_i_sur, &q_data_sur, NULL));
+
+    PetscCallCeed(ceed, CeedOperatorCreate(ceed, ceed_data->qf_setup_sur, NULL, NULL, &op_setup_sur));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "dx", elem_restr_x_sur, basis_x_sur, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "weight", CEED_ELEMRESTRICTION_NONE, basis_x_sur, CEED_VECTOR_NONE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "surface qdata", elem_restr_qd_i_sur, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+
+    PetscCallCeed(ceed, CeedOperatorApply(op_setup_sur, ceed_data->x_coord, q_data_sur, CEED_REQUEST_IMMEDIATE));
+    PetscCallCeed(ceed, CeedOperatorDestroy(&op_setup_sur));
+  }
 
   // ----- CEED Operator for Physics
   PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_apply_bc, NULL, NULL, &op_apply_bc));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "q", elem_restr_q_sur, ceed_data->basis_q_sur, CEED_VECTOR_ACTIVE));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "Grad_q", elem_restr_q_sur, ceed_data->basis_q_sur, CEED_VECTOR_ACTIVE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "q", elem_restr_q_sur, basis_q_sur, CEED_VECTOR_ACTIVE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "Grad_q", elem_restr_q_sur, basis_q_sur, CEED_VECTOR_ACTIVE));
   PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "surface qdata", elem_restr_qd_i_sur, CEED_BASIS_NONE, q_data_sur));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "x", elem_restr_x_sur, ceed_data->basis_x_sur, ceed_data->x_coord));
-  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "v", elem_restr_q_sur, ceed_data->basis_q_sur, CEED_VECTOR_ACTIVE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "x", elem_restr_x_sur, basis_x_sur, ceed_data->x_coord));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "v", elem_restr_q_sur, basis_q_sur, CEED_VECTOR_ACTIVE));
   if (elem_restr_jd_i_sur)
     PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc, "surface jacobian data", elem_restr_jd_i_sur, CEED_BASIS_NONE, jac_data_sur));
 
   if (qf_apply_bc_jacobian && elem_restr_jd_i_sur) {
     PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_apply_bc_jacobian, NULL, NULL, &op_apply_bc_jacobian));
-    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "dq", elem_restr_q_sur, ceed_data->basis_q_sur, CEED_VECTOR_ACTIVE));
-    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "Grad_dq", elem_restr_q_sur, ceed_data->basis_q_sur, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "dq", elem_restr_q_sur, basis_q_sur, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "Grad_dq", elem_restr_q_sur, basis_q_sur, CEED_VECTOR_ACTIVE));
     PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "surface qdata", elem_restr_qd_i_sur, CEED_BASIS_NONE, q_data_sur));
-    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "x", elem_restr_x_sur, ceed_data->basis_x_sur, ceed_data->x_coord));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "x", elem_restr_x_sur, basis_x_sur, ceed_data->x_coord));
     PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "surface jacobian data", elem_restr_jd_i_sur, CEED_BASIS_NONE, jac_data_sur));
-    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "v", elem_restr_q_sur, ceed_data->basis_q_sur, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_apply_bc_jacobian, "v", elem_restr_q_sur, basis_q_sur, CEED_VECTOR_ACTIVE));
   }
 
-  // ----- Apply CEED operator for Setup
-  PetscCallCeed(ceed, CeedOperatorApply(op_setup_sur, ceed_data->x_coord, q_data_sur, CEED_REQUEST_IMMEDIATE));
-
   // ----- Apply Sub-Operator for Physics
-  PetscCallCeed(ceed, CeedCompositeOperatorAddSub(*op_apply, op_apply_bc));
-  if (op_apply_bc_jacobian) PetscCallCeed(ceed, CeedCompositeOperatorAddSub(*op_apply_ijacobian, op_apply_bc_jacobian));
+  PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_apply, op_apply_bc));
+  if (op_apply_bc_jacobian) PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_apply_ijacobian, op_apply_bc_jacobian));
 
   // ----- Cleanup
   PetscCallCeed(ceed, CeedVectorDestroy(&q_data_sur));
@@ -158,60 +156,14 @@ PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DMLabel do
   PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_x_sur));
   PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_qd_i_sur));
   PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_jd_i_sur));
-  PetscCallCeed(ceed, CeedOperatorDestroy(&op_setup_sur));
   PetscCallCeed(ceed, CeedOperatorDestroy(&op_apply_bc));
   PetscCallCeed(ceed, CeedOperatorDestroy(&op_apply_bc_jacobian));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-// Utility function to create CEED Composite Operator for the entire domain
-PetscErrorCode CreateOperatorForDomain(Ceed ceed, DM dm, SimpleBC bc, CeedData ceed_data, Physics phys, CeedOperator op_apply_vol,
-                                       CeedOperator op_apply_ijacobian_vol, CeedInt height, CeedInt P_sur, CeedInt Q_sur, CeedInt q_data_size_sur,
-                                       CeedInt jac_data_size_sur, CeedOperator *op_apply, CeedOperator *op_apply_ijacobian) {
-  DMLabel domain_label;
-
-  PetscFunctionBeginUser;
-  // Create Composite Operaters
-  PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, op_apply));
-  if (op_apply_ijacobian) PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, op_apply_ijacobian));
-
-  // --Apply Sub-Operator for the volume
-  PetscCallCeed(ceed, CeedCompositeOperatorAddSub(*op_apply, op_apply_vol));
-  if (op_apply_ijacobian) PetscCallCeed(ceed, CeedCompositeOperatorAddSub(*op_apply_ijacobian, op_apply_ijacobian_vol));
-
-  // -- Create Sub-Operator for in/outflow BCs
-  PetscCall(DMGetLabel(dm, "Face Sets", &domain_label));
-
-  // --- Create Sub-Operator for inflow boundaries
-  for (CeedInt i = 0; i < bc->num_inflow; i++) {
-    PetscCall(AddBCSubOperator(ceed, dm, ceed_data, domain_label, bc->inflows[i], height, Q_sur, q_data_size_sur, jac_data_size_sur,
-                               ceed_data->qf_apply_inflow, ceed_data->qf_apply_inflow_jacobian, op_apply, op_apply_ijacobian));
-  }
-  // --- Create Sub-Operator for outflow boundaries
-  for (CeedInt i = 0; i < bc->num_outflow; i++) {
-    PetscCall(AddBCSubOperator(ceed, dm, ceed_data, domain_label, bc->outflows[i], height, Q_sur, q_data_size_sur, jac_data_size_sur,
-                               ceed_data->qf_apply_outflow, ceed_data->qf_apply_outflow_jacobian, op_apply, op_apply_ijacobian));
-  }
-  // --- Create Sub-Operator for freestream boundaries
-  for (CeedInt i = 0; i < bc->num_freestream; i++) {
-    PetscCall(AddBCSubOperator(ceed, dm, ceed_data, domain_label, bc->freestreams[i], height, Q_sur, q_data_size_sur, jac_data_size_sur,
-                               ceed_data->qf_apply_freestream, ceed_data->qf_apply_freestream_jacobian, op_apply, op_apply_ijacobian));
-  }
-  // --- Create Sub-Operator for slip boundaries
-  for (CeedInt i = 0; i < bc->num_slip; i++) {
-    PetscCall(AddBCSubOperator(ceed, dm, ceed_data, domain_label, bc->slips[i], height, Q_sur, q_data_size_sur, jac_data_size_sur,
-                               ceed_data->qf_apply_slip, ceed_data->qf_apply_slip_jacobian, op_apply, op_apply_ijacobian));
-  }
-
-  // ----- Get Context Labels for Operator
-  PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(*op_apply, "solution time", &phys->solution_time_label));
-  PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(*op_apply, "timestep size", &phys->timestep_size_label));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_x, PetscInt num_comp_q, PetscInt q_data_size_sur,
-                                 PetscInt jac_data_size_sur, ProblemQFunctionSpec apply_bc, ProblemQFunctionSpec apply_bc_jacobian,
-                                 CeedQFunction *qf_apply_bc, CeedQFunction *qf_apply_bc_jacobian) {
+static PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_x, PetscInt num_comp_q, PetscInt q_data_size_sur,
+                                        PetscInt jac_data_size_sur, ProblemQFunctionSpec apply_bc, ProblemQFunctionSpec apply_bc_jacobian,
+                                        CeedQFunction *qf_apply_bc, CeedQFunction *qf_apply_bc_jacobian) {
   PetscFunctionBeginUser;
   if (apply_bc.qfunction) {
     PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, apply_bc.qfunction, apply_bc.qfunction_loc, qf_apply_bc));
@@ -235,6 +187,115 @@ PetscErrorCode SetupBCQFunctions(Ceed ceed, PetscInt dim_sur, PetscInt num_comp_
     PetscCallCeed(ceed, CeedQFunctionAddInput(*qf_apply_bc_jacobian, "surface jacobian data", jac_data_size_sur, CEED_EVAL_NONE));
     PetscCallCeed(ceed, CeedQFunctionAddOutput(*qf_apply_bc_jacobian, "v", num_comp_q, CEED_EVAL_INTERP));
   }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+// Utility function to create CEED Composite Operator for the entire domain
+static PetscErrorCode AddBCSubOperators(User user, Ceed ceed, DM dm, SimpleBC bc, ProblemData problem, CeedData ceed_data, CeedOperator op_apply,
+                                        CeedOperator op_apply_ijacobian) {
+  CeedInt       height = 1, num_comp_q, num_comp_x;
+  CeedInt       dim_sur, P_sur = user->app_ctx->degree + 1, Q_sur = P_sur + user->app_ctx->q_extra;
+  const CeedInt q_data_size_sur = problem->q_data_size_sur, jac_data_size_sur = user->phys->implicit ? problem->jac_data_size_sur : 0;
+  PetscInt      dim;
+  DMLabel       face_sets_label;
+  CeedBasis     basis_q_sur, basis_x_sur;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMGetDimension(dm, &dim));
+  dim_sur = dim - height;
+  {  // Get number of components and coordinate dimension from op_apply
+    CeedOperator       *sub_ops;
+    CeedOperatorField   field;
+    PetscInt            sub_op_index = 0;  // will be 0 for the volume op
+    CeedElemRestriction elem_restr_q, elem_restr_x;
+
+    PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(op_apply, &sub_ops));
+    PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
+    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_q));
+    PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_q, &num_comp_q));
+
+    PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "x", &field));
+    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_x));
+    PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_x, &num_comp_x));
+  }
+
+  {  // Get bases
+    DM dm_coord;
+
+    PetscCall(DMGetCoordinateDM(dm, &dm_coord));
+    DMLabel  label       = NULL;
+    PetscInt label_value = 0;
+    PetscInt field       = 0;  // Still want the normal, default field
+    PetscCall(CreateBasisFromPlex(ceed, dm, label, label_value, height, field, &basis_q_sur));
+    PetscCall(CreateBasisFromPlex(ceed, dm_coord, label, label_value, height, field, &basis_x_sur));
+  }
+
+  PetscCall(DMGetLabel(dm, "Face Sets", &face_sets_label));
+
+  {  // -- Create QFunction for quadrature data
+    PetscCallCeed(ceed,
+                  CeedQFunctionCreateInterior(ceed, 1, problem->setup_sur.qfunction, problem->setup_sur.qfunction_loc, &ceed_data->qf_setup_sur));
+    PetscCallCeed(ceed, CeedQFunctionSetContext(ceed_data->qf_setup_sur, problem->setup_sur.qfunction_context));
+    PetscCallCeed(ceed, CeedQFunctionSetUserFlopsEstimate(ceed_data->qf_setup_sur, 0));
+    PetscCallCeed(ceed, CeedQFunctionAddInput(ceed_data->qf_setup_sur, "dx", num_comp_x * dim_sur, CEED_EVAL_GRAD));
+    PetscCallCeed(ceed, CeedQFunctionAddInput(ceed_data->qf_setup_sur, "weight", 1, CEED_EVAL_WEIGHT));
+    PetscCallCeed(ceed, CeedQFunctionAddOutput(ceed_data->qf_setup_sur, "surface qdata", q_data_size_sur, CEED_EVAL_NONE));
+  }
+
+  {  // --- Create Sub-Operator for inflow boundaries
+    CeedQFunction qf_apply_inflow = NULL, qf_apply_inflow_jacobian = NULL;
+
+    PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_inflow,
+                                problem->apply_inflow_jacobian, &qf_apply_inflow, &qf_apply_inflow_jacobian));
+    for (CeedInt i = 0; i < bc->num_inflow; i++) {
+      PetscCall(AddBCSubOperator(ceed, dm, ceed_data, face_sets_label, bc->inflows[i], height, Q_sur, q_data_size_sur, jac_data_size_sur, basis_q_sur,
+                                 basis_x_sur, qf_apply_inflow, qf_apply_inflow_jacobian, op_apply, op_apply_ijacobian));
+    }
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_inflow));
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_inflow_jacobian));
+  }
+
+  {  // --- Create Sub-Operator for outflow boundaries
+    CeedQFunction qf_apply_outflow = NULL, qf_apply_outflow_jacobian = NULL;
+
+    PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_outflow,
+                                problem->apply_outflow_jacobian, &qf_apply_outflow, &qf_apply_outflow_jacobian));
+    for (CeedInt i = 0; i < bc->num_outflow; i++) {
+      PetscCall(AddBCSubOperator(ceed, dm, ceed_data, face_sets_label, bc->outflows[i], height, Q_sur, q_data_size_sur, jac_data_size_sur,
+                                 basis_q_sur, basis_x_sur, qf_apply_outflow, qf_apply_outflow_jacobian, op_apply, op_apply_ijacobian));
+    }
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_outflow));
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_outflow_jacobian));
+  }
+
+  {  // --- Create Sub-Operator for freestream boundaries
+    CeedQFunction qf_apply_freestream = NULL, qf_apply_freestream_jacobian = NULL;
+
+    PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_freestream,
+                                problem->apply_freestream_jacobian, &qf_apply_freestream, &qf_apply_freestream_jacobian));
+    for (CeedInt i = 0; i < bc->num_freestream; i++) {
+      PetscCall(AddBCSubOperator(ceed, dm, ceed_data, face_sets_label, bc->freestreams[i], height, Q_sur, q_data_size_sur, jac_data_size_sur,
+                                 basis_q_sur, basis_x_sur, qf_apply_freestream, qf_apply_freestream_jacobian, op_apply, op_apply_ijacobian));
+    }
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_freestream));
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_freestream_jacobian));
+  }
+
+  {  // --- Create Sub-Operator for slip boundaries
+    CeedQFunction qf_apply_slip = NULL, qf_apply_slip_jacobian = NULL;
+
+    PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_slip,
+                                problem->apply_slip_jacobian, &qf_apply_slip, &qf_apply_slip_jacobian));
+    for (CeedInt i = 0; i < bc->num_slip; i++) {
+      PetscCall(AddBCSubOperator(ceed, dm, ceed_data, face_sets_label, bc->slips[i], height, Q_sur, q_data_size_sur, jac_data_size_sur, basis_q_sur,
+                                 basis_x_sur, qf_apply_slip, qf_apply_slip_jacobian, op_apply, op_apply_ijacobian));
+    }
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_slip));
+    PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_apply_slip_jacobian));
+  }
+
+  PetscCallCeed(ceed, CeedBasisDestroy(&basis_q_sur));
+  PetscCallCeed(ceed, CeedBasisDestroy(&basis_x_sur));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -262,7 +323,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
 
   PetscCall(CreateBasisFromPlex(ceed, dm, domain_label, label_value, height, dm_field, &ceed_data->basis_q));
   PetscCall(CreateBasisFromPlex(ceed, dm_coord, domain_label, label_value, height, dm_field, &ceed_data->basis_x));
-  PetscCallCeed(ceed, CeedBasisCreateProjection(ceed_data->basis_x, ceed_data->basis_q, &ceed_data->basis_xc));
   PetscCallCeed(ceed, CeedBasisGetNumQuadraturePoints(ceed_data->basis_q, &num_qpts));
 
   PetscCall(DMPlexCeedElemRestrictionCreate(ceed, dm, domain_label, label_value, height, 0, &ceed_data->elem_restr_q));
@@ -314,9 +374,11 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   }
 
   {  // -- Create QFunction for ICs
+    CeedBasis     basis_xc;
     CeedQFunction qf_ics;
     CeedOperator  op_ics;
 
+    PetscCallCeed(ceed, CeedBasisCreateProjection(ceed_data->basis_x, ceed_data->basis_q, &basis_xc));
     PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, problem->ics.qfunction, problem->ics.qfunction_loc, &qf_ics));
     PetscCallCeed(ceed, CeedQFunctionSetContext(qf_ics, problem->ics.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionSetUserFlopsEstimate(qf_ics, 0));
@@ -325,12 +387,13 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     PetscCallCeed(ceed, CeedQFunctionAddOutput(qf_ics, "q0", num_comp_q, CEED_EVAL_NONE));
 
     PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_ics, NULL, NULL, &op_ics));
-    PetscCallCeed(ceed, CeedOperatorSetField(op_ics, "x", ceed_data->elem_restr_x, ceed_data->basis_xc, CEED_VECTOR_ACTIVE));
-    PetscCallCeed(ceed, CeedOperatorSetField(op_ics, "dx", ceed_data->elem_restr_x, ceed_data->basis_xc, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_ics, "x", ceed_data->elem_restr_x, basis_xc, CEED_VECTOR_ACTIVE));
+    PetscCallCeed(ceed, CeedOperatorSetField(op_ics, "dx", ceed_data->elem_restr_x, basis_xc, CEED_VECTOR_ACTIVE));
     PetscCallCeed(ceed, CeedOperatorSetField(op_ics, "q0", ceed_data->elem_restr_q, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
     PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(op_ics, "evaluation time", &user->phys->ics_time_label));
     PetscCall(OperatorApplyContextCreate(NULL, dm, user->ceed, op_ics, ceed_data->x_coord, NULL, NULL, user->Q_loc, &ceed_data->op_ics_ctx));
 
+    PetscCallCeed(ceed, CeedBasisDestroy(&basis_xc));
     PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_ics));
     PetscCallCeed(ceed, CeedOperatorDestroy(&op_ics));
   }
@@ -420,67 +483,39 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_ijacobian_vol));
   }
 
-  // *****************************************************************************
-  // Set up CEED objects for the exterior domain (surface)
-  // *****************************************************************************
-  height                = 1;
-  CeedInt       dim_sur = dim - height, P_sur = app_ctx->degree + 1, Q_sur = P_sur + app_ctx->q_extra;
-  const CeedInt q_data_size_sur = problem->q_data_size_sur, jac_data_size_sur = user->phys->implicit ? problem->jac_data_size_sur : 0;
-
-  // -----------------------------------------------------------------------------
-  // CEED Bases
-  // -----------------------------------------------------------------------------
-
-  {
-    DM dm_coord;
-
-    PetscCall(DMGetCoordinateDM(dm, &dm_coord));
-    DMLabel  label   = NULL;
-    PetscInt face_id = 0;
-    PetscInt field   = 0;  // Still want the normal, default field
-    PetscCall(CreateBasisFromPlex(ceed, dm, label, face_id, height, field, &ceed_data->basis_q_sur));
-    PetscCall(CreateBasisFromPlex(ceed, dm_coord, label, face_id, height, field, &ceed_data->basis_x_sur));
-  }
-
-  // -----------------------------------------------------------------------------
-  // CEED QFunctions
-  // -----------------------------------------------------------------------------
-  // -- Create QFunction for quadrature data
-  PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, problem->setup_sur.qfunction, problem->setup_sur.qfunction_loc, &ceed_data->qf_setup_sur));
-  if (problem->setup_sur.qfunction_context) {
-    PetscCallCeed(ceed, CeedQFunctionSetContext(ceed_data->qf_setup_sur, problem->setup_sur.qfunction_context));
-  }
-  PetscCallCeed(ceed, CeedQFunctionSetUserFlopsEstimate(ceed_data->qf_setup_sur, 0));
-  PetscCallCeed(ceed, CeedQFunctionAddInput(ceed_data->qf_setup_sur, "dx", num_comp_x * dim_sur, CEED_EVAL_GRAD));
-  PetscCallCeed(ceed, CeedQFunctionAddInput(ceed_data->qf_setup_sur, "weight", 1, CEED_EVAL_WEIGHT));
-  PetscCallCeed(ceed, CeedQFunctionAddOutput(ceed_data->qf_setup_sur, "surface qdata", q_data_size_sur, CEED_EVAL_NONE));
-
-  PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_inflow,
-                              problem->apply_inflow_jacobian, &ceed_data->qf_apply_inflow, &ceed_data->qf_apply_inflow_jacobian));
-  PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_outflow,
-                              problem->apply_outflow_jacobian, &ceed_data->qf_apply_outflow, &ceed_data->qf_apply_outflow_jacobian));
-  PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_freestream,
-                              problem->apply_freestream_jacobian, &ceed_data->qf_apply_freestream, &ceed_data->qf_apply_freestream_jacobian));
-  PetscCall(SetupBCQFunctions(ceed, dim_sur, num_comp_x, num_comp_q, q_data_size_sur, jac_data_size_sur, problem->apply_slip,
-                              problem->apply_slip_jacobian, &ceed_data->qf_apply_slip, &ceed_data->qf_apply_slip_jacobian));
-
-  // *****************************************************************************
-  // CEED Operator Apply
-  // *****************************************************************************
   // -- Create and apply CEED Composite Operator for the entire domain
   if (!user->phys->implicit) {  // RHS
     CeedOperator op_rhs;
-    PetscCall(CreateOperatorForDomain(ceed, dm, bc, ceed_data, user->phys, user->op_rhs_vol, NULL, height, P_sur, Q_sur, q_data_size_sur, 0, &op_rhs,
-                                      NULL));
+
+    PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &op_rhs));
+    PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_rhs, user->op_rhs_vol));
+    PetscCall(AddBCSubOperators(user, ceed, dm, bc, problem, ceed_data, op_rhs, NULL));
+
     PetscCall(OperatorApplyContextCreate(dm, dm, ceed, op_rhs, user->q_ceed, user->g_ceed, user->Q_loc, NULL, &user->op_rhs_ctx));
+
+    // ----- Get Context Labels for Operator
+    PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(op_rhs, "solution time", &user->phys->solution_time_label));
+    PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(op_rhs, "timestep size", &user->phys->timestep_size_label));
+
     PetscCallCeed(ceed, CeedOperatorDestroy(&op_rhs));
     PetscCall(CreateKSPMass(user, problem));
     PetscCheck(app_ctx->sgs_model_type == SGS_MODEL_NONE, user->comm, PETSC_ERR_SUP, "SGS modeling not implemented for explicit timestepping");
   } else {  // IFunction
     CeedOperator op_ijacobian = NULL;
 
-    PetscCall(CreateOperatorForDomain(ceed, dm, bc, ceed_data, user->phys, user->op_ifunction_vol, op_ijacobian_vol, height, P_sur, Q_sur,
-                                      q_data_size_sur, jac_data_size_sur, &user->op_ifunction, op_ijacobian_vol ? &op_ijacobian : NULL));
+    // Create Composite Operaters
+    PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &user->op_ifunction));
+    PetscCallCeed(ceed, CeedCompositeOperatorAddSub(user->op_ifunction, user->op_ifunction_vol));
+    if (op_ijacobian_vol) {
+      PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &op_ijacobian));
+      PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_ijacobian, op_ijacobian_vol));
+    }
+    PetscCall(AddBCSubOperators(user, ceed, dm, bc, problem, ceed_data, user->op_ifunction, op_ijacobian));
+
+    // ----- Get Context Labels for Operator
+    PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(user->op_ifunction, "solution time", &user->phys->solution_time_label));
+    PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(user->op_ifunction, "timestep size", &user->phys->timestep_size_label));
+
     if (op_ijacobian) {
       PetscCall(MatCeedCreate(user->dm, user->dm, op_ijacobian, NULL, &user->mat_ijacobian));
       PetscCall(MatCeedSetLocalVectors(user->mat_ijacobian, user->Q_dot_loc, NULL));

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -26,8 +26,21 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
   PetscFunctionBeginUser;
   PetscCall(DMGetLabel(dm, "Face Sets", &domain_label));
 
-  // Basis
-  PetscCallCeed(ceed, CeedBasisCreateProjection(ceed_data->basis_x_sur, ceed_data->basis_q_sur, &basis_x_to_q_sur));
+  {  // Basis
+    CeedBasis basis_x_sur, basis_q_sur;
+    DM        dm_coord;
+
+    PetscCall(DMGetCoordinateDM(dm, &dm_coord));
+    DMLabel  label       = NULL;
+    PetscInt label_value = 0;
+    PetscCall(CreateBasisFromPlex(ceed, dm, label, label_value, height, dm_field, &basis_q_sur));
+    PetscCall(CreateBasisFromPlex(ceed, dm_coord, label, label_value, height, dm_field, &basis_x_sur));
+
+    PetscCallCeed(ceed, CeedBasisCreateProjection(basis_x_sur, basis_q_sur, &basis_x_to_q_sur));
+
+    PetscCallCeed(ceed, CeedBasisDestroy(&basis_q_sur));
+    PetscCallCeed(ceed, CeedBasisDestroy(&basis_x_sur));
+  }
 
   // Setup QFunction
   PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, SetupStrongBC, SetupStrongBC_loc, &qf_setup));

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -183,7 +183,6 @@ PetscErrorCode GetQuadratureCoords(Ceed ceed, DM dm, CeedElemRestriction elem_re
 
 PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data, ProblemData problem, SpanStatsSetupData *stats_data) {
   DM       dm = user->spanstats.dm;
-  PetscInt dim;
   CeedInt  num_comp_x, num_comp_stats = user->spanstats.num_comp_stats;
   Vec      X_loc;
   DMLabel  domain_label = NULL;
@@ -192,7 +191,6 @@ PetscErrorCode SpanStatsSetupDataCreate(Ceed ceed, User user, CeedData ceed_data
   PetscFunctionBeginUser;
   PetscCall(PetscNew(stats_data));
 
-  PetscCall(DMGetDimension(dm, &dim));
   PetscCall(DMPlexCeedElemRestrictionCreate(ceed, dm, domain_label, label_value, height, dm_field, &(*stats_data)->elem_restr_parent_stats));
   PetscCall(DMPlexCeedElemRestrictionCoordinateCreate(ceed, dm, domain_label, label_value, height, &(*stats_data)->elem_restr_parent_x));
   PetscCall(DMPlexCeedElemRestrictionQDataCreate(ceed, dm, domain_label, label_value, height, problem->q_data_size_sur,


### PR DESCRIPTION
*(Currently draft for testing purposes)*

Also known as the war against global structs.

Fixing up things such as:
- Put QFunction and Operator creation together
- Don't store QFunctions in global structs that are only needed locally


Misc TODOs:
- [x] ~~Rename `apply_vol_rhs` to `spec_vol_rhs` (and so forth for the other similar ones)~~ I'll wait on this until I figure out which ones are going to be kept anyways
- [ ] ~~Create function for creating Qdata (ie. Separate the setup functions and other info from everything else)~~ Moved to #1571 as it's very extensive.
    - So we can remove `ceed_data->qf_setup_sur`, which is used by the spanstats setup
