### PR TITLE
Reset work vectors in operator setup to save memory

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -353,8 +353,16 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionDestroy(&rstr_i));
     }
   }
-
   CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
+  {
+    // Create two work vectors for diagonal assembly
+    CeedVector temp_1, temp_2;
+
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_1));
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_2));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_1));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_2));
+  }
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;
@@ -742,9 +750,16 @@ static int CeedOperatorSetupAtPoints_Cuda(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionDestroy(&rstr_i));
     }
   }
-
   CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
+  {
+    // Create two work vectors for diagonal assembly
+    CeedVector temp_1, temp_2;
 
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_1));
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_2));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_1));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_2));
+  }
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -353,6 +353,8 @@ static int CeedOperatorSetup_Cuda(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionDestroy(&rstr_i));
     }
   }
+
+  CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;
@@ -740,6 +742,9 @@ static int CeedOperatorSetupAtPoints_Cuda(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionDestroy(&rstr_i));
     }
   }
+
+  CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
+
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -352,6 +352,7 @@ static int CeedOperatorSetup_Hip(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionDestroy(&rstr_i));
     }
   }
+  CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;
@@ -738,6 +739,7 @@ static int CeedOperatorSetupAtPoints_Hip(CeedOperator op) {
       CeedCallBackend(CeedElemRestrictionDestroy(&rstr_i));
     }
   }
+  CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -353,6 +353,15 @@ static int CeedOperatorSetup_Hip(CeedOperator op) {
     }
   }
   CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
+  {
+    // Create two work vectors for diagonal assembly
+    CeedVector temp_1, temp_2;
+
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_1));
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_2));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_1));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_2));
+  }
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;
@@ -740,6 +749,15 @@ static int CeedOperatorSetupAtPoints_Hip(CeedOperator op) {
     }
   }
   CeedCallBackend(CeedClearWorkVectors(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len));
+  {
+    // Create two work vectors for diagonal assembly
+    CeedVector temp_1, temp_2;
+
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_1));
+    CeedCallBackend(CeedGetWorkVector(CeedOperatorReturnCeed(op), impl->max_active_e_vec_len, &temp_2));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_1));
+    CeedCallBackend(CeedRestoreWorkVector(CeedOperatorReturnCeed(op), &temp_2));
+  }
   CeedCallBackend(CeedOperatorSetSetupDone(op));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
   return CEED_ERROR_SUCCESS;

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -256,6 +256,7 @@ CEED_EXTERN int CeedSetData(Ceed ceed, void *data);
 CEED_EXTERN int CeedReference(Ceed ceed);
 CEED_EXTERN int CeedGetWorkVector(Ceed ceed, CeedSize len, CeedVector *vec);
 CEED_EXTERN int CeedRestoreWorkVector(Ceed ceed, CeedVector *vec);
+CEED_EXTERN int CeedClearWorkVectors(Ceed ceed, CeedSize min_len);
 CEED_EXTERN int CeedGetJitSourceRoots(Ceed ceed, CeedInt *num_source_roots, const char ***jit_source_roots);
 CEED_EXTERN int CeedRestoreJitSourceRoots(Ceed ceed, const char ***jit_source_roots);
 CEED_EXTERN int CeedGetJitDefines(Ceed ceed, CeedInt *num_defines, const char ***jit_defines);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -257,6 +257,7 @@ CEED_EXTERN int CeedReference(Ceed ceed);
 CEED_EXTERN int CeedGetWorkVector(Ceed ceed, CeedSize len, CeedVector *vec);
 CEED_EXTERN int CeedRestoreWorkVector(Ceed ceed, CeedVector *vec);
 CEED_EXTERN int CeedClearWorkVectors(Ceed ceed, CeedSize min_len);
