### PR TITLE
fluids: MatCeed and Ratel Updates

### DIFF
--- a/examples/fluids/include/mat-ceed-impl.h
+++ b/examples/fluids/include/mat-ceed-impl.h
@@ -7,45 +7,16 @@
 #pragma once
 
 #include <ceed.h>
+#include <petsc-ceed.h>
 #include <petscdm.h>
 #include <petscmat.h>
 #include <petsc/private/petscimpl.h>
-
-#if defined(__clang_analyzer__)
-#define MATCEED_EXTERN extern
-#elif defined(__cplusplus)
-#define MATCEED_EXTERN extern "C"
-#else
-#define MATCEED_EXTERN extern
-#endif
-
-#if defined(__clang_analyzer__)
-#define MATCEED_INTERN
-#else
-#define MATCEED_INTERN MATCEED_EXTERN __attribute__((visibility("hidden")))
-#endif
-
-/**
-  @brief Calls a libCEED function and then checks the resulting error code.
-  If the error code is non-zero, then a PETSc error is set with the libCEED error message.
-**/
-#ifndef PetscCallCeed
-#define PetscCallCeed(ceed_, ...)                                   \
-  do {                                                              \
-    int ierr_q_ = __VA_ARGS__;                                      \
-    if (ierr_q_ != CEED_ERROR_SUCCESS) {                            \
-      const char *error_message;                                    \
-      CeedGetErrorMessage(ceed_, &error_message);                   \
-      SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, "%s", error_message); \
-    }                                                               \
-  } while (0)
-#endif
 
 // MatCeed context for applying composite CeedOperator on a DM
 typedef struct MatCeedContext_private *MatCeedContext;
 struct MatCeedContext_private {
   Ceed           ceed;
-  char          *name, *internal_mat_type;
+  char          *name, *coo_mat_type;
   PetscMemType   mem_type;
   PetscInt       ref_count, num_mats_assembled_full, num_mats_assembled_pbd;
   PetscBool      is_destroyed, is_ceed_pbd_valid, is_ceed_vpbd_valid;
@@ -59,17 +30,17 @@ struct MatCeedContext_private {
 };
 
 // Context data
-MATCEED_INTERN PetscErrorCode MatCeedContextCreate(DM dm_x, DM dm_y, Vec X_loc, Vec Y_loc_transpose, CeedOperator op_mult,
-                                                   CeedOperator op_mult_transpose, PetscLogEvent log_event_mult,
-                                                   PetscLogEvent log_event_mult_transpose, MatCeedContext *ctx);
-MATCEED_INTERN PetscErrorCode MatCeedContextReference(MatCeedContext ctx);
-MATCEED_INTERN PetscErrorCode MatCeedContextReferenceCopy(MatCeedContext ctx, MatCeedContext *ctx_copy);
-MATCEED_INTERN PetscErrorCode MatCeedContextDestroy(MatCeedContext ctx);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedContextCreate(DM dm_x, DM dm_y, Vec X_loc, Vec Y_loc_transpose, CeedOperator op_mult,
+                                                      CeedOperator op_mult_transpose, PetscLogEvent log_event_mult,
+                                                      PetscLogEvent log_event_mult_transpose, MatCeedContext *ctx);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedContextReference(MatCeedContext ctx);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedContextReferenceCopy(MatCeedContext ctx, MatCeedContext *ctx_copy);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedContextDestroy(MatCeedContext ctx);
 
-// Mat Ceed
-MATCEED_INTERN PetscErrorCode MatGetDiagonal_Ceed(Mat A, Vec D);
-MATCEED_INTERN PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y);
-MATCEED_INTERN PetscErrorCode MatMultTranspose_Ceed(Mat A, Vec Y, Vec X);
+// MatCEED
+PETSC_CEED_EXTERN PetscErrorCode MatGetDiagonal_Ceed(Mat A, Vec D);
+PETSC_CEED_EXTERN PetscErrorCode MatMult_Ceed(Mat A, Vec X, Vec Y);
+PETSC_CEED_EXTERN PetscErrorCode MatMultTranspose_Ceed(Mat A, Vec Y, Vec X);
 
 extern PetscClassId  MATCEED_CLASSID;
 extern PetscLogEvent MATCEED_MULT, MATCEED_MULT_TRANSPOSE;

--- a/examples/fluids/include/mat-ceed.h
+++ b/examples/fluids/include/mat-ceed.h
@@ -7,38 +7,36 @@
 #pragma once
 
 #include <ceed.h>
+#include <petsc-ceed.h>
 #include <petscdm.h>
 #include <petscmat.h>
 
 #define MATCEED "ceed"
 
