### PR TITLE
gen - unload module when destroying op

### DIFF
--- a/backends/cuda-gen/ceed-cuda-gen-operator.c
+++ b/backends/cuda-gen/ceed-cuda-gen-operator.c
@@ -27,6 +27,7 @@ static int CeedOperatorDestroy_Cuda_gen(CeedOperator op) {
 
   CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
   CeedCallBackend(CeedOperatorGetData(op, &impl));
+  if (impl->module) CeedCallCuda(ceed, cuModuleUnload(impl->module));
   if (impl->points.num_per_elem) CeedCallCuda(ceed, cudaFree((void **)impl->points.num_per_elem));
   CeedCallBackend(CeedFree(&impl));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/cuda-shared/ceed-cuda-shared.h
+++ b/backends/cuda-shared/ceed-cuda-shared.h
@@ -32,8 +32,6 @@ typedef struct {
   CeedScalar *d_collo_grad_1d;
   CeedScalar *d_q_weight_1d;
   CeedScalar *d_chebyshev_interp_1d;
-  CeedScalar *c_B;
-  CeedScalar *c_G;
   CeedInt     num_elem_at_points;
   CeedInt    *h_points_per_elem;
   CeedInt    *d_points_per_elem;

--- a/backends/hip-gen/ceed-hip-gen-operator.c
+++ b/backends/hip-gen/ceed-hip-gen-operator.c
@@ -25,6 +25,7 @@ static int CeedOperatorDestroy_Hip_gen(CeedOperator op) {
 
   CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
   CeedCallBackend(CeedOperatorGetData(op, &impl));
+  if (impl->module) CeedCallHip(ceed, hipModuleUnload(impl->module));
   if (impl->points.num_per_elem) CeedCallHip(ceed, hipFree((void **)impl->points.num_per_elem));
   CeedCallBackend(CeedFree(&impl));
   CeedCallBackend(CeedDestroy(&ceed));


### PR DESCRIPTION
Oops.... we never caught this before because we didn't typically have many OP to destroy in the middle of a simulation