### PR TITLE
SYCL backend updates for latest oneAPI release/2025.0.5

### DIFF
--- a/backends/sycl/ceed-sycl-common.sycl.cpp
+++ b/backends/sycl/ceed-sycl-common.sycl.cpp
@@ -9,6 +9,7 @@
 #include "ceed-sycl-common.hpp"
 
 #include <string>
+#include <sstream>
 #include <sycl/sycl.hpp>
 
 //------------------------------------------------------------------------------

--- a/backends/sycl/ceed-sycl-common.sycl.cpp
+++ b/backends/sycl/ceed-sycl-common.sycl.cpp
@@ -8,8 +8,8 @@
 
 #include "ceed-sycl-common.hpp"
 
-#include <string>
 #include <sstream>
+#include <string>
 #include <sycl/sycl.hpp>
 
 //------------------------------------------------------------------------------

--- a/backends/sycl/online_compiler.hpp
+++ b/backends/sycl/online_compiler.hpp
@@ -63,7 +63,7 @@ class device_arch {
 class online_compile_error : public sycl::exception {
  public:
   online_compile_error() = default;
-  online_compile_error(const std::string &Msg) : sycl::exception(Msg) {}
+  online_compile_error(const std::string &Msg) : sycl::exception(std::error_code(), Msg) {}
 };
 
 /// Designates a source language for the online compiler.

--- a/backends/sycl/online_compiler.hpp
+++ b/backends/sycl/online_compiler.hpp
@@ -63,7 +63,7 @@ class device_arch {
 class online_compile_error : public sycl::exception {
  public:
   online_compile_error() = default;
-  online_compile_error(const std::string &Msg) : sycl::exception(std::error_code(), Msg) {}
+  online_compile_error(const std::string &Msg) : sycl::exception(make_error_code(errc::invalid), Msg) {}
 };
 
 /// Designates a source language for the online compiler.


### PR DESCRIPTION
There are a few minor updates needed to compile with the latest oneAPI version release/2025.0.5