-#if defined(__clang_analyzer__)
-#define MATCEED_EXTERN extern
-#elif defined(__cplusplus)
-#define MATCEED_EXTERN extern "C"
-#else
-#define MATCEED_EXTERN extern
-#endif
+// Core functionality
+PETSC_CEED_EXTERN PetscErrorCode MatCeedCreate(DM dm_x, DM dm_y, CeedOperator op_mult, CeedOperator op_mult_transpose, Mat *mat);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedCopy(Mat mat_ceed, Mat mat_other);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedCreateMatCOO(Mat mat_ceed, Mat *mat_coo);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetPreallocationCOO(Mat mat_ceed, Mat mat_coo);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedAssembleCOO(Mat mat_ceed, Mat mat_coo);
 
-#if defined(__clang_analyzer__)
-#define MATCEED_INTERN
-#else
-#define MATCEED_INTERN MATCEED_EXTERN __attribute__((visibility("hidden")))
-#endif
+PETSC_CEED_INTERN PetscErrorCode MatCeedSetContextDouble(Mat mat, const char *name, double value);
+PETSC_CEED_INTERN PetscErrorCode MatCeedGetContextDouble(Mat mat, const char *name, double *value);
 
-// Context data
-MATCEED_INTERN PetscErrorCode MatCeedCreate(DM dm_x, DM dm_y, CeedOperator op_mult, CeedOperator op_mult_transpose, Mat *mat);
-MATCEED_INTERN PetscErrorCode MatCeedCopy(Mat mat_ceed, Mat mat_other);
-MATCEED_INTERN PetscErrorCode MatCeedAssembleCOO(Mat mat_ceed, Mat mat_coo);
-MATCEED_INTERN PetscErrorCode MatCeedSetContext(Mat mat, PetscErrorCode (*f)(void *), void *ctx);
-MATCEED_INTERN PetscErrorCode MatCeedGetContext(Mat mat, void *ctx);
-MATCEED_INTERN PetscErrorCode MatCeedSetInnerMatType(Mat mat, MatType type);
-MATCEED_INTERN PetscErrorCode MatCeedGetInnerMatType(Mat mat, MatType *type);
-MATCEED_INTERN PetscErrorCode MatCeedSetOperation(Mat mat, MatOperation op, void (*g)(void));
-MATCEED_INTERN PetscErrorCode MatCeedSetLocalVectors(Mat mat, Vec X_loc, Vec Y_loc_transpose);
-MATCEED_INTERN PetscErrorCode MatCeedGetLocalVectors(Mat mat, Vec *X_loc, Vec *Y_loc_transpose);
-MATCEED_INTERN PetscErrorCode MatCeedRestoreLocalVectors(Mat mat, Vec *X_loc, Vec *Y_loc_transpose);
-MATCEED_INTERN PetscErrorCode MatCeedGetCeedOperators(Mat mat, CeedOperator *op_mult, CeedOperator *op_mult_transpose);
-MATCEED_INTERN PetscErrorCode MatCeedRestoreCeedOperators(Mat mat, CeedOperator *op_mult, CeedOperator *op_mult_transpose);
-MATCEED_INTERN PetscErrorCode MatCeedSetLogEvents(Mat mat, PetscLogEvent log_event_mult, PetscLogEvent log_event_mult_transpose);
-MATCEED_INTERN PetscErrorCode MatCeedGetLogEvents(Mat mat, PetscLogEvent *log_event_mult, PetscLogEvent *log_event_mult_transpose);
+// Advanced functionality
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetContext(Mat mat, PetscErrorCode (*f)(void *), void *ctx);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetContext(Mat mat, void *ctx);
+
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetOperation(Mat mat, MatOperation op, void (*g)(void));
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetCOOMatType(Mat mat, MatType type);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetCOOMatType(Mat mat, MatType *type);
+
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetLocalVectors(Mat mat, Vec X_loc, Vec Y_loc_transpose);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetLocalVectors(Mat mat, Vec *X_loc, Vec *Y_loc_transpose);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedRestoreLocalVectors(Mat mat, Vec *X_loc, Vec *Y_loc_transpose);
+
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetCeedOperators(Mat mat, CeedOperator *op_mult, CeedOperator *op_mult_transpose);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedRestoreCeedOperators(Mat mat, CeedOperator *op_mult, CeedOperator *op_mult_transpose);
+
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetLogEvents(Mat mat, PetscLogEvent log_event_mult, PetscLogEvent log_event_mult_transpose);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetLogEvents(Mat mat, PetscLogEvent *log_event_mult, PetscLogEvent *log_event_mult_transpose);

--- a/examples/fluids/include/petsc-ceed-utils.h
+++ b/examples/fluids/include/petsc-ceed-utils.h
@@ -9,17 +9,43 @@
 #include <ceed.h>
 #include <petscdm.h>
 
-#define PetscCallCeed(ceed, ...)                                    \
-  do {                                                              \
-    int ierr_q_;                                                    \
-    PetscStackUpdateLine;                                           \
-    ierr_q_ = __VA_ARGS__;                                          \
-    if (PetscUnlikely(ierr_q_ != CEED_ERROR_SUCCESS)) {             \
-      const char *error_message;                                    \
-      CeedGetErrorMessage(ceed, &error_message);                    \
-      SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, "%s", error_message); \
-    }                                                               \
-  } while (0)
+/**
+  @brief Copy the reference to a `Vec`.
+         Note: If `vec_copy` is non-null, it is assumed to be a valid pointer to a `Vec` and `VecDestroy()` will be called.
+
+  Collective across MPI processes.
+
+  @param[in]   vec       `Vec` to reference
+  @param[out]  vec_copy  Copy of reference
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static inline PetscErrorCode VecReferenceCopy(Vec vec, Vec *vec_copy) {
+  PetscFunctionBeginUser;
+  PetscCall(PetscObjectReference((PetscObject)vec));
+  PetscCall(VecDestroy(vec_copy));
+  *vec_copy = vec;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Copy the reference to a `DM`.
+         Note: If `dm_copy` is non-null, it is assumed to be a valid pointer to a `DM` and `DMDestroy()` will be called.
+
+  Collective across MPI processes.
+
+  @param[in]   dm       `DM` to reference
+  @param[out]  dm_copy  Copy of reference
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+static inline PetscErrorCode DMReferenceCopy(DM dm, DM *dm_copy) {
+  PetscFunctionBeginUser;
+  PetscCall(PetscObjectReference((PetscObject)dm));
+  PetscCall(DMDestroy(dm_copy));
+  *dm_copy = dm;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
 
 /**
   @brief Translate PetscMemType to CeedMemType

--- a/examples/fluids/include/petsc-ceed.h
+++ b/examples/fluids/include/petsc-ceed.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+#pragma once
+
+#include <petscsys.h>
+
+#if defined(__clang_analyzer__)
+#define PETSC_CEED_EXTERN extern
+#elif defined(__cplusplus)
+#define PETSC_CEED_EXTERN extern "C"
+#else
+#define PETSC_CEED_EXTERN extern
+#endif
+
+#if defined(__clang_analyzer__)
+#define PETSC_CEED_INTERN
+#else
+#define PETSC_CEED_INTERN PETSC_CEED_EXTERN __attribute__((visibility("hidden")))
+#endif
+
+/**
+  @brief Calls a libCEED function and then checks the resulting error code.
+  If the error code is non-zero, then a PETSc error is set with the libCEED error message.
+**/
+/// @ingroup RatelInternal
+#ifndef PetscCallCeed
+#define PetscCallCeed(ceed_, ...)                                   \
+  do {                                                              \
+    int ierr_q_;                                                    \
+    PetscStackUpdateLine;                                           \
+    ierr_q_ = __VA_ARGS__;                                          \
+    if (PetscUnlikely(ierr_q_ != CEED_ERROR_SUCCESS)) {             \
+      const char *error_message;                                    \
+      CeedGetErrorMessage(ceed_, &error_message);                   \
+      SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, "%s", error_message); \
+    }                                                               \
+  } while (0)
+#endif

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -6,9 +6,9 @@
 // This file is part of CEED:  http://github.com/ceed
 #pragma once
 
-#include <ceed-utils.h>
 #include <ceed.h>
 #include <mat-ceed.h>
+#include <petsc-ceed-utils.h>
 #include <petscts.h>
 #include <stdbool.h>
 

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -276,7 +276,6 @@ struct Physics_private {
   CeedContextFieldLabel stg_solution_time_label;
   CeedContextFieldLabel timestep_size_label;
   CeedContextFieldLabel ics_time_label;
-  CeedContextFieldLabel ijacobian_time_shift_label;
 };
 
 typedef struct {

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -309,10 +309,8 @@ PetscErrorCode ApplyAddCeedOperatorLocalToLocal(Vec X_loc, Vec Y_loc, OperatorAp
  */
 PetscErrorCode CreateSolveOperatorsFromMatCeed(KSP ksp, Mat mat_ceed, PetscBool assemble, Mat *Amat, Mat *Pmat) {
   PetscBool use_matceed_pmat, assemble_amat = PETSC_FALSE;
-  MatType   mat_ceed_inner_type;
 
   PetscFunctionBeginUser;
-  PetscCall(MatCeedGetCOOMatType(mat_ceed, &mat_ceed_inner_type));
   {  // Determine if Amat should be MATCEED or assembled
     const char *ksp_prefix = NULL;
 
@@ -323,7 +321,7 @@ PetscErrorCode CreateSolveOperatorsFromMatCeed(KSP ksp, Mat mat_ceed, PetscBool 
   }
 
   if (assemble_amat) {
-    PetscCall(MatConvert(mat_ceed, mat_ceed_inner_type, MAT_INITIAL_MATRIX, Amat));
+    PetscCall(MatCeedCreateMatCOO(mat_ceed, Amat));
     if (assemble) PetscCall(MatCeedAssembleCOO(mat_ceed, *Amat));
 
     PetscCall(PetscObjectReference((PetscObject)*Amat));
@@ -347,7 +345,7 @@ PetscErrorCode CreateSolveOperatorsFromMatCeed(KSP ksp, Mat mat_ceed, PetscBool 
     PetscCall(PetscObjectReference((PetscObject)mat_ceed));
     *Pmat = mat_ceed;
   } else {
-    PetscCall(MatConvert(mat_ceed, mat_ceed_inner_type, MAT_INITIAL_MATRIX, Pmat));
+    PetscCall(MatCeedCreateMatCOO(mat_ceed, Pmat));
     if (assemble) PetscCall(MatCeedAssembleCOO(mat_ceed, *Pmat));
   }
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/examples/fluids/src/petsc_ops.c
+++ b/examples/fluids/src/petsc_ops.c
@@ -312,7 +312,7 @@ PetscErrorCode CreateSolveOperatorsFromMatCeed(KSP ksp, Mat mat_ceed, PetscBool 
   MatType   mat_ceed_inner_type;
 
   PetscFunctionBeginUser;
-  PetscCall(MatCeedGetInnerMatType(mat_ceed, &mat_ceed_inner_type));
+  PetscCall(MatCeedGetCOOMatType(mat_ceed, &mat_ceed_inner_type));
   {  // Determine if Amat should be MATCEED or assembled
     const char *ksp_prefix = NULL;
 

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -468,7 +468,6 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     if (op_ijacobian) {
       PetscCall(MatCeedCreate(user->dm, user->dm, op_ijacobian, NULL, &user->mat_ijacobian));
       PetscCall(MatCeedSetLocalVectors(user->mat_ijacobian, user->Q_dot_loc, NULL));
-      PetscCallCeed(ceed, CeedOperatorGetContextFieldLabel(op_ijacobian, "ijacobian time shift", &user->phys->ijacobian_time_shift_label));
       PetscCallCeed(ceed, CeedOperatorDestroy(&op_ijacobian));
     }
     if (app_ctx->sgs_model_type == SGS_MODEL_DATA_DRIVEN) PetscCall(SgsDDSetup(ceed, user, ceed_data, problem));

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -154,8 +154,8 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
 }
 
 PetscErrorCode FormIJacobian_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, PetscReal shift, Mat J, Mat J_pre, void *user_data) {
-  User      user = *(User *)user_data;
-  Ceed      ceed = user->ceed;
+  User      user         = *(User *)user_data;
+  double    shift_double = shift;
   PetscBool J_is_matceed, J_is_mffd, J_pre_is_matceed, J_pre_is_mffd;
 
   PetscFunctionBeginUser;
@@ -163,12 +163,8 @@ PetscErrorCode FormIJacobian_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, PetscReal 
   PetscCall(PetscObjectTypeCompare((PetscObject)J, MATCEED, &J_is_matceed));
   PetscCall(PetscObjectTypeCompare((PetscObject)J_pre, MATMFFD, &J_pre_is_mffd));
   PetscCall(PetscObjectTypeCompare((PetscObject)J_pre, MATCEED, &J_pre_is_matceed));
-  if (user->phys->ijacobian_time_shift_label) {
-    CeedOperator op_ijacobian;
 
-    PetscCall(MatCeedGetCeedOperators(user->mat_ijacobian, &op_ijacobian, NULL));
-    PetscCallCeed(ceed, CeedOperatorSetContextDouble(op_ijacobian, user->phys->ijacobian_time_shift_label, &shift));
-  }
+  PetscCall(MatCeedSetContextDouble(user->mat_ijacobian, "ijacobian time shift", shift_double));
 
   if (J_is_matceed || J_is_mffd) {
     PetscCall(MatAssemblyBegin(J, MAT_FINAL_ASSEMBLY));


### PR DESCRIPTION
Sync with Ratel, mostly for MatCeed. Namely:
- `MatCeedCreateCOOMat`: https://gitlab.com/micromorph/ratel/-/merge_requests/831
- `MatCeedSetContextDouble`

*EDIT: moved to #1575*: Note @jeremylt I also added a `MatCeed{Get,Set}ContextReal` instead of the `MatCeedSet{Time,Dt,Shifts}`. I think that makes more sense than the application-specific `MatCeedSet*`for upstreaming to PETSc. I could see them as `RatelJacobianSet{Time,Dt,Shifts}` though.