### PR TITLE
basis: Projection uses highest dimension topology

### DIFF
--- a/interface/ceed-basis.c
+++ b/interface/ceed-basis.c
@@ -1139,7 +1139,7 @@ cleanup:
   @brief Create a non tensor-product basis for \f$H^1\f$ discretizations
 
   @param[in]  ceed      `Ceed` object used to create the `CeedBasis`
-  @param[in]  topo      Topology of element, e.g. hypercube, simplex, ect
+  @param[in]  topo      Topology of element, e.g. hypercube, simplex, etc
   @param[in]  num_comp  Number of field components (1 for scalar fields)
   @param[in]  num_nodes Total number of nodes
   @param[in]  num_qpts  Total number of quadrature points
@@ -1368,7 +1368,7 @@ int CeedBasisCreateProjection(CeedBasis basis_from, CeedBasis basis_to, CeedBasi
     CeedInt          num_nodes_to, num_nodes_from;
     CeedElemTopology topo;
 
-    CeedCall(CeedBasisGetTopology(basis_to, &topo));
+    CeedCall(CeedBasisGetTopology(basis_from, &topo));
     CeedCall(CeedBasisGetNumNodes(basis_from, &num_nodes_from));
     CeedCall(CeedBasisGetNumNodes(basis_to, &num_nodes_to));
     CeedCall(CeedBasisCreateH1(ceed, topo, num_comp, num_nodes_from, num_nodes_to, interp_project, grad_project, NULL, NULL, basis_project));


### PR DESCRIPTION
`CeedBasisCreateProjection` should use the highest dimensional topology between `basis_to` and `basis_from`.

Alternatively, I think it'd also be fine to set the topology based on the `basis_from` topology, as any mixed-topology basis transforms would go from larger topology to smaller topology. Example; projection a tet onto a tri face makes sense, but a tri face onto a tet seems ill-defined to me, albeit mathematically possible (I think anyways, idk much about limitations of pseudo inverses).

---

Reason for this comes from needing to project `dxdX` from cell to face nodes. Before this change, when running:
```c
CeedQFunctionAddInput(qf_setup, "dxdX", dXdx_size, CEED_EVAL_GRAD);
...
CeedBasisCreateProjection(basis_x_cell_to_face, basis_q_face, &basis_x_to_q_cell);
...
CeedOperatorSetField(op_setup, "dxdX", elem_restr_x_cell, basis_x_to_q_cell, CEED_VECTOR_ACTIVE);
```
I was seeing this error:
```
[0]PETSC ERROR: /home/jrwrigh/software/libCEED/interface/ceed-operator.c:73 in CeedOperatorCheckField(): Field 'dxdX' of size 9 and EvalMode gradient: CeedElemRestriction/Basis has 6 components
```

The `basis_cell_to_face` (resulting from `CeedBasisCreateProjection`) had a topology of `CEED_TOPOLOGY_QUAD`, so the dimensionality of the gradient basis apply was 2 instead of 3.