### PR TITLE
Must Destroy OperatorField Objects

### DIFF
--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -818,6 +818,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
     max_rstr_buffer_size = CeedIntMax(max_rstr_buffer_size, num_comp * elem_size);
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
   }
   for (CeedInt i = 0; i < num_output_fields; i++) {
     CeedInt             num_comp, elem_size;
@@ -827,6 +828,7 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op) {
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
     max_rstr_buffer_size = CeedIntMax(max_rstr_buffer_size, num_comp * elem_size);
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
   }
   code << "    // Scratch restriction buffer space\n";
   code << "    CeedScalar r_e_scratch[" << max_rstr_buffer_size << "];\n";

--- a/backends/occa/ceed-occa-basis.cpp
+++ b/backends/occa/ceed-occa-basis.cpp
@@ -43,9 +43,11 @@ Basis *Basis::from(CeedBasis basis) {
 }
 
 Basis *Basis::from(CeedOperatorField operatorField) {
-  CeedBasis basis;
-  CeedCallOcca(CeedOperatorFieldGetBasis(operatorField, &basis));
-  return from(basis);
+  CeedBasis ceedBasis;
+  CeedCallOcca(CeedOperatorFieldGetBasis(operatorField, &ceedBasis));
+  Basis *basis = from(ceedBasis);
+  CeedCallOcca(CeedBasisDestroy(&ceedBasis));
+  return basis;
 }
 
 int Basis::setCeedFields(CeedBasis basis) {

--- a/backends/occa/ceed-occa-elem-restriction.cpp
+++ b/backends/occa/ceed-occa-elem-restriction.cpp
@@ -200,10 +200,10 @@ ElemRestriction *ElemRestriction::from(CeedElemRestriction r) {
 
 ElemRestriction *ElemRestriction::from(CeedOperatorField operatorField) {
   CeedElemRestriction ceedElemRestriction;
-
   CeedCallOcca(CeedOperatorFieldGetElemRestriction(operatorField, &ceedElemRestriction));
-
-  return from(ceedElemRestriction);
+  ElemRestriction *elemRestriction = from(ceedElemRestriction);
+  CeedCallOcca(CeedElemRestrictionDestroy(&ceedElemRestriction));
+  return elemRestriction;
 }
 
 ElemRestriction *ElemRestriction::setupFrom(CeedElemRestriction r) {

--- a/backends/occa/ceed-occa-operator-field.cpp
+++ b/backends/occa/ceed-occa-operator-field.cpp
@@ -19,9 +19,7 @@ OperatorField::OperatorField(CeedOperatorField opField) : _isValid(false), _uses
   CeedElemRestriction ceedElemRestriction;
 
   CeedCallOccaValid(_isValid, CeedOperatorFieldGetBasis(opField, &ceedBasis));
-
   CeedCallOccaValid(_isValid, CeedOperatorFieldGetVector(opField, &ceedVector));
-
   CeedCallOccaValid(_isValid, CeedOperatorFieldGetElemRestriction(opField, &ceedElemRestriction));
 
   _isValid          = true;
@@ -30,6 +28,10 @@ OperatorField::OperatorField(CeedOperatorField opField) : _isValid(false), _uses
   vec             = Vector::from(ceedVector);
   basis           = Basis::from(ceedBasis);
   elemRestriction = ElemRestriction::from(ceedElemRestriction);
+
+  CeedCallOccaValid(_isValid, CeedBasisDestroy(&ceedBasis));
+  CeedCallOccaValid(_isValid, CeedVectorDestroy(&ceedVector));
+  CeedCallOccaValid(_isValid, CeedElemRestrictionDestroy(&ceedElemRestriction));
 }
 
 bool OperatorField::isValid() const { return _isValid; }

--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
@@ -155,12 +155,12 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
         // LCOV_EXCL_STOP
       }
     }
+    CeedCallBackend(CeedBasisDestroy(&basis));
   }
   // Check output bases for Q_1d, dim as well
   //   The only input basis might be CEED_BASIS_NONE
   for (CeedInt i = 0; i < num_output_fields; i++) {
     CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
-
     if (basis != CEED_BASIS_NONE) {
       bool is_tensor;
 
@@ -178,6 +178,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
         // LCOV_EXCL_STOP
       }
     }
+    CeedCallBackend(CeedBasisDestroy(&basis));
   }
   impl->dim  = dim;
   impl->Q_1d = Q_1d;
@@ -196,6 +197,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
         CeedCallBackend(CeedBasisGetData(basis, &basis_impl));
         use_collograd_parallelization = basis_impl->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
+        CeedCallBackend(CeedBasisDestroy(&basis));
       }
     }
     for (CeedInt i = 0; i < num_output_fields; i++) {
@@ -205,6 +207,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
         CeedCallBackend(CeedBasisGetData(basis, &basis_impl));
         use_collograd_parallelization = basis_impl->d_collo_grad_1d && (was_grad_found ? use_collograd_parallelization : true);
         was_grad_found                = true;
+        CeedCallBackend(CeedBasisDestroy(&basis));
       }
     }
   }
@@ -273,6 +276,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
 
     // Set field constants
     if (eval_mode != CEED_EVAL_WEIGHT) {
@@ -321,6 +325,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
       case CEED_EVAL_CURL:
         break;  // TODO: Not implemented
     }
+    CeedCallBackend(CeedBasisDestroy(&basis));
   }
 
   code << "\n  // -- Output field constants and basis data --\n";
@@ -331,6 +336,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
 
     // Set field constants
     CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
@@ -382,6 +388,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
       }
         // LCOV_EXCL_STOP
     }
+    CeedCallBackend(CeedBasisDestroy(&basis));
   }
   code << "\n  // -- Element loop --\n";
   code << "  work_group_barrier(CLK_LOCAL_MEM_FENCE);\n";
@@ -431,6 +438,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
              << ", num_elem, d_u_" << i << ", r_u_" << i << ");\n";
       }
     }
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
 
     // Basis action
     code << "    // EvalMode: " << CeedEvalModes[eval_mode] << "\n";