+CEED_EXTERN int CeedGetWorkVectorMemoryUsage(Ceed ceed, CeedScalar *usage_mb);
 CEED_EXTERN int CeedGetJitSourceRoots(Ceed ceed, CeedInt *num_source_roots, const char ***jit_source_roots);
 CEED_EXTERN int CeedRestoreJitSourceRoots(Ceed ceed, const char ***jit_source_roots);
 CEED_EXTERN int CeedGetJitDefines(Ceed ceed, CeedInt *num_defines, const char ***jit_defines);

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -818,6 +818,63 @@ int CeedReference(Ceed ceed) {
 }
 
 /**
+  @brief Computes the current memory usage of the work vectors in a `Ceed` context and prints to debug.abort
+
+  @param[in] ceed `Ceed` context
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Developer
+**/
+static int CeedViewWorkVectorMemoryUsage(Ceed ceed) {
+  CeedScalar work_len = 0.;
+
+  if (ceed->work_vectors) {
+    for (CeedInt i = 0; i < ceed->work_vectors->num_vecs; i++) {
+      CeedSize vec_len;
+      CeedCall(CeedVectorGetLength(ceed->work_vectors->vecs[i], &vec_len));
+      work_len += vec_len;
+    }
+    work_len *= sizeof(CeedScalar) * 1e-6;
+    CeedDebug(ceed, "Resource {%s} Work Vectors Memory Usage: %" CeedInt_FMT " vectors, %g MB\n", ceed->resource, ceed->work_vectors->num_vecs,
+              work_len);
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Clear inactive work vectors in a `Ceed` context below a minimum length.
+
+  @param[in,out] ceed    `Ceed` context
+  @param[in]     min_len Minimum length of work vector to keep
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedClearWorkVectors(Ceed ceed, CeedSize min_len) {
+  if (!ceed->work_vectors) return CEED_ERROR_SUCCESS;
+  for (CeedInt i = 0; i < ceed->work_vectors->num_vecs; i++) {
+    if (ceed->work_vectors->is_in_use[i]) continue;
+    CeedSize vec_len;
+    CeedCall(CeedVectorGetLength(ceed->work_vectors->vecs[i], &vec_len));
+    if (vec_len < min_len) {
+      ceed->ref_count += 2;  // Note: increase ref_count to prevent Ceed destructor from triggering again
+      CeedCall(CeedVectorDestroy(&ceed->work_vectors->vecs[i]));
+      ceed->ref_count -= 1;  // Note: restore ref_count
+      ceed->work_vectors->num_vecs--;
+      if (ceed->work_vectors->num_vecs > 0) {
+        ceed->work_vectors->vecs[i]                                 = ceed->work_vectors->vecs[ceed->work_vectors->num_vecs];
+        ceed->work_vectors->is_in_use[i]                            = ceed->work_vectors->is_in_use[ceed->work_vectors->num_vecs];
+        ceed->work_vectors->is_in_use[ceed->work_vectors->num_vecs] = false;
+        i--;
+      }
+    }
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Get a `CeedVector` for scratch work from a `Ceed` context.
 
   Note: This vector must be restored with @ref CeedRestoreWorkVector().
@@ -858,6 +915,7 @@ int CeedGetWorkVector(Ceed ceed, CeedSize len, CeedVector *vec) {
     ceed->work_vectors->num_vecs++;
     CeedCallBackend(CeedVectorCreate(ceed, len, &ceed->work_vectors->vecs[i]));
     ceed->ref_count--;  // Note: ref_count manipulation to prevent a ref-loop
+    if (ceed->is_debug) CeedViewWorkVectorMemoryUsage(ceed);
   }
   // Return pointer to work vector
   ceed->work_vectors->is_in_use[i] = true;

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -858,7 +858,7 @@ int CeedClearWorkVectors(Ceed ceed, CeedSize min_len) {
     CeedSize vec_len;
     CeedCall(CeedVectorGetLength(ceed->work_vectors->vecs[i], &vec_len));
     if (vec_len < min_len) {
-      ceed->ref_count += 2;  // Note: increase ref_count to prevent Ceed destructor from triggering again
+      ceed->ref_count += 2;  // Note: increase ref_count to prevent Ceed destructor from triggering
       CeedCall(CeedVectorDestroy(&ceed->work_vectors->vecs[i]));
       ceed->ref_count -= 1;  // Note: restore ref_count
       ceed->work_vectors->num_vecs--;

--- a/tests/t131-vector.c
+++ b/tests/t131-vector.c
@@ -1,0 +1,58 @@
+/// @file
+/// Test clearing work vectors
+/// \test Test clearing work vectors
+
+#include <ceed.h>
+#include <ceed/backend.h>
+#include <math.h>
+#include <stdio.h>
+
+static CeedScalar expected_usage(CeedSize length) { return length * sizeof(CeedScalar) * 1e-6; }
+
+int main(int argc, char **argv) {
+  Ceed       ceed;
+  CeedVector x, y, z;
+  CeedScalar usage_mb;
+
+  CeedInit(argv[1], &ceed);
+
+  // Add work vectors of different lengths
+  CeedGetWorkVector(ceed, 10, &x);
+  CeedGetWorkVector(ceed, 20, &y);
+  CeedGetWorkVector(ceed, 30, &z);
+
+  // Check memory usage, should be 60 * sizeof(CeedScalar)
+  CeedGetWorkVectorMemoryUsage(ceed, &usage_mb);
+  if (fabs(usage_mb - expected_usage(60)) > 100. * CEED_EPSILON) printf("Wrong usage: %0.8g MB != %0.8g MB\n", usage_mb, expected_usage(60));
+
+  // Restore x and z
+  CeedRestoreWorkVector(ceed, &x);
+  CeedRestoreWorkVector(ceed, &z);
+
+  // Clear work vectors with length < 30. This should:
+  //  - Remove x
+  //  - Leave y, since it is still in use
+  //  - Leave z, since it is length 30
+  CeedClearWorkVectors(ceed, 30);
+  CeedGetWorkVectorMemoryUsage(ceed, &usage_mb);
+  if (fabs(usage_mb - expected_usage(50)) > 100. * CEED_EPSILON) printf("Wrong usage: %0.8g MB != %0.8g MB\n", usage_mb, expected_usage(50));
+
+  // Clear work vectors with length < 31. This should:
+  //  - Leave y, since it is still in use
+  //  - Remove z
+  CeedClearWorkVectors(ceed, 31);
+  CeedGetWorkVectorMemoryUsage(ceed, &usage_mb);
+  if (fabs(usage_mb - expected_usage(20)) > 100. * CEED_EPSILON) printf("Wrong usage: %0.8g MB != %0.8g MB\n", usage_mb, expected_usage(20));
+
+  // Restore y
+  CeedRestoreWorkVector(ceed, &y);
+
+  // Make sure we can still get back y without allocating a new work vector
+  CeedGetWorkVector(ceed, 20, &y);
+  CeedGetWorkVectorMemoryUsage(ceed, &usage_mb);
+  if (fabs(usage_mb - expected_usage(20)) > 100. * CEED_EPSILON) printf("Wrong usage: %0.8g MB != %0.8g MB\n", usage_mb, expected_usage(20));
+  CeedRestoreWorkVector(ceed, &y);
+
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
This should only matter for situations where many operators are created throughout a single execution. Prior to this change, minor increases in max vector length would lead to a growing cache of unused work vectors. 

Also, adds a utility to log current work vector usage when new vectors are allocated when in debug mode.