### PR TITLE
Fix Gen for Ratel

### DIFF
--- a/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-flattened-templates.h
+++ b/include/ceed/jit-source/cuda/cuda-shared-basis-tensor-flattened-templates.h
@@ -138,6 +138,7 @@ inline __device__ void InterpTensor2dFlattened(SharedData_Cuda &data, CeedScalar
     ContractX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp], c_B, r_t);
     ContractY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_U);
   if (Q_1D != T_1D) QPack2d<NUM_COMP, Q_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
@@ -156,6 +157,7 @@ inline __device__ void InterpTransposeTensor2dFlattened(SharedData_Cuda &data, C
     ContractTransposeY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp], c_B, r_t);
     ContractTransposeX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
 
@@ -175,6 +177,7 @@ inline __device__ void GradTensor2dFlattened(SharedData_Cuda &data, CeedScalar *
     ContractX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp], c_B, r_t);
     ContractY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_G, &r_V[comp + 1 * NUM_COMP]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_U);
   if (Q_1D != T_1D) QPack2d<NUM_COMP * 2, Q_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
@@ -195,6 +198,7 @@ inline __device__ void GradTransposeTensor2dFlattened(SharedData_Cuda &data, Cee
     ContractTransposeY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp + 1 * NUM_COMP], c_G, r_t);
     ContractTransposeAddX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
 
@@ -404,6 +408,7 @@ inline __device__ void InterpTensor3dFlattened(SharedData_Cuda &data, CeedScalar
     ContractY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractZ3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_U);
   if (Q_1D != T_1D) QPack3d<NUM_COMP, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
@@ -423,6 +428,7 @@ inline __device__ void InterpTransposeTensor3dFlattened(SharedData_Cuda &data, C
     ContractTransposeY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractTransposeX3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
 
@@ -447,6 +453,7 @@ inline __device__ void GradTensor3dFlattened(SharedData_Cuda &data, CeedScalar *
     ContractY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractZ3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_G, &r_V[comp + 2 * NUM_COMP]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_U);
   if (Q_1D != T_1D) QPack3d<NUM_COMP * 3, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
@@ -472,6 +479,7 @@ inline __device__ void GradTransposeTensor3dFlattened(SharedData_Cuda &data, Cee
     ContractTransposeY3dFlattened<NUM_COMP, t_id_x, t_id_y, t_id_z, P_1D, Q_1D, T_1D>(data, r_t1, c_B, r_t2);
     ContractTransposeAddX3dFlattened<NUM_COMP, t_id_x, t_id_y, t_id_z, P_1D, Q_1D, T_1D>(data, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
 
@@ -493,6 +501,7 @@ inline __device__ void GradTensorCollocated3dFlattened(SharedData_Cuda &data, Ce
     ContractY3dFlattened<NUM_COMP, Q_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_G, &r_V[comp + 1 * NUM_COMP]);
     ContractZ3dFlattened<NUM_COMP, Q_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_G, &r_V[comp + 2 * NUM_COMP]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_U);
   if (Q_1D != T_1D) QPack3d<NUM_COMP * 3, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
@@ -515,6 +524,7 @@ inline __device__ void GradTransposeTensorCollocated3dFlattened(SharedData_Cuda 
     ContractTransposeY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractTransposeX3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
 

--- a/include/ceed/jit-source/hip/hip-shared-basis-tensor-flattened-templates.h
+++ b/include/ceed/jit-source/hip/hip-shared-basis-tensor-flattened-templates.h
@@ -138,6 +138,7 @@ inline __device__ void InterpTensor2dFlattened(SharedData_Hip &data, CeedScalar 
     ContractX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp], c_B, r_t);
     ContractY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_U);
   if (Q_1D != T_1D) QPack2d<NUM_COMP, Q_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
@@ -156,6 +157,7 @@ inline __device__ void InterpTransposeTensor2dFlattened(SharedData_Hip &data, Ce
     ContractTransposeY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp], c_B, r_t);
     ContractTransposeX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
 
