### PR TITLE
fix(jit): OOB array access in CeedNormalizePath

### DIFF
--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -97,7 +97,7 @@ static int CeedNormalizePath(Ceed ceed, const char *source_file_path, char **nor
 
         while (last_slash[0] != '/' && last_slash != *normalized_source_file_path) last_slash--;
         CeedCheck(last_slash != *normalized_source_file_path, ceed, CEED_ERROR_MAJOR, "Malformed source path %s", source_file_path);
-        for (CeedInt i = 0; first_dot[i - 1]; i++) last_slash[i] = first_dot[i + 2];
+        for (CeedInt i = 0; first_dot[i + 1]; i++) last_slash[i] = first_dot[i + 2];
         search_from = last_slash;
       }
     }


### PR DESCRIPTION
For loop would read past string bounds. Caught using ASAN with CUDA backends.

The loop idea is to use `NULL` byte at the end of `first_dot` as the for loop stop, but also copy that `NULL` byte. So the difference between the "check" byte and the "copy" byte should be 1, not 3.

Side note: I could only get ASAN and CUDA to cooperate with `export ASAN_OPTIONS=protect_shadow_gap=0`, see https://github.com/google/sanitizers/issues/629#issuecomment-161357276