### PR TITLE
atpoints - fix diagonal bug with stale qvec data

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -1656,7 +1656,10 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
       }
 
       // Reset vec
-      if (s == e_vec_size - 1) CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
+      if (s == e_vec_size - 1) {
+        CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
+        CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
+      }
     }
 
     // Restore CEED_EVAL_NONE

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -1513,7 +1513,6 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
 
     CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
     if (vec != CEED_VECTOR_ACTIVE) continue;
-    CeedCallBackend(CeedVectorSetValue(impl->e_vecs[i], 0.0));
     CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
   }
 
@@ -1565,6 +1564,7 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
       if (!is_active_input) continue;
 
       // Update unit vector
+      if (s == 0) CeedCallBackend(CeedVectorSetValue(impl->e_vecs[i], 0.0));
       else CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s - 1, e_vec_size, 0.0));
       CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 1.0));
 
@@ -1656,26 +1656,21 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
       }
 
       // Reset vec
-      if (s == e_vec_size - 1) {
-        CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
-        CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
-      }
+      if (s == e_vec_size - 1 && i != num_input_fields - 1) CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
     }
+  }
 
-    // Restore CEED_EVAL_NONE
-    for (CeedInt i = 0; i < num_output_fields; i++) {
-      CeedEvalMode        eval_mode;
-      CeedElemRestriction elem_rstr;
+  // Restore CEED_EVAL_NONE
+  for (CeedInt i = 0; i < num_output_fields; i++) {
+    CeedEvalMode eval_mode;
 
-      // Get eval_mode
-      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
+    // Get eval_mode
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
 
-      // Restore evec
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
-      if (eval_mode == CEED_EVAL_NONE) {
-        CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
-      }
+    // Restore evec
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
+    if (eval_mode == CEED_EVAL_NONE) {
+      CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
     }
   }
 

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -1510,7 +1510,6 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Hip(CeedOperator op, Ce
 
     CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
     if (vec != CEED_VECTOR_ACTIVE) continue;
-    CeedCallBackend(CeedVectorSetValue(impl->e_vecs[i], 0.0));
     CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
   }
 
@@ -1562,6 +1561,7 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Hip(CeedOperator op, Ce
       if (!is_active_input) continue;
 
       // Update unit vector
+      if (s == 0) CeedCallBackend(CeedVectorSetValue(impl->e_vecs[i], 0.0));
       else CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s - 1, e_vec_size, 0.0));
       CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 1.0));
 
@@ -1653,26 +1653,21 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Hip(CeedOperator op, Ce
       }
 
       // Reset vec
-      if (s == e_vec_size - 1) {
-        CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
-        CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
-      }
+      if (s == e_vec_size - 1 && i != num_input_fields - 1) CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
     }
+  }
 
-    // Restore CEED_EVAL_NONE
-    for (CeedInt i = 0; i < num_output_fields; i++) {
-      CeedEvalMode        eval_mode;
-      CeedElemRestriction elem_rstr;
+  // Restore CEED_EVAL_NONE
+  for (CeedInt i = 0; i < num_output_fields; i++) {
+    CeedEvalMode eval_mode;
 
-      // Get eval_mode
-      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
+    // Get eval_mode
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
 
-      // Restore evec
-      CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
-      if (eval_mode == CEED_EVAL_NONE) {
-        CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
-      }
+    // Restore evec
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
+    if (eval_mode == CEED_EVAL_NONE) {
+      CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs[i + impl->num_inputs], &e_data[i + num_input_fields]));
     }
   }
 

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -1653,7 +1653,10 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Hip(CeedOperator op, Ce
       }
 
       // Reset vec
-      if (s == e_vec_size - 1) CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
+      if (s == e_vec_size - 1) {
+        CeedCallBackend(CeedVectorSetValueStrided(impl->e_vecs[i], s, e_vec_size, 0.0));
+        CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
+      }
     }
 
     // Restore CEED_EVAL_NONE

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -1167,7 +1167,6 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Ref(CeedOperator op, Ce
 
     CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
     if (vec != CEED_VECTOR_ACTIVE) continue;
-    CeedCallBackend(CeedVectorSetValue(impl->e_vecs_in[i], 0.0));
     CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
   }
 
@@ -1215,6 +1214,7 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Ref(CeedOperator op, Ce
         {
           CeedScalar *array;
 
+          if (s == 0) CeedCallBackend(CeedVectorSetValue(impl->e_vecs_in[i], 0.0));
           CeedCallBackend(CeedVectorGetArray(impl->e_vecs_in[i], CEED_MEM_HOST, &array));
           array[s] = 1.0;
           if (s > 0) array[s - 1] = 0.0;
@@ -1317,14 +1317,7 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Ref(CeedOperator op, Ce
           }
         }
         // -- Reset unit vector
-        if (s == e_vec_size - 1) {
-          CeedScalar *array;
-
-          CeedCallBackend(CeedVectorGetArray(impl->e_vecs_in[i], CEED_MEM_HOST, &array));
-          array[s] = 0.0;
-          CeedCallBackend(CeedVectorRestoreArray(impl->e_vecs_in[i], &array));
-          CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
-        }
+        if (s == e_vec_size - 1) CeedCallBackend(CeedVectorSetValue(impl->q_vecs_in[i], 0.0));
       }
     }
     num_points_offset += num_points;


### PR DESCRIPTION
CG is too good and accounts for bugs that aren't too big, this is a better fix
```
  0 SNES Function norm 7.981366173789e-03
    0 KSP Residual norm 1.906739256988e-02
    1 KSP Residual norm 1.133026883989e-02
    2 KSP Residual norm 6.193022690644e-03
    3 KSP Residual norm 1.387872543034e-03
    4 KSP Residual norm 3.211734455270e-04
    5 KSP Residual norm 1.478256477347e-04
    6 KSP Residual norm 9.712677425269e-05
    7 KSP Residual norm 6.158649485781e-05
    8 KSP Residual norm 3.967832285086e-05
    9 KSP Residual norm 2.146662731434e-05
   10 KSP Residual norm 8.908305678412e-06
   11 KSP Residual norm 4.275244854390e-06
   12 KSP Residual norm 1.596758075922e-06
   13 KSP Residual norm 3.743327669677e-07
   14 KSP Residual norm 1.202134006077e-07
  1 SNES Function norm 4.231286222104e-08
    0 KSP Residual norm 1.202134006065e-07
    1 KSP Residual norm 4.497892037491e-08
    2 KSP Residual norm 1.474816907980e-08
    3 KSP Residual norm 8.383450566003e-09
    4 KSP Residual norm 4.658905611034e-09
    5 KSP Residual norm 3.474702905544e-09
    6 KSP Residual norm 2.552378821076e-09
    7 KSP Residual norm 1.843846827831e-09
    8 KSP Residual norm 6.346014153950e-10
    9 KSP Residual norm 3.798572942618e-10
   10 KSP Residual norm 1.569768492542e-10
   11 KSP Residual norm 5.736853440592e-11
   12 KSP Residual norm 2.383221609152e-11
   13 KSP Residual norm 5.452571943714e-12
   14 KSP Residual norm 6.995826921566e-13
  2 SNES Function norm 3.536200451966e-13
```