### PR TITLE
fix(sycl): Replaces pragma once with include guards

### DIFF
--- a/include/ceed/jit-source/sycl/sycl-types.h
+++ b/include/ceed/jit-source/sycl/sycl-types.h
@@ -7,7 +7,8 @@
 
 /// @file
 /// Internal header for SYCL type definitions
-#pragma once
+#ifndef CEED_SYCL_TYPES_H
+#define CEED_SYCL_TYPES_H
 
 #include <ceed/types.h>
 
@@ -34,3 +35,5 @@ typedef struct {
   CeedInt       *outputs[CEED_SYCL_NUMBER_FIELDS];
 } FieldsInt_Sycl;
 #endif
+
+#endif  // CEED_SYCL_TYPES_H

--- a/include/ceed/types.h
+++ b/include/ceed/types.h
@@ -7,7 +7,8 @@
 
 /// @file
 /// Public header for types and macros used in user QFunction source code
-#pragma once
+#ifndef CEED_QFUNCTION_DEFS_H
+#define CEED_QFUNCTION_DEFS_H
 
 #ifndef CEED_RUNNING_JIT_PASS
 #include <stddef.h>
@@ -252,3 +253,5 @@ typedef enum {
   /// Boolean value
   CEED_CONTEXT_FIELD_BOOL = 3,
 } CeedContextFieldType;
+
+#endif  // CEED_QFUNCTION_DEFS_H


### PR DESCRIPTION
OpenCL doesn't really like pragma once evidently. I think we've been 'getting away' with it previously as the JIT processing automatically doesn't allow for nested includes, but the same is not done for <ceed/types.h>?