### PR TITLE
Add fallback compiler settings equivalent to gcc default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,9 @@ V ?= $(VERBOSE)
 AFLAGS ?= -fsanitize=address #-fsanitize=undefined -fno-omit-frame-pointer
 
 # Note: Intel oneAPI C/C++ compiler is now icx/icpx
-CC_VENDOR := $(firstword $(filter gcc (GCC) clang icc icc_orig oneAPI XL emcc,$(subst -, ,$(shell $(CC) --version))))
+CC_VENDOR := $(firstword $(filter gcc (GCC) clang cc icc icc_orig oneAPI XL emcc,$(subst -, ,$(shell $(CC) --version))))
 CC_VENDOR := $(subst (GCC),gcc,$(subst icc_orig,icc,$(CC_VENDOR)))
+CC_VENDOR := $(if $(filter cc,$(CC_VENDOR)),gcc,$(CC_VENDOR))
 FC_VENDOR := $(if $(FC),$(firstword $(filter GNU ifort ifx XL,$(shell $(FC) --version 2>&1 || $(FC) -qversion))))
 
 # Default extra flags by vendor


### PR DESCRIPTION
My ubuntu vended `/usr/bin/cc` fails in the vendor check because it's a wrapper of gcc:
```
/usr/bin/cc --version
cc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
resulting in flags not being set correctly. This PR adds a gcc-equivalent default for the relevant flags (given parsing `(` or `)` within Makefile is tricky, so can't search for just `Ubuntu`). These flags are then overridden for specific compilers when necessary. Should preserve the "only set if not explicitly set" behaviour and detects against any other wrappers around gcc-equivalent compilers. If a future compiler vendor needs to be supported, should just need another if branch.

Note: this was being encountered for libceed builds nested within Palace builds as part of a spack build (which was using `/usr/bin/cc`).

Before the change:
```
make VERBOSE=1
make: 'lib' with optional backends: /cpu/self/memcheck/serial /cpu/self/memcheck/blocked
/usr/bin/cc -I./include -O        -c -o build/interface/ceed-basis.o 
```
after the change:
```
make VERBOSE=1
make: 'lib' with optional backends: /cpu/self/memcheck/serial /cpu/self/memcheck/blocked /cpu/self/avx/serial /cpu/self/avx/blocked
/usr/bin/cc -I./include -O -march=native -g -ffp-contract=fast -fopenmp-simd -fPIC -std=c99 -Wall -Wextra -Wno-unused-parameter -MMD -MP    -c -o build/interface/ceed-basis.o
```