@@ -452,12 +460,14 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
                << i << ", r_t_" << i << ", elem_scratch);\n";
         } else {
           CeedInt P_1d;
+
           CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
           CeedCallBackend(CeedBasisGetNumNodes1D(basis, &P_1d));
           code << "    CeedScalar r_t_" << i << "[num_comp_in_" << i << "*DIM*Q_1D];\n";
           code << "    Grad" << (dim > 1 ? "Tensor" : "") << (dim == 3 && Q_1d >= P_1d ? "Collocated" : "") << dim << "d(num_comp_in_" << i
                << ", P_in_" << i << ", Q_1D, r_u_" << i << (dim > 1 ? ", s_B_in_" : "") << (dim > 1 ? std::to_string(i) : "") << ", s_G_in_" << i
                << ", r_t_" << i << ", elem_scratch);\n";
+          CeedCallBackend(CeedBasisDestroy(&basis));
         }
         break;
       case CEED_EVAL_WEIGHT:
@@ -466,6 +476,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
         CeedCallBackend(CeedBasisGetData(basis, &basis_impl));
         impl->W = basis_impl->d_q_weight_1d;
         code << "    Weight" << (dim > 1 ? "Tensor" : "") << dim << "d(Q_1D, W, r_t_" << i << ");\n";
+        CeedCallBackend(CeedBasisDestroy(&basis));
         break;  // No action
       case CEED_EVAL_DIV:
         break;  // TODO: Not implemented
@@ -544,6 +555,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
                  << "3d(num_comp_in_" << i << ", Q_1D," << strides[0] << ", " << strides[1] << ", " << strides[2] << ", num_elem, q, d_u_" << i
                  << ", r_q_" << i << ");\n";
           }
+          CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
           break;
         case CEED_EVAL_INTERP:
           code << "      CeedScalar r_q_" << i << "[num_comp_in_" << i << "];\n";
@@ -690,6 +702,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
           code << "    GradTranspose" << (dim > 1 ? "Tensor" : "") << (dim == 3 && Q_1d >= P_1d ? "Collocated" : "") << dim << "d(num_comp_out_" << i
                << ", P_out_" << i << ", Q_1D, r_tt_" << i << (dim > 1 ? ", s_B_out_" : "") << (dim > 1 ? std::to_string(i) : "") << ", s_G_out_" << i
                << ", r_v_" << i << ", elem_scratch);\n";
+          CeedCallBackend(CeedBasisDestroy(&basis));
         }
         break;
       // LCOV_EXCL_START
@@ -734,6 +747,7 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
       code << "    writeDofsStrided" << dim << "d(num_comp_out_" << i << ",P_out_" << i << "," << strides[0] << "," << strides[1] << "," << strides[2]
            << ", num_elem, r_v_" << i << ", d_v_" << i << ");\n";
     }
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
   }
 
   code << "  }\n";

--- a/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator-build.sycl.cpp
@@ -274,9 +274,9 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
     // Get elem_size, eval_mode, num_comp
     CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &elem_rstr));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
     CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
 
     // Set field constants
     if (eval_mode != CEED_EVAL_WEIGHT) {
@@ -334,9 +334,9 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
     // Get elem_size, eval_mode, num_comp
     CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
     CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
 
     // Set field constants
     CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
@@ -401,8 +401,8 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
     // Get elem_size, eval_mode, num_comp
     CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &elem_rstr));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
 
     // Restriction
     if (eval_mode != CEED_EVAL_WEIGHT && !((eval_mode == CEED_EVAL_NONE) && use_collograd_parallelization)) {
@@ -677,8 +677,8 @@ extern "C" int CeedOperatorBuildKernel_Sycl_gen(CeedOperator op) {
     // Get elem_size, eval_mode, num_comp
     CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
     CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
-    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     CeedCallBackend(CeedElemRestrictionGetNumComponents(elem_rstr, &num_comp));
+    CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     // Basis action
     code << "    // EvalMode: " << CeedEvalModes[eval_mode] << "\n";
     switch (eval_mode) {

--- a/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
@@ -107,12 +107,12 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
           break;
         }
       }
-      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
       if (index == -1) {
         CeedCallBackend(CeedVectorGetArray(vec, CEED_MEM_DEVICE, &impl->fields->outputs[i]));
       } else {
         impl->fields->outputs[i] = impl->fields->outputs[index];
       }
+      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
     }
   }
 
@@ -189,10 +189,10 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
           break;
         }
       }
-      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
       if (index == -1) {
         CeedCallBackend(CeedVectorRestoreArray(vec, &impl->fields->outputs[i]));
       }
+      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
     }
   }
 

--- a/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
+++ b/backends/sycl-gen/ceed-sycl-gen-operator.sycl.cpp
@@ -73,12 +73,15 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
     if (eval_mode == CEED_EVAL_WEIGHT) {  // Skip
       impl->fields->inputs[i] = NULL;
     } else {
+      bool       is_active;
       CeedVector vec;
 
       // Get input vector
       CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
-      if (vec == CEED_VECTOR_ACTIVE) vec = input_vec;
+      is_active = vec == CEED_VECTOR_ACTIVE;
+      if (is_active) vec = input_vec;
       CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, &impl->fields->inputs[i]));
+      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
     }
   }
 
@@ -88,11 +91,13 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
     if (eval_mode == CEED_EVAL_WEIGHT) {  // Skip
       impl->fields->outputs[i] = NULL;
     } else {
+      bool       is_active;
       CeedVector vec;
 
       // Get output vector
       CeedCallBackend(CeedOperatorFieldGetVector(op_output_fields[i], &vec));
-      if (vec == CEED_VECTOR_ACTIVE) vec = output_vec;
+      is_active = vec == CEED_VECTOR_ACTIVE;
+      if (is_active) vec = output_vec;
       output_vecs[i] = vec;
       // Check for multiple output modes
       CeedInt index = -1;
@@ -102,6 +107,7 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
           break;
         }
       }
