### PR TITLE
test - fix path to stay in folder

### DIFF
--- a/tests/t406-qfunction.h
+++ b/tests/t406-qfunction.h
@@ -19,7 +19,7 @@
 // Also test include path with "/../"
 #include "../tests/t406-qfunction-helper.h"
 // Also test include path with "/../../"
-#include "../../libCEED/tests/t406-qfunction-helper.h"
+#include "output/../../tests/t406-qfunction-helper.h"
 #  include "t406-qfunction-scales.h"
 // clang-format on
 


### PR DESCRIPTION
Fixes #1705

We've seen this  a couple of times and it was just a bad idea on my part to assume the folder name