### PR TITLE
Version 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ On this page we provide a summary of the main API changes, new features and exam
 
 ### Interface changes
 
+### New features
+
+### Examples
+
+(v1-0)=
+
+## v1.0 (August 15, 2025)
+
+### Interface changes
+
 - Add `bool` field type for `CeedQFunctionContext` and related interfaces to use `bool` fields.
 - `CEED_BASIS_COLLOCATED` removed; users should only use `CEED_BASIS_NONE`.
 - Remove unneeded pointer for `CeedElemRestrictionGetELayout`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: "libCEED: Efficient Extensible Discretization"
-version: 0.12.0
-date-released: 2023-10-31
+version: 1.0.0
+date-released: 2025-08-15
 license:  BSD-2-Clause
 message: "Please cite the following works when using this software."
 authors:

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = libCEED
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.12.0
+PROJECT_NUMBER         = v1.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Rust users can include libCEED via `Cargo.toml`:
 
 ```toml
 [dependencies]
-libceed = "0.12.0"
+libceed = "1.0.0"
 ```
 
 See the [Cargo documentation](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) for details.

--- a/ceed.pc.template
+++ b/ceed.pc.template
@@ -5,7 +5,7 @@ cflags_extra=%opt%
 
 Name: CEED
 Description: Code for Efficient Extensible Discretization
-Version: 0.12.0
+Version: 1.0.0
 Cflags: -I${includedir}
 Libs: -L${libdir} -lceed
 Libs.private: %libs_private%

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -147,10 +147,10 @@ CEED_EXTERN int CeedErrorExit(Ceed ceed, const char *filename, int line_no, cons
 
 /// libCEED library version numbering
 /// @ingroup Ceed
-#define CEED_VERSION_MAJOR 0
-#define CEED_VERSION_MINOR 12
+#define CEED_VERSION_MAJOR 1
+#define CEED_VERSION_MINOR 0
 #define CEED_VERSION_PATCH 0
-#define CEED_VERSION_RELEASE false
+#define CEED_VERSION_RELEASE true
 
 /// Compile-time check that the the current library version is at least as recent as the specified version.
 /// This macro is typically used in

--- a/julia/LibCEED.jl/Project.toml
+++ b/julia/LibCEED.jl/Project.toml
@@ -1,6 +1,6 @@
 name = "LibCEED"
 uuid = "2cd74e05-b976-4426-91fa-5f1011f8952b"
-version = "0.3.0"
+version = "1.0.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -25,7 +25,7 @@ Requires = "1"
 StaticArrays = "1"
 UnsafeArrays = "1"
 julia = "1.6"
-libCEED_jll = "0.12"
+libCEED_jll = "1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/rust/libceed-sys/Cargo.toml
+++ b/rust/libceed-sys/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 build = "build.rs"
 name = "libceed-sys"
-version = "0.12.0"
+version = "1.0.0"
 links = "libceed-sys"
 edition = "2018"
 license = "BSD-2-Clause"

--- a/rust/libceed-sys/README.md
+++ b/rust/libceed-sys/README.md
@@ -12,7 +12,7 @@ While our focus is on high-order finite elements, the approach is mostly algebra
 To use low level libCEED bindings in a Rust package, the following `Cargo.toml` can be used.
 ```toml
 [dependencies]
-libceed-sys = "0.12.0"
+libceed-sys = "1.0.0"
 ```
 
 For a development version of the libCEED Rust bindings, use the following `Cargo.toml`.

--- a/rust/libceed-sys/build.rs
+++ b/rust/libceed-sys/build.rs
@@ -45,7 +45,7 @@ fn main() {
     };
     pkg_config::Config::new()
         .statik(!shared)
-        .atleast_version("0.12.0")
+        .atleast_version("1.0.0")
         .probe(&ceed_pc)
         .unwrap();
 

--- a/rust/libceed/Cargo.toml
+++ b/rust/libceed/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Jeremy L Thompson <thompson.jeremy.luke@gmail.com>",
 ]
 name = "libceed"
-version = "0.12.0"
+version = "1.0.0"
 edition = "2018"
 rust-version = "1.56"
 license = "BSD-2-Clause"
@@ -18,7 +18,7 @@ keywords = ["libceed", "exascale", "high-order"]
 categories = ["science"]
 
 [dependencies]
-libceed-sys = { version = "0.12", path = "../libceed-sys", default-features = false}
+libceed-sys = { version = "1.0.0", path = "../libceed-sys", default-features = false}
 katexit = { version = "0.1.1", optional = true }
 
 [dev-dependencies]

--- a/rust/libceed/README.md
+++ b/rust/libceed/README.md
@@ -14,7 +14,7 @@ See the [libCEED user manual](https://libceed.org) for details on [interface con
 To call libCEED from a Rust package, the following `Cargo.toml` can be used.
 ```toml
 [dependencies]
-libceed = "0.12.0"
+libceed = "1.0.0"
 ```
 
 For a development version of the libCEED Rust bindings, use the following `Cargo.toml`.


### PR DESCRIPTION
~~Blocked by #1788~~ 
~~Blocked by #1711~~
~~Blocked by #1653~~
~~Blocked by #1881~~
~~Blocked by #1875~~
Blocked by ~~#1818~~ ~~#1919~~
Blocked by #1813

Draft release notes:

Release of libCEED v1.0 :tada: 

### New features

- Add `CeedOperatorCreateAtPoints` which evaluates the `CeedQFunction` at arbitrary locations in each element, for use in Particle in Cell, Material Point Method, and similar methods.
- Add `CeedElemRestrictionGetLLayout` to provide L-vector layout for strided `CeedElemRestriction` created with `CEED_BACKEND_STRIDES`.
- Add `CeedVectorReturnCeed` and similar when parent `Ceed` context for a libCEED object is only needed once in a calling scope.
- Enable `#pragma once` for all JiT source; remove duplicate includes in JiT source string before compilation.
- Allow user to set additional compiler options for CUDA and HIP JiT.
Specifically, directories set with `CeedAddJitSourceRoot(ceed, "foo/bar")` will be used to set `-Ifoo/bar` and defines set with `CeedAddJitDefine(ceed, "foo=bar")` will be used to set `-Dfoo=bar`.
- Added non-tensor basis support to code generation backends `/gpu/cuda/gen` and `/gpu/hip/gen`.
- Added support to code generation backends `/gpu/cuda/gen` and `/gpu/hip/gen` for operators with both tensor and non-tensor bases.
- Added support for QFunctions written in Rust for CUDA backends.
- Add `CeedGetGitVersion()` to access the Git commit and dirty state of the repository at build time.
- Add `CeedGetBuildConfiguration()` to access compilers, flags, and related information about the build environment.

### Interface changes

- Add `bool` field type for `CeedQFunctionContext` and related interfaces to use `bool` fields.
- `CEED_BASIS_COLLOCATED` removed; users should only use `CEED_BASIS_NONE`.
- Remove unneeded pointer for `CeedElemRestrictionGetELayout`.
- Change QFunction source include file handling in JiT compilers
    - Add `CEED_RUNNING_JIT_PASS` compiler definition for wrapping header files that device JiT compilers cannot read
    - Users should now prefer `#include <ceed/types.h>` rather than `#include <ceed.h>` in QFunction source files
- Require use of `Ceed*Destroy()` on Ceed objects returned from `Ceed*Get*()`.
- Rename `CeedCompositeOperatorCreate()` to `CeedOperatorCreateComposite()` for uniformity.
- Rename `CeedCompositeOperator*()` to `CeedOperatorComposite*()` for uniformity.