### PR TITLE
Fix diagonal assembly for mixed operators AtPoints

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -1475,9 +1475,7 @@ static int CeedOperatorLinearAssembleQFunctionAtPoints_Cuda(CeedOperator op, Cee
 // Assemble Linear Diagonal AtPoints
 //------------------------------------------------------------------------------
 static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, CeedVector assembled, CeedRequest *request) {
-  bool                is_active_at_points = true;
-  CeedSize            e_vec_size          = 0;
-  CeedInt             max_num_points, num_elem, num_input_fields, num_output_fields, elem_size_active = 1, num_comp_active = 1;
+  CeedInt             max_num_points, num_elem, num_input_fields, num_output_fields;
   CeedScalar         *e_data[2 * CEED_FIELD_MAX] = {NULL};
   CeedQFunctionField *qf_input_fields, *qf_output_fields;
   CeedQFunction       qf;
@@ -1499,24 +1497,6 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
   // Input Evecs and Restriction
   CeedCallBackend(CeedOperatorSetupInputs_Cuda(num_input_fields, qf_input_fields, op_input_fields, NULL, true, e_data, impl, request));
 
-  // Check if active field is at points
-  for (CeedInt i = 0; i < num_input_fields; i++) {
-    CeedRestrictionType rstr_type;
-    CeedVector          vec;
-    CeedElemRestriction elem_rstr;
-
-    CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
-    // Skip non-active input
-    if (vec != CEED_VECTOR_ACTIVE) continue;
-
-    // Get active restriction type
-    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &elem_rstr));
-    CeedCallBackend(CeedElemRestrictionGetType(elem_rstr, &rstr_type));
-    CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp_active));
-    is_active_at_points = rstr_type == CEED_RESTRICTION_POINTS;
-    if (!is_active_at_points) CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size_active));
-  }
-
   // Get point coordinates
   if (!impl->point_coords_elem) {
     CeedVector          point_coords = NULL;
@@ -1525,6 +1505,16 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
     CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
     CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+  }
+
+  // Clear active input Qvecs
+  for (CeedInt i = 0; i < num_input_fields; i++) {
+    CeedVector vec;
+
+    CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
+    if (vec != CEED_VECTOR_ACTIVE) continue;
+    CeedCallBackend(CeedVectorSetValue(impl->e_vecs[i], 0.0));
+    CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
   }
 
   // Input basis apply if needed
@@ -1543,9 +1533,27 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
   }
 
   // Loop over active fields
-  e_vec_size = (is_active_at_points ? max_num_points : elem_size_active) * num_comp_active;
-  for (CeedInt s = 0; s < e_vec_size; s++) {
-    for (CeedInt i = 0; i < num_input_fields; i++) {
+  for (CeedInt i = 0; i < num_input_fields; i++) {
+    bool                is_active_at_points = true;
+    CeedInt             elem_size = 1, num_comp_active = 1, e_vec_size = 0;
+    CeedRestrictionType rstr_type;
+    CeedVector          vec;
+    CeedElemRestriction elem_rstr;
+
+    CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
+    // -- Skip non-active input
+    if (vec != CEED_VECTOR_ACTIVE) continue;
+
+    // -- Get active restriction type
+    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &elem_rstr));
+    CeedCallBackend(CeedElemRestrictionGetType(elem_rstr, &rstr_type));
+    is_active_at_points = rstr_type == CEED_RESTRICTION_POINTS;
+    if (!is_active_at_points) CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
+    else elem_size = max_num_points;
+    CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp_active));
+
+    e_vec_size = elem_size * num_comp_active;
+    for (CeedInt s = 0; s < e_vec_size; s++) {
       bool         is_active_input = false;
       CeedEvalMode eval_mode;
       CeedVector   vec;
@@ -1557,7 +1565,6 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
       if (!is_active_input) continue;
 
       // Update unit vector
-      if (s == 0) CeedCallBackend(CeedVectorSetValue(impl->e_vecs[i], 0.0));
       else CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s - 1, e_vec_size, 0.0));
       CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 1.0));
 
@@ -1578,92 +1585,94 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
         case CEED_EVAL_WEIGHT:
           break;  // No action
       }