+      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
       if (index == -1) {
         CeedCallBackend(CeedVectorGetArray(vec, CEED_MEM_DEVICE, &impl->fields->outputs[i]));
       } else {
@@ -152,11 +158,14 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
     if (eval_mode == CEED_EVAL_WEIGHT) {  // Skip
     } else {
+      bool       is_active;
       CeedVector vec;
 
       CeedCallBackend(CeedOperatorFieldGetVector(op_input_fields[i], &vec));
-      if (vec == CEED_VECTOR_ACTIVE) vec = input_vec;
+      is_active = vec == CEED_VECTOR_ACTIVE;
+      if (is_active) vec = input_vec;
       CeedCallBackend(CeedVectorRestoreArrayRead(vec, &impl->fields->inputs[i]));
+      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
     }
   }
 
@@ -165,10 +174,12 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     if (eval_mode == CEED_EVAL_WEIGHT) {  // Skip
     } else {
+      bool       is_active;
       CeedVector vec;
 
       CeedCallBackend(CeedOperatorFieldGetVector(op_output_fields[i], &vec));
-      if (vec == CEED_VECTOR_ACTIVE) vec = output_vec;
+      is_active = vec == CEED_VECTOR_ACTIVE;
+      if (is_active) vec = output_vec;
       // Check for multiple output modes
       CeedInt index = -1;
 
@@ -178,6 +189,7 @@ static int CeedOperatorApplyAdd_Sycl_gen(CeedOperator op, CeedVector input_vec, 
           break;
         }
       }
+      if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
       if (index == -1) {
         CeedCallBackend(CeedVectorRestoreArray(vec, &impl->fields->outputs[i]));
       }

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -1023,9 +1023,9 @@ static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
       CeedCallBackend(CeedOperatorFieldGetBasis(input_fields[i], &basis));
       CeedCheck(!basis_in || basis_in == basis, ceed, CEED_ERROR_BACKEND, "Backend does not implement operator assembly with multiple active bases");
       if (!basis_in) CeedCallBackend(CeedBasisReferenceCopy(basis, &basis_in));
+      CeedCallBackend(CeedBasisGetDimension(basis, &dim));
+      CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis, &num_qpts));
       CeedCallBackend(CeedBasisDestroy(&basis));
-      CeedCallBackend(CeedBasisGetDimension(basis_in, &dim));
-      CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts));
       CeedCallBackend(CeedOperatorFieldGetElemRestriction(input_fields[i], &elem_rstr));
       if (!rstr_in) CeedCallBackend(CeedElemRestrictionReferenceCopy(elem_rstr, &rstr_in));
       CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -70,7 +70,7 @@ static int CeedOperatorDestroy_Sycl(CeedOperator op) {
   }
   CeedCallBackend(CeedFree(&impl->q_vecs_out));
 
-  // QFunction assembly dataf
+  // QFunction assembly data
   for (CeedInt i = 0; i < impl->num_active_in; i++) {
     CeedCallBackend(CeedVectorDestroy(&impl->qf_active_in[i]));
   }
@@ -132,7 +132,7 @@ static int CeedOperatorSetupFields_Sycl(CeedQFunction qf, CeedOperator op, bool 
   for (CeedInt i = 0; i < num_fields; i++) {
     CeedEvalMode        eval_mode;
     CeedVector          vec;
-    CeedElemRestriction rstr;
+    CeedElemRestriction elem_rstr;
     CeedBasis           basis;
 
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_fields[i], &eval_mode));
@@ -140,7 +140,7 @@ static int CeedOperatorSetupFields_Sycl(CeedQFunction qf, CeedOperator op, bool 
     is_strided       = false;
     skip_restriction = false;
     if (eval_mode != CEED_EVAL_WEIGHT) {
-      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_fields[i], &rstr));
+      CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_fields[i], &elem_rstr));
 
       // Check whether this field can skip the element restriction:
       // must be passive input, with  eval_mode NONE, and have a strided restriction with CEED_STRIDES_BACKEND.
@@ -153,10 +153,10 @@ static int CeedOperatorSetupFields_Sycl(CeedQFunction qf, CeedOperator op, bool 
           // Check  eval_mode
           if (eval_mode == CEED_EVAL_NONE) {
             // Check for  is_strided restriction
-            CeedCallBackend(CeedElemRestrictionIsStrided(rstr, &is_strided));
+            CeedCallBackend(CeedElemRestrictionIsStrided(elem_rstr, &is_strided));
             if (is_strided) {
               // Check if vector is already in preferred backend ordering
-              CeedCallBackend(CeedElemRestrictionHasBackendStrides(rstr, &skip_restriction));
+              CeedCallBackend(CeedElemRestrictionHasBackendStrides(elem_rstr, &skip_restriction));
             }
           }
         }
@@ -166,9 +166,9 @@ static int CeedOperatorSetupFields_Sycl(CeedQFunction qf, CeedOperator op, bool 
         // We do not need an E-Vector, but will use the input field vector's data directly in the operator application
         e_vecs[i + start_e] = NULL;
       } else {
-        CeedCallBackend(CeedElemRestrictionCreateVector(rstr, NULL, &e_vecs[i + start_e]));
+        CeedCallBackend(CeedElemRestrictionCreateVector(elem_rstr, NULL, &e_vecs[i + start_e]));
       }
-      CeedCallBackend(CeedElemRestrictionDestroy(&rstr));
+      CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
     }
 
     switch (eval_mode) {
@@ -276,11 +276,11 @@ static inline int CeedOperatorSetupInputs_Sycl(CeedInt num_input_fields, CeedQFu
         // No restriction for this field; read data directly from vec.
         CeedCallBackend(CeedVectorGetArrayRead(vec, CEED_MEM_DEVICE, (const CeedScalar **)&e_data[i]));
       } else {
-        CeedElemRestriction rstr;
+        CeedElemRestriction elem_rstr;
 
-        CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &rstr));
-        CeedCallBackend(CeedElemRestrictionApply(rstr, CEED_NOTRANSPOSE, vec, impl->e_vecs[i], request));
-        CeedCallBackend(CeedElemRestrictionDestroy(&rstr));
+        CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_input_fields[i], &elem_rstr));
+        CeedCallBackend(CeedElemRestrictionApply(elem_rstr, CEED_NOTRANSPOSE, vec, impl->e_vecs[i], request));
+        CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
         CeedCallBackend(CeedVectorGetArrayRead(impl->e_vecs[i], CEED_MEM_DEVICE, (const CeedScalar **)&e_data[i]));
       }
     }
