### PR TITLE
Add sychronization calls after hipMemcpyDeviceToDevice

### DIFF
--- a/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
+++ b/backends/hip-ref/ceed-hip-ref-qfunctioncontext.c
@@ -194,6 +194,7 @@ static int CeedQFunctionContextSetDataDevice_Hip(const CeedQFunctionContext ctx,
       impl->d_data_borrowed = NULL;
       impl->d_data          = impl->d_data_owned;
       CeedCallHip(ceed, hipMemcpy(impl->d_data, data, ctx_size, hipMemcpyDeviceToDevice));
+      CeedCallHip(ceed, hipDeviceSynchronize());
     } break;
     case CEED_OWN_POINTER:
       impl->d_data_owned    = data;

--- a/backends/hip/ceed-hip-common.c
+++ b/backends/hip/ceed-hip-common.c
@@ -68,7 +68,10 @@ static inline int CeedSetDeviceGenericArray_Hip(Ceed ceed, const void *source_ar
           *(void **)target_array = *(void **)target_array_owned;
         }
       }
-      if (source_array) CeedCallHip(ceed, hipMemcpy(*(void **)target_array, source_array, size_unit * num_values, hipMemcpyDeviceToDevice));
+      if (source_array) {
+        CeedCallHip(ceed, hipMemcpy(*(void **)target_array, source_array, size_unit * num_values, hipMemcpyDeviceToDevice));
+        CeedCallHip(ceed, hipDeviceSynchronize());
+      }
       break;
     case CEED_OWN_POINTER:
       CeedCallHip(ceed, hipFree(*(void **)target_array_owned));


### PR DESCRIPTION
Turns out that `hipMemcpy` with `hipMemcpyDeviceToDevice` is asynchronous on the host. This MR adds synchronization calls to prevent any potential race conditions.