### PR TITLE
Clarify __syncthreads usage

### DIFF
--- a/include/ceed/jit-source/cuda/cuda-gen-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-gen-templates.h
@@ -274,6 +274,7 @@ inline __device__ void GradColloSlice3d(SharedData_Cuda &data, const CeedInt q, 
                                         CeedScalar *__restrict__ r_V) {
   if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) {
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+      __syncthreads();
       data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[q + comp * Q_1D];
       __syncthreads();
       // X derivative
@@ -291,7 +292,6 @@ inline __device__ void GradColloSlice3d(SharedData_Cuda &data, const CeedInt q, 
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[comp + 2 * NUM_COMP] += c_G[i + q * Q_1D] * r_U[i + comp * Q_1D];
       }
-      __syncthreads();
     }
   }
 }
@@ -304,20 +304,20 @@ inline __device__ void GradColloSliceTranspose3d(SharedData_Cuda &data, const Ce
                                                  CeedScalar *__restrict__ r_V) {
   if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) {
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+      __syncthreads();
       data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 0 * NUM_COMP];
       __syncthreads();
       // X derivative
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[q + comp * Q_1D] += c_G[data.t_id_x + i * Q_1D] * data.slice[i + data.t_id_y * T_1D];
       }
-      __syncthreads();
       // Y derivative
+      __syncthreads();
       data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 1 * NUM_COMP];
       __syncthreads();
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[q + comp * Q_1D] += c_G[data.t_id_y + i * Q_1D] * data.slice[data.t_id_x + i * T_1D];
       }