@@ -297,7 +297,6 @@ static inline int CeedOperatorInputBasis_Sycl(CeedInt num_elem, CeedQFunctionFie
                                               CeedOperator_Sycl *impl) {
   for (CeedInt i = 0; i < num_input_fields; i++) {
     CeedEvalMode eval_mode;
-    CeedBasis    basis;
 
     // Skip active input
     if (skip_active) {
@@ -316,11 +315,14 @@ static inline int CeedOperatorInputBasis_Sycl(CeedInt num_elem, CeedQFunctionFie
         CeedCallBackend(CeedVectorSetArray(impl->q_vecs_in[i], CEED_MEM_DEVICE, CEED_USE_POINTER, e_data[i]));
         break;
       case CEED_EVAL_INTERP:
-      case CEED_EVAL_GRAD:
+      case CEED_EVAL_GRAD: {
+        CeedBasis basis;
+
         CeedCallBackend(CeedOperatorFieldGetBasis(op_input_fields[i], &basis));
         CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_NOTRANSPOSE, eval_mode, impl->e_vecs[i], impl->q_vecs_in[i]));
         CeedCallBackend(CeedBasisDestroy(&basis));
         break;
+      }
       case CEED_EVAL_WEIGHT:
         break;  // No action
       case CEED_EVAL_DIV:
@@ -405,13 +407,12 @@ static int CeedOperatorApplyAdd_Sycl(CeedOperator op, CeedVector in_vec, CeedVec
 
   // Output basis apply if needed
   for (CeedInt i = 0; i < num_output_fields; i++) {
-    CeedElemRestriction rstr;
-    CeedBasis           basis;
+    CeedElemRestriction elem_rstr;
 
     // Get elem_size, eval_mode, size
-    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &rstr));
-    CeedCallBackend(CeedElemRestrictionGetElementSize(rstr, &elem_size));
-    CeedCallBackend(CeedElemRestrictionDestroy(&rstr));
+    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
+    CeedCallBackend(CeedElemRestrictionGetElementSize(elem_rstr, &elem_size));
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
     CeedCallBackend(CeedQFunctionFieldGetSize(qf_output_fields[i], &size));
     // Basis action
@@ -419,18 +420,22 @@ static int CeedOperatorApplyAdd_Sycl(CeedOperator op, CeedVector in_vec, CeedVec
       case CEED_EVAL_NONE:
         break;
       case CEED_EVAL_INTERP:
-      case CEED_EVAL_GRAD:
+      case CEED_EVAL_GRAD: {
+        CeedBasis basis;
+
         CeedCallBackend(CeedOperatorFieldGetBasis(op_output_fields[i], &basis));
         CeedCallBackend(CeedBasisApply(basis, num_elem, CEED_TRANSPOSE, eval_mode, impl->q_vecs_out[i], impl->e_vecs[i + impl->num_e_in]));
         CeedCallBackend(CeedBasisDestroy(&basis));
         break;
+      }
       // LCOV_EXCL_START
-      case CEED_EVAL_WEIGHT:
+      case CEED_EVAL_WEIGHT: {
         Ceed ceed;
 
         CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
         return CeedError(ceed, CEED_ERROR_BACKEND, "CEED_EVAL_WEIGHT cannot be an output evaluation mode");
         break;  // Should not occur
+      }
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL: {
         Ceed ceed;
@@ -448,7 +453,7 @@ static int CeedOperatorApplyAdd_Sycl(CeedOperator op, CeedVector in_vec, CeedVec
     bool                is_active;
     CeedEvalMode        eval_mode;
     CeedVector          vec;
-    CeedElemRestriction rstr;
+    CeedElemRestriction elem_rstr;
 
     // Restore evec
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_output_fields[i], &eval_mode));
@@ -458,11 +463,11 @@ static int CeedOperatorApplyAdd_Sycl(CeedOperator op, CeedVector in_vec, CeedVec
     // Restrict
     CeedCallBackend(CeedOperatorFieldGetVector(op_output_fields[i], &vec));
     is_active = vec == CEED_VECTOR_ACTIVE;
-    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &rstr));
+    CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_output_fields[i], &elem_rstr));
     if (is_active) vec = out_vec;
-    CeedCallBackend(CeedElemRestrictionApply(rstr, CEED_TRANSPOSE, impl->e_vecs[i + impl->num_inputs], vec, request));
+    CeedCallBackend(CeedElemRestrictionApply(elem_rstr, CEED_TRANSPOSE, impl->e_vecs[i + impl->num_e_in], vec, request));
     if (!is_active) CeedCallBackend(CeedVectorDestroy(&vec));
-    CeedCallBackend(CeedElemRestrictionDestroy(&rstr));
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
   }
 
   // Restore input arrays
@@ -473,8 +478,8 @@ static int CeedOperatorApplyAdd_Sycl(CeedOperator op, CeedVector in_vec, CeedVec
 //------------------------------------------------------------------------------
 // Core code for assembling linear QFunction
 //------------------------------------------------------------------------------
-static inline int CeedOperatorLinearAssembleQFunctionCore_Sycl(CeedOperator op, bool build_objects, CeedVector *assembled, CeedElemRestriction *rstr,
-                                                               CeedRequest *request) {
+static inline int CeedOperatorLinearAssembleQFunctionCore_Sycl(CeedOperator op, bool build_objects, CeedVector *assembled,
+                                                               CeedElemRestriction *elem_rstr, CeedRequest *request) {
   Ceed                ceed, ceed_parent;
   CeedSize            q_size;
   CeedInt             num_active_in, num_active_out, Q, num_elem, num_input_fields, num_output_fields, size;
@@ -555,7 +560,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Sycl(CeedOperator op, 
     CeedInt  strides[3] = {1, num_elem * Q, Q}; /* *NOPAD* */
 
     // Create output restriction
-    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out, l_size, strides, rstr));
+    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out, l_size, strides, elem_rstr));
     // Create assembled vector
     CeedCallBackend(CeedVectorCreate(ceed_parent, l_size, assembled));
   }
