### PR TITLE
ceed - replace usage of `ceed->op_fallback_parent` with `ceed->parent`

### DIFF
--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -96,7 +96,7 @@ struct Ceed_private {
   Ceed         parent;
   ObjDelegate *obj_delegates;
   int          obj_delegate_count;
-  Ceed         op_fallback_ceed, op_fallback_parent;
+  Ceed         op_fallback_ceed;
   const char  *op_fallback_resource;
   char       **jit_source_roots;
   CeedInt      num_jit_source_roots, max_jit_source_roots, num_jit_source_roots_readers;


### PR DESCRIPTION
The `ceed->op_fallback_parent` member is redundant and creates potential data mismatches between a given `Ceed` context and its children. This removes the need to manually copy over JiT source roots and defines from the parent to fallback `Ceed` and prevents possible footguns when using the `Ceed*Parent*` interfaces. 