### PR TITLE
fluids: Correct printing of MatTypes

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -229,9 +229,6 @@ int main(int argc, char **argv) {
     PetscCall(SetupICsFromBinary(comm, app_ctx, Q));
   }
 
-  // Print problem summary
-  if (app_ctx->test_type == TESTTYPE_NONE) PetscCall(PrintRunInfo(user, phys_ctx, problem, comm));
-
   // -- Zero Q_loc
   PetscCall(VecZeroEntries(user->Q_loc));
 
@@ -240,7 +237,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   TS          ts;
   PetscScalar final_time;
-  PetscCall(TSSolve_NS(dm, user, app_ctx, phys_ctx, &Q, &final_time, &ts));
+  PetscCall(TSSolve_NS(dm, user, app_ctx, phys_ctx, problem, &Q, &final_time, &ts));
 
   // ---------------------------------------------------------------------------
   // Post-processing

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -366,7 +366,7 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
 PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time, Vec Q, void *ctx);
 
 // TS: Create, setup, and solve
-PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q, PetscScalar *f_time, TS *ts);
+PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, ProblemData problem, Vec *Q, PetscScalar *f_time, TS *ts);
 
 // Update Boundary Values when time has changed
 PetscErrorCode UpdateBoundaryValues(User user, Vec Q_loc, PetscReal t);

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -325,7 +325,7 @@ extern PetscErrorCode PRINT_ADVECTION(User user, ProblemData problem, AppCtx app
 
 extern PetscErrorCode PRINT_ADVECTION2D(User user, ProblemData problem, AppCtx app_ctx);
 
-PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData problem, MPI_Comm comm);
+PetscErrorCode PrintRunInfo(User user, Physics phys_ctx, ProblemData problem, TS ts);
 
 // -----------------------------------------------------------------------------
 // libCEED functions

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -338,7 +338,7 @@ PetscErrorCode CreateSolveOperatorsFromMatCeed(KSP ksp, Mat mat_ceed, PetscBool 
 
     PetscCall(KSPGetPC(ksp, &pc));
     PetscCall(PCGetType(pc, &pc_type));
-    PetscCall(PetscStrcmpAny(pc_type, &use_matceed_pmat, PCJACOBI, PCVPBJACOBI, PCPBJACOBI, ""));
+    PetscCall(PetscStrcmpAny(pc_type, &use_matceed_pmat, PCNONE, PCJACOBI, PCVPBJACOBI, PCPBJACOBI, ""));
   }
 
   if (use_matceed_pmat) {

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -298,7 +298,7 @@ PetscErrorCode TSMonitor_NS(TS ts, PetscInt step_no, PetscReal time, Vec Q, void
 }
 
 // TS: Create, setup, and solve
-PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q, PetscScalar *f_time, TS *ts) {
+PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, ProblemData problem, Vec *Q, PetscScalar *f_time, TS *ts) {
   MPI_Comm    comm = user->comm;
   TSAdapt     adapt;
   PetscScalar final_time;
@@ -377,6 +377,8 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Vec *Q
     PetscCall(TSMonitorSet(*ts, TSMonitor_SGS_DD_Training, user, NULL));
     PetscCall(TSSetPostStep(*ts, TSPostStep_SGS_DD_Training));
   }
+
+  if (app_ctx->test_type == TESTTYPE_NONE) PetscCall(PrintRunInfo(user, user->phys, problem, comm));
   // Solve
   PetscReal start_time;
   PetscInt  start_step;

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -378,7 +378,7 @@ PetscErrorCode TSSolve_NS(DM dm, User user, AppCtx app_ctx, Physics phys, Proble
     PetscCall(TSSetPostStep(*ts, TSPostStep_SGS_DD_Training));
   }
 
-  if (app_ctx->test_type == TESTTYPE_NONE) PetscCall(PrintRunInfo(user, user->phys, problem, comm));
+  if (app_ctx->test_type == TESTTYPE_NONE) PetscCall(PrintRunInfo(user, user->phys, problem, *ts));
   // Solve
   PetscReal start_time;
   PetscInt  start_step;


### PR DESCRIPTION
This does a few things (beyond the title):

- Makes `MatCeedSetUpInnerMat` public
    - Previous usage of `MatConvert` did not actually work in my testing
    - Additionally, `MatConvert` does manual assembly of the matrix during the conversion, when all we want is a matrix ready for COO assembly.
    - @jeremylt I'm not sure if this is the "best" solution, but it was the simplest.
- Moves the run info printing to be done right before `TSSolve` is called
- Gets it's Amat and Pmat info from the `TS` directly.
    - This printing was incorrect previously
    
I'm not 100% sure on the format of the info being printed right now. A few questions for feedback:

Do we even want to print out `A MatType` or `P MatType` when running explicit? They don't really mean anything:
```
$ build/fluids-navierstokes -ceed /cpu/self/memcheck/blocked -options_file examples/fluids/gaussianwave.yaml -dm_plex_box_faces 2,2,1 -ts_max_steps 5 -degree 3 -implicit false -ts_type rk -stab supg -state_var conservative -mass_ksp_type gmres -mass_pc_jacobi_type diagonal

-- Navier-Stokes solver - libCEED + PETSc --
[...]
  PETSc:
    Box Faces                          : 2,2,1
    A MatType                          : seqaij
    P MatType                          : seqaij
```

Currently, instead of `shell`, it will print `ceed`. This obviously conflicts with the `-amat_type` flag. We could go with deprecating the `-amat_type` flag like I had proposed awhile back (and I think we all oked the idea? Relevant [Zulip link](https://phypid.zulipchat.com/#narrow/stream/232375-ceed-phasta/topic/Change.20default.20Amat.20type.20behavior/near/426357458). But not sure if we want to do that now.