@@ -612,15 +617,16 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Sycl(CeedOperator op, 
 //------------------------------------------------------------------------------
 // Assemble Linear QFunction
 //------------------------------------------------------------------------------
-static int CeedOperatorLinearAssembleQFunction_Sycl(CeedOperator op, CeedVector *assembled, CeedElemRestriction *rstr, CeedRequest *request) {
-  return CeedOperatorLinearAssembleQFunctionCore_Sycl(op, true, assembled, rstr, request);
+static int CeedOperatorLinearAssembleQFunction_Sycl(CeedOperator op, CeedVector *assembled, CeedElemRestriction *elem_rstr, CeedRequest *request) {
+  return CeedOperatorLinearAssembleQFunctionCore_Sycl(op, true, assembled, elem_rstr, request);
 }
 
 //------------------------------------------------------------------------------
 // Update Assembled Linear QFunction
 //------------------------------------------------------------------------------
-static int CeedOperatorLinearAssembleQFunctionUpdate_Sycl(CeedOperator op, CeedVector assembled, CeedElemRestriction rstr, CeedRequest *request) {
-  return CeedOperatorLinearAssembleQFunctionCore_Sycl(op, false, &assembled, &rstr, request);
+static int CeedOperatorLinearAssembleQFunctionUpdate_Sycl(CeedOperator op, CeedVector assembled, CeedElemRestriction elem_rstr,
+                                                          CeedRequest *request) {
+  return CeedOperatorLinearAssembleQFunctionCore_Sycl(op, false, &assembled, &elem_rstr, request);
 }
 
 //------------------------------------------------------------------------------
@@ -892,22 +898,25 @@ static int CeedOperatorLinearDiagonal_Sycl(sycl::queue &sycl_queue, const bool i
 // Assemble diagonal common code
 //------------------------------------------------------------------------------
 static inline int CeedOperatorAssembleDiagonalCore_Sycl(CeedOperator op, CeedVector assembled, CeedRequest *request, const bool is_point_block) {
-  Ceed                ceed;
-  Ceed_Sycl          *sycl_data;
-  CeedInt             num_elem;
-  CeedScalar         *elem_diag_array;
-  const CeedScalar   *assembled_qf_array;
-  CeedVector          assembled_qf = NULL;
-  CeedElemRestriction rstr         = NULL;
-  CeedOperator_Sycl  *impl;
+  Ceed               ceed;
+  Ceed_Sycl         *sycl_data;
+  CeedInt            num_elem;
+  CeedScalar        *elem_diag_array;
+  const CeedScalar  *assembled_qf_array;
+  CeedVector         assembled_qf = NULL;
+  CeedOperator_Sycl *impl;
 
   CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
   CeedCallBackend(CeedOperatorGetData(op, &impl));
   CeedCallBackend(CeedGetData(ceed, &sycl_data));
 
   // Assemble QFunction
-  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &rstr, request));
-  CeedCallBackend(CeedElemRestrictionDestroy(&rstr));
+  {
+    CeedElemRestriction elem_rstr = NULL;
+
+    CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &elem_rstr, request));
+    CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
+  }
 
   // Setup
   if (!impl->diag) {

--- a/backends/sycl-ref/ceed-sycl-ref.hpp
+++ b/backends/sycl-ref/ceed-sycl-ref.hpp
@@ -86,16 +86,16 @@ typedef struct {
   CeedBasis           basis_in, basis_out;
   CeedElemRestriction diag_rstr, point_block_diag_rstr;
   CeedVector          elem_diag, point_block_elem_diag;
-  CeedInt             num_e_mode_in, num_e_mode_out, num_nodes;
+  CeedInt             num_eval_mode_in, num_eval_mode_out, num_nodes;
   CeedInt             num_qpts, num_comp;  // Kernel parameters
-  CeedEvalMode       *h_e_mode_in, *h_e_mode_out;
-  CeedEvalMode       *d_e_mode_in, *d_e_mode_out;
+  CeedEvalMode       *h_eval_mode_in, *h_eval_mode_out;
+  CeedEvalMode       *d_eval_mode_in, *d_eval_mode_out;
   CeedScalar         *d_identity, *d_interp_in, *d_interp_out, *d_grad_in, *d_grad_out;
 } CeedOperatorDiag_Sycl;
 
 typedef struct {
   CeedInt     num_elem, block_size_x, block_size_y, elems_per_block;
-  CeedInt     num_e_mode_in, num_e_mode_out, num_qpts, num_nodes, block_size, num_comp;  // Kernel parameters
+  CeedInt     num_eval_mode_in, num_eval_mode_out, num_qpts, num_nodes, block_size, num_comp;  // Kernel parameters
   bool        fallback;
   CeedScalar *d_B_in, *d_B_out;
 } CeedOperatorAssemble_Sycl;

--- a/backends/sycl-ref/ceed-sycl-ref.hpp
+++ b/backends/sycl-ref/ceed-sycl-ref.hpp
@@ -106,7 +106,6 @@ typedef struct {
   CeedVector                *q_vecs_out;  // Output Q-vectors needed to apply operator
   CeedInt                    num_e_in;
   CeedInt                    num_e_out;
-  CeedInt                    num_inputs, num_outputs;
   CeedInt                    num_active_in, num_active_out;
   CeedVector                *qf_active_in;
   CeedOperatorDiag_Sycl     *diag;

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -11,6 +11,7 @@ On this page we provide a summary of the main API changes, new features and exam
 - Add `bool` field type for `CeedQFunctionContext` and related interfaces to use `bool` fields.
 - `CEED_BASIS_COLLOCATED` removed; users should only use `CEED_BASIS_NONE`.
 - Remove unneeded pointer for `CeedElemRestrictionGetELayout`.
+- Require use of `Ceed*Destroy()` on Ceed objects returned from `CeedOperatorFieldGet*()`;
 
 ### New features
 

--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -37,12 +37,10 @@ PetscErrorCode CreateKSPMassOperator_AdvectionStabilized(User user, CeedOperator
 
     PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(user->op_rhs_ctx->op, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
-    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_q));
-    PetscCallCeed(ceed, CeedOperatorFieldGetBasis(field, &basis_q));
+    PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_q, &basis_q, NULL));
 
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "qdata", &field));
-    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_qd_i));
-    PetscCallCeed(ceed, CeedOperatorFieldGetVector(field, &q_data));
+    PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_qd_i, NULL, &q_data));
 
     PetscCallCeed(ceed, CeedOperatorGetContext(sub_ops[sub_op_index], &qf_ctx));
   }