@@ -175,6 +177,7 @@ inline __device__ void GradTensor2dFlattened(SharedData_Hip &data, CeedScalar *_
     ContractX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp], c_B, r_t);
     ContractY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_G, &r_V[comp + 1 * NUM_COMP]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_U);
   if (Q_1D != T_1D) QPack2d<NUM_COMP * 2, Q_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
@@ -195,6 +198,7 @@ inline __device__ void GradTransposeTensor2dFlattened(SharedData_Hip &data, Ceed
     ContractTransposeY2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, &r_U[comp + 1 * NUM_COMP], c_G, r_t);
     ContractTransposeAddX2dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, r_t, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack2d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, r_V);
 }
 
@@ -404,6 +408,7 @@ inline __device__ void InterpTensor3dFlattened(SharedData_Hip &data, CeedScalar 
     ContractY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractZ3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_U);
   if (Q_1D != T_1D) QPack3d<NUM_COMP, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
@@ -423,6 +428,7 @@ inline __device__ void InterpTransposeTensor3dFlattened(SharedData_Hip &data, Ce
     ContractTransposeY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractTransposeX3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
 
@@ -447,6 +453,7 @@ inline __device__ void GradTensor3dFlattened(SharedData_Hip &data, CeedScalar *_
     ContractY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractZ3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_G, &r_V[comp + 2 * NUM_COMP]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_U);
   if (Q_1D != T_1D) QPack3d<NUM_COMP * 3, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
@@ -472,6 +479,7 @@ inline __device__ void GradTransposeTensor3dFlattened(SharedData_Hip &data, Ceed
     ContractTransposeY3dFlattened<NUM_COMP, t_id_x, t_id_y, t_id_z, P_1D, Q_1D, T_1D>(data, r_t1, c_B, r_t2);
     ContractTransposeAddX3dFlattened<NUM_COMP, t_id_x, t_id_y, t_id_z, P_1D, Q_1D, T_1D>(data, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
 
@@ -493,6 +501,7 @@ inline __device__ void GradTensorCollocated3dFlattened(SharedData_Hip &data, Cee
     ContractY3dFlattened<NUM_COMP, Q_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_G, &r_V[comp + 1 * NUM_COMP]);
     ContractZ3dFlattened<NUM_COMP, Q_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_G, &r_V[comp + 2 * NUM_COMP]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_U);
   if (Q_1D != T_1D) QPack3d<NUM_COMP * 3, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
@@ -515,6 +524,7 @@ inline __device__ void GradTransposeTensorCollocated3dFlattened(SharedData_Hip &
     ContractTransposeY3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t1, c_B, r_t2);
     ContractTransposeX3dFlattened<NUM_COMP, P_1D, Q_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_t2, c_B, &r_V[comp]);
   }
+  __syncthreads();
   if (P_1D != T_1D) QPack3d<NUM_COMP, P_1D, T_1D>(data, t_id_x, t_id_y, t_id_z, r_V);
 }
 

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -586,7 +586,7 @@ int CeedOperatorHasTensorBases(CeedOperator op, bool *has_tensor_bases) {
     CeedCall(CeedOperatorFieldGetBasis(input_fields[i], &basis));
     if (basis != CEED_BASIS_NONE) {
       CeedCall(CeedBasisIsTensor(basis, &is_tensor));
-      *has_tensor_bases &= is_tensor;
+      *has_tensor_bases = *has_tensor_bases & is_tensor;
     }
     CeedCall(CeedBasisDestroy(&basis));
   }
@@ -597,7 +597,7 @@ int CeedOperatorHasTensorBases(CeedOperator op, bool *has_tensor_bases) {
     CeedCall(CeedOperatorFieldGetBasis(output_fields[i], &basis));
     if (basis != CEED_BASIS_NONE) {
       CeedCall(CeedBasisIsTensor(basis, &is_tensor));
-      *has_tensor_bases &= is_tensor;
+      *has_tensor_bases = *has_tensor_bases & is_tensor;
     }
     CeedCall(CeedBasisDestroy(&basis));
   }


### PR DESCRIPTION
Found an edge case that hadn't popped up yet, this fixes a strain energy calculation error in the Ratel test suite for Gen backends.