### PR TITLE
Skip unneeded restrictions in OpApply for GPU Ref

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -31,6 +31,7 @@ static int CeedOperatorDestroy_Cuda(CeedOperator op) {
     CeedCallBackend(CeedVectorDestroy(&impl->e_vecs[i]));
   }
   CeedCallBackend(CeedFree(&impl->e_vecs));
+  CeedCallBackend(CeedFree(&impl->input_states));
 
   for (CeedInt i = 0; i < impl->num_inputs; i++) {
     CeedCallBackend(CeedVectorDestroy(&impl->q_vecs_in[i]));
@@ -201,6 +202,7 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
 
   // Allocate
   CeedCallBackend(CeedCalloc(num_input_fields + num_output_fields, &impl->e_vecs));
+  CeedCallBackend(CeedCalloc(CEED_FIELD_MAX, &impl->input_states));
   CeedCallBackend(CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_in));
   CeedCallBackend(CeedCalloc(CEED_FIELD_MAX, &impl->q_vecs_out));
   impl->num_inputs  = num_input_fields;
@@ -247,7 +249,13 @@ static inline int CeedOperatorSetupInputs_Cuda(CeedInt num_input_fields, CeedQFu
         // No restriction for this field; read data directly from vec.
         CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, (const CeedScalar **)&e_data[i]));
       } else {
-        CeedCallBackend(CeedElemRestrictionApply(elem_rstr, CEED_NOTRANSPOSE, vec, impl->e_vecs[i], request));
+        uint64_t state;
+
+        CeedCallBackend(CeedVectorGetState(vec, &state));
+        if (state != impl->input_states[i]) {
+          CeedCallBackend(CeedElemRestrictionApply(elem_rstr, CEED_NOTRANSPOSE, vec, impl->e_vecs[i], request));
+          impl->input_states[i] = state;
+        }
         // Get evec
         CeedCallBackend(CeedVectorGetArrayRead(impl->e_vecs[i], CEED_MEM_DEVICE, (const CeedScalar **)&e_data[i]));
       }

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -123,9 +123,10 @@ typedef struct {
 } CeedOperatorAssemble_Cuda;
 
 typedef struct {
-  CeedVector                *e_vecs;      // E-vectors, inputs followed by outputs
-  CeedVector                *q_vecs_in;   // Input Q-vectors needed to apply operator
-  CeedVector                *q_vecs_out;  // Output Q-vectors needed to apply operator
+  CeedVector                *e_vecs;        // E-vectors, inputs followed by outputs
+  uint64_t                  *input_states;  // State tracking for passive inputs
+  CeedVector                *q_vecs_in;     // Input Q-vectors needed to apply operator
+  CeedVector                *q_vecs_out;    // Output Q-vectors needed to apply operator
   CeedInt                    num_inputs, num_outputs;
   CeedInt                    num_active_in, num_active_out;
   CeedVector                *qf_active_in;

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -127,9 +127,10 @@ typedef struct {
 } CeedOperatorAssemble_Hip;
 
 typedef struct {
-  CeedVector               *e_vecs;      // E-vectors, inputs followed by outputs
-  CeedVector               *q_vecs_in;   // Input Q-vectors needed to apply operator
-  CeedVector               *q_vecs_out;  // Output Q-vectors needed to apply operator
+  CeedVector               *e_vecs;        // E-vectors, inputs followed by outputs
+  uint64_t                 *input_states;  // State tracking for passive inputs
+  CeedVector               *q_vecs_in;     // Input Q-vectors needed to apply operator
+  CeedVector               *q_vecs_out;    // Output Q-vectors needed to apply operator
   CeedInt                   num_inputs, num_outputs;
   CeedInt                   num_active_in, num_active_out;
   CeedVector               *qf_active_in;


### PR DESCRIPTION
This drops some extra ElemRestrictionApply for the ref HIP and CUDA operators