@@ -74,6 +72,10 @@ PetscErrorCode CreateKSPMassOperator_AdvectionStabilized(User user, CeedOperator
   PetscCallCeed(ceed, CeedOperatorSetField(*op_mass, "v", elem_restr_q, basis_q, CEED_VECTOR_ACTIVE));
   PetscCallCeed(ceed, CeedOperatorSetField(*op_mass, "Grad_v", elem_restr_q, basis_q, CEED_VECTOR_ACTIVE));
 
+  PetscCallCeed(ceed, CeedVectorDestroy(&q_data));
+  PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_q));
+  PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_qd_i));
+  PetscCallCeed(ceed, CeedBasisDestroy(&basis_q));
   PetscCallCeed(ceed, CeedQFunctionContextDestroy(&qf_ctx));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_mass));
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -173,12 +173,10 @@ PetscErrorCode CreateKSPMassOperator_NewtonianStabilized(User user, CeedOperator
 
     PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(user->op_rhs_ctx->op, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
-    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_q));
-    PetscCallCeed(ceed, CeedOperatorFieldGetBasis(field, &basis_q));
+    PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_q, &basis_q, NULL));
 
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "qdata", &field));
-    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_qd_i));
-    PetscCallCeed(ceed, CeedOperatorFieldGetVector(field, &q_data));
+    PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_qd_i, NULL, &q_data));
 
     PetscCallCeed(ceed, CeedOperatorGetContext(sub_ops[sub_op_index], &qf_ctx));
   }
@@ -203,6 +201,10 @@ PetscErrorCode CreateKSPMassOperator_NewtonianStabilized(User user, CeedOperator
   PetscCallCeed(ceed, CeedOperatorSetField(*op_mass, "v", elem_restr_q, basis_q, CEED_VECTOR_ACTIVE));
   PetscCallCeed(ceed, CeedOperatorSetField(*op_mass, "Grad_v", elem_restr_q, basis_q, CEED_VECTOR_ACTIVE));
 
+  PetscCallCeed(ceed, CeedVectorDestroy(&q_data));
+  PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_q));
+  PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_qd_i));
+  PetscCallCeed(ceed, CeedBasisDestroy(&basis_q));
   PetscCallCeed(ceed, CeedQFunctionContextDestroy(&qf_ctx));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_mass));
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -137,8 +137,7 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
         char              field_name[PETSC_MAX_PATH_LEN];
         PetscCall(PetscSNPrintf(field_name, PETSC_MAX_PATH_LEN, "v%" PetscInt_FMT, i));
         PetscCallCeed(ceed, CeedOperatorGetFieldByName(diff_filter->op_rhs_ctx->op, field_name, &op_field));
-        PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(op_field, &elem_restr_filter));
-        PetscCallCeed(ceed, CeedOperatorFieldGetBasis(op_field, &basis_filter));
+        PetscCallCeed(ceed, CeedOperatorFieldGetData(op_field, NULL, &elem_restr_filter, &basis_filter, NULL));
       }
 
       PetscCallCeed(ceed, CeedOperatorCreate(ceed, qf_lhs, NULL, NULL, &op_lhs_sub));
@@ -151,6 +150,8 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
       PetscCallCeed(ceed, CeedOperatorSetField(op_lhs_sub, "Grad_v", elem_restr_filter, basis_filter, CEED_VECTOR_ACTIVE));
 
       PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_lhs, op_lhs_sub));
+      PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_filter));
+      PetscCallCeed(ceed, CeedBasisDestroy(&basis_filter));
       PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_lhs));
       PetscCallCeed(ceed, CeedOperatorDestroy(&op_lhs_sub));
     }

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -30,12 +30,10 @@ static PetscErrorCode CreateKSPMassOperator_Unstabilized(User user, CeedOperator
 
     PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(user->op_rhs_ctx->op, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
-    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_q));
-    PetscCallCeed(ceed, CeedOperatorFieldGetBasis(field, &basis_q));
+    PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_q, &basis_q, NULL));
 
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "qdata", &field));
-    PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_qd_i));
-    PetscCallCeed(ceed, CeedOperatorFieldGetVector(field, &q_data));
+    PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_qd_i, NULL, &q_data));
   }
 
   PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_q, &num_comp_q));
@@ -47,6 +45,10 @@ static PetscErrorCode CreateKSPMassOperator_Unstabilized(User user, CeedOperator
   PetscCallCeed(ceed, CeedOperatorSetField(*op_mass, "qdata", elem_restr_qd_i, CEED_BASIS_NONE, q_data));
   PetscCallCeed(ceed, CeedOperatorSetField(*op_mass, "v", elem_restr_q, basis_q, CEED_VECTOR_ACTIVE));
 
+  PetscCallCeed(ceed, CeedVectorDestroy(&q_data));
+  PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_q));
+  PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_qd_i));
+  PetscCallCeed(ceed, CeedBasisDestroy(&basis_q));
   PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_mass));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -199,10 +201,12 @@ static PetscErrorCode AddBCSubOperators(User user, Ceed ceed, DM dm, SimpleBC bc
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
     PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_q));
     PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_q, &num_comp_q));
+    PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_q));
 
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "x", &field));
     PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_x));
     PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_x, &num_comp_x));
+    PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_x));
   }
 
   {  // Get bases

--- a/rust/libceed/src/basis.rs
+++ b/rust/libceed/src/basis.rs
@@ -173,6 +173,13 @@ impl<'a> Basis<'a> {
         })
     }
 
