### PR TITLE
gpu - minimum input/output array size of 1

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunction-load.cpp
@@ -69,7 +69,7 @@ extern "C" int CeedQFunctionBuildKernel_Cuda_ref(CeedQFunction qf) {
     code << "  const CeedInt size_input_" << i << " = " << size << ";\n";
     code << "  CeedScalar input_" << i << "[size_input_" << i << "];\n";
   }
-  code << "  const CeedScalar* inputs[" << num_input_fields << "];\n";
+  code << "  const CeedScalar *inputs[" << CeedIntMax(num_input_fields, 1) << "];\n";
   for (CeedInt i = 0; i < num_input_fields; i++) {
     code << "  inputs[" << i << "] = input_" << i << ";\n";
   }
@@ -82,7 +82,7 @@ extern "C" int CeedQFunctionBuildKernel_Cuda_ref(CeedQFunction qf) {
     code << "  const CeedInt size_output_" << i << " = " << size << ";\n";
     code << "  CeedScalar output_" << i << "[size_output_" << i << "];\n";
   }
-  code << "  CeedScalar* outputs[" << num_output_fields << "];\n";
+  code << "  CeedScalar *outputs[" << CeedIntMax(num_output_fields, 1) << "];\n";
   for (CeedInt i = 0; i < num_output_fields; i++) {
     code << "  outputs[" << i << "] = output_" << i << ";\n";
   }

--- a/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
+++ b/backends/hip-ref/ceed-hip-ref-qfunction-load.cpp
@@ -69,7 +69,7 @@ extern "C" int CeedQFunctionBuildKernel_Hip_ref(CeedQFunction qf) {
     code << "  const CeedInt size_input_" << i << " = " << size << ";\n";
     code << "  CeedScalar input_" << i << "[size_input_" << i << "];\n";
   }
-  code << "  const CeedScalar* inputs[" << num_input_fields << "];\n";
+  code << "  const CeedScalar *inputs[" << CeedIntMax(num_input_fields, 1) << "];\n";
   for (CeedInt i = 0; i < num_input_fields; i++) {
     code << "  inputs[" << i << "] = input_" << i << ";\n";
   }
@@ -82,7 +82,7 @@ extern "C" int CeedQFunctionBuildKernel_Hip_ref(CeedQFunction qf) {
     code << "  const CeedInt size_output_" << i << " = " << size << ";\n";
     code << "  CeedScalar output_" << i << "[size_output_" << i << "];\n";
   }
-  code << "  CeedScalar* outputs[" << num_output_fields << "];\n";
+  code << "  CeedScalar *outputs[" << CeedIntMax(num_output_fields, 1) << "];\n";
   for (CeedInt i = 0; i < num_output_fields; i++) {
     code << "  outputs[" << i << "] = output_" << i << ";\n";
   }

--- a/backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-qfunction-load.sycl.cpp
@@ -118,7 +118,7 @@ extern "C" int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf) {
   for (CeedInt i = 0; i < num_input_fields; ++i) {
     code << "  CeedScalar U_" << i << "[" << input_sizes[i] << "];\n";
   }
-  code << "  const CeedScalar *inputs[" << num_input_fields << "] = {U_0";
+  code << "  const CeedScalar *inputs[" << CeedIntMax(num_input_fields, 1) << "] = {U_0";
   for (CeedInt i = 1; i < num_input_fields; i++) {
     code << ", U_" << i << "\n";
   }
@@ -129,7 +129,7 @@ extern "C" int CeedQFunctionBuildKernel_Sycl(CeedQFunction qf) {
   for (CeedInt i = 0; i < num_output_fields; i++) {
     code << "  CeedScalar V_" << i << "[" << output_sizes[i] << "];\n";
   }
-  code << "  CeedScalar *outputs[" << num_output_fields << "] = {V_0";
+  code << "  CeedScalar *outputs[" << CeedIntMax(num_output_fields, 1) << "] = {V_0";
   for (CeedInt i = 1; i < num_output_fields; i++) {
     code << ", V_" << i << "\n";
   }


### PR DESCRIPTION
Minor bug for QFunctions with no inputs/outputs, like `SetPointFields_MPM_NeoHookean`