+
+      // Q function
+      CeedCallBackend(CeedQFunctionApply(qf, num_elem * max_num_points, impl->q_vecs_in, impl->q_vecs_out));
+
+      // Output basis apply if needed
+      for (CeedInt j = 0; j < num_output_fields; j++) {
+        bool                is_active_output = false;
+        CeedInt             elem_size        = 0;
+        CeedRestrictionType rstr_type;
+        CeedEvalMode        eval_mode;
+        CeedVector          vec;
+        CeedElemRestriction elem_rstr;
+        CeedBasis           basis;
+
+        CeedCallBackend(CeedOperatorFieldGetVector(op_output_fields[j], &vec));
+        // ---- Skip non-active output
+        is_active_output = vec == CEED_VECTOR_ACTIVE;
+        if (!is_active_output) continue;
+
+        // ---- Check if elem size matches
+        CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[j], &elem_rstr));
+        CeedCallBackend(CeedElemRestrictionGetType(elem_rstr, &rstr_type));
+        if (is_active_at_points && rstr_type != CEED_RESTRICTION_POINTS) continue;
+        if (rstr_type == CEED_RESTRICTION_POINTS) {
+          CeedCallBackend(CeedElemRestrictionGetMaxPointsInElement(elem_rstr, &elem_size));
+        } else {
+          CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
+        }
+        {
+          CeedInt num_comp = 0;
+
+          CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
+          if (e_vec_size != num_comp * elem_size) continue;
+        }
+
+        // Basis action
+        CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[j], &eval_mode));
+        switch (eval_mode) {
+          case CEED_EVAL_NONE:
+            CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[j + impl->num_inputs], &e_data[j + num_input_fields]));
+            break;
+          case CEED_EVAL_INTERP:
+          case CEED_EVAL_GRAD:
+          case CEED_EVAL_DIV:
+          case CEED_EVAL_CURL:
+            CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[j], &basis));
+            CeedCallBackend(CeedBasisApplyAtPoints(basis, num_elem, num_points, CEED_TRANSPOSE, eval_mode, impl->point_coords_elem,
+                                                   impl->q_vecs_out[j], impl->e_vecs[j + impl->num_inputs]));
+            break;
+          // LCOV_EXCL_START
+          case CEED_EVAL_WEIGHT: {
+            return CeedError(CeedOperatorReturnCeed(op), CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
+            // LCOV_EXCL_STOP
+          }
+        }
+
+        // Mask output e-vec
+        CeedCallBackend(CeedVectorPointwiseMult(impl->e_vecs[j + impl->num_inputs], impl->e_vecs[i], impl->e_vecs[j + impl->num_inputs]));
+
+        // Restrict
+        CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[j], &elem_rstr));
+        CeedCallBackend(CeedElemRestrictionApply(elem_rstr, CEED_TRANSPOSE, impl->e_vecs[j + impl->num_inputs], assembled, request));
+
+        // Reset q_vec for
+        if (eval_mode == CEED_EVAL_NONE) {
+          CeedCallBackend(CeedVectorGetArrayWrite(impl->e_vecs[j + impl->num_inputs], CEED_MEM_DEVICE, &e_data[j + num_input_fields]));
+          CeedCallBackend(CeedVectorSetArray(impl->q_vecs_out[j], CEED_MEM_DEVICE, CEED_USE_POINTER, e_data[j + num_input_fields]));
+        }
+      }
+
+      // Reset vec
+      if (s == e_vec_size - 1) CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
     }
 
-    // Q function
-    CeedCallBackend(CeedQFunctionApply(qf, num_elem * max_num_points, impl->q_vecs_in, impl->q_vecs_out));
-
-    // Output basis apply if needed
+    // Restore CEED_EVAL_NONE
     for (CeedInt i = 0; i < num_output_fields; i++) {
-      bool                is_active_output = false;
       CeedEvalMode        eval_mode;
-      CeedVector          vec;
       CeedElemRestriction elem_rstr;
-      CeedBasis           basis;
 
-      // Get output vector
-      CeedCallBackend(CeedOperatorFieldGetVector(op_output_fields[i], &vec));
-      is_active_output = vec == CEED_VECTOR_ACTIVE;
-      if (!is_active_output) continue;
-
-      // Basis action
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
-      switch (eval_mode) {
-        case CEED_EVAL_NONE:
-          CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
-          break;
-        case CEED_EVAL_INTERP:
-        case CEED_EVAL_GRAD:
-        case CEED_EVAL_DIV:
-        case CEED_EVAL_CURL:
-          CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
-          CeedCallBackend(CeedBasisApplyAtPoints(basis, num_elem, num_points, CEED_TRANSPOSE, eval_mode, impl->point_coords_elem, impl->q_vecs_out[i],
-                                                 impl->e_vecs[i + impl->num_inputs]));
-          break;
-        // LCOV_EXCL_START
-        case CEED_EVAL_WEIGHT: {
-          return CeedError(CeedOperatorReturnCeed(op), CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
-          // LCOV_EXCL_STOP
-        }
-      }
-
-      // Mask output e-vec
-      {
-        CeedInt  j = num_input_fields;
-        CeedSize out_size;
-
-        CeedCallBackend(CeedVectorGetLength(impl->e_vecs[i + impl->num_inputs], &out_size));
-        for (j = 0; j < num_input_fields; j++) {
-          bool       is_active_input = false;
-          CeedSize   in_size;
-          CeedVector vec;
-
-          // Skip non-active input
-          CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[j], &vec));
-          is_active_input = vec == CEED_VECTOR_ACTIVE;
-          if (!is_active_input) continue;
-          CeedCallBackend(CeedVectorGetLength(impl->e_vecs[j], &in_size));
-          if (in_size == out_size) break;
-        }
-        CeedCheck(j < num_input_fields, CeedOperatorReturnCeed(op), CEED_ERROR_BACKEND, "Matching input field not found");
-        CeedCallBackend(CeedVectorPointwiseMult(impl->e_vecs[i + impl->num_inputs], impl->e_vecs[j], impl->e_vecs[i + impl->num_inputs]));
-      }
-
-      // Restrict
+      // Get eval_mode
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
-      CeedCallBackend(CeedElemRestrictionApply(elem_rstr, CEED_TRANSPOSE, impl->e_vecs[i + impl->num_inputs], assembled, request));
+      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
 