+    pub(crate) fn from_raw(ptr: bind_ceed::CeedBasis) -> crate::Result<Self> {
+        Ok(Self {
+            ptr,
+            _lifeline: PhantomData,
+        })
+    }
+
     pub fn create_tensor_H1_Lagrange(
         ceed: &crate::Ceed,
         dim: usize,

--- a/rust/libceed/src/elem_restriction.rs
+++ b/rust/libceed/src/elem_restriction.rs
@@ -193,6 +193,13 @@ impl<'a> ElemRestriction<'a> {
         })
     }
 
+    pub(crate) fn from_raw(ptr: bind_ceed::CeedElemRestriction) -> crate::Result<Self> {
+        Ok(Self {
+            ptr,
+            _lifeline: PhantomData,
+        })
+    }
+
     pub fn create_oriented(
         ceed: &crate::Ceed,
         nelem: usize,

--- a/rust/libceed/src/operator.rs
+++ b/rust/libceed/src/operator.rs
@@ -142,6 +142,14 @@ impl<'a> OperatorField<'a> {
     ///     inputs[0].elem_restriction().is_some(),
     ///     "Incorrect field ElemRestriction"
     /// );
+    /// if let ElemRestrictionOpt::Some(r) = inputs[0].elem_restriction() {
+    ///     assert_eq!(
+    ///         r.num_elements(),
+    ///         ne,
+    ///         "Incorrect field ElemRestriction number of elements"
+    ///     );
+    /// }
+    ///
     /// assert!(
     ///     inputs[1].elem_restriction().is_none(),
     ///     "Incorrect field ElemRestriction"
@@ -153,6 +161,13 @@ impl<'a> OperatorField<'a> {
     ///     outputs[0].elem_restriction().is_some(),
     ///     "Incorrect field ElemRestriction"
     /// );
+    /// if let ElemRestrictionOpt::Some(r) = outputs[0].elem_restriction() {
+    ///     assert_eq!(
+    ///         r.num_elements(),
+    ///         ne,
+    ///         "Incorrect field ElemRestriction number of elements"
+    ///     );
+    /// }
     /// # Ok(())
     /// # }
     /// ```
@@ -196,7 +211,21 @@ impl<'a> OperatorField<'a> {
     /// let inputs = op.inputs()?;
     ///
     /// assert!(inputs[0].basis().is_some(), "Incorrect field Basis");
+    /// if let BasisOpt::Some(b) = inputs[0].basis() {
+    ///     assert_eq!(
+    ///         b.num_quadrature_points(),
+    ///         q,
+    ///         "Incorrect field Basis number of quadrature points"
+    ///     );
+    /// }
     /// assert!(inputs[1].basis().is_some(), "Incorrect field Basis");
+    /// if let BasisOpt::Some(b) = inputs[1].basis() {
+    ///     assert_eq!(
+    ///         b.num_quadrature_points(),
+    ///         q,
+    ///         "Incorrect field Basis number of quadrature points"
+    ///     );
+    /// }
     ///
     /// let outputs = op.outputs()?;
     ///

--- a/rust/libceed/src/operator.rs
+++ b/rust/libceed/src/operator.rs
@@ -17,6 +17,9 @@ use crate::prelude::*;
 #[derive(Debug)]
 pub struct OperatorField<'a> {
     pub(crate) ptr: bind_ceed::CeedOperatorField,
+    pub(crate) vector: crate::Vector<'a>,
+    pub(crate) elem_restriction: crate::ElemRestriction<'a>,
+    pub(crate) basis: crate::Basis<'a>,
     _lifeline: PhantomData<&'a ()>,
 }
 
@@ -24,6 +27,39 @@ pub struct OperatorField<'a> {
 // Implementations
 // -----------------------------------------------------------------------------
 impl<'a> OperatorField<'a> {
+    pub(crate) fn from_raw(
+        ptr: bind_ceed::CeedOperatorField,
+        ceed: crate::Ceed,
+    ) -> crate::Result<Self> {
+        let vector = {
+            let mut vector_ptr = std::ptr::null_mut();
+            let ierr = unsafe { bind_ceed::CeedOperatorFieldGetVector(ptr, &mut vector_ptr) };
+            ceed.check_error(ierr)?;
+            crate::Vector::from_raw(vector_ptr)?
+        };
+        let elem_restriction = {
+            let mut elem_restriction_ptr = std::ptr::null_mut();
+            let ierr = unsafe {
+                bind_ceed::CeedOperatorFieldGetElemRestriction(ptr, &mut elem_restriction_ptr)
+            };
+            ceed.check_error(ierr)?;
+            crate::ElemRestriction::from_raw(elem_restriction_ptr)?
+        };
+        let basis = {
+            let mut basis_ptr = std::ptr::null_mut();
+            let ierr = unsafe { bind_ceed::CeedOperatorFieldGetBasis(ptr, &mut basis_ptr) };
+            ceed.check_error(ierr)?;
+            crate::Basis::from_raw(basis_ptr)?
+        };
+        Ok(Self {
+            ptr,
+            vector,
+            elem_restriction,
+            basis,
+            _lifeline: PhantomData,
+        })
+    }
+
     /// Get the name of an OperatorField
     ///
     /// ```
@@ -110,24 +146,21 @@ impl<'a> OperatorField<'a> {
     ///     inputs[1].elem_restriction().is_none(),
     ///     "Incorrect field ElemRestriction"
     /// );
+    ///
+    /// let outputs = op.outputs()?;
+    ///
+    /// assert!(
+    ///     outputs[0].elem_restriction().is_some(),
+    ///     "Incorrect field ElemRestriction"
+    /// );
     /// # Ok(())
     /// # }
     /// ```
     pub fn elem_restriction(&self) -> ElemRestrictionOpt {
-        let mut ptr = std::ptr::null_mut();
-        unsafe {
-            bind_ceed::CeedOperatorFieldGetElemRestriction(self.ptr, &mut ptr);
-        }
-        if ptr == unsafe { bind_ceed::CEED_ELEMRESTRICTION_NONE } {
+        if self.elem_restriction.ptr == unsafe { bind_ceed::CEED_ELEMRESTRICTION_NONE } {
             ElemRestrictionOpt::None
         } else {
-            let slice = unsafe {
-                std::slice::from_raw_parts(
-                    &ptr as *const bind_ceed::CeedElemRestriction as *const crate::ElemRestriction,
-                    1 as usize,
-                )
-            };
-            ElemRestrictionOpt::Some(&slice[0])
+            ElemRestrictionOpt::Some(&self.elem_restriction)
         }
     }
 
@@ -172,20 +205,10 @@ impl<'a> OperatorField<'a> {
     /// # }
     /// ```
     pub fn basis(&self) -> BasisOpt {
-        let mut ptr = std::ptr::null_mut();
-        unsafe {
-            bind_ceed::CeedOperatorFieldGetBasis(self.ptr, &mut ptr);
-        }
-        if ptr == unsafe { bind_ceed::CEED_BASIS_NONE } {
+        if self.basis.ptr == unsafe { bind_ceed::CEED_BASIS_NONE } {
             BasisOpt::None
         } else {
-            let slice = unsafe {
-                std::slice::from_raw_parts(
-                    &ptr as *const bind_ceed::CeedBasis as *const crate::Basis,
-                    1 as usize,
-                )
-            };
-            BasisOpt::Some(&slice[0])
+            BasisOpt::Some(&self.basis)
         }
     }
 
@@ -222,26 +245,20 @@ impl<'a> OperatorField<'a> {
     ///
     /// assert!(inputs[0].vector().is_active(), "Incorrect field Vector");
     /// assert!(inputs[1].vector().is_none(), "Incorrect field Vector");
+    ///
+    /// let outputs = op.outputs()?;
+    ///
+    /// assert!(outputs[0].vector().is_active(), "Incorrect field Vector");
     /// # Ok(())
     /// # }
     /// ```
     pub fn vector(&self) -> VectorOpt {
-        let mut ptr = std::ptr::null_mut();
-        unsafe {
-            bind_ceed::CeedOperatorFieldGetVector(self.ptr, &mut ptr);
-        }
-        if ptr == unsafe { bind_ceed::CEED_VECTOR_ACTIVE } {
+        if self.vector.ptr == unsafe { bind_ceed::CEED_VECTOR_ACTIVE } {
             VectorOpt::Active
-        } else if ptr == unsafe { bind_ceed::CEED_VECTOR_NONE } {
+        } else if self.vector.ptr == unsafe { bind_ceed::CEED_VECTOR_NONE } {
             VectorOpt::None
         } else {
-            let slice = unsafe {
-                std::slice::from_raw_parts(
-                    &ptr as *const bind_ceed::CeedVector as *const crate::Vector,
-                    1 as usize,
-                )
-            };
-            VectorOpt::Some(&slice[0])
+            VectorOpt::Some(&self.vector)
         }
     }
 }
@@ -814,7 +831,7 @@ impl<'a> Operator<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn inputs(&self) -> crate::Result<&[crate::OperatorField]> {
+    pub fn inputs(&self) -> crate::Result<Vec<crate::OperatorField>> {
         // Get array of raw C pointers for inputs
         let mut num_inputs = 0;
         let mut inputs_ptr = std::ptr::null_mut();
@@ -831,11 +848,24 @@ impl<'a> Operator<'a> {
         // Convert raw C pointers to fixed length slice
         let inputs_slice = unsafe {
             std::slice::from_raw_parts(
-                inputs_ptr as *const crate::OperatorField,
+                inputs_ptr as *mut bind_ceed::CeedOperatorField,
                 num_inputs as usize,
             )
         };
-        Ok(inputs_slice)
+        // And finally build vec
+        let ceed = {
+            let mut ptr = std::ptr::null_mut();
+            let mut ptr_copy = std::ptr::null_mut();
+            unsafe {
+                bind_ceed::CeedOperatorGetCeed(self.op_core.ptr, &mut ptr);
+                bind_ceed::CeedReferenceCopy(ptr, &mut ptr_copy); // refcount
+            }
+            crate::Ceed { ptr }
+        };
+        let inputs = (0..num_inputs as usize)
+            .map(|i| crate::OperatorField::from_raw(inputs_slice[i], ceed.clone()))
+            .collect::<crate::Result<Vec<_>>>()?;
+        Ok(inputs)
     }
 
     /// Get a slice of Operator outputs
@@ -873,7 +903,7 @@ impl<'a> Operator<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn outputs(&self) -> crate::Result<&[crate::OperatorField]> {
+    pub fn outputs(&self) -> crate::Result<Vec<crate::OperatorField>> {
         // Get array of raw C pointers for outputs
         let mut num_outputs = 0;
         let mut outputs_ptr = std::ptr::null_mut();
@@ -890,11 +920,24 @@ impl<'a> Operator<'a> {
         // Convert raw C pointers to fixed length slice
         let outputs_slice = unsafe {
             std::slice::from_raw_parts(
-                outputs_ptr as *const crate::OperatorField,
+                outputs_ptr as *mut bind_ceed::CeedOperatorField,
                 num_outputs as usize,
             )
         };
-        Ok(outputs_slice)
+        // And finally build vec
+        let ceed = {
+            let mut ptr = std::ptr::null_mut();
+            let mut ptr_copy = std::ptr::null_mut();
+            unsafe {
+                bind_ceed::CeedOperatorGetCeed(self.op_core.ptr, &mut ptr);
+                bind_ceed::CeedReferenceCopy(ptr, &mut ptr_copy); // refcount
+            }
+            crate::Ceed { ptr }
+        };
+        let outputs = (0..num_outputs as usize)
+            .map(|i| crate::OperatorField::from_raw(outputs_slice[i], ceed.clone()))
+            .collect::<crate::Result<Vec<_>>>()?;
+        Ok(outputs)
     }
 
     /// Check if Operator is setup correctly


### PR DESCRIPTION
Fixes #1639 

What do we think @jrwrigh. You can see how this does get a bit invasive.

---

Ok, now the Vector/ElemRestriction/Basis retrieved from the OperatorField needs to be Destroyed per the corresponding interface.