### PR TITLE
Add OPT as cflags_extra in ceed.pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -845,6 +845,7 @@ $(OBJDIR)/ceed.pc : pkgconfig-prefix = $(prefix)
 %/ceed.pc : ceed.pc.template | $$(@D)/.DIR
 	@$(SED) \
 	    -e "s:%prefix%:$(pkgconfig-prefix):" \
+	    -e "s:%opt%:$(OPT):" \
 	    -e "s:%libs_private%:$(pkgconfig-libs-private):" $< > $@
 
 $(OBJDIR)/interface/ceed-jit-source-root-default.o : CPPFLAGS += -DCEED_JIT_SOURCE_ROOT_DEFAULT="\"$(abspath ./include)/\""

--- a/ceed.pc.template
+++ b/ceed.pc.template
@@ -1,6 +1,7 @@
 prefix=%prefix%
 includedir=${prefix}/include
 libdir=${prefix}/lib
+cflags_extra=%opt%
 
 Name: CEED
 Description: Code for Efficient Extensible Discretization


### PR DESCRIPTION
Fixes #1658 

This mirrors where PETSc puts OPT flags in its .pc

```
prefix=/home/jeremy/Dev/petsc/arch-cuda-mpich
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${prefix}/lib
ccompiler=mpicc
cflags_extra=-fPIC -Wall -Wwrite-strings -Wno-unknown-pragmas -Wno-lto-type-mismatch -Wno-stringop-overflow -fstack-protector -fvisibility=hidden -O2 -march=native -ffp-contract=fast
cflags_dep=-MMD -MP
ldflag_rpath=-Wl,-rpath,
cxxcompiler=mpicxx
cxxflags_extra=-Wall -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wno-lto-type-mismatch -Wno-psabi -fstack-protector -fvisibility=hidden -O2 -march=native -ffp-contract=fast  -std=c++14 -fPIC
fcompiler=mpif90
fflags_extra=-fPIC -Wall -ffree-line-length-none -ffree-line-length-0 -Wno-lto-type-mismatch -Wno-unused-dummy-argument -g -O0
cudacompiler=nvcc
cudaflags_extra=-std=c++20 -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -O2 -arch=sm_89
cudalib=-Wl,-rpath,/opt/cuda/lib -L/opt/cuda/lib -L/opt/cuda/lib/stubs -lcudart -lnvToolsExt -lcufft -lcublas -lcusparse -lcusolver -lcurand -lcuda
cudainclude=-I/opt/cuda/include
cuda_cxx="/usr/bin"/g++-13
cuda_cxxflags=

Name: PETSc
Description: Library to solve ODEs and algebraic equations
Version: 3.22.99
Cflags:  -I${includedir} -I/home/jeremy/Dev/petsc/include
Libs: -L${libdir} -lpetsc
Libs.private: -L/home/jeremy/Dev/petsc/arch-cuda-mpich/lib -L/opt/cuda/lib -L/opt/cuda/lib/stubs -L/usr/lib/gcc/x86_64-pc-linux-gnu/14.2.1 -lHYPRE -ldmumps -lmumps_common -lpord -lpthread -lscalapack -llapack -lblas -lparmetis -lmetis -lexoIIv2for32 -lexodus -lcgns -lnetcdf -lpnetcdf -lhdf5_hl -lhdf5 -ltriangle -lm -lz -lctetgen -lcudart -lnvToolsExt -lcufft -lcublas -lcusparse -lcusolver -lcurand -lcuda -lX11 -lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi -lgfortran -lm -lgfortran -lm -lgcc_s -lquadmath -lstdc++prefix=/home/jeremy/Dev/petsc/arch-cuda-mpich
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${prefix}/lib
ccompiler=mpicc
cflags_extra=-fPIC -Wall -Wwrite-strings -Wno-unknown-pragmas -Wno-lto-type-mismatch -Wno-stringop-overflow -fstack-protector -fvisibility=hidden -O2 -march=native -ffp-contract=fast
cflags_dep=-MMD -MP
ldflag_rpath=-Wl,-rpath,
cxxcompiler=mpicxx
cxxflags_extra=-Wall -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wno-lto-type-mismatch -Wno-psabi -fstack-protector -fvisibility=hidden -O2 -march=native -ffp-contract=fast  -std=c++14 -fPIC
fcompiler=mpif90
fflags_extra=-fPIC -Wall -ffree-line-length-none -ffree-line-length-0 -Wno-lto-type-mismatch -Wno-unused-dummy-argument -g -O0
cudacompiler=nvcc
cudaflags_extra=-std=c++20 -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -O2 -arch=sm_89
cudalib=-Wl,-rpath,/opt/cuda/lib -L/opt/cuda/lib -L/opt/cuda/lib/stubs -lcudart -lnvToolsExt -lcufft -lcublas -lcusparse -lcusolver -lcurand -lcuda
cudainclude=-I/opt/cuda/include
cuda_cxx="/usr/bin"/g++-13
cuda_cxxflags=

Name: PETSc
Description: Library to solve ODEs and algebraic equations
Version: 3.22.99
Cflags:  -I${includedir} -I/home/jeremy/Dev/petsc/include
Libs: -L${libdir} -lpetsc
Libs.private: -L/home/jeremy/Dev/petsc/arch-cuda-mpich/lib -L/opt/cuda/lib -L/opt/cuda/lib/stubs -L/usr/lib/gcc/x86_64-pc-linux-gnu/14.2.1 -lHYPRE -ldmumps -lmumps_common -lpord -lpthread -lscalapack -llapack -lblas -lparmetis -lmetis -lexoIIv2for32 -lexodus -lcgns -lnetcdf -lpnetcdf -lhdf5_hl -lhdf5 -ltriangle -lm -lz -lctetgen -lcudart -lnvToolsExt -lcufft -lcublas -lcusparse -lcusolver -lcurand -lcuda -lX11 -lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi -lgfortran -lm -lgfortran -lm -lgcc_s -lquadmath -lstdc++
```