### PR TITLE
feat(sycl): Define CEED_RUNNING_JIT_PASS in JIT

### DIFF
--- a/backends/sycl/ceed-sycl-compile.sycl.cpp
+++ b/backends/sycl/ceed-sycl-compile.sycl.cpp
@@ -61,7 +61,7 @@ static int CeedJitAddDefinitions_Sycl(Ceed ceed, const std::string &kernel_sourc
 // TODO: Add architecture flags, optimization flags
 //------------------------------------------------------------------------------
 static inline int CeedJitGetFlags_Sycl(std::vector<std::string> &flags) {
-  flags = {std::string("-cl-std=CL3.0"), std::string("-Dint32_t=int")};
+  flags = {std::string("-cl-std=CL3.0"), std::string("-Dint32_t=int"), std::string("-DCEED_RUNNING_JIT_PASS=1")};
   return CEED_ERROR_SUCCESS;
 }
 


### PR DESCRIPTION
Update to include `CEED_RUNNING_JIT_PASS` to the SYCL backend's definitions. This was added in #1696, but not to the SYCL backend.

Confirmed this works on Aurora. 