### PR TITLE
fix(sycl): Use CeedSize value in LinearAssembleQF

### DIFF
--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -553,8 +553,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Sycl(CeedOperator op, 
     CeedInt  strides[3] = {1, num_elem * Q, Q}; /* *NOPAD* */
 
     // Create output restriction
-    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out,
-                                                     num_active_in * num_active_out * num_elem * Q, strides, rstr));
+    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out, l_size, strides, rstr));
     // Create assembled vector
     CeedCallBackend(CeedVectorCreate(ceed_parent, l_size, assembled));
   }


### PR DESCRIPTION
Fixes overflow in the assembly process.

`l_size` passed to `CeedElemRestrictionCreateStrided` should be cast to `CeedSize` before beginning the multiplication. Doesn't help much to cast after the overflow has happened.

Reported by @rickybalin (@KennethEJansen also probably ran into it at some point).