### PR TITLE
fix(bc): Correct PetscOptionsItems pointer status 

### DIFF
--- a/examples/fluids/include/bc_definition.h
+++ b/examples/fluids/include/bc_definition.h
@@ -34,7 +34,7 @@ struct _p_BCDefinition {
 **/
 #define PetscOptionsBCDefinition(opt, text, man, name, bc_def, set) \
   PetscOptionsBCDefinition_Private(PetscOptionsObject, opt, text, man, name, bc_def, set)
-PetscErrorCode PetscOptionsBCDefinition_Private(PetscOptionItems *PetscOptionsObject, const char opt[], const char text[], const char man[],
+PetscErrorCode PetscOptionsBCDefinition_Private(PetscOptionItems PetscOptionsObject, const char opt[], const char text[], const char man[],
                                                 const char name[], BCDefinition *bc_def, PetscBool *set);
 
 PetscErrorCode BCDefinitionCreate(const char *name, PetscInt num_label_values, PetscInt label_values[], BCDefinition *bc_def);

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -310,7 +310,7 @@ CEED_QFUNCTION(ICsStg)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSc
       for (CeedInt j = 0; j < 3; j++) u[j] = ubar[j];
     }
 
-    CeedScalar Y[5] = {P0, u[0], u[1], u[2], theta0}, q[5];
+    CeedScalar Y[5] = {P0, u[0], u[1], u[2], theta0}, q[5] = {0.};
     State      s    = StateFromY(gas, Y);
     StateToQ(gas, s, q, gas->state_var);
     for (CeedInt j = 0; j < 5; j++) {
@@ -508,7 +508,7 @@ CEED_QFUNCTION(StgShur14InflowStrongQF)(void *ctx, CeedInt Q, const CeedScalar *
       for (CeedInt j = 0; j < 3; j++) u[j] = ubar[j];
     }
 
-    CeedScalar Y[5] = {P0, u[0], u[1], u[2], theta0}, q[5];
+    CeedScalar Y[5] = {P0, u[0], u[1], u[2], theta0}, q[5] = {0.};
     State      s    = StateFromY(gas, Y);
     StateToQ(gas, s, q, gas->state_var);
     switch (gas->state_var) {

--- a/examples/fluids/qfunctions/stg_shur14.h
+++ b/examples/fluids/qfunctions/stg_shur14.h
@@ -311,7 +311,7 @@ CEED_QFUNCTION(ICsStg)(void *ctx, CeedInt Q, const CeedScalar *const *in, CeedSc
     }
 
     CeedScalar Y[5] = {P0, u[0], u[1], u[2], theta0}, q[5] = {0.};
-    State      s    = StateFromY(gas, Y);
+    State      s = StateFromY(gas, Y);
     StateToQ(gas, s, q, gas->state_var);
     for (CeedInt j = 0; j < 5; j++) {
       q0[j][i] = q[j];
@@ -509,7 +509,7 @@ CEED_QFUNCTION(StgShur14InflowStrongQF)(void *ctx, CeedInt Q, const CeedScalar *
     }
 
     CeedScalar Y[5] = {P0, u[0], u[1], u[2], theta0}, q[5] = {0.};
-    State      s    = StateFromY(gas, Y);
+    State      s = StateFromY(gas, Y);
     StateToQ(gas, s, q, gas->state_var);
     switch (gas->state_var) {
       case STATEVAR_CONSERVATIVE:

--- a/examples/fluids/src/bc_definition.c
+++ b/examples/fluids/src/bc_definition.c
@@ -91,7 +91,7 @@ PetscErrorCode BCDefinitionGetEssential(BCDefinition bc_def, PetscInt *num_essen
 #define LABEL_ARRAY_SIZE 256
 
 // @brief See `PetscOptionsBCDefinition`
-PetscErrorCode PetscOptionsBCDefinition_Private(PetscOptionItems *PetscOptionsObject, const char opt[], const char text[], const char man[],
+PetscErrorCode PetscOptionsBCDefinition_Private(PetscOptionItems PetscOptionsObject, const char opt[], const char text[], const char man[],
                                                 const char name[], BCDefinition *bc_def, PetscBool *set) {
   PetscInt num_label_values = LABEL_ARRAY_SIZE, label_values[LABEL_ARRAY_SIZE] = {0};
 

--- a/examples/fluids/src/misc.c
+++ b/examples/fluids/src/misc.c
@@ -95,6 +95,7 @@ PetscErrorCode DMPlexInsertBoundaryValues_FromICs(DM dm, PetscBool insert_essent
 
 static PetscErrorCode BinaryReadIntoInt(PetscViewer viewer, PetscInt *out, PetscDataType file_type) {
   PetscFunctionBeginUser;
+  *out = -13;  // appease the overzealous GCC compiler warning Gods
   if (file_type == PETSC_INT32) {
     PetscInt32 val;
     PetscCall(PetscViewerBinaryRead(viewer, &val, 1, NULL, PETSC_INT32));


### PR DESCRIPTION
PETSc !7517 changed PetscOptionsItems from a struct to a pointer to struct. This MR reflects that change.
This is obviously a breaking change.

HONEE MR: https://gitlab.com/phypid/honee/-/merge_requests/103