### PR TITLE
Add `CeedElemRestrictionGetMinPointsInElement` and `CeedElemRestrictionGetMinMaxPointsInElement`

### DIFF
--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -279,6 +279,8 @@ CEED_EXTERN int  CeedElemRestrictionGetElementSize(CeedElemRestriction rstr, Cee
 CEED_EXTERN int  CeedElemRestrictionGetNumPoints(CeedElemRestriction rstr, CeedInt *num_points);
 CEED_EXTERN int  CeedElemRestrictionGetNumPointsInElement(CeedElemRestriction rstr, CeedInt elem, CeedInt *num_points);
 CEED_EXTERN int  CeedElemRestrictionGetMaxPointsInElement(CeedElemRestriction rstr, CeedInt *max_points);
+CEED_EXTERN int  CeedElemRestrictionGetMinPointsInElement(CeedElemRestriction rstr, CeedInt *min_points);
+CEED_EXTERN int  CeedElemRestrictionGetMinMaxPointsInElement(CeedElemRestriction rstr, CeedInt *min_points, CeedInt *max_points);
 CEED_EXTERN int  CeedElemRestrictionGetLVectorSize(CeedElemRestriction rstr, CeedSize *l_size);
 CEED_EXTERN int  CeedElemRestrictionGetEVectorSize(CeedElemRestriction rstr, CeedSize *e_size);
 CEED_EXTERN int  CeedElemRestrictionGetNumComponents(CeedElemRestriction rstr, CeedInt *num_comp);

--- a/tests/t233-elemrestriction.c
+++ b/tests/t233-elemrestriction.c
@@ -48,9 +48,15 @@ int main(int argc, char **argv) {
   }
 
   {
-    CeedInt max_points;
+    CeedInt min_points, max_points;
 
+    CeedElemRestrictionGetMinPointsInElement(elem_restriction, &min_points);
     CeedElemRestrictionGetMaxPointsInElement(elem_restriction, &max_points);
+    if (min_points != 1 || max_points != num_elem) {
+      // LCOV_EXCL_START
+      printf("Error in min/max points: min %" CeedInt_FMT " max %" CeedInt_FMT "\n", min_points, max_points);
+      // LCOV_EXCL_STOP
+    }
     CeedVectorCreate(ceed, max_points, &y);
   }
 

--- a/tests/t234-elemrestriction.c
+++ b/tests/t234-elemrestriction.c
@@ -35,9 +35,15 @@ int main(int argc, char **argv) {
   CeedElemRestrictionCreateVector(elem_restriction, &x, NULL);
   CeedVectorSetValue(x, 0.0);
   {
-    CeedInt max_points;
+    CeedInt min_points, max_points;
 
+    CeedElemRestrictionGetMinPointsInElement(elem_restriction, &min_points);
     CeedElemRestrictionGetMaxPointsInElement(elem_restriction, &max_points);
+    if (min_points != 1 || max_points != num_elem) {
+      // LCOV_EXCL_START
+      printf("Error in min/max points: min %" CeedInt_FMT " max %" CeedInt_FMT "\n", min_points, max_points);
+      // LCOV_EXCL_STOP
+    }
     CeedVectorCreate(ceed, max_points, &y);
     CeedVectorSetValue(y, 1.0);
   }


### PR DESCRIPTION
Adds the ability to query minimum points per element and unifies min/max computation under a single function to reduce repeat work.