### PR TITLE
petsc - fix vec type checking

### DIFF
--- a/examples/petsc/area.c
+++ b/examples/petsc/area.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   Ceed                 ceed;
   CeedData             ceed_data;
   ProblemType          problem_choice;
-  VecType              vec_type;
+  VecType              vec_type = VECSTANDARD;
   PetscMemType         mem_type;
 
   PetscCall(PetscInitialize(&argc, &argv, NULL, help));
@@ -110,15 +110,6 @@ int main(int argc, char **argv) {
   // Create DM
   PetscCall(SetupDMByDegree(dm, degree, q_extra, num_comp_u, topo_dim, false));
 
-  // Create vectors
-  PetscCall(DMCreateGlobalVector(dm, &U));
-  PetscCall(VecGetLocalSize(U, &l_size));
-  PetscCall(VecGetSize(U, &g_size));
-  PetscCall(DMCreateLocalVector(dm, &U_loc));
-  PetscCall(VecGetSize(U_loc, &xl_size));
-  PetscCall(VecDuplicate(U, &V));
-  PetscCall(VecDuplicate(U_loc, &V_loc));
-
   // Setup op_apply_ctx structure
   PetscCall(PetscMalloc1(1, &op_apply_ctx));
 
@@ -127,23 +118,31 @@ int main(int argc, char **argv) {
   CeedMemType mem_type_backend;
   CeedGetPreferredMemType(ceed, &mem_type_backend);
 
-  PetscCall(DMGetVecType(dm, &vec_type));
-  if (!vec_type) {  // Not yet set by op_apply_ctx -dm_vec_type
-    switch (mem_type_backend) {
-      case CEED_MEM_HOST:
-        vec_type = VECSTANDARD;
-        break;
-      case CEED_MEM_DEVICE: {
-        const char *resolved;
-        CeedGetResource(ceed, &resolved);
-        if (strstr(resolved, "/gpu/cuda")) vec_type = VECCUDA;
-        else if (strstr(resolved, "/gpu/hip/occa")) vec_type = VECSTANDARD;  // https://github.com/CEED/libCEED/issues/678
-        else if (strstr(resolved, "/gpu/hip")) vec_type = VECHIP;
-        else vec_type = VECSTANDARD;
-      }
+  // Set mesh vec_type
+  switch (mem_type_backend) {
+    case CEED_MEM_HOST:
+      vec_type = VECSTANDARD;
+      break;
+    case CEED_MEM_DEVICE: {
+      const char *resolved;
+
+      CeedGetResource(ceed, &resolved);
+      if (strstr(resolved, "/gpu/cuda")) vec_type = VECCUDA;
+      else if (strstr(resolved, "/gpu/hip/occa")) vec_type = VECSTANDARD;  // https://github.com/CEED/libCEED/issues/678
+      else if (strstr(resolved, "/gpu/hip")) vec_type = VECHIP;
+      else vec_type = VECSTANDARD;
     }
-    PetscCall(DMSetVecType(dm, vec_type));
   }
+  PetscCall(DMSetVecType(dm, vec_type));
+
+  // Create vectors
+  PetscCall(DMCreateGlobalVector(dm, &U));
+  PetscCall(VecGetLocalSize(U, &l_size));
+  PetscCall(VecGetSize(U, &g_size));
+  PetscCall(DMCreateLocalVector(dm, &U_loc));
+  PetscCall(VecGetSize(U_loc, &xl_size));
+  PetscCall(VecDuplicate(U, &V));
+  PetscCall(VecDuplicate(U_loc, &V_loc));
 
   // Print summary
   if (!test_mode) {

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -62,7 +62,7 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm, const char *ceed_resource) 
   CeedQFunction        qf_error;
   CeedOperator         op_error;
   CeedVector           rhs_ceed, target;
-  VecType              vec_type;
+  VecType              vec_type = VECSTANDARD;
   PetscMemType         mem_type;
 
   PetscFunctionBeginUser;
@@ -71,23 +71,22 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm, const char *ceed_resource) 
   CeedMemType mem_type_backend;
   CeedGetPreferredMemType(ceed, &mem_type_backend);
 
-  PetscCall(DMGetVecType(dm, &vec_type));
-  if (!vec_type) {  // Not yet set by user -dm_vec_type
-    switch (mem_type_backend) {
-      case CEED_MEM_HOST:
-        vec_type = VECSTANDARD;
-        break;
-      case CEED_MEM_DEVICE: {
-        const char *resolved;
-        CeedGetResource(ceed, &resolved);
-        if (strstr(resolved, "/gpu/cuda")) vec_type = VECCUDA;
-        else if (strstr(resolved, "/gpu/hip/occa")) vec_type = VECSTANDARD;  // https://github.com/CEED/libCEED/issues/678
-        else if (strstr(resolved, "/gpu/hip")) vec_type = VECHIP;
-        else vec_type = VECSTANDARD;
-      }
+  // Set mesh vec_type
+  switch (mem_type_backend) {
+    case CEED_MEM_HOST:
+      vec_type = VECSTANDARD;
+      break;
+    case CEED_MEM_DEVICE: {
+      const char *resolved;
+
+      CeedGetResource(ceed, &resolved);
+      if (strstr(resolved, "/gpu/cuda")) vec_type = VECCUDA;
+      else if (strstr(resolved, "/gpu/hip/occa")) vec_type = VECSTANDARD;  // https://github.com/CEED/libCEED/issues/678
+      else if (strstr(resolved, "/gpu/hip")) vec_type = VECHIP;
+      else vec_type = VECSTANDARD;
     }
-    PetscCall(DMSetVecType(dm, vec_type));
   }
+  PetscCall(DMSetVecType(dm, vec_type));
 
   // Create global and local solution vectors
   PetscCall(DMCreateGlobalVector(dm, &X));

--- a/examples/petsc/bps.c
+++ b/examples/petsc/bps.c
@@ -87,6 +87,7 @@ static PetscErrorCode RunWithDM(RunParams rp, DM dm, const char *ceed_resource) 
     }
   }
   PetscCall(DMSetVecType(dm, vec_type));
+  PetscCall(DMSetFromOptions(dm));
 
   // Create global and local solution vectors
   PetscCall(DMCreateGlobalVector(dm, &X));

--- a/examples/petsc/bpsraw.c
+++ b/examples/petsc/bpsraw.c
@@ -403,6 +403,7 @@ int main(int argc, char **argv) {
       break;
     case CEED_MEM_DEVICE: {
       const char *resolved;
+
       CeedGetResource(ceed, &resolved);
       if (strstr(resolved, "/gpu/cuda")) default_vec_type = VECCUDA;
       else if (strstr(resolved, "/gpu/hip/occa")) default_vec_type = VECSTANDARD;  // https://github.com/CEED/libCEED/issues/678

--- a/examples/petsc/bpsswarm.c
+++ b/examples/petsc/bpsswarm.c
@@ -216,6 +216,7 @@ int main(int argc, char **argv) {
     }
   }
   PetscCall(DMSetVecType(dm_mesh, vec_type));
+  PetscCall(DMSetFromOptions(dm_mesh));
 
   // Create vectors
   PetscCall(DMCreateGlobalVector(dm_mesh, &X));

--- a/examples/petsc/multigrid.c
+++ b/examples/petsc/multigrid.c
@@ -120,13 +120,16 @@ int main(int argc, char **argv) {
     PetscCall(DMPlexCreateBoxMesh(PETSC_COMM_WORLD, dim, simplex, mesh_elem, NULL, NULL, NULL, PETSC_TRUE, 0, PETSC_FALSE, &dm_orig));
   }
 
-  VecType vec_type;
+  // Set mesh vec_type
+  VecType vec_type = VECSTANDARD;
+
   switch (mem_type_backend) {
     case CEED_MEM_HOST:
       vec_type = VECSTANDARD;
       break;
     case CEED_MEM_DEVICE: {
       const char *resolved;
+
       CeedGetResource(ceed, &resolved);
       if (strstr(resolved, "/gpu/cuda")) vec_type = VECCUDA;
       else if (strstr(resolved, "/gpu/hip/occa")) vec_type = VECSTANDARD;  // https://github.com/CEED/libCEED/issues/678


### PR DESCRIPTION
By default now, `DMGetVecType` gives `VECSTANDARD`, so we're locked into host arrays, which makes benchmaking show a ton of extra copies back and forth.