### PR TITLE
Add ex03 mass+diff

### DIFF
--- a/.github/workflows/c-fortan-test-ppc64le.yml
+++ b/.github/workflows/c-fortan-test-ppc64le.yml
@@ -37,4 +37,4 @@ jobs:
           uname -a
           make info
           make -j
-          make prove -j
+          make prove -j search="t5 ex"

--- a/examples/ceed/README.md
+++ b/examples/ceed/README.md
@@ -9,3 +9,8 @@ This example uses the mass matrix to compute the length, area, or volume of a re
 ### Example 2: ex2-surface
 
 This example uses the diffusion matrix to compute the surface area of a region, in 1D, 2D or 3D, depending upon runtime parameters.
+
+### Example 3: ex3-volume
+
+This example uses the mass matrix to compute the length, area, or volume of a region, depending upon runtime parameters.
+Unlike ex1, this example also adds the diffusion matrix to add a zero contribution to this calculation while demonstrating the ability of libCEED to handle multiple basis evaluation modes on the same input and output vectors.

--- a/examples/ceed/ex1-volume.h
+++ b/examples/ceed/ex1-volume.h
@@ -14,43 +14,46 @@ struct BuildContext {
 
 /// libCEED Q-function for building quadrature data for a mass operator
 CEED_QFUNCTION(build_mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  // in[0] is Jacobians with shape [dim, nc=dim, Q]
-  // in[1] is quadrature weights, size (Q)
+  // in[0] is Jacobians with shape [dim, dim, Q]
+  // in[1] is quadrature weights with shape [1, Q]
+  const CeedScalar    *w          = in[1];
+  CeedScalar          *q_data     = out[0];
   struct BuildContext *build_data = (struct BuildContext *)ctx;
-  const CeedScalar    *J = in[0], *w = in[1];
-  CeedScalar          *q_data = out[0];
 
   switch (build_data->dim + 10 * build_data->space_dim) {
-    case 11:
+    case 11: {
+      const CeedScalar(*J)[1][CEED_Q_VLA] = (const CeedScalar(*)[1][CEED_Q_VLA])in[0];
+
       // Quadrature Point Loop
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { q_data[i] = J[i] * w[i]; }  // End of Quadrature Point Loop
-      break;
-    case 22:
-      // Quadrature Point Loop
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-        // 0 2
-        // 1 3
-        q_data[i] = (J[i + Q * 0] * J[i + Q * 3] - J[i + Q * 1] * J[i + Q * 2]) * w[i];
-      }  // End of Quadrature Point Loop
-      break;
-    case 33:
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { q_data[i] = J[0][0][i] * w[i]; }  // End of Quadrature Point Loop
+    } break;
+    case 22: {
+      const CeedScalar(*J)[2][CEED_Q_VLA] = (const CeedScalar(*)[2][CEED_Q_VLA])in[0];
+
       // Quadrature Point Loop
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-        // 0 3 6
-        // 1 4 7
-        // 2 5 8
-        q_data[i] = (J[i + Q * 0] * (J[i + Q * 4] * J[i + Q * 8] - J[i + Q * 5] * J[i + Q * 7]) -
-                     J[i + Q * 1] * (J[i + Q * 3] * J[i + Q * 8] - J[i + Q * 5] * J[i + Q * 6]) +
-                     J[i + Q * 2] * (J[i + Q * 3] * J[i + Q * 7] - J[i + Q * 4] * J[i + Q * 6])) *
-                    w[i];
+        q_data[i] = (J[0][0][i] * J[1][1][i] - J[0][1][i] * J[1][0][i]) * w[i];
       }  // End of Quadrature Point Loop
-      break;
+    } break;
+    case 33: {
+      const CeedScalar(*J)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
+
+      // Quadrature Point Loop
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
+        q_data[i] =
+            (J[0][0][i] * (J[1][1][i] * J[2][2][i] - J[1][2][i] * J[2][1][i]) - J[0][1][i] * (J[1][0][i] * J[2][2][i] - J[1][2][i] * J[2][0][i]) +
+             J[0][2][i] * (J[1][0][i] * J[2][1][i] - J[1][1][i] * J[2][0][i])) *
+            w[i];
+      }  // End of Quadrature Point Loop
+    } break;
   }
   return CEED_ERROR_SUCCESS;
 }
 
 /// libCEED Q-function for applying a mass operator
 CEED_QFUNCTION(apply_mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  // in[0], out[0] are solution variables with shape [1, Q]
+  // in[1] is quadrature data with shape [1, Q]
   const CeedScalar *u = in[0], *q_data = in[1];
   CeedScalar       *v = out[0];
 

--- a/examples/ceed/ex1-volume.h
+++ b/examples/ceed/ex1-volume.h
@@ -46,7 +46,7 @@ CEED_QFUNCTION(build_mass)(void *ctx, const CeedInt Q, const CeedScalar *const *
       }  // End of Quadrature Point Loop
       break;
   }
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }
 
 /// libCEED Q-function for applying a mass operator
@@ -56,5 +56,5 @@ CEED_QFUNCTION(apply_mass)(void *ctx, const CeedInt Q, const CeedScalar *const *
 
   // Quadrature Point Loop
   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { v[i] = q_data[i] * u[i]; }  // End of Quadrature Point Loop
-  return 0;
+  return CEED_ERROR_SUCCESS;
 }

