### PR TITLE
rust - re-export libceed-sys features through libceed to allow building non-static without using libceed-sys directly

### DIFF
--- a/doc/sphinx/source/CHANGELOG.md
+++ b/doc/sphinx/source/CHANGELOG.md
@@ -17,6 +17,8 @@ On this page we provide a summary of the main API changes, new features and exam
 - Require use of `Ceed*Destroy()` on Ceed objects returned from `Ceed*Get*()`.
 - Rename `CeedCompositeOperatorCreate()` to `CeedOperatorCreateComposite()` for uniformity.
 - Rename `CeedCompositeOperator*()` to `CeedOperatorComposite*()` for uniformity.
+- Rust `libceed` crate: add features `shared` and `system`.
+- Rust `libceed-sys` crate: feature `static` (default) with `shared` (not default).
 
 ### New features
 

--- a/rust/libceed-sys/Cargo.toml
+++ b/rust/libceed-sys/Cargo.toml
@@ -25,8 +25,7 @@ include = [
 ]
 
 [features]
-default = ["static"]
-static = []
+shared = []
 system = []
 
 [build-dependencies]

--- a/rust/libceed-sys/build.rs
+++ b/rust/libceed-sys/build.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 fn main() {
     let out_dir = PathBuf::from(env("OUT_DIR").unwrap());
-    let statik = env("CARGO_FEATURE_STATIC").is_some();
+    let shared = env("CARGO_FEATURE_SHARED").is_some();
     let system = env("CARGO_FEATURE_SYSTEM").is_some();
 
     let ceed_pc = if system {
@@ -32,7 +32,7 @@ fn main() {
         if optflags.len() > 0 {
             make.env("OPT", optflags);
         }
-        if statik {
+        if !shared {
             make.arg("STATIC=1");
         }
         run(&mut make);
@@ -44,7 +44,7 @@ fn main() {
             .into_owned()
     };
     pkg_config::Config::new()
-        .statik(statik)
+        .statik(!shared)
         .atleast_version("0.12.0")
         .probe(&ceed_pc)
         .unwrap();

--- a/rust/libceed/Cargo.toml
+++ b/rust/libceed/Cargo.toml
@@ -25,8 +25,7 @@ katexit = { version = "0.1.1", optional = true }
 version-sync = "0.9.2"
 
 [features]
-default = ["static"]
-static = ["libceed-sys/static"]
+shared = ["libceed-sys/shared"]
 system = ["libceed-sys/system"]
 
 [package.metadata.docs.rs]

--- a/rust/libceed/Cargo.toml
+++ b/rust/libceed/Cargo.toml
@@ -18,11 +18,16 @@ keywords = ["libceed", "exascale", "high-order"]
 categories = ["science"]
 
 [dependencies]
-libceed-sys = { version = "0.12", path = "../libceed-sys" }
+libceed-sys = { version = "0.12", path = "../libceed-sys", default-features = false}
 katexit = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.2"
+
+[features]
+default = ["static"]
+static = ["libceed-sys/static"]
+system = ["libceed-sys/system"]
 
 [package.metadata.docs.rs]
 features = ["katexit"]


### PR DESCRIPTION
Fix #1694 

I will note that there is nothing wrong with depending on `libceed-sys` directly to set the feature at that level, so I don't think this is a necessary change, just a convenience.

Thanks-to: @eliasboegel