### PR TITLE
fluids: Add CreateQData and CreateQDataBoundary functions

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -285,16 +285,11 @@ int main(int argc, char **argv) {
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->apply_freestream_jacobian.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->apply_slip.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->apply_slip_jacobian.qfunction_context));
-    PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->setup_sur.qfunction_context));
-    PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->setup_vol.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->ics.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->apply_vol_rhs.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->apply_vol_ifunction.qfunction_context));
     PetscCallCeed(ceed, CeedQFunctionContextDestroy(&problem->apply_vol_ijacobian.qfunction_context));
   }
-
-  // -- QFunctions
-  PetscCallCeed(ceed, CeedQFunctionDestroy(&ceed_data->qf_setup_sur));
 
   // -- Operators
   PetscCall(OperatorApplyContextDestroy(ceed_data->op_ics_ctx));

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -155,7 +155,6 @@ struct CeedData_private {
   CeedBasis            basis_x, basis_q;
   CeedElemRestriction  elem_restr_x, elem_restr_q, elem_restr_qd_i;
   OperatorApplyContext op_ics_ctx;
-  CeedQFunction        qf_setup_sur;
 };
 
 typedef struct {
@@ -291,8 +290,8 @@ typedef struct ProblemData_private *ProblemData;
 struct ProblemData_private {
   CeedInt              dim, q_data_size_vol, q_data_size_sur, jac_data_size_sur;
   CeedScalar           dm_scale;
-  ProblemQFunctionSpec setup_vol, setup_sur, ics, apply_vol_rhs, apply_vol_ifunction, apply_vol_ijacobian, apply_inflow, apply_outflow,
-      apply_freestream, apply_slip, apply_inflow_jacobian, apply_outflow_jacobian, apply_freestream_jacobian, apply_slip_jacobian;
+  ProblemQFunctionSpec ics, apply_vol_rhs, apply_vol_ifunction, apply_vol_ijacobian, apply_inflow, apply_outflow, apply_freestream, apply_slip,
+      apply_inflow_jacobian, apply_outflow_jacobian, apply_freestream_jacobian, apply_slip_jacobian;
   bool      non_zero_time;
   PetscBool bc_from_ics, use_strong_bc_ceed, uses_newtonian;
   PetscErrorCode (*print_info)(User, ProblemData, AppCtx);
@@ -349,6 +348,12 @@ PetscErrorCode CreateBasisFromPlex(Ceed ceed, DM dm, DMLabel domain_label, CeedI
 
 PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, AppCtx app_ctx, ProblemData problem, SimpleBC bc);
 
+PetscErrorCode QDataGet(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, CeedElemRestriction elem_restr_x, CeedBasis basis_x,
+                        CeedVector x_coord, CeedElemRestriction *elem_restr_qd, CeedVector *q_data, CeedInt *q_data_size);
+PetscErrorCode QDataGetNumComponents(DM dm, CeedInt *q_data_size);
+PetscErrorCode QDataBoundaryGet(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, CeedElemRestriction elem_restr_x, CeedBasis basis_x,
+                                CeedVector x_coord, CeedElemRestriction *elem_restr_qd, CeedVector *q_data, CeedInt *q_data_size);
+PetscErrorCode QDataBoundaryGetNumComponents(DM dm, CeedInt *q_data_size);
 // -----------------------------------------------------------------------------
 // Time-stepping functions
 // -----------------------------------------------------------------------------

--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -14,8 +14,6 @@
 #include <petscdm.h>
 
 #include "../navierstokes.h"
-#include "../qfunctions/setupgeo.h"
-#include "../qfunctions/setupgeo2d.h"
 
 // @brief Create CeedOperator for stabilized mass KSP for explicit timestepping
 //
@@ -106,12 +104,6 @@ PetscErrorCode NS_ADVECTION(ProblemData problem, DM dm, void *ctx, SimpleBC bc) 
   switch (dim) {
     case 2:
       problem->dim                               = 2;
-      problem->q_data_size_vol                   = 5;
-      problem->q_data_size_sur                   = 3;
-      problem->setup_vol.qfunction               = Setup2d;
-      problem->setup_vol.qfunction_loc           = Setup2d_loc;
-      problem->setup_sur.qfunction               = SetupBoundary2d;
-      problem->setup_sur.qfunction_loc           = SetupBoundary2d_loc;
       problem->ics.qfunction                     = ICsAdvection2d;
       problem->ics.qfunction_loc                 = ICsAdvection2d_loc;
       problem->apply_vol_rhs.qfunction           = RHS_Advection2d;
@@ -125,12 +117,6 @@ PetscErrorCode NS_ADVECTION(ProblemData problem, DM dm, void *ctx, SimpleBC bc) 
       break;
     case 3:
       problem->dim                               = 3;
-      problem->q_data_size_vol                   = 10;
-      problem->q_data_size_sur                   = 10;
-      problem->setup_vol.qfunction               = Setup;
-      problem->setup_vol.qfunction_loc           = Setup_loc;
-      problem->setup_sur.qfunction               = SetupBoundary;
-      problem->setup_sur.qfunction_loc           = SetupBoundary_loc;
       problem->ics.qfunction                     = ICsAdvection;
       problem->ics.qfunction_loc                 = ICsAdvection_loc;
       problem->apply_vol_rhs.qfunction           = RHS_Advection;

--- a/examples/fluids/problems/eulervortex.c
+++ b/examples/fluids/problems/eulervortex.c
@@ -14,7 +14,6 @@
 #include <petscdm.h>
 
 #include "../navierstokes.h"
-#include "../qfunctions/setupgeo.h"
 
 PetscErrorCode NS_EULER_VORTEX(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   EulerTestType        euler_test;
@@ -33,12 +32,6 @@ PetscErrorCode NS_EULER_VORTEX(ProblemData problem, DM dm, void *ctx, SimpleBC b
   //               SET UP DENSITY_CURRENT
   // ------------------------------------------------------
   problem->dim                               = 3;
-  problem->q_data_size_vol                   = 10;
-  problem->q_data_size_sur                   = 10;
-  problem->setup_vol.qfunction               = Setup;
-  problem->setup_vol.qfunction_loc           = Setup_loc;
-  problem->setup_sur.qfunction               = SetupBoundary;
-  problem->setup_sur.qfunction_loc           = SetupBoundary_loc;
   problem->ics.qfunction                     = ICsEuler;
   problem->ics.qfunction_loc                 = ICsEuler_loc;
   problem->apply_vol_rhs.qfunction           = Euler;

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -14,7 +14,6 @@
 #include <petscdm.h>
 
 #include "../navierstokes.h"
-#include "../qfunctions/setupgeo.h"
 
 // For use with PetscOptionsEnum
 static const char *const StateVariables[] = {"CONSERVATIVE", "PRIMITIVE", "StateVariable", "STATEVAR_", NULL};
@@ -136,17 +135,11 @@ PetscErrorCode NS_NEWTONIAN_IG(ProblemData problem, DM dm, void *ctx, SimpleBC b
   // ------------------------------------------------------
   //           Setup Generic Newtonian IG Problem
   // ------------------------------------------------------
-  problem->dim                     = 3;
-  problem->q_data_size_vol         = 10;
-  problem->q_data_size_sur         = 10;
-  problem->jac_data_size_sur       = 11;
-  problem->setup_vol.qfunction     = Setup;
-  problem->setup_vol.qfunction_loc = Setup_loc;
-  problem->setup_sur.qfunction     = SetupBoundary;
-  problem->setup_sur.qfunction_loc = SetupBoundary_loc;
-  problem->non_zero_time           = PETSC_FALSE;
-  problem->print_info              = PRINT_NEWTONIAN;
-  problem->uses_newtonian          = PETSC_TRUE;
+  problem->dim               = 3;
+  problem->jac_data_size_sur = 11;
+  problem->non_zero_time     = PETSC_FALSE;
+  problem->print_info        = PRINT_NEWTONIAN;
+  problem->uses_newtonian    = PETSC_TRUE;
 
   // ------------------------------------------------------
   //             Create the libCEED context

--- a/examples/fluids/problems/shocktube.c
+++ b/examples/fluids/problems/shocktube.c
@@ -14,7 +14,6 @@
 #include <petscdm.h>
 
 #include "../navierstokes.h"
-#include "../qfunctions/setupgeo.h"
 
 PetscErrorCode NS_SHOCKTUBE(ProblemData problem, DM dm, void *ctx, SimpleBC bc) {
   SetupContextShock    setup_context;
@@ -35,12 +34,6 @@ PetscErrorCode NS_SHOCKTUBE(ProblemData problem, DM dm, void *ctx, SimpleBC bc) 
   //               SET UP SHOCKTUBE
   // ------------------------------------------------------
   problem->dim                               = 3;
-  problem->q_data_size_vol                   = 10;
-  problem->q_data_size_sur                   = 4;
-  problem->setup_vol.qfunction               = Setup;
-  problem->setup_vol.qfunction_loc           = Setup_loc;
-  problem->setup_sur.qfunction               = SetupBoundary;
-  problem->setup_sur.qfunction_loc           = SetupBoundary_loc;
   problem->ics.qfunction                     = ICsShockTube;
   problem->ics.qfunction_loc                 = ICsShockTube_loc;
   problem->apply_vol_rhs.qfunction           = EulerShockTube;

--- a/examples/fluids/src/qdata.c
+++ b/examples/fluids/src/qdata.c
@@ -1,0 +1,199 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#include "../navierstokes.h"
+
+#include <petscsection.h>
+#include "../qfunctions/setupgeo.h"
+#include "../qfunctions/setupgeo2d.h"
+
+/**
+ * @brief Get number of components of quadrature data for domain
+ *
+ * @param[in]  dm          DM where quadrature data would be used
+ * @param[out] q_data_size Number of components of quadrature data
+ */
+PetscErrorCode QDataGetNumComponents(DM dm, CeedInt *q_data_size) {
+  PetscInt num_comp_x, dim;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMGetDimension(dm, &dim));
+  {  // Get number of coordinate components
+    DM           dm_coord;
+    PetscSection section_coord;
+    PetscInt     field = 0;  // Default field has the coordinates
+    PetscCall(DMGetCoordinateDM(dm, &dm_coord));
+    PetscCall(DMGetLocalSection(dm_coord, &section_coord));
+    PetscCall(PetscSectionGetFieldComponents(section_coord, field, &num_comp_x));
+  }
+  switch (dim) {
+    case 2:
+      switch (num_comp_x) {
+        case 2:
+          *q_data_size = 5;
+          break;
+        case 3:
+          *q_data_size = 7;
+          break;
+        default:
+          SETERRQ(PetscObjectComm((PetscObject)dm), PETSC_ERR_SUP,
+                  "QData not valid for DM of dimension %" PetscInt_FMT " and coordinates with dimension %" PetscInt_FMT, dim, num_comp_x);
+          break;
+      }
+      break;
+    case 3:
+      *q_data_size = 10;
+      break;
+    default:
+      SETERRQ(PetscObjectComm((PetscObject)dm), PETSC_ERR_SUP,
+              "QData not valid for DM of dimension %" PetscInt_FMT " and coordinates with dimension %" PetscInt_FMT, dim, num_comp_x);
+      break;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+ * @brief Create quadrature data for domain
+ *
+ * @param[in]  ceed          Ceed object quadrature data will be used with
+ * @param[in]  dm            DM where quadrature data would be used
+ * @param[in]  domain_label  DMLabel that quadrature data would be used one
+ * @param[in]  label_value   Value of label
+ * @param[in]  elem_restr_x  CeedElemRestriction of the coordinates (must match `domain_label` and `label_value` selections)
+ * @param[in]  basis_x       CeedBasis of the coordinates
+ * @param[in]  x_coord       CeedVector of the coordinates
+ * @param[out] elem_restr_qd CeedElemRestriction of the quadrature data
+ * @param[out] q_data        CeedVector of the quadrature data
+ * @param[out] q_data_size   number of components of quadrature data
+ */
+PetscErrorCode QDataGet(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, CeedElemRestriction elem_restr_x, CeedBasis basis_x,
+                        CeedVector x_coord, CeedElemRestriction *elem_restr_qd, CeedVector *q_data, CeedInt *q_data_size) {
+  CeedQFunction qf_setup;
+  CeedOperator  op_setup;
+  CeedInt       num_comp_x;
+  PetscInt      dim, height = 0;
+
+  PetscFunctionBeginUser;
+  PetscCall(QDataGetNumComponents(dm, q_data_size));
+  PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_x, &num_comp_x));
+  PetscCall(DMGetDimension(dm, &dim));
+  switch (dim) {
+    case 2:
+      switch (num_comp_x) {
+        case 2:
+          PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, Setup2d, Setup2d_loc, &qf_setup));
+          break;
+        case 3:
+          PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, Setup2D_3Dcoords, Setup2D_3Dcoords_loc, &qf_setup));
+          break;
+      }
+      break;
+    case 3:
+      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, Setup, Setup_loc, &qf_setup));
+      break;
+  }
+
+  // -- Create QFunction for quadrature data
+  PetscCallCeed(ceed, CeedQFunctionSetUserFlopsEstimate(qf_setup, 0));
+  PetscCallCeed(ceed, CeedQFunctionAddInput(qf_setup, "dx", num_comp_x * (dim - height), CEED_EVAL_GRAD));
+  PetscCallCeed(ceed, CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT));
+  PetscCallCeed(ceed, CeedQFunctionAddOutput(qf_setup, "surface qdata", *q_data_size, CEED_EVAL_NONE));
+
+  PetscCall(DMPlexCeedElemRestrictionQDataCreate(ceed, dm, domain_label, label_value, height, *q_data_size, elem_restr_qd));
+  PetscCallCeed(ceed, CeedElemRestrictionCreateVector(*elem_restr_qd, q_data, NULL));
+
+  PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_setup, NULL, NULL, &op_setup));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_setup, "dx", elem_restr_x, basis_x, CEED_VECTOR_ACTIVE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_setup, "surface qdata", *elem_restr_qd, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+
+  PetscCallCeed(ceed, CeedOperatorApply(op_setup, x_coord, *q_data, CEED_REQUEST_IMMEDIATE));
+
+  PetscCallCeed(ceed, CeedOperatorDestroy(&op_setup));
+  PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_setup));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+ * @brief Get number of components of quadrature data for boundary of domain
+ *
+ * @param[in]  dm          DM where quadrature data would be used
+ * @param[out] q_data_size Number of components of quadrature data
+ */
+PetscErrorCode QDataBoundaryGetNumComponents(DM dm, CeedInt *q_data_size) {
+  PetscInt dim;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMGetDimension(dm, &dim));
+  switch (dim) {
+    case 2:
+      *q_data_size = 3;
+      break;
+    case 3:
+      *q_data_size = 10;
+      break;
+    default:
+      SETERRQ(PetscObjectComm((PetscObject)dm), PETSC_ERR_SUP, "QDataBoundary not valid for DM of dimension %" PetscInt_FMT, dim);
+      break;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+ * @brief Create quadrature data for boundary of domain
+ *
+ * @param[in]  ceed          Ceed object quadrature data will be used with
+ * @param[in]  dm            DM where quadrature data would be used
+ * @param[in]  domain_label  DMLabel that quadrature data would be used one
+ * @param[in]  label_value   Value of label
+ * @param[in]  elem_restr_x  CeedElemRestriction of the coordinates (must match `domain_label` and `label_value` selections)
+ * @param[in]  basis_x       CeedBasis of the coordinates
+ * @param[in]  x_coord       CeedVector of the coordinates
+ * @param[out] elem_restr_qd CeedElemRestriction of the quadrature data
+ * @param[out] q_data        CeedVector of the quadrature data
+ * @param[out] q_data_size   number of components of quadrature data
+ */
+PetscErrorCode QDataBoundaryGet(Ceed ceed, DM dm, DMLabel domain_label, PetscInt label_value, CeedElemRestriction elem_restr_x, CeedBasis basis_x,
+                                CeedVector x_coord, CeedElemRestriction *elem_restr_qd, CeedVector *q_data, CeedInt *q_data_size) {
+  CeedQFunction qf_setup_sur;
+  CeedOperator  op_setup_sur;
+  CeedInt       num_comp_x;
+  PetscInt      dim, height = 1;
+
+  PetscFunctionBeginUser;
+  PetscCall(QDataBoundaryGetNumComponents(dm, q_data_size));
+  PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_x, &num_comp_x));
+  PetscCall(DMGetDimension(dm, &dim));
+  switch (dim) {
+    case 2:
+      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, SetupBoundary2d, SetupBoundary2d_loc, &qf_setup_sur));
+      break;
+    case 3:
+      PetscCallCeed(ceed, CeedQFunctionCreateInterior(ceed, 1, SetupBoundary, SetupBoundary_loc, &qf_setup_sur));
+      break;
+  }
+
+  // -- Create QFunction for quadrature data
+  PetscCallCeed(ceed, CeedQFunctionSetUserFlopsEstimate(qf_setup_sur, 0));
+  PetscCallCeed(ceed, CeedQFunctionAddInput(qf_setup_sur, "dx", num_comp_x * (dim - height), CEED_EVAL_GRAD));
+  PetscCallCeed(ceed, CeedQFunctionAddInput(qf_setup_sur, "weight", 1, CEED_EVAL_WEIGHT));
+  PetscCallCeed(ceed, CeedQFunctionAddOutput(qf_setup_sur, "surface qdata", *q_data_size, CEED_EVAL_NONE));
+
+  PetscCall(DMPlexCeedElemRestrictionQDataCreate(ceed, dm, domain_label, label_value, height, *q_data_size, elem_restr_qd));
+  PetscCallCeed(ceed, CeedElemRestrictionCreateVector(*elem_restr_qd, q_data, NULL));
+
+  PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_setup_sur, NULL, NULL, &op_setup_sur));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "dx", elem_restr_x, basis_x, CEED_VECTOR_ACTIVE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE));
+  PetscCallCeed(ceed, CeedOperatorSetField(op_setup_sur, "surface qdata", *elem_restr_qd, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
+
+  PetscCallCeed(ceed, CeedOperatorApply(op_setup_sur, x_coord, *q_data, CEED_REQUEST_IMMEDIATE));
+
+  PetscCallCeed(ceed, CeedOperatorDestroy(&op_setup_sur));
+  PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_setup_sur));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}


### PR DESCRIPTION
Create function for creating Qdata (ie. Separate the setup functions and other info from everything else)
So we can remove `ceed_data->qf_setup_sur`, which is used by the spanstats setup. This will also remove `spec_setup_{vol,sur}` as well.

Depends on https://github.com/CEED/libCEED/pull/1567