-      __syncthreads();
       // Z derivative
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[i + comp * Q_1D] += c_G[i + q * Q_1D] * r_U[comp + 2 * NUM_COMP];

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-at-points-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-at-points-templates.h
@@ -95,6 +95,7 @@ inline __device__ void GradAtPoints1d(SharedData_Cuda &data, const CeedInt p, co
   for (CeedInt i = 0; i < NUM_COMP; i++) r_V[i] = 0.0;
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
     // Load coefficients
+    __syncthreads();
     if (data.t_id_x < Q_1D) data.slice[data.t_id_x] = r_C[comp];
     __syncthreads();
     // Contract x direction
@@ -145,6 +146,7 @@ inline __device__ void InterpAtPoints2d(SharedData_Cuda &data, const CeedInt p, 
     CeedScalar chebyshev_x[Q_1D];
 
     // Load coefficients
+    __syncthreads();
     if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[comp];
     __syncthreads();
     // Contract x direction
@@ -213,6 +215,7 @@ inline __device__ void GradAtPoints2d(SharedData_Cuda &data, const CeedInt p, co
     CeedScalar chebyshev_x[Q_1D];
 
     // Load coefficients
+    __syncthreads();
     if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[comp];
     __syncthreads();
     for (CeedInt dim = 0; dim < 2; dim++) {
@@ -294,6 +297,7 @@ inline __device__ void InterpAtPoints3d(SharedData_Cuda &data, const CeedInt p, 
       CeedScalar chebyshev_x[Q_1D];
 
       // Load coefficients
+      __syncthreads();
       if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[k + comp * Q_1D];
       __syncthreads();
       // Contract x direction
@@ -372,6 +376,7 @@ inline __device__ void GradAtPoints3d(SharedData_Cuda &data, const CeedInt p, co
       CeedScalar chebyshev_x[Q_1D];
 
       // Load coefficients
+      __syncthreads();
       if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[k + comp * Q_1D];
       __syncthreads();
       for (CeedInt dim = 0; dim < 3; dim++) {

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-at-points.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-at-points.h
@@ -129,7 +129,6 @@ extern "C" __global__ void InterpTransposeAtPoints(const CeedInt num_elem, const
         InterpTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {
@@ -189,7 +188,6 @@ extern "C" __global__ void InterpTransposeAddAtPoints(const CeedInt num_elem, co
         InterpTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {
@@ -319,7 +317,6 @@ extern "C" __global__ void GradTransposeAtPoints(const CeedInt num_elem, const C
         GradTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {
@@ -380,7 +377,6 @@ extern "C" __global__ void GradTransposeAddAtPoints(const CeedInt num_elem, cons
         GradTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-flattened-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-flattened-templates.h
@@ -19,6 +19,7 @@
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractX2dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const CeedScalar *U, const CeedScalar *B,
                                             CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -27,7 +28,6 @@ inline __device__ void ContractX2dFlattened(SharedData_Cuda &data, const int t_i
       *V += B[i + t_id_x * P_1D] * data.slice[i + t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -36,6 +36,7 @@ inline __device__ void ContractX2dFlattened(SharedData_Cuda &data, const int t_i
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractY2dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const CeedScalar *U, const CeedScalar *B,
                                             CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -44,7 +45,6 @@ inline __device__ void ContractY2dFlattened(SharedData_Cuda &data, const int t_i
       *V += B[i + t_id_y * P_1D] * data.slice[t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -53,6 +53,7 @@ inline __device__ void ContractY2dFlattened(SharedData_Cuda &data, const int t_i
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeY2dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -61,7 +62,6 @@ inline __device__ void ContractTransposeY2dFlattened(SharedData_Cuda &data, cons
       *V += B[t_id_y + i * P_1D] * data.slice[t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -70,6 +70,7 @@ inline __device__ void ContractTransposeY2dFlattened(SharedData_Cuda &data, cons
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeX2dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -78,7 +79,6 @@ inline __device__ void ContractTransposeX2dFlattened(SharedData_Cuda &data, cons
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -87,6 +87,7 @@ inline __device__ void ContractTransposeX2dFlattened(SharedData_Cuda &data, cons
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddX2dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const CeedScalar *U,
                                                         const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   if (t_id_x < P_1D && t_id_y < P_1D) {
@@ -94,7 +95,6 @@ inline __device__ void ContractTransposeAddX2dFlattened(SharedData_Cuda &data, c
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -105,10 +105,10 @@ inline __device__ void QPack2d(SharedData_Cuda &data, const int t_id_x, const in
   const CeedInt new_t_id_x = data.t_id_x % Q_1D, new_t_id_y = data.t_id_x / Q_1D;
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (t_id_x < Q_1D && t_id_y < Q_1D) data.slice[t_id_x + t_id_y * T_1D] = U[comp];
     __syncthreads();
     U[comp] = data.t_id_x < (Q_1D * Q_1D) ? data.slice[new_t_id_x + new_t_id_y * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 
@@ -117,10 +117,10 @@ inline __device__ void QUnpack2d(SharedData_Cuda &data, const int t_id_x, const 
   const CeedInt old_t_id_x = data.t_id_x % Q_1D, old_t_id_y = data.t_id_x / Q_1D;
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (data.t_id_x < (Q_1D * Q_1D)) data.slice[old_t_id_x + old_t_id_y * T_1D] = U[comp];
     __syncthreads();
     U[comp] = (t_id_x < Q_1D && t_id_y < Q_1D) ? data.slice[t_id_x + t_id_y * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 
@@ -218,6 +218,7 @@ inline __device__ void WeightTensor2dFlattened(SharedData_Cuda &data, const Ceed
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractX3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                             const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -226,7 +227,6 @@ inline __device__ void ContractX3dFlattened(SharedData_Cuda &data, const int t_i
       *V += B[i + t_id_x * P_1D] * data.slice[i + t_id_y * T_1D + t_id_z * T_1D * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -235,6 +235,7 @@ inline __device__ void ContractX3dFlattened(SharedData_Cuda &data, const int t_i
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractY3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                             const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -243,7 +244,6 @@ inline __device__ void ContractY3dFlattened(SharedData_Cuda &data, const int t_i
       *V += B[i + t_id_y * P_1D] * data.slice[t_id_x + i * T_1D + t_id_z * T_1D * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -252,6 +252,7 @@ inline __device__ void ContractY3dFlattened(SharedData_Cuda &data, const int t_i
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractZ3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                             const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -260,7 +261,6 @@ inline __device__ void ContractZ3dFlattened(SharedData_Cuda &data, const int t_i
       *V += B[i + t_id_z * P_1D] * data.slice[t_id_x + t_id_y * T_1D + i * T_1D * T_1D];  // Contract z direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -269,6 +269,7 @@ inline __device__ void ContractZ3dFlattened(SharedData_Cuda &data, const int t_i
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeZ3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -277,7 +278,6 @@ inline __device__ void ContractTransposeZ3dFlattened(SharedData_Cuda &data, cons
       *V += B[t_id_z + i * P_1D] * data.slice[t_id_x + t_id_y * T_1D + i * T_1D * T_1D];  // Contract z direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -286,6 +286,7 @@ inline __device__ void ContractTransposeZ3dFlattened(SharedData_Cuda &data, cons
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddZ3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z,
                                                         const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   if (t_id_x < Q_1D && t_id_y < Q_1D && t_id_z < P_1D) {
@@ -293,7 +294,6 @@ inline __device__ void ContractTransposeAddZ3dFlattened(SharedData_Cuda &data, c
       *V += B[t_id_z + i * P_1D] * data.slice[t_id_x + t_id_y * T_1D + i * T_1D * T_1D];  // Contract z direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -302,6 +302,7 @@ inline __device__ void ContractTransposeAddZ3dFlattened(SharedData_Cuda &data, c
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeY3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -310,7 +311,6 @@ inline __device__ void ContractTransposeY3dFlattened(SharedData_Cuda &data, cons
       *V += B[t_id_y + i * P_1D] * data.slice[t_id_x + i * T_1D + t_id_z * T_1D * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -319,6 +319,7 @@ inline __device__ void ContractTransposeY3dFlattened(SharedData_Cuda &data, cons
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddY3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z,
                                                         const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   if (t_id_x < Q_1D && t_id_y < P_1D && t_id_z < P_1D) {
@@ -326,7 +327,6 @@ inline __device__ void ContractTransposeAddY3dFlattened(SharedData_Cuda &data, c
       *V += B[t_id_y + i * P_1D] * data.slice[t_id_x + i * T_1D + t_id_z * T_1D * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -335,6 +335,7 @@ inline __device__ void ContractTransposeAddY3dFlattened(SharedData_Cuda &data, c
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeX3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -343,7 +344,6 @@ inline __device__ void ContractTransposeX3dFlattened(SharedData_Cuda &data, cons
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D + t_id_z * T_1D * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -352,6 +352,7 @@ inline __device__ void ContractTransposeX3dFlattened(SharedData_Cuda &data, cons
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddX3dFlattened(SharedData_Cuda &data, const int t_id_x, const int t_id_y, const int t_id_z,
                                                         const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   if (t_id_x < P_1D && t_id_y < P_1D && t_id_z < P_1D) {
@@ -359,7 +360,6 @@ inline __device__ void ContractTransposeAddX3dFlattened(SharedData_Cuda &data, c
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D + t_id_z * T_1D * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -370,10 +370,10 @@ inline __device__ void QPack3d(SharedData_Cuda &data, const int t_id_x, const in
   const CeedInt new_t_id_x = data.t_id_x % Q_1D, new_t_id_y = (data.t_id_x / Q_1D) % Q_1D, new_t_id_z = data.t_id_x / (Q_1D * Q_1D);
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (t_id_x < Q_1D && t_id_y < Q_1D) data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = U[comp];
     __syncthreads();
     U[comp] = data.t_id_x < (Q_1D * Q_1D * Q_1D) ? data.slice[new_t_id_x + new_t_id_y * T_1D + new_t_id_z * T_1D * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 
@@ -382,10 +382,10 @@ inline __device__ void QUnpack3d(SharedData_Cuda &data, const int t_id_x, const 
   const CeedInt old_t_id_x = data.t_id_x % Q_1D, old_t_id_y = (data.t_id_x / Q_1D) % Q_1D, old_t_id_z = data.t_id_x / (Q_1D * Q_1D);
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (data.t_id_x < Q_1D * Q_1D * Q_1D) data.slice[old_t_id_x + old_t_id_y * T_1D + old_t_id_z * T_1D * T_1D] = U[comp];
     __syncthreads();
     U[comp] = (t_id_x < Q_1D && t_id_y < Q_1D) ? data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 

--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-templates.h
@@ -18,6 +18,7 @@
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D>
 inline __device__ void ContractX1d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x] = *U;
   __syncthreads();
   *V = 0.0;
@@ -26,7 +27,6 @@ inline __device__ void ContractX1d(SharedData_Cuda &data, const CeedScalar *U, c
       *V += B[i + data.t_id_x * P_1D] * data.slice[i];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -34,6 +34,7 @@ inline __device__ void ContractX1d(SharedData_Cuda &data, const CeedScalar *U, c
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D>
 inline __device__ void ContractTransposeX1d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x] = *U;
   __syncthreads();
   *V = 0.0;
@@ -42,7 +43,6 @@ inline __device__ void ContractTransposeX1d(SharedData_Cuda &data, const CeedSca
       *V += B[data.t_id_x + i * P_1D] * data.slice[i];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -105,6 +105,7 @@ inline __device__ void Weight1d(SharedData_Cuda &data, const CeedScalar *__restr
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractX2d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -113,7 +114,6 @@ inline __device__ void ContractX2d(SharedData_Cuda &data, const CeedScalar *U, c
       *V += B[i + data.t_id_x * P_1D] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -121,6 +121,7 @@ inline __device__ void ContractX2d(SharedData_Cuda &data, const CeedScalar *U, c
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractY2d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -129,7 +130,6 @@ inline __device__ void ContractY2d(SharedData_Cuda &data, const CeedScalar *U, c
       *V += B[i + data.t_id_y * P_1D] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -137,6 +137,7 @@ inline __device__ void ContractY2d(SharedData_Cuda &data, const CeedScalar *U, c
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeY2d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -145,7 +146,6 @@ inline __device__ void ContractTransposeY2d(SharedData_Cuda &data, const CeedSca
       *V += B[data.t_id_y + i * P_1D] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -153,6 +153,7 @@ inline __device__ void ContractTransposeY2d(SharedData_Cuda &data, const CeedSca
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeX2d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -161,7 +162,6 @@ inline __device__ void ContractTransposeX2d(SharedData_Cuda &data, const CeedSca
       *V += B[data.t_id_x + i * P_1D] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -169,6 +169,7 @@ inline __device__ void ContractTransposeX2d(SharedData_Cuda &data, const CeedSca
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddX2d(SharedData_Cuda &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   if (data.t_id_x < P_1D && data.t_id_y < P_1D) {
@@ -176,7 +177,6 @@ inline __device__ void ContractTransposeAddX2d(SharedData_Cuda &data, const Ceed
       *V += B[data.t_id_x + i * P_1D] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -258,6 +258,7 @@ inline __device__ void ContractX3d(SharedData_Cuda &data, const CeedScalar *U, c
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -266,7 +267,6 @@ inline __device__ void ContractX3d(SharedData_Cuda &data, const CeedScalar *U, c
         V[k] += r_B[i] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -281,6 +281,7 @@ inline __device__ void ContractY3d(SharedData_Cuda &data, const CeedScalar *U, c
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -289,7 +290,6 @@ inline __device__ void ContractY3d(SharedData_Cuda &data, const CeedScalar *U, c
         V[k] += r_B[i] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -334,6 +334,7 @@ inline __device__ void ContractTransposeY3d(SharedData_Cuda &data, const CeedSca
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -342,7 +343,6 @@ inline __device__ void ContractTransposeY3d(SharedData_Cuda &data, const CeedSca
         V[k] += r_B[i] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -357,6 +357,7 @@ inline __device__ void ContractTransposeAddY3d(SharedData_Cuda &data, const Ceed
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     if (data.t_id_x < Q_1D && data.t_id_y < P_1D) {
@@ -364,7 +365,6 @@ inline __device__ void ContractTransposeAddY3d(SharedData_Cuda &data, const Ceed
         V[k] += r_B[i] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -379,6 +379,7 @@ inline __device__ void ContractTransposeX3d(SharedData_Cuda &data, const CeedSca
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -387,7 +388,6 @@ inline __device__ void ContractTransposeX3d(SharedData_Cuda &data, const CeedSca
         V[k] += r_B[i] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -402,6 +402,7 @@ inline __device__ void ContractTransposeAddX3d(SharedData_Cuda &data, const Ceed
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     if (data.t_id_x < P_1D && data.t_id_y < P_1D) {
@@ -409,7 +410,6 @@ inline __device__ void ContractTransposeAddX3d(SharedData_Cuda &data, const Ceed
         V[k] += r_B[i] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
       }
     }
-    __syncthreads();
   }
 }
 

--- a/include/ceed/jit-source/hip/hip-gen-templates.h
+++ b/include/ceed/jit-source/hip/hip-gen-templates.h
@@ -271,6 +271,7 @@ inline __device__ void GradColloSlice3d(SharedData_Hip &data, const CeedInt q, c
                                         CeedScalar *__restrict__ r_V) {
   if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) {
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+      __syncthreads();
       data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[q + comp * Q_1D];
       __syncthreads();
       // X derivative
@@ -288,7 +289,6 @@ inline __device__ void GradColloSlice3d(SharedData_Hip &data, const CeedInt q, c
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[comp + 2 * NUM_COMP] += c_G[i + q * Q_1D] * r_U[i + comp * Q_1D];
       }
-      __syncthreads();
     }
   }
 }
@@ -302,19 +302,19 @@ inline __device__ void GradColloSliceTranspose3d(SharedData_Hip &data, const Cee
   if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) {
     for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
       // X derivative
+      __syncthreads();
       data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 0 * NUM_COMP];
       __syncthreads();
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[q + comp * Q_1D] += c_G[data.t_id_x + i * Q_1D] * data.slice[i + data.t_id_y * T_1D];
       }
-      __syncthreads();
       // Y derivative
+      __syncthreads();
       data.slice[data.t_id_x + data.t_id_y * T_1D] = r_U[comp + 1 * NUM_COMP];
       __syncthreads();
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[q + comp * Q_1D] += c_G[data.t_id_y + i * Q_1D] * data.slice[data.t_id_x + i * T_1D];
       }
-      __syncthreads();
       // Z derivative
       for (CeedInt i = 0; i < Q_1D; i++) {
         r_V[i + comp * Q_1D] += c_G[i + q * Q_1D] * r_U[comp + 2 * NUM_COMP];

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor-at-points-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor-at-points-templates.h
@@ -49,6 +49,7 @@ inline __device__ void InterpAtPoints1d(SharedData_Hip &data, const CeedInt p, c
   ChebyshevPolynomialsAtPoint<Q_1D>(r_X[0], chebyshev_x);
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
     // Load coefficients
+    __syncthreads();
     if (data.t_id_x < Q_1D) data.slice[data.t_id_x] = r_C[comp];
     __syncthreads();
     // Contract x direction
@@ -94,6 +95,7 @@ inline __device__ void GradAtPoints1d(SharedData_Hip &data, const CeedInt p, con
   ChebyshevDerivativeAtPoint<Q_1D>(r_X[0], chebyshev_x);
   for (CeedInt i = 0; i < NUM_COMP; i++) r_V[i] = 0.0;
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     // Load coefficients
     if (data.t_id_x < Q_1D) data.slice[data.t_id_x] = r_C[comp];
     __syncthreads();
@@ -145,6 +147,7 @@ inline __device__ void InterpAtPoints2d(SharedData_Hip &data, const CeedInt p, c
     CeedScalar chebyshev_x[Q_1D];
 
     // Load coefficients
+    __syncthreads();
     if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[comp];
     __syncthreads();
     // Contract x direction
@@ -213,6 +216,7 @@ inline __device__ void GradAtPoints2d(SharedData_Hip &data, const CeedInt p, con
     CeedScalar chebyshev_x[Q_1D];
 
     // Load coefficients
+    __syncthreads();
     if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[comp];
     __syncthreads();
     for (CeedInt dim = 0; dim < 2; dim++) {
@@ -294,6 +298,7 @@ inline __device__ void InterpAtPoints3d(SharedData_Hip &data, const CeedInt p, c
       CeedScalar chebyshev_x[Q_1D];
 
       // Load coefficients
+      __syncthreads();
       if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[k + comp * Q_1D];
       __syncthreads();
       // Contract x direction
@@ -372,6 +377,7 @@ inline __device__ void GradAtPoints3d(SharedData_Hip &data, const CeedInt p, con
       CeedScalar chebyshev_x[Q_1D];
 
       // Load coefficients
+      __syncthreads();
       if (data.t_id_x < Q_1D && data.t_id_y < Q_1D) data.slice[data.t_id_x + data.t_id_y * Q_1D] = r_C[k + comp * Q_1D];
       __syncthreads();
       for (CeedInt dim = 0; dim < 3; dim++) {

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor-at-points.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor-at-points.h
@@ -130,7 +130,6 @@ extern "C" __launch_bounds__(BASIS_INTERP_BLOCK_SIZE) __global__
         InterpTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {
@@ -190,7 +189,6 @@ extern "C" __launch_bounds__(BASIS_INTERP_BLOCK_SIZE) __global__
         InterpTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {
@@ -321,7 +319,6 @@ extern "C" __launch_bounds__(BASIS_INTERP_BLOCK_SIZE) __global__
         GradTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {
@@ -382,7 +379,6 @@ extern "C" __launch_bounds__(BASIS_INTERP_BLOCK_SIZE) __global__
         GradTransposeAtPoints3d<BASIS_NUM_COMP, BASIS_NUM_PTS, BASIS_P_1D, BASIS_Q_1D>(data, i, r_U, r_X, r_C);
       }
     }
-    __syncthreads();
 
     // Map from coefficients
     if (BASIS_DIM == 1) {

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor-flattened-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor-flattened-templates.h
@@ -19,6 +19,7 @@
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractX2dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const CeedScalar *U, const CeedScalar *B,
                                             CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -27,7 +28,6 @@ inline __device__ void ContractX2dFlattened(SharedData_Hip &data, const int t_id
       *V += B[i + t_id_x * P_1D] * data.slice[i + t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -36,6 +36,7 @@ inline __device__ void ContractX2dFlattened(SharedData_Hip &data, const int t_id
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractY2dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const CeedScalar *U, const CeedScalar *B,
                                             CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -44,7 +45,6 @@ inline __device__ void ContractY2dFlattened(SharedData_Hip &data, const int t_id
       *V += B[i + t_id_y * P_1D] * data.slice[t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -53,6 +53,7 @@ inline __device__ void ContractY2dFlattened(SharedData_Hip &data, const int t_id
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeY2dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -61,7 +62,6 @@ inline __device__ void ContractTransposeY2dFlattened(SharedData_Hip &data, const
       *V += B[t_id_y + i * P_1D] * data.slice[t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -70,6 +70,7 @@ inline __device__ void ContractTransposeY2dFlattened(SharedData_Hip &data, const
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeX2dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -78,7 +79,6 @@ inline __device__ void ContractTransposeX2dFlattened(SharedData_Hip &data, const
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -87,6 +87,7 @@ inline __device__ void ContractTransposeX2dFlattened(SharedData_Hip &data, const
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddX2dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const CeedScalar *U,
                                                         const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D] = *U;
   __syncthreads();
   if (t_id_x < P_1D && t_id_y < P_1D) {
@@ -94,7 +95,6 @@ inline __device__ void ContractTransposeAddX2dFlattened(SharedData_Hip &data, co
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -105,10 +105,10 @@ inline __device__ void QPack2d(SharedData_Hip &data, const int t_id_x, const int
   const CeedInt new_t_id_x = data.t_id_x % Q_1D, new_t_id_y = data.t_id_x / Q_1D;
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (t_id_x < Q_1D && t_id_y < Q_1D) data.slice[t_id_x + t_id_y * T_1D] = U[comp];
     __syncthreads();
     U[comp] = data.t_id_x < (Q_1D * Q_1D) ? data.slice[new_t_id_x + new_t_id_y * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 
@@ -117,10 +117,10 @@ inline __device__ void QUnpack2d(SharedData_Hip &data, const int t_id_x, const i
   const CeedInt old_t_id_x = data.t_id_x % Q_1D, old_t_id_y = data.t_id_x / Q_1D;
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (data.t_id_x < (Q_1D * Q_1D)) data.slice[old_t_id_x + old_t_id_y * T_1D] = U[comp];
     __syncthreads();
     U[comp] = (t_id_x < Q_1D && t_id_y < Q_1D) ? data.slice[t_id_x + t_id_y * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 
@@ -218,6 +218,7 @@ inline __device__ void WeightTensor2dFlattened(SharedData_Hip &data, const CeedS
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractX3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                             const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -226,7 +227,6 @@ inline __device__ void ContractX3dFlattened(SharedData_Hip &data, const int t_id
       *V += B[i + t_id_x * P_1D] * data.slice[i + t_id_y * T_1D + t_id_z * T_1D * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -235,6 +235,7 @@ inline __device__ void ContractX3dFlattened(SharedData_Hip &data, const int t_id
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractY3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                             const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -243,7 +244,6 @@ inline __device__ void ContractY3dFlattened(SharedData_Hip &data, const int t_id
       *V += B[i + t_id_y * P_1D] * data.slice[t_id_x + i * T_1D + t_id_z * T_1D * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -252,6 +252,7 @@ inline __device__ void ContractY3dFlattened(SharedData_Hip &data, const int t_id
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractZ3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                             const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -260,7 +261,6 @@ inline __device__ void ContractZ3dFlattened(SharedData_Hip &data, const int t_id
       *V += B[i + t_id_z * P_1D] * data.slice[t_id_x + t_id_y * T_1D + i * T_1D * T_1D];  // Contract z direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -269,6 +269,7 @@ inline __device__ void ContractZ3dFlattened(SharedData_Hip &data, const int t_id
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeZ3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -277,7 +278,6 @@ inline __device__ void ContractTransposeZ3dFlattened(SharedData_Hip &data, const
       *V += B[t_id_z + i * P_1D] * data.slice[t_id_x + t_id_y * T_1D + i * T_1D * T_1D];  // Contract z direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -286,6 +286,7 @@ inline __device__ void ContractTransposeZ3dFlattened(SharedData_Hip &data, const
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddZ3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z,
                                                         const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   if (t_id_x < Q_1D && t_id_y < Q_1D && t_id_z < P_1D) {
@@ -293,7 +294,6 @@ inline __device__ void ContractTransposeAddZ3dFlattened(SharedData_Hip &data, co
       *V += B[t_id_z + i * P_1D] * data.slice[t_id_x + t_id_y * T_1D + i * T_1D * T_1D];  // Contract z direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -302,6 +302,7 @@ inline __device__ void ContractTransposeAddZ3dFlattened(SharedData_Hip &data, co
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeY3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -310,7 +311,6 @@ inline __device__ void ContractTransposeY3dFlattened(SharedData_Hip &data, const
       *V += B[t_id_y + i * P_1D] * data.slice[t_id_x + i * T_1D + t_id_z * T_1D * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -319,6 +319,7 @@ inline __device__ void ContractTransposeY3dFlattened(SharedData_Hip &data, const
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddY3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z,
                                                         const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   if (t_id_x < Q_1D && t_id_y < P_1D && t_id_z < P_1D) {
@@ -326,7 +327,6 @@ inline __device__ void ContractTransposeAddY3dFlattened(SharedData_Hip &data, co
       *V += B[t_id_y + i * P_1D] * data.slice[t_id_x + i * T_1D + t_id_z * T_1D * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -335,6 +335,7 @@ inline __device__ void ContractTransposeAddY3dFlattened(SharedData_Hip &data, co
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeX3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z, const CeedScalar *U,
                                                      const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -343,7 +344,6 @@ inline __device__ void ContractTransposeX3dFlattened(SharedData_Hip &data, const
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D + t_id_z * T_1D * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -352,6 +352,7 @@ inline __device__ void ContractTransposeX3dFlattened(SharedData_Hip &data, const
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddX3dFlattened(SharedData_Hip &data, const int t_id_x, const int t_id_y, const int t_id_z,
                                                         const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = *U;
   __syncthreads();
   if (t_id_x < P_1D && t_id_y < P_1D && t_id_z < P_1D) {
@@ -359,7 +360,6 @@ inline __device__ void ContractTransposeAddX3dFlattened(SharedData_Hip &data, co
       *V += B[t_id_x + i * P_1D] * data.slice[i + t_id_y * T_1D + t_id_z * T_1D * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -370,10 +370,10 @@ inline __device__ void QPack3d(SharedData_Hip &data, const int t_id_x, const int
   const CeedInt new_t_id_x = data.t_id_x % Q_1D, new_t_id_y = (data.t_id_x / Q_1D) % Q_1D, new_t_id_z = data.t_id_x / (Q_1D * Q_1D);
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (t_id_x < Q_1D && t_id_y < Q_1D) data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] = U[comp];
     __syncthreads();
     U[comp] = data.t_id_x < (Q_1D * Q_1D * Q_1D) ? data.slice[new_t_id_x + new_t_id_y * T_1D + new_t_id_z * T_1D * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 
@@ -382,10 +382,10 @@ inline __device__ void QUnpack3d(SharedData_Hip &data, const int t_id_x, const i
   const CeedInt old_t_id_x = data.t_id_x % Q_1D, old_t_id_y = (data.t_id_x / Q_1D) % Q_1D, old_t_id_z = data.t_id_x / (Q_1D * Q_1D);
 
   for (CeedInt comp = 0; comp < NUM_COMP; comp++) {
+    __syncthreads();
     if (data.t_id_x < Q_1D * Q_1D * Q_1D) data.slice[old_t_id_x + old_t_id_y * T_1D + old_t_id_z * T_1D * T_1D] = U[comp];
     __syncthreads();
     U[comp] = (t_id_x < Q_1D && t_id_y < Q_1D) ? data.slice[t_id_x + t_id_y * T_1D + t_id_z * T_1D * T_1D] : 0.0;
-    __syncthreads();
   }
 }
 

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor-templates.h
@@ -18,6 +18,7 @@
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D>
 inline __device__ void ContractX1d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x] = *U;
   __syncthreads();
   *V = 0.0;
@@ -26,7 +27,6 @@ inline __device__ void ContractX1d(SharedData_Hip &data, const CeedScalar *U, co
       *V += B[i + data.t_id_x * P_1D] * data.slice[i];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -34,6 +34,7 @@ inline __device__ void ContractX1d(SharedData_Hip &data, const CeedScalar *U, co
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D>
 inline __device__ void ContractTransposeX1d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x] = *U;
   __syncthreads();
   *V = 0.0;
@@ -42,7 +43,6 @@ inline __device__ void ContractTransposeX1d(SharedData_Hip &data, const CeedScal
       *V += B[data.t_id_x + i * P_1D] * data.slice[i];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -105,6 +105,7 @@ inline __device__ void Weight1d(SharedData_Hip &data, const CeedScalar *__restri
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractX2d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -113,7 +114,6 @@ inline __device__ void ContractX2d(SharedData_Hip &data, const CeedScalar *U, co
       *V += B[i + data.t_id_x * P_1D] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -121,6 +121,7 @@ inline __device__ void ContractX2d(SharedData_Hip &data, const CeedScalar *U, co
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractY2d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -129,7 +130,6 @@ inline __device__ void ContractY2d(SharedData_Hip &data, const CeedScalar *U, co
       *V += B[i + data.t_id_y * P_1D] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -137,6 +137,7 @@ inline __device__ void ContractY2d(SharedData_Hip &data, const CeedScalar *U, co
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeY2d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -145,7 +146,6 @@ inline __device__ void ContractTransposeY2d(SharedData_Hip &data, const CeedScal
       *V += B[data.t_id_y + i * P_1D] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -153,6 +153,7 @@ inline __device__ void ContractTransposeY2d(SharedData_Hip &data, const CeedScal
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeX2d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   *V = 0.0;
@@ -161,7 +162,6 @@ inline __device__ void ContractTransposeX2d(SharedData_Hip &data, const CeedScal
       *V += B[data.t_id_x + i * P_1D] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -169,6 +169,7 @@ inline __device__ void ContractTransposeX2d(SharedData_Hip &data, const CeedScal
 //------------------------------------------------------------------------------
 template <int NUM_COMP, int P_1D, int Q_1D, int T_1D>
 inline __device__ void ContractTransposeAddX2d(SharedData_Hip &data, const CeedScalar *U, const CeedScalar *B, CeedScalar *V) {
+  __syncthreads();
   data.slice[data.t_id_x + data.t_id_y * T_1D] = *U;
   __syncthreads();
   if (data.t_id_x < P_1D && data.t_id_y < P_1D) {
@@ -176,7 +177,6 @@ inline __device__ void ContractTransposeAddX2d(SharedData_Hip &data, const CeedS
       *V += B[data.t_id_x + i * P_1D] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
     }
   }
-  __syncthreads();
 }
 
 //------------------------------------------------------------------------------
@@ -257,6 +257,7 @@ inline __device__ void ContractX3d(SharedData_Hip &data, const CeedScalar *U, co
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -265,7 +266,6 @@ inline __device__ void ContractX3d(SharedData_Hip &data, const CeedScalar *U, co
         V[k] += r_B[i] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -280,6 +280,7 @@ inline __device__ void ContractY3d(SharedData_Hip &data, const CeedScalar *U, co
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -288,7 +289,6 @@ inline __device__ void ContractY3d(SharedData_Hip &data, const CeedScalar *U, co
         V[k] += r_B[i] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -333,6 +333,7 @@ inline __device__ void ContractTransposeY3d(SharedData_Hip &data, const CeedScal
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -341,7 +342,6 @@ inline __device__ void ContractTransposeY3d(SharedData_Hip &data, const CeedScal
         V[k] += r_B[i] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -356,6 +356,7 @@ inline __device__ void ContractTransposeAddY3d(SharedData_Hip &data, const CeedS
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     if (data.t_id_x < Q_1D && data.t_id_y < P_1D) {
@@ -363,7 +364,6 @@ inline __device__ void ContractTransposeAddY3d(SharedData_Hip &data, const CeedS
         V[k] += r_B[i] * data.slice[data.t_id_x + i * T_1D];  // Contract y direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -378,6 +378,7 @@ inline __device__ void ContractTransposeX3d(SharedData_Hip &data, const CeedScal
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     V[k] = 0.0;
@@ -386,7 +387,6 @@ inline __device__ void ContractTransposeX3d(SharedData_Hip &data, const CeedScal
         V[k] += r_B[i] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
       }
     }
-    __syncthreads();
   }
 }
 
@@ -401,6 +401,7 @@ inline __device__ void ContractTransposeAddX3d(SharedData_Hip &data, const CeedS
   }
 
   for (CeedInt k = 0; k < P_1D; k++) {
+    __syncthreads();
     data.slice[data.t_id_x + data.t_id_y * T_1D] = U[k];
     __syncthreads();
     if (data.t_id_x < P_1D && data.t_id_y < P_1D) {
@@ -408,7 +409,6 @@ inline __device__ void ContractTransposeAddX3d(SharedData_Hip &data, const CeedS
         V[k] += r_B[i] * data.slice[i + data.t_id_y * T_1D];  // Contract x direction
       }
     }
-    __syncthreads();
   }
 }
 


### PR DESCRIPTION
This fixes the intermittent t354 failures in CI

Basically, we really just need `__syncthreads` when we're changing the contents shared memory buffers so I moved them to clarify this (and dropped a couple)