--- a/examples/ceed/ex2-surface.h
+++ b/examples/ceed/ex2-surface.h
@@ -14,63 +14,69 @@ struct BuildContext {
 
 /// libCEED Q-function for building quadrature data for a diffusion operator
 CEED_QFUNCTION(build_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  struct BuildContext *build_data = (struct BuildContext *)ctx;
-  // in[0] is Jacobians with shape [dim, nc=dim, Q]
+  // in[0] is Jacobians with shape [dim, dim, Q]
   // in[1] is quadrature weights, size (Q)
-  //
+  const CeedScalar *w             = in[1];
+  CeedScalar(*q_data)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  struct BuildContext *build_data = (struct BuildContext *)ctx;
+
   // At every quadrature point, compute w/det(J).adj(J).adj(J)^T and store
   // the symmetric part of the result.
-  const CeedScalar *J = in[0], *w = in[1];
-  CeedScalar       *q_data = out[0];
-
   switch (build_data->dim + 10 * build_data->space_dim) {
-    case 11:
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { q_data[i] = w[i] / J[i]; }  // End of Quadrature Point Loop
-      break;
-    case 22:
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-        // J: 0 2   q_data: 0 2   adj(J):  J22 -J12
-        //    1 3           2 1           -J21  J11
-        const CeedScalar J11 = J[i + Q * 0];
-        const CeedScalar J21 = J[i + Q * 1];
-        const CeedScalar J12 = J[i + Q * 2];
-        const CeedScalar J22 = J[i + Q * 3];
-        const CeedScalar qw  = w[i] / (J11 * J22 - J21 * J12);
+    case 11: {
+      const CeedScalar(*J)[1][CEED_Q_VLA] = (const CeedScalar(*)[1][CEED_Q_VLA])in[0];
 
-        q_data[i + Q * 0] = qw * (J12 * J12 + J22 * J22);
-        q_data[i + Q * 1] = qw * (J11 * J11 + J21 * J21);
-        q_data[i + Q * 2] = -qw * (J11 * J12 + J21 * J22);
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { q_data[0][i] = w[i] / J[0][0][i]; }  // End of Quadrature Point Loop
+    } break;
+    case 22: {
+      const CeedScalar(*J)[2][CEED_Q_VLA] = (const CeedScalar(*)[2][CEED_Q_VLA])in[0];
+
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
+        // J: 0 2   q_data: 0 2   adj(J):  J11 -J01
+        //    1 3           2 1           -J10  J00
+        const CeedScalar J00 = J[0][0][i];
+        const CeedScalar J10 = J[0][1][i];
+        const CeedScalar J01 = J[1][0][i];
+        const CeedScalar J11 = J[1][1][i];
+        const CeedScalar qw  = w[i] / (J00 * J11 - J10 * J01);
+
+        q_data[0][i] = qw * (J01 * J01 + J11 * J11);
+        q_data[1][i] = qw * (J00 * J00 + J10 * J10);
+        q_data[2][i] = -qw * (J00 * J01 + J10 * J11);
       }  // End of Quadrature Point Loop
-      break;
-    case 33:
+    } break;
+    case 33: {
+      const CeedScalar(*J)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Compute the adjoint
         CeedScalar A[3][3];
+
         for (CeedInt j = 0; j < 3; j++) {
           for (CeedInt k = 0; k < 3; k++) {
             // Equivalent code with J as a VLA and no mod operations:
             // A[k][j] = J[j+1][k+1]*J[j+2][k+2] - J[j+1][k+2]*J[j+2][k+1]
-            A[k][j] = J[i + Q * ((j + 1) % 3 + 3 * ((k + 1) % 3))] * J[i + Q * ((j + 2) % 3 + 3 * ((k + 2) % 3))] -
-                      J[i + Q * ((j + 1) % 3 + 3 * ((k + 2) % 3))] * J[i + Q * ((j + 2) % 3 + 3 * ((k + 1) % 3))];
+            A[k][j] =
+                J[(k + 1) % 3][(j + 1) % 3][i] * J[(k + 2) % 3][(j + 2) % 3][i] - J[(k + 2) % 3][(j + 1) % 3][i] * J[(k + 1) % 3][(j + 2) % 3][i];
           }
         }
 
         // Compute quadrature weight / det(J)
-        const CeedScalar qw = w[i] / (J[i + Q * 0] * A[0][0] + J[i + Q * 1] * A[0][1] + J[i + Q * 2] * A[0][2]);
+        const CeedScalar qw = w[i] / (J[0][0][i] * A[0][0] + J[0][1][i] * A[0][1] + J[0][2][i] * A[0][2]);
 
         // Compute geometric factors
         // Stored in Voigt convention
         // 0 5 4
         // 5 1 3
         // 4 3 2
-        q_data[i + Q * 0] = qw * (A[0][0] * A[0][0] + A[0][1] * A[0][1] + A[0][2] * A[0][2]);
-        q_data[i + Q * 1] = qw * (A[1][0] * A[1][0] + A[1][1] * A[1][1] + A[1][2] * A[1][2]);
-        q_data[i + Q * 2] = qw * (A[2][0] * A[2][0] + A[2][1] * A[2][1] + A[2][2] * A[2][2]);
-        q_data[i + Q * 3] = qw * (A[1][0] * A[2][0] + A[1][1] * A[2][1] + A[1][2] * A[2][2]);
-        q_data[i + Q * 4] = qw * (A[0][0] * A[2][0] + A[0][1] * A[2][1] + A[0][2] * A[2][2]);
-        q_data[i + Q * 5] = qw * (A[0][0] * A[1][0] + A[0][1] * A[1][1] + A[0][2] * A[1][2]);
+        q_data[0][i] = qw * (A[0][0] * A[0][0] + A[0][1] * A[0][1] + A[0][2] * A[0][2]);
+        q_data[1][i] = qw * (A[1][0] * A[1][0] + A[1][1] * A[1][1] + A[1][2] * A[1][2]);
+        q_data[2][i] = qw * (A[2][0] * A[2][0] + A[2][1] * A[2][1] + A[2][2] * A[2][2]);
+        q_data[3][i] = qw * (A[1][0] * A[2][0] + A[1][1] * A[2][1] + A[1][2] * A[2][2]);
+        q_data[4][i] = qw * (A[0][0] * A[2][0] + A[0][1] * A[2][1] + A[0][2] * A[2][2]);
+        q_data[5][i] = qw * (A[0][0] * A[1][0] + A[0][1] * A[1][1] + A[0][2] * A[1][2]);
       }  // End of Quadrature Point Loop
-      break;
+    } break;
   }
   return CEED_ERROR_SUCCESS;
 }
@@ -78,50 +84,55 @@ CEED_QFUNCTION(build_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *
 /// libCEED Q-function for applying a diff operator
 CEED_QFUNCTION(apply_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   struct BuildContext *build_data = (struct BuildContext *)ctx;
-  // in[0], out[0] have shape [dim, nc=1, Q]
-  const CeedScalar *ug = in[0], *q_data = in[1];
-  CeedScalar       *vg = out[0];
+  // in[0], out[0] solution gradients with shape [dim, 1, Q]
+  // in[1] is quadrature data with shape [num_components, Q]
+  const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
 
   switch (build_data->dim) {
-    case 1:
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { vg[i] = ug[i] * q_data[i]; }  // End of Quadrature Point Loop
-      break;
-    case 2:
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-        // Read spatial derivatives of u
-        const CeedScalar du[2] = {ug[i + Q * 0], ug[i + Q * 1]};
+    case 1: {
+      const CeedScalar *ug = in[0];
+      CeedScalar       *vg = out[0];
 
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) { vg[i] = ug[i] * q_data[0][i]; }  // End of Quadrature Point Loop
+    } break;
+    case 2: {
+      const CeedScalar(*ug)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
+      CeedScalar(*vg)[CEED_Q_VLA]       = (CeedScalar(*)[CEED_Q_VLA])out[0];
+
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Read q_data (dXdxdXdx_T symmetric matrix)
         // Stored in Voigt convention
         // 0 2
         // 2 1
         const CeedScalar dXdxdXdx_T[2][2] = {
-            {q_data[i + 0 * Q], q_data[i + 2 * Q]},
-            {q_data[i + 2 * Q], q_data[i + 1 * Q]}
+            {q_data[0][i], q_data[2][i]},
+            {q_data[2][i], q_data[1][i]}
         };
-        // j = direction of vg
-        for (int j = 0; j < 2; j++) vg[i + j * Q] = (du[0] * dXdxdXdx_T[0][j] + du[1] * dXdxdXdx_T[1][j]);
-      }  // End of Quadrature Point Loop
-      break;
-    case 3:
-      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-        // Read spatial derivatives of u
-        const CeedScalar du[3] = {ug[i + Q * 0], ug[i + Q * 1], ug[i + Q * 2]};
 
+        // j = direction of vg
+        for (int j = 0; j < 2; j++) vg[j][i] = (ug[0][i] * dXdxdXdx_T[0][j] + ug[1][i] * dXdxdXdx_T[1][j]);
+      }  // End of Quadrature Point Loop
+    } break;
+    case 3: {
+      const CeedScalar(*ug)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
+      CeedScalar(*vg)[CEED_Q_VLA]       = (CeedScalar(*)[CEED_Q_VLA])out[0];
+
+      CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Read q_data (dXdxdXdx_T symmetric matrix)
         // Stored in Voigt convention
         // 0 5 4
         // 5 1 3
         // 4 3 2
         const CeedScalar dXdxdXdx_T[3][3] = {
-            {q_data[i + 0 * Q], q_data[i + 5 * Q], q_data[i + 4 * Q]},
-            {q_data[i + 5 * Q], q_data[i + 1 * Q], q_data[i + 3 * Q]},
-            {q_data[i + 4 * Q], q_data[i + 3 * Q], q_data[i + 2 * Q]}
+            {q_data[0][i], q_data[5][i], q_data[4][i]},
+            {q_data[5][i], q_data[1][i], q_data[3][i]},
+            {q_data[4][i], q_data[3][i], q_data[2][i]}
         };
+
         // j = direction of vg
-        for (int j = 0; j < 3; j++) vg[i + j * Q] = (du[0] * dXdxdXdx_T[0][j] + du[1] * dXdxdXdx_T[1][j] + du[2] * dXdxdXdx_T[2][j]);
+        for (int j = 0; j < 3; j++) vg[j][i] = (ug[0][i] * dXdxdXdx_T[0][j] + ug[1][i] * dXdxdXdx_T[1][j] + ug[2][i] * dXdxdXdx_T[2][j]);
       }  // End of Quadrature Point Loop
-      break;
+    } break;
   }
   return CEED_ERROR_SUCCESS;
 }

--- a/examples/ceed/ex3-volume.c
+++ b/examples/ceed/ex3-volume.c
@@ -19,7 +19,7 @@
 //
 // Build with:
 //
-//     make ex1-volume [CEED_DIR=</path/to/libceed>]
+//     make ex3-volume [CEED_DIR=</path/to/libceed>]
 //
 // Sample runs:
 //

--- a/examples/ceed/ex3-volume.c
+++ b/examples/ceed/ex3-volume.c
@@ -5,9 +5,11 @@
 //
 // This file is part of CEED:  http://github.com/ceed
 
-//                             libCEED Example 2
+//                             libCEED Example 1
 //
-// This example illustrates a simple usage of libCEED to compute the surface area of a 3D body using matrix-free application of a diffusion operator.
+// This example illustrates a simple usage of libCEED to compute the volume of a 3D body using matrix-free application of a mass operator.
+// This example also uses a diffusion operator, which provides zero contribution to the computed volume but demonstrates libCEED's ability
+// to handle multiple basis evaluation modes for the same input and output vectors.
 // Arbitrary mesh and solution degrees in 1D, 2D and 3D are supported from the same code.
 //
 // The example has no dependencies, and is designed to be self-contained.
@@ -17,26 +19,23 @@
 //
 // Build with:
 //
-//     make ex2-surface [CEED_DIR=</path/to/libceed>]
+//     make ex1-volume [CEED_DIR=</path/to/libceed>]
 //
 // Sample runs:
 //
-//     ./ex2-surface
-//     ./ex2-surface -ceed /cpu/self
-//     ./ex2-surface -ceed /gpu/cuda
+//     ./ex3-volume
+//     ./ex3-volume -ceed /cpu/self
+//     ./ex3-volume -ceed /gpu/cuda
 //
 // Test in 1D-3D
 //TESTARGS(name="1D User QFunction") -ceed {ceed_resource} -d 1 -t
 //TESTARGS(name="2D User QFunction") -ceed {ceed_resource} -d 2 -t
 //TESTARGS(name="3D User QFunction") -ceed {ceed_resource} -d 3 -t
-//TESTARGS(name="1D Gallery QFunction") -ceed {ceed_resource} -d 1 -t -g
-//TESTARGS(name="2D Gallery QFunction") -ceed {ceed_resource} -d 2 -t -g
-//TESTARGS(name="3D Gallery QFunction") -ceed {ceed_resource} -d 3 -t -g
 
 /// @file
-/// libCEED example using diffusion operator to compute surface area
+/// libCEED example using mass operator to compute volume
 
-#include "ex2-surface.h"
+#include "ex3-volume.h"
 
 #include <ceed.h>
 #include <math.h>
@@ -45,10 +44,10 @@
 #include <string.h>
 
 // Auxiliary functions
-int        GetCartesianMeshSize(CeedInt dim, CeedInt degree, CeedInt prob_size, CeedInt num_xyz[3]);
-int        BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[3], CeedInt degree, CeedInt num_comp, CeedInt *size, CeedInt num_qpts,
+int        GetCartesianMeshSize(CeedInt dim, CeedInt degree, CeedInt prob_size, CeedInt num_xyz[dim]);
+int        BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[dim], CeedInt degree, CeedInt num_comp, CeedInt *size, CeedInt num_qpts,
                                      CeedElemRestriction *restriction, CeedElemRestriction *q_data_restriction);
-int        SetCartesianMeshCoords(CeedInt dim, CeedInt num_xyz[3], CeedInt mesh_degree, CeedVector mesh_coords);
+int        SetCartesianMeshCoords(CeedInt dim, CeedInt num_xyz[dim], CeedInt mesh_degree, CeedVector mesh_coords);
 CeedScalar TransformMeshCoords(CeedInt dim, CeedInt mesh_size, CeedVector mesh_coords);
 
 // Main example
@@ -60,7 +59,7 @@ int main(int argc, const char *argv[]) {
   CeedInt     sol_degree  = 4;               // polynomial degree for the solution
   CeedInt     num_qpts    = sol_degree + 2;  // number of 1D quadrature points
   CeedInt     prob_size   = -1;              // approximate problem size
-  CeedInt     help = 0, test = 0, gallery = 0, benchmark = 0;
+  CeedInt     help = 0, test = 0, benchmark = 0;
 
   // Process command line arguments.
   for (int ia = 1; ia < argc; ia++) {
@@ -85,8 +84,6 @@ int main(int argc, const char *argv[]) {
       parse_error = next_arg ? benchmark = atoi(argv[++ia]), 0 : 1;
     } else if (!strcmp(argv[ia], "-t")) {
       test = 1;
-    } else if (!strcmp(argv[ia], "-g")) {
-      gallery = 1;
     }
     if (parse_error) {
       printf("Error parsing command line options.\n");
@@ -94,11 +91,7 @@ int main(int argc, const char *argv[]) {
     }
     // LCOV_EXCL_STOP
   }
-  if (prob_size < 0) prob_size = test ? 16 * 16 * dim * dim : 256 * 1024;
-
-  // Set mesh_degree = sol_degree.
-  mesh_degree = fmax(mesh_degree, sol_degree);
-  sol_degree  = mesh_degree;
+  if (prob_size < 0) prob_size = test ? 8 * 16 : 256 * 1024;
 
   // Print the values of all options:
   if (!test || help) {
@@ -110,7 +103,7 @@ int main(int argc, const char *argv[]) {
     printf("  Solution degree        [-p] : %" CeedInt_FMT "\n", sol_degree);
     printf("  Num. 1D quadrature pts [-q] : %" CeedInt_FMT "\n", num_qpts);
     printf("  Approx. # unknowns     [-s] : %" CeedInt_FMT "\n", prob_size);
-    printf("  QFunction source       [-g] : %s\n", gallery ? "gallery" : "header");
+    printf("  QFunction source            : header");
     if (help) {
       printf("Test/quiet mode is %s\n", (test ? "ON" : "OFF (use -t to enable)"));
       return 0;
@@ -131,10 +124,9 @@ int main(int argc, const char *argv[]) {
   CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, sol_degree + 1, num_qpts, CEED_GAUSS, &sol_basis);
 
   // Determine the mesh size based on the given approximate problem size.
-  CeedInt num_xyz[3];
+  CeedInt num_xyz[dim];
 
   GetCartesianMeshSize(dim, sol_degree, prob_size, num_xyz);
-
   if (!test) {
     // LCOV_EXCL_START
     printf("Mesh size: nx = %" CeedInt_FMT, num_xyz[0]);
@@ -149,7 +141,7 @@ int main(int argc, const char *argv[]) {
   CeedElemRestriction mesh_restriction, sol_restriction, q_data_restriction;
 
   BuildCartesianRestriction(ceed, dim, num_xyz, mesh_degree, num_comp_x, &mesh_size, num_qpts, &mesh_restriction, NULL);
-  BuildCartesianRestriction(ceed, dim, num_xyz, sol_degree, dim * (dim + 1) / 2, &sol_size, num_qpts, NULL, &q_data_restriction);
+  BuildCartesianRestriction(ceed, dim, num_xyz, sol_degree, 1 + dim * (dim + 1) / 2, &sol_size, num_qpts, NULL, &q_data_restriction);
   BuildCartesianRestriction(ceed, dim, num_xyz, sol_degree, 1, &sol_size, num_qpts, &sol_restriction, NULL);
   if (!test) {
     // LCOV_EXCL_START
@@ -165,9 +157,9 @@ int main(int argc, const char *argv[]) {
   SetCartesianMeshCoords(dim, num_xyz, mesh_degree, mesh_coords);
 
   // Apply a transformation to the mesh.
-  CeedScalar exact_surface_area = TransformMeshCoords(dim, mesh_size, mesh_coords);
+  CeedScalar exact_volume = TransformMeshCoords(dim, mesh_size, mesh_coords);
 
-  // Context data to be passed to the 'build_diff' QFunction.
+  // Context data to be passed to the 'build_mass_diff' QFunction.
   CeedQFunctionContext build_ctx;
   struct BuildContext  build_ctx_data;
 
@@ -175,24 +167,16 @@ int main(int argc, const char *argv[]) {
   CeedQFunctionContextCreate(ceed, &build_ctx);
   CeedQFunctionContextSetData(build_ctx, CEED_MEM_HOST, CEED_USE_POINTER, sizeof(build_ctx_data), &build_ctx_data);
 
-  // Create the QFunction that builds the diffusion operator (i.e. computes its quadrature data) and set its context data.
+  // Create the QFunction that builds the mass + diffusion operator (i.e. computes its quadrature data) and set its context data.
   CeedQFunction qf_build;
 
-  if (gallery) {
-    // This creates the QFunction via the gallery.
-    char name[16] = "";
-    snprintf(name, sizeof name, "Poisson%" CeedInt_FMT "DBuild", dim);
-    CeedQFunctionCreateInteriorByName(ceed, name, &qf_build);
-  } else {
-    // This creates the QFunction directly.
-    CeedQFunctionCreateInterior(ceed, 1, build_diff, build_diff_loc, &qf_build);
-    CeedQFunctionAddInput(qf_build, "dx", num_comp_x * dim, CEED_EVAL_GRAD);
-    CeedQFunctionAddInput(qf_build, "weights", 1, CEED_EVAL_WEIGHT);
-    CeedQFunctionAddOutput(qf_build, "qdata", dim * (dim + 1) / 2, CEED_EVAL_NONE);
-    CeedQFunctionSetContext(qf_build, build_ctx);
-  }
+  CeedQFunctionCreateInterior(ceed, 1, build_mass_diff, build_mass_diff_loc, &qf_build);
+  CeedQFunctionAddInput(qf_build, "dx", num_comp_x * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_build, "weights", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddOutput(qf_build, "qdata", 1 + dim * (dim + 1) / 2, CEED_EVAL_NONE);
+  CeedQFunctionSetContext(qf_build, build_ctx);
 
-  // Create the operator that builds the quadrature data for the diffusion operator.
+  // Create the operator that builds the quadrature data for the mass + diffusion operator.
   CeedOperator op_build;
 
   CeedOperatorCreate(ceed, qf_build, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_build);
@@ -200,38 +184,34 @@ int main(int argc, const char *argv[]) {
   CeedOperatorSetField(op_build, "weights", CEED_ELEMRESTRICTION_NONE, mesh_basis, CEED_VECTOR_NONE);
   CeedOperatorSetField(op_build, "qdata", q_data_restriction, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
 
-  // Compute the quadrature data for the diffusion operator.
+  // Compute the quadrature data for the mass + diffusion operator.
   CeedVector q_data;
   CeedInt    elem_qpts = CeedIntPow(num_qpts, dim);
   CeedInt    num_elem  = 1;
 
   for (CeedInt d = 0; d < dim; d++) num_elem *= num_xyz[d];
-  CeedVectorCreate(ceed, num_elem * elem_qpts * dim * (dim + 1) / 2, &q_data);
+  CeedVectorCreate(ceed, num_elem * elem_qpts * (1 + dim * (dim + 1) / 2), &q_data);
   CeedOperatorApply(op_build, mesh_coords, q_data, CEED_REQUEST_IMMEDIATE);
 
-  // Create the QFunction that defines the action of the diffusion operator.
+  // Create the QFunction that defines the action of the mass + diffusion operator.
   CeedQFunction qf_apply;
 
-  if (gallery) {
-    // This creates the QFunction via the gallery.
-    char name[25] = "";
-    snprintf(name, sizeof name, "Poisson%" CeedInt_FMT "DApply", dim);
-    CeedQFunctionCreateInteriorByName(ceed, name, &qf_apply);
-  } else {
-    // This creates the QFunction directly.
-    CeedQFunctionCreateInterior(ceed, 1, apply_diff, apply_diff_loc, &qf_apply);
-    CeedQFunctionAddInput(qf_apply, "du", dim, CEED_EVAL_GRAD);
-    CeedQFunctionAddInput(qf_apply, "qdata", dim * (dim + 1) / 2, CEED_EVAL_NONE);
-    CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
-    CeedQFunctionSetContext(qf_apply, build_ctx);
-  }
+  CeedQFunctionCreateInterior(ceed, 1, apply_mass_diff, apply_mass_diff_loc, &qf_apply);
+  CeedQFunctionAddInput(qf_apply, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_apply, "du", dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_apply, "qdata", 1 + dim * (dim + 1) / 2, CEED_EVAL_NONE);
+  CeedQFunctionAddOutput(qf_apply, "v", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "dv", dim, CEED_EVAL_GRAD);
+  CeedQFunctionSetContext(qf_apply, build_ctx);
 
-  // Create the diffusion operator.
+  // Create the mass +diffusion operator.
   CeedOperator op_apply;
 
   CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_apply);
+  CeedOperatorSetField(op_apply, "u", sol_restriction, sol_basis, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "du", sol_restriction, sol_basis, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "qdata", q_data_restriction, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_apply, "v", sol_restriction, sol_basis, CEED_VECTOR_ACTIVE);
   CeedOperatorSetField(op_apply, "dv", sol_restriction, sol_basis, CEED_VECTOR_ACTIVE);
 
   // Create auxiliary solution-size vectors.
@@ -240,22 +220,10 @@ int main(int argc, const char *argv[]) {
   CeedVectorCreate(ceed, sol_size, &u);
   CeedVectorCreate(ceed, sol_size, &v);
 
-  // Initialize 'u' with sum of coordinates, x+y+z.
-  {
-    CeedScalar       *u_array;
-    const CeedScalar *x_array;
+  // Initialize 'u' with ones.
+  CeedVectorSetValue(u, 1.0);
 
-    CeedVectorGetArrayWrite(u, CEED_MEM_HOST, &u_array);
-    CeedVectorGetArrayRead(mesh_coords, CEED_MEM_HOST, &x_array);
-    for (CeedInt i = 0; i < sol_size; i++) {
-      u_array[i] = 0;
-      for (CeedInt d = 0; d < dim; d++) u_array[i] += x_array[i + d * sol_size];
-    }
-    CeedVectorRestoreArray(u, &u_array);
-    CeedVectorRestoreArrayRead(mesh_coords, &x_array);
-  }
-
-  // Compute the mesh surface area using the diff operator: surface_area = 1^T \cdot abs( K \cdot x).
+  // Compute the mesh volume using the mass + diffusion operator: volume = 1^T \cdot M \cdot 1
   CeedOperatorApply(op_apply, u, v, CEED_REQUEST_IMMEDIATE);
 
   // Benchmark runs
@@ -270,26 +238,27 @@ int main(int argc, const char *argv[]) {
     // LCOV_EXCL_STOP
   }
 
-  // Compute and print the sum of the entries of 'v' giving the mesh surface area.
-  CeedScalar surface_area = 0.;
+  // Compute and print the sum of the entries of 'v' giving the mesh volume.
+  CeedScalar volume = 0.;
+
   {
     const CeedScalar *v_array;
 
     CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
-    for (CeedInt i = 0; i < sol_size; i++) surface_area += fabs(v_array[i]);
+    for (CeedInt i = 0; i < sol_size; i++) volume += v_array[i];
     CeedVectorRestoreArrayRead(v, &v_array);
   }
   if (!test) {
     // LCOV_EXCL_START
     printf(" done.\n");
-    printf("Exact mesh surface area    : % .14g\n", exact_surface_area);
-    printf("Computed mesh surface area : % .14g\n", surface_area);
-    printf("Surface area error         : % .14g\n", surface_area - exact_surface_area);
+    printf("Exact mesh volume    : % .14g\n", exact_volume);
+    printf("Computed mesh volume : % .14g\n", volume);
+    printf("Volume error         : % .14g\n", volume - exact_volume);
     // LCOV_EXCL_STOP
   } else {
-    CeedScalar tol = (dim == 1 ? 10000. * CEED_EPSILON : dim == 2 ? 1E-1 : 1E-1);
+    CeedScalar tol = (dim == 1 ? 200. * CEED_EPSILON : dim == 2 ? 1E-5 : 1E-5);
 
-    if (fabs(surface_area - exact_surface_area) > tol) printf("Surface area error         : % .14g\n", surface_area - exact_surface_area);
+    if (fabs(volume - exact_volume) > tol) printf("Volume error : % .1e\n", volume - exact_volume);
   }
 
   // Free dynamically allocated memory.
@@ -311,7 +280,7 @@ int main(int argc, const char *argv[]) {
   return 0;
 }
 
-int GetCartesianMeshSize(CeedInt dim, CeedInt degree, CeedInt prob_size, CeedInt num_xyz[3]) {
+int GetCartesianMeshSize(CeedInt dim, CeedInt degree, CeedInt prob_size, CeedInt num_xyz[dim]) {
   // Use the approximate formula:
   //    prob_size ~ num_elem * degree^dim
   CeedInt num_elem = prob_size / CeedIntPow(degree, dim);
@@ -335,7 +304,7 @@ int GetCartesianMeshSize(CeedInt dim, CeedInt degree, CeedInt prob_size, CeedInt
   return 0;
 }
 
-int BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[3], CeedInt degree, CeedInt num_comp, CeedInt *size, CeedInt num_qpts,
+int BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[dim], CeedInt degree, CeedInt num_comp, CeedInt *size, CeedInt num_qpts,
                               CeedElemRestriction *restriction, CeedElemRestriction *q_data_restriction) {
   CeedInt p         = degree + 1;
   CeedInt num_nodes = CeedIntPow(p, dim);         // number of scalar nodes per element
@@ -351,7 +320,7 @@ int BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[3], CeedIn
   // elem:         0             1                 n-1
   //           |---*-...-*---|---*-...-*---|- ... -|--...--|
   // num_nodes:   0   1    p-1  p  p+1       2*p             n*p
-  CeedInt *el_nodes = malloc(sizeof(CeedInt) * num_elem * num_nodes);
+  CeedInt *elem_nodes = malloc(sizeof(CeedInt) * num_elem * num_nodes);
 
   for (CeedInt e = 0; e < num_elem; e++) {
     CeedInt e_xyz[3] = {1, 1, 1}, re = e;
@@ -360,7 +329,7 @@ int BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[3], CeedIn
       e_xyz[d] = re % num_xyz[d];
       re /= num_xyz[d];
     }
-    CeedInt *local_elem_nodes = el_nodes + e * num_nodes;
+    CeedInt *local_elem_nodes = elem_nodes + e * num_nodes;
 
     for (CeedInt l_nodes = 0; l_nodes < num_nodes; l_nodes++) {
       CeedInt g_nodes = 0, g_nodes_stride = 1, r_nodes = l_nodes;
@@ -374,19 +343,17 @@ int BuildCartesianRestriction(Ceed ceed, CeedInt dim, CeedInt num_xyz[3], CeedIn
     }
   }
   if (restriction) {
-    CeedElemRestrictionCreate(ceed, num_elem, num_nodes, num_comp, scalar_size, num_comp * scalar_size, CEED_MEM_HOST, CEED_COPY_VALUES, el_nodes,
+    CeedElemRestrictionCreate(ceed, num_elem, num_nodes, num_comp, scalar_size, num_comp * scalar_size, CEED_MEM_HOST, CEED_COPY_VALUES, elem_nodes,
                               restriction);
   }
-  free(el_nodes);
-
   if (q_data_restriction) {
     CeedElemRestrictionCreateStrided(ceed, num_elem, elem_qpts, num_comp, num_comp * elem_qpts * num_elem, CEED_STRIDES_BACKEND, q_data_restriction);
   }
-
+  free(elem_nodes);
   return 0;
 }
 
-int SetCartesianMeshCoords(CeedInt dim, CeedInt num_xyz[3], CeedInt mesh_degree, CeedVector mesh_coords) {
+int SetCartesianMeshCoords(CeedInt dim, CeedInt num_xyz[dim], CeedInt mesh_degree, CeedVector mesh_coords) {
   CeedInt p = mesh_degree + 1;
   CeedInt nd[3], scalar_size = 1;
 
@@ -406,9 +373,8 @@ int SetCartesianMeshCoords(CeedInt dim, CeedInt num_xyz[3], CeedInt mesh_degree,
     CeedInt r_nodes = gs_nodes;
 
     for (CeedInt d = 0; d < dim; d++) {
-      CeedInt d1d = r_nodes % nd[d];
-
-      coords[gs_nodes + scalar_size * d] = ((d1d / (p - 1)) + nodes[d1d % (p - 1)]) / num_xyz[d];
+      CeedInt d_1d                       = r_nodes % nd[d];
+      coords[gs_nodes + scalar_size * d] = ((d_1d / (p - 1)) + nodes[d_1d % (p - 1)]) / num_xyz[d];
       r_nodes /= nd[d];
     }
   }
@@ -419,17 +385,34 @@ int SetCartesianMeshCoords(CeedInt dim, CeedInt num_xyz[3], CeedInt mesh_degree,
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
+#define M_PI_2 1.57079632679489661923
 #endif
 
 CeedScalar TransformMeshCoords(CeedInt dim, CeedInt mesh_size, CeedVector mesh_coords) {
-  CeedScalar  exact_surface_area = (dim == 1 ? 2 : dim == 2 ? 4 : 6);
+  CeedScalar  exact_volume;
   CeedScalar *coords;
 
   CeedVectorGetArray(mesh_coords, CEED_MEM_HOST, &coords);
-  for (CeedInt i = 0; i < mesh_size; i++) {
-    // map [0,1] to [0,1] varying the mesh density
-    coords[i] = 0.5 + 1. / sqrt(3.) * sin((2. / 3.) * M_PI * (coords[i] - 0.5));
+  if (dim == 1) {
+    for (CeedInt i = 0; i < mesh_size; i++) {
+      // map [0,1] to [0,1] varying the mesh density
+      coords[i] = 0.5 + 1. / sqrt(3.) * sin((2. / 3.) * M_PI * (coords[i] - 0.5));
+    }
+    exact_volume = 1.;
+  } else {
+    CeedInt num_nodes = mesh_size / dim;
+    for (CeedInt i = 0; i < num_nodes; i++) {
+      // map (x,y) from [0,1]x[0,1] to the quarter annulus with polar
+      // coordinates, (r,phi) in [1,2]x[0,pi/2] with area = 3/4*pi
+      CeedScalar u = coords[i], v = coords[i + num_nodes];
+
+      u                     = 1. + u;
+      v                     = M_PI_2 * v;
+      coords[i]             = u * cos(v);
+      coords[i + num_nodes] = u * sin(v);
+    }
+    exact_volume = 3. / 4. * M_PI;
   }
   CeedVectorRestoreArray(mesh_coords, &coords);
-  return exact_surface_area;
+  return exact_volume;
 }

--- a/examples/ceed/ex3-volume.h
+++ b/examples/ceed/ex3-volume.h
@@ -14,73 +14,82 @@ struct BuildContext {
 
 /// libCEED Q-function for building quadrature data for a mass + diffusion operator
 CEED_QFUNCTION(build_mass_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  struct BuildContext *build_data = (struct BuildContext *)ctx;
-  // in[0] is Jacobians with shape [dim, nc=dim, Q]
+  // in[0] is Jacobians with shape [dim, dim, Q]
   // in[1] is quadrature weights, size (Q)
-  //
+  const CeedScalar *w             = in[1];
+  CeedScalar(*q_data)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  struct BuildContext *build_data = (struct BuildContext *)ctx;
+
   // At every quadrature point, compute w/det(J).adj(J).adj(J)^T and store
   // the symmetric part of the result.
-  const CeedScalar *J = in[0], *w = in[1];
-  CeedScalar       *q_data = out[0];
-
   switch (build_data->dim + 10 * build_data->space_dim) {
-    case 11:
+    case 11: {
+      const CeedScalar(*J)[1][CEED_Q_VLA] = (const CeedScalar(*)[1][CEED_Q_VLA])in[0];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Mass
-        q_data[i + Q * 0] = w[i] * J[i];
+        q_data[0][i] = w[i] * J[0][0][i];
+
         // Diffusion
-        q_data[i + Q * 1] = w[i] / J[i];
+        q_data[1][i] = w[i] / J[0][0][i];
       }  // End of Quadrature Point Loop
-      break;
-    case 22:
+    } break;
+    case 22: {
+      const CeedScalar(*J)[2][CEED_Q_VLA] = (const CeedScalar(*)[2][CEED_Q_VLA])in[0];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
-        // J: 0 2   q_data: 1 3   adj(J):  J22 -J12
-        //    1 3           3 2           -J21  J11
-        const CeedScalar J11 = J[i + Q * 0];
-        const CeedScalar J21 = J[i + Q * 1];
-        const CeedScalar J12 = J[i + Q * 2];
-        const CeedScalar J22 = J[i + Q * 3];
-        const CeedScalar qw  = w[i] / (J11 * J22 - J21 * J12);
+        // J: 0 2   q_data: 0 2   adj(J):  J22 -J12
+        //    1 3           2 1           -J10  J00
+        const CeedScalar J00 = J[0][0][i];
+        const CeedScalar J10 = J[0][1][i];
+        const CeedScalar J01 = J[1][0][i];
+        const CeedScalar J11 = J[1][1][i];
+        const CeedScalar qw  = w[i] / (J00 * J11 - J10 * J01);
 
         // Mass
-        q_data[i + Q * 0] = w[i] * (J11 * J22 - J21 * J12);
+        q_data[0][i] = w[i] * (J00 * J11 - J10 * J01);
+
         // Diffusion
-        q_data[i + Q * 1] = qw * (J12 * J12 + J22 * J22);
-        q_data[i + Q * 2] = qw * (J11 * J11 + J21 * J21);
-        q_data[i + Q * 3] = -qw * (J11 * J12 + J21 * J22);
+        q_data[1][i] = qw * (J01 * J01 + J11 * J11);
+        q_data[2][i] = qw * (J00 * J00 + J10 * J10);
+        q_data[3][i] = -qw * (J00 * J01 + J10 * J11);
       }  // End of Quadrature Point Loop
-      break;
-    case 33:
+    } break;
+    case 33: {
+      const CeedScalar(*J)[3][CEED_Q_VLA] = (const CeedScalar(*)[3][CEED_Q_VLA])in[0];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Compute the adjoint
         CeedScalar A[3][3];
+
         for (CeedInt j = 0; j < 3; j++) {
           for (CeedInt k = 0; k < 3; k++) {
             // Equivalent code with J as a VLA and no mod operations:
             // A[k][j] = J[j+1][k+1]*J[j+2][k+2] - J[j+1][k+2]*J[j+2][k+1]
-            A[k][j] = J[i + Q * ((j + 1) % 3 + 3 * ((k + 1) % 3))] * J[i + Q * ((j + 2) % 3 + 3 * ((k + 2) % 3))] -
-                      J[i + Q * ((j + 1) % 3 + 3 * ((k + 2) % 3))] * J[i + Q * ((j + 2) % 3 + 3 * ((k + 1) % 3))];
+            A[k][j] =
+                J[(k + 1) % 3][(j + 1) % 3][i] * J[(k + 2) % 3][(j + 2) % 3][i] - J[(k + 2) % 3][(j + 1) % 3][i] * J[(k + 1) % 3][(j + 2) % 3][i];
           }
         }
 
         // Compute quadrature weight / det(J)
-        const CeedScalar qw = w[i] / (J[i + Q * 0] * A[0][0] + J[i + Q * 1] * A[0][1] + J[i + Q * 2] * A[0][2]);
+        const CeedScalar qw = w[i] / (J[0][0][i] * A[0][0] + J[0][1][i] * A[0][1] + J[0][2][i] * A[0][2]);
 
         // Mass
-        q_data[i + Q * 0] = w[i] * (J[i + Q * 0] * A[0][0] + J[i + Q * 1] * A[0][1] + J[i + Q * 2] * A[0][2]);
+        q_data[0][i] = w[i] * (J[0][0][i] * A[0][0] + J[0][1][i] * A[0][1] + J[0][2][i] * A[0][2]);
+
         // Diffusion
         // Stored in Voigt convention
         // 1 6 5
         // 6 2 4
         // 5 4 3
-        q_data[i + Q * 1] = qw * (A[0][0] * A[0][0] + A[0][1] * A[0][1] + A[0][2] * A[0][2]);
-        q_data[i + Q * 2] = qw * (A[1][0] * A[1][0] + A[1][1] * A[1][1] + A[1][2] * A[1][2]);
-        q_data[i + Q * 3] = qw * (A[2][0] * A[2][0] + A[2][1] * A[2][1] + A[2][2] * A[2][2]);
-        q_data[i + Q * 4] = qw * (A[1][0] * A[2][0] + A[1][1] * A[2][1] + A[1][2] * A[2][2]);
-        q_data[i + Q * 5] = qw * (A[0][0] * A[2][0] + A[0][1] * A[2][1] + A[0][2] * A[2][2]);
-        q_data[i + Q * 6] = qw * (A[0][0] * A[1][0] + A[0][1] * A[1][1] + A[0][2] * A[1][2]);
+        q_data[1][i] = qw * (A[0][0] * A[0][0] + A[0][1] * A[0][1] + A[0][2] * A[0][2]);
+        q_data[2][i] = qw * (A[1][0] * A[1][0] + A[1][1] * A[1][1] + A[1][2] * A[1][2]);
+        q_data[3][i] = qw * (A[2][0] * A[2][0] + A[2][1] * A[2][1] + A[2][2] * A[2][2]);
+        q_data[4][i] = qw * (A[1][0] * A[2][0] + A[1][1] * A[2][1] + A[1][2] * A[2][2]);
+        q_data[5][i] = qw * (A[0][0] * A[2][0] + A[0][1] * A[2][1] + A[0][2] * A[2][2]);
+        q_data[6][i] = qw * (A[0][0] * A[1][0] + A[0][1] * A[1][1] + A[0][2] * A[1][2]);
       }  // End of Quadrature Point Loop
-      break;
+    } break;
   }
   return CEED_ERROR_SUCCESS;
 }
@@ -88,64 +97,74 @@ CEED_QFUNCTION(build_mass_diff)(void *ctx, const CeedInt Q, const CeedScalar *co
 /// libCEED Q-function for applying a mass + diffusion operator
 CEED_QFUNCTION(apply_mass_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
   struct BuildContext *build_data = (struct BuildContext *)ctx;
-  // in[0], out[0] have shape [1,   nc=1, Q]
-  // in[1], out[1] have shape [dim, nc=1, Q]
-  const CeedScalar *u = in[0], *ug = in[1], *q_data = in[2];
-  CeedScalar       *v = out[0], *vg = out[1];
+  // in[1], out[1] solution values with shape [1, 1, Q]
+  // in[1], out[1] solution gradients with shape [dim, 1, Q]
+  // in[2] is quadrature data with shape [num_components, Q]
+  const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];
 
   switch (build_data->dim) {
-    case 1:
+    case 1: {
+      const CeedScalar *u = in[0], *ug = in[1];
+      CeedScalar       *v = out[0], *vg = out[1];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Mass
-        v[i] = q_data[i + Q * 0] * u[i];
+        v[i] = q_data[0][i] * u[i];
+
         // Diffusion
-        vg[i] = ug[i] * q_data[i + Q * 1];
+        vg[i] = q_data[1][i] * ug[i];
       }  // End of Quadrature Point Loop
-      break;
-    case 2:
+    } break;
+    case 2: {
+      const CeedScalar *u               = in[0];
+      const CeedScalar(*ug)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+      CeedScalar *v                     = out[0];
+      CeedScalar(*vg)[CEED_Q_VLA]       = (CeedScalar(*)[CEED_Q_VLA])out[1];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Mass
-        v[i] = q_data[i + Q * 0] * u[i];
+        v[i] = q_data[0][i] * u[i];
 
         // Diffusion
-        // Read spatial derivatives of u
-        const CeedScalar du[2] = {ug[i + Q * 0], ug[i + Q * 1]};
-
         // Read q_data (dXdxdXdx_T symmetric matrix)
         // Stored in Voigt convention
         // 1 3
-        // 3 2
+        // 23 2
         const CeedScalar dXdxdXdx_T[2][2] = {
-            {q_data[i + 1 * Q], q_data[i + 3 * Q]},
-            {q_data[i + 3 * Q], q_data[i + 2 * Q]}
+            {q_data[1][i], q_data[3][i]},
+            {q_data[3][i], q_data[2][i]}
         };
+
         // j = direction of vg
-        for (int j = 0; j < 2; j++) vg[i + j * Q] = (du[0] * dXdxdXdx_T[0][j] + du[1] * dXdxdXdx_T[1][j]);
+        for (int j = 0; j < 2; j++) vg[j][i] = (ug[0][i] * dXdxdXdx_T[0][j] + ug[1][i] * dXdxdXdx_T[1][j]);
       }  // End of Quadrature Point Loop
-      break;
-    case 3:
+    } break;
+    case 3: {
+      const CeedScalar *u               = in[0];
+      const CeedScalar(*ug)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+      CeedScalar *v                     = out[0];
+      CeedScalar(*vg)[CEED_Q_VLA]       = (CeedScalar(*)[CEED_Q_VLA])out[1];
+
       CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++) {
         // Mass
-        v[i] = q_data[i + Q * 0] * u[i];
+        v[i] = q_data[0][i] * u[i];
 
         // Diffusion
-        // Read spatial derivatives of u
-        const CeedScalar du[3] = {ug[i + Q * 0], ug[i + Q * 1], ug[i + Q * 2]};
-
         // Read q_data (dXdxdXdx_T symmetric matrix)
         // Stored in Voigt convention
-        // 0 5 4
-        // 5 1 3
-        // 4 3 2
+        // 1 6 5
+        // 6 2 4
+        // 5 4 3
         const CeedScalar dXdxdXdx_T[3][3] = {
-            {q_data[i + 1 * Q], q_data[i + 6 * Q], q_data[i + 5 * Q]},
-            {q_data[i + 6 * Q], q_data[i + 2 * Q], q_data[i + 4 * Q]},
-            {q_data[i + 5 * Q], q_data[i + 4 * Q], q_data[i + 3 * Q]}
+            {q_data[1][i], q_data[6][i], q_data[5][i]},
+            {q_data[6][i], q_data[2][i], q_data[4][i]},
+            {q_data[5][i], q_data[4][i], q_data[3][i]}
         };
+
         // j = direction of vg
-        for (int j = 0; j < 3; j++) vg[i + j * Q] = (du[0] * dXdxdXdx_T[0][j] + du[1] * dXdxdXdx_T[1][j] + du[2] * dXdxdXdx_T[2][j]);
+        for (int j = 0; j < 3; j++) vg[j][i] = (ug[0][i] * dXdxdXdx_T[0][j] + ug[1][i] * dXdxdXdx_T[1][j] + ug[2][i] * dXdxdXdx_T[2][j]);
       }  // End of Quadrature Point Loop
-      break;
+    } break;
   }
   return CEED_ERROR_SUCCESS;
 }


### PR DESCRIPTION
This adds a simple usage of multiple eval modes per input/output vector, which allows us to check for excessive restriction calls.

This is what I was thinking for BP1+3 and BP2+4 as well, but it doesn't need to be me who adds it.