### PR TITLE
fix(fluids): Remove comm arg from CeedOperatorCreateLocalVecs

### DIFF
--- a/examples/fluids/include/petsc_ops.h
+++ b/examples/fluids/include/petsc_ops.h
@@ -26,7 +26,7 @@ PetscErrorCode OperatorApplyContextDestroy(OperatorApplyContext op_apply_ctx);
 PetscErrorCode DMGetGlobalVectorInfo(DM dm, PetscInt *local_size, PetscInt *global_size, VecType *vec_type);
 PetscErrorCode DMGetLocalVectorInfo(DM dm, PetscInt *local_size, PetscInt *global_size, VecType *vec_type);
 
-PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, MPI_Comm comm, Vec *input, Vec *output);
+PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, Vec *input, Vec *output);
 VecType        DMReturnVecType(DM dm);
 
 PetscErrorCode ApplyCeedOperatorGlobalToGlobal(Vec X, Vec Y, OperatorApplyContext ctx);

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -169,11 +169,10 @@ VecType DMReturnVecType(DM dm) {
  *
  * @param[in]  op       Operator to make the Vecs for
  * @param[in]  vec_type `VecType` for the new Vecs
- * @param[in]  comm     `MPI_Comm` for the new Vecs
  * @param[out] input    Vec for CeedOperator active input
  * @param[out] output   Vec for CeedOperator active output
  */
-PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, MPI_Comm comm, Vec *input, Vec *output) {
+PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, Vec *input, Vec *output) {
   CeedSize input_size, output_size;
   Ceed     ceed;
 
@@ -181,12 +180,12 @@ PetscErrorCode CeedOperatorCreateLocalVecs(CeedOperator op, VecType vec_type, MP
   PetscCall(CeedOperatorGetCeed(op, &ceed));
   PetscCallCeed(ceed, CeedOperatorGetActiveVectorLengths(op, &input_size, &output_size));
   if (input) {
-    PetscCall(VecCreate(comm, input));
+    PetscCall(VecCreate(PETSC_COMM_SELF, input));
     PetscCall(VecSetType(*input, vec_type));
     PetscCall(VecSetSizes(*input, input_size, input_size));
   }
   if (output) {
-    PetscCall(VecCreate(comm, output));
+    PetscCall(VecCreate(PETSC_COMM_SELF, output));
     PetscCall(VecSetType(*output, vec_type));
     PetscCall(VecSetSizes(*output, output_size, output_size));
   }

--- a/examples/fluids/src/turb_spanstats.c
+++ b/examples/fluids/src/turb_spanstats.c
@@ -169,7 +169,7 @@ PetscErrorCode GetQuadratureCoords(Ceed ceed, DM dm, CeedElemRestriction elem_re
   PetscCallCeed(ceed, CeedOperatorSetField(op_quad_coords, "input", elem_restr_x, basis_x, x_coords));
   PetscCallCeed(ceed, CeedOperatorSetField(op_quad_coords, "output", elem_restr_qx, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
 
-  PetscCall(CeedOperatorCreateLocalVecs(op_quad_coords, DMReturnVecType(dm), PetscObjectComm((PetscObject)dm), NULL, Qx_coords));
+  PetscCall(CeedOperatorCreateLocalVecs(op_quad_coords, DMReturnVecType(dm), NULL, Qx_coords));
   PetscCall(OperatorApplyContextCreate(NULL, NULL, ceed, op_quad_coords, CEED_VECTOR_NONE, NULL, NULL, NULL, &op_quad_coords_ctx));
 
   PetscCall(ApplyCeedOperatorLocalToLocal(NULL, *Qx_coords, op_quad_coords_ctx));
@@ -314,7 +314,7 @@ PetscErrorCode SetupL2ProjectionStats(Ceed ceed, User user, CeedData ceed_data, 
   PetscCallCeed(ceed, CeedOperatorSetField(op_proj_rhs, "output", stats_data->elem_restr_parent_stats, stats_data->basis_stats, CEED_VECTOR_ACTIVE));
 
   PetscCall(OperatorApplyContextCreate(NULL, user->spanstats.dm, ceed, op_proj_rhs, NULL, NULL, NULL, NULL, &user->spanstats.op_proj_rhs_ctx));
-  PetscCall(CeedOperatorCreateLocalVecs(op_proj_rhs, DMReturnVecType(user->spanstats.dm), comm, &user->spanstats.Parent_Stats_loc, NULL));
+  PetscCall(CeedOperatorCreateLocalVecs(op_proj_rhs, DMReturnVecType(user->spanstats.dm), &user->spanstats.Parent_Stats_loc, NULL));
 
   // -- Setup LHS of L^2 projection
   // Get q_data for mass matrix operator
@@ -431,8 +431,7 @@ PetscErrorCode CreateStatisticCollectionOperator(Ceed ceed, User user, CeedData 
   PetscCall(OperatorApplyContextCreate(user->dm, user->spanstats.dm, user->ceed, op_stats_collect, user->q_ceed, NULL, NULL, NULL,
                                        &user->spanstats.op_stats_collect_ctx));
 
-  PetscCall(CeedOperatorCreateLocalVecs(op_stats_collect, DMReturnVecType(user->spanstats.dm), PetscObjectComm((PetscObject)user->spanstats.dm), NULL,
-                                        &user->spanstats.Child_Stats_loc));
+  PetscCall(CeedOperatorCreateLocalVecs(op_stats_collect, DMReturnVecType(user->spanstats.dm), NULL, &user->spanstats.Child_Stats_loc));
   PetscCall(VecZeroEntries(user->spanstats.Child_Stats_loc));
 
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_stats_collect));


### PR DESCRIPTION
`Vec`s created this way should always be purely local and thus always use `PETSC_COMM_SELF`.

This caused issues when using the spanwise statistics in parallel:
```
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: Invalid argument
[0]PETSC ERROR: Int value must be same on all processes, argument # 3
[0]PETSC ERROR: #1 VecSetSizes() at /lus/gecko/projects/PHASTA_aesp_CNDA/petsc-kjansen-fork1015002/src/vec/vec/interface/vector.c:1467
[0]PETSC ERROR: #2 CeedOperatorCreateLocalVecs() at /lus/gecko/projects/PHASTA_aesp_CNDA/libCEED_1015002/examples/fluids/src/petsc_ops.c:326
[0]PETSC ERROR: #3 GetQuadratureCoords() at /lus/gecko/projects/PHASTA_aesp_CNDA/libCEED_1015002/examples/fluids/src/turb_spanstats.c:169
[0]PETSC ERROR: #4 CreateStatsSF() at /lus/gecko/projects/PHASTA_aesp_CNDA/libCEED_1015002/examples/fluids/src/turb_spanstats.c:262
[0]PETSC ERROR: #5 TurbulenceStatisticsSetup() at /lus/gecko/projects/PHASTA_aesp_CNDA/libCEED_1015002/examples/fluids/src/turb_spanstats.c:494
[0]PETSC ERROR: #6 SetupLibceed() at /lus/gecko/projects/PHASTA_aesp_CNDA/libCEED_1015002/examples/fluids/src/setuplibceed.c:413
[0]PETSC ERROR: #7 main() at /lus/gecko/projects/PHASTA_aesp_CNDA/libCEED_1015002/examples/fluids/navierstokes.c:199
```