### PR TITLE
fluids: Add `MatCeed{Get,Set}ContextReal`

### DIFF
--- a/examples/fluids/include/mat-ceed.h
+++ b/examples/fluids/include/mat-ceed.h
@@ -26,6 +26,8 @@ PETSC_CEED_INTERN PetscErrorCode MatCeedGetContextDouble(Mat mat, const char *na
 // Advanced functionality
 PETSC_CEED_EXTERN PetscErrorCode MatCeedSetContext(Mat mat, PetscErrorCode (*f)(void *), void *ctx);
 PETSC_CEED_EXTERN PetscErrorCode MatCeedGetContext(Mat mat, void *ctx);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetContextReal(Mat mat, const char *name, PetscReal value);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetContextReal(Mat mat, const char *name, PetscReal *value);
 
 PETSC_CEED_EXTERN PetscErrorCode MatCeedSetOperation(Mat mat, MatOperation op, void (*g)(void));
 PETSC_CEED_EXTERN PetscErrorCode MatCeedSetCOOMatType(Mat mat, MatType type);

--- a/examples/fluids/src/mat-ceed.c
+++ b/examples/fluids/src/mat-ceed.c
@@ -710,6 +710,25 @@ PetscErrorCode MatCeedSetContextDouble(Mat mat, const char *name, double value) 
 }
 
 /**
+  @brief Set the current `PetscReal` value of a context field for a `MatCEED`.
+
+  Not collective across MPI processes.
+
+  @param[in,out]  mat    `MatCEED`
+  @param[in]      name   Name of the context field
+  @param[in]      value  New context field value
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+PetscErrorCode MatCeedSetContextReal(Mat mat, const char *name, PetscReal value) {
+  double value_double = value;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatCeedSetContextDouble(mat, name, value_double));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
   @brief Get the current value of a context field for a `MatCEED`.
 
   Not collective across MPI processes.
@@ -743,6 +762,26 @@ PetscErrorCode MatCeedGetContextDouble(Mat mat, const char *name, double *value)
       PetscCallCeed(ctx->ceed, CeedOperatorRestoreContextDoubleRead(op, label, &values_ceed));
     }
   }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/**
+  @brief Get the current `PetscReal` value of a context field for a `MatCEED`.
+
+  Not collective across MPI processes.
+
+  @param[in]   mat    `MatCEED`
+  @param[in]   name   Name of the context field
+  @param[out]  value  Current context field value
+
+  @return An error code: 0 - success, otherwise - failure
+**/
+PetscErrorCode MatCeedGetContextReal(Mat mat, const char *name, PetscReal *value) {
+  double value_double;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatCeedGetContextDouble(mat, name, &value_double));
+  *value = value_double;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/examples/fluids/src/setupts.c
+++ b/examples/fluids/src/setupts.c
@@ -154,8 +154,7 @@ PetscErrorCode IFunction_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, Vec G, void *u
 }
 
 PetscErrorCode FormIJacobian_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, PetscReal shift, Mat J, Mat J_pre, void *user_data) {
-  User      user         = *(User *)user_data;
-  double    shift_double = shift;
+  User      user = *(User *)user_data;
   PetscBool J_is_matceed, J_is_mffd, J_pre_is_matceed, J_pre_is_mffd;
 
   PetscFunctionBeginUser;
@@ -164,7 +163,7 @@ PetscErrorCode FormIJacobian_NS(TS ts, PetscReal t, Vec Q, Vec Q_dot, PetscReal 
   PetscCall(PetscObjectTypeCompare((PetscObject)J_pre, MATMFFD, &J_pre_is_mffd));
   PetscCall(PetscObjectTypeCompare((PetscObject)J_pre, MATCEED, &J_pre_is_matceed));
 
-  PetscCall(MatCeedSetContextDouble(user->mat_ijacobian, "ijacobian time shift", shift_double));
+  PetscCall(MatCeedSetContextReal(user->mat_ijacobian, "ijacobian time shift", shift));
 
   if (J_is_matceed || J_is_mffd) {
     PetscCall(MatAssemblyBegin(J, MAT_FINAL_ASSEMBLY));


### PR DESCRIPTION
*Split from #1574, copied relevant description from there:*

> Note @jeremylt I also added a `MatCeed{Get,Set}ContextReal` instead of the `MatCeedSet{Time,Dt,Shifts}`. I think that makes more sense than the application-specific `MatCeedSet*` for upstreaming to PETSc. I could see them as `RatelJacobianSet{Time,Dt,Shifts}` though.