-      // Reset q_vec for
+      // Restore evec
+      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
       if (eval_mode == CEED_EVAL_NONE) {
-        CeedCallBackend(CeedVectorGetArrayWrite(impl->e_vecs[i + impl->num_inputs], CEED_MEM_DEVICE, &e_data[i + num_input_fields]));
-        CeedCallBackend(CeedVectorSetArray(impl->q_vecs_out[i], CEED_MEM_DEVICE, CEED_USE_POINTER, e_data[i + num_input_fields]));
+        CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
       }
-    }
-  }
-
-  // Restore CEED_EVAL_NONE
-  for (CeedInt i = 0; i < num_output_fields; i++) {
-    CeedEvalMode        eval_mode;
-    CeedElemRestriction elem_rstr;
-
-    // Get eval_mode
-    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
-
-    // Restore evec
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
-    if (eval_mode == CEED_EVAL_NONE) {
-      CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
     }
   }
 


### PR DESCRIPTION
Fixes #1640 

Works locally for me with CUDA and CPU

```
$ ./build/ex01-static -options_file examples/ex01-static-elasticity-mpm-mixed-linear-mms-pcfieldsplit-jacobi.yml -snes_monitor -ksp_monitor -pc_type jacobi -ceed /gpu/cuda/ref
----- Ratel Static Example -----

Ratel Context:
  MPI:
    Hostname: taliensis
    Total ranks: 1
  libCEED:
    Backend resource: /gpu/cuda/ref
    Backend MemType: device
  PETSc:
    VecType: cuda
    MatType: shell
...
  0 SNES Function norm 7.981366173789e-03
    0 KSP Residual norm 2.395003134058e-02
    1 KSP Residual norm 2.210373338493e-02
    2 KSP Residual norm 6.097487983922e-03
    3 KSP Residual norm 1.617911273539e-03
    4 KSP Residual norm 9.823135102314e-04
    5 KSP Residual norm 5.893867487065e-04
    6 KSP Residual norm 2.565469680526e-04
    7 KSP Residual norm 1.746499452301e-04
    8 KSP Residual norm 1.478945999930e-04
    9 KSP Residual norm 1.026774486366e-04
   10 KSP Residual norm 6.886334228664e-05
   11 KSP Residual norm 3.435901027863e-05
   12 KSP Residual norm 1.997305317950e-05
   13 KSP Residual norm 7.303567079192e-06
   14 KSP Residual norm 3.428983165088e-06
   15 KSP Residual norm 2.501281433428e-06
   16 KSP Residual norm 7.179831187973e-07
   17 KSP Residual norm 4.050262890271e-07
   18 KSP Residual norm 2.183135205084e-07
  1 SNES Function norm 7.123484755724e-08
    0 KSP Residual norm 2.183135205089e-07
    1 KSP Residual norm 1.663911710237e-07
    2 KSP Residual norm 7.715843222042e-08
    3 KSP Residual norm 5.607675274239e-08
    4 KSP Residual norm 3.464069749801e-08
    5 KSP Residual norm 2.989658296587e-08
    6 KSP Residual norm 2.127249959792e-08
    7 KSP Residual norm 1.552890280323e-08
    8 KSP Residual norm 8.345326236960e-09
    9 KSP Residual norm 3.462643151019e-09
   10 KSP Residual norm 2.006707522212e-09
   11 KSP Residual norm 1.095536636824e-09
   12 KSP Residual norm 5.392162821277e-10
   13 KSP Residual norm 2.020418360772e-10
   14 KSP Residual norm 1.360606576653e-10
   15 KSP Residual norm 7.323618126310e-11
   16 KSP Residual norm 3.426223955267e-11
   17 KSP Residual norm 1.708577153159e-11
   18 KSP Residual norm 1.077684742078e-11
   19 KSP Residual norm 4.429119141116e-12
   20 KSP Residual norm 3.261378024791e-12
   21 KSP Residual norm 1.686127504871e-12
  2 SNES Function norm 5.359947927304e-13
SNES iterations: 2
SNES converged reason: CONVERGED_FNORM_RELATIVE
L2 Error, field 0: 6.462523038751e-04
L2 Error, field 1: 5.636349190204e-03
Computed strain energy: 8.612334648074e-05
Max displacement:       [1.596771316061e-03, 3.101904080036e-03, 4.652856120054e-03]
Max pressure:            8.766546914649e-03
Time taken to compute solution (sec): 1.45302
```