### PR TITLE
fluids: Add back CeedOperator PetscLogEvents

### DIFF
--- a/examples/fluids/include/mat-ceed-impl.h
+++ b/examples/fluids/include/mat-ceed-impl.h
@@ -20,7 +20,7 @@ struct MatCeedContext_private {
   PetscMemType   mem_type;
   PetscInt       ref_count, num_mats_assembled_full, num_mats_assembled_pbd;
   PetscBool      is_destroyed, is_ceed_pbd_valid, is_ceed_vpbd_valid;
-  PetscLogEvent  log_event_mult, log_event_mult_transpose;
+  PetscLogEvent  log_event_mult, log_event_mult_transpose, log_event_ceed_mult, log_event_ceed_mult_transpose;
   DM             dm_x, dm_y;
   Mat           *mats_assembled_full, *mats_assembled_pbd, mat_assembled_full_internal, mat_assembled_pbd_internal;
   Vec            X_loc, Y_loc_transpose;
@@ -32,7 +32,8 @@ struct MatCeedContext_private {
 // Context data
 PETSC_CEED_EXTERN PetscErrorCode MatCeedContextCreate(DM dm_x, DM dm_y, Vec X_loc, Vec Y_loc_transpose, CeedOperator op_mult,
                                                       CeedOperator op_mult_transpose, PetscLogEvent log_event_mult,
-                                                      PetscLogEvent log_event_mult_transpose, MatCeedContext *ctx);
+                                                      PetscLogEvent log_event_mult_transpose, PetscLogEvent log_event_ceed_mult,
+                                                      PetscLogEvent log_event_ceed_mult_transpose, MatCeedContext *ctx);
 PETSC_CEED_EXTERN PetscErrorCode MatCeedContextReference(MatCeedContext ctx);
 PETSC_CEED_EXTERN PetscErrorCode MatCeedContextReferenceCopy(MatCeedContext ctx, MatCeedContext *ctx_copy);
 PETSC_CEED_EXTERN PetscErrorCode MatCeedContextDestroy(MatCeedContext ctx);

--- a/examples/fluids/include/mat-ceed.h
+++ b/examples/fluids/include/mat-ceed.h
@@ -42,3 +42,5 @@ PETSC_CEED_EXTERN PetscErrorCode MatCeedRestoreCeedOperators(Mat mat, CeedOperat
 
 PETSC_CEED_EXTERN PetscErrorCode MatCeedSetLogEvents(Mat mat, PetscLogEvent log_event_mult, PetscLogEvent log_event_mult_transpose);
 PETSC_CEED_EXTERN PetscErrorCode MatCeedGetLogEvents(Mat mat, PetscLogEvent *log_event_mult, PetscLogEvent *log_event_mult_transpose);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedSetCeedOperatorLogEvents(Mat mat, PetscLogEvent log_event_mult, PetscLogEvent log_event_mult_transpose);
+PETSC_CEED_EXTERN PetscErrorCode MatCeedGetCeedOperatorLogEvents(Mat mat, PetscLogEvent *log_event_mult, PetscLogEvent *log_event_mult_transpose);

--- a/examples/fluids/navierstokes.h
+++ b/examples/fluids/navierstokes.h
@@ -80,9 +80,6 @@ static const char *const DifferentialFilterDampingFunctions[] = {
 // Log Events
 // -----------------------------------------------------------------------------
 extern PetscLogEvent FLUIDS_CeedOperatorApply;
-extern PetscLogEvent FLUIDS_CeedOperatorAssemble;
-extern PetscLogEvent FLUIDS_CeedOperatorAssembleDiagonal;
-extern PetscLogEvent FLUIDS_CeedOperatorAssemblePointBlockDiagonal;
 extern PetscLogEvent FLUIDS_SmartRedis_Init;
 extern PetscLogEvent FLUIDS_SmartRedis_Meta;
 extern PetscLogEvent FLUIDS_SmartRedis_Train;

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -365,9 +365,6 @@ PetscErrorCode PhastaDatFileReadToArrayReal(MPI_Comm comm, const char path[PETSC
 }
 
 PetscLogEvent       FLUIDS_CeedOperatorApply;
-PetscLogEvent       FLUIDS_CeedOperatorAssemble;
-PetscLogEvent       FLUIDS_CeedOperatorAssembleDiagonal;
-PetscLogEvent       FLUIDS_CeedOperatorAssemblePointBlockDiagonal;
 PetscLogEvent       FLUIDS_SmartRedis_Init;
 PetscLogEvent       FLUIDS_SmartRedis_Meta;
 PetscLogEvent       FLUIDS_SmartRedis_Train;
@@ -380,9 +377,6 @@ PetscErrorCode RegisterLogEvents() {
   PetscFunctionBeginUser;
   PetscCall(PetscClassIdRegister("libCEED", &libCEED_classid));
   PetscCall(PetscLogEventRegister("CeedOpApply", libCEED_classid, &FLUIDS_CeedOperatorApply));
-  PetscCall(PetscLogEventRegister("CeedOpAsm", libCEED_classid, &FLUIDS_CeedOperatorAssemble));
-  PetscCall(PetscLogEventRegister("CeedOpAsmD", libCEED_classid, &FLUIDS_CeedOperatorAssembleDiagonal));
-  PetscCall(PetscLogEventRegister("CeedOpAsmPBD", libCEED_classid, &FLUIDS_CeedOperatorAssemblePointBlockDiagonal));
 
   PetscCall(PetscClassIdRegister("onlineTrain", &onlineTrain_classid));
   PetscCall(PetscLogEventRegister("SmartRedis_Init", onlineTrain_classid, &FLUIDS_SmartRedis_Init));


### PR DESCRIPTION
Adds (back) `CeedOperator` log events for MatCeed. Also removes the unused fluids-based log events.

Worked on in Ratel: https://gitlab.com/micromorph/ratel/-/merge_requests/833