### PR TITLE
op - Add `CeedOperatorApplyAddActive()` for only summing into active outputs

### DIFF
--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -469,6 +469,7 @@ CEED_EXTERN int  CeedOperatorGetContextBooleanRead(CeedOperator op, CeedContextF
 CEED_EXTERN int  CeedOperatorRestoreContextBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, const bool **values);
 CEED_EXTERN int  CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
 CEED_EXTERN int  CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
+CEED_EXTERN int  CeedOperatorApplyAddActive(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
 CEED_EXTERN int  CeedOperatorAssemblyDataStrip(CeedOperator op);
 CEED_EXTERN int  CeedOperatorDestroy(CeedOperator *op);
 


### PR DESCRIPTION
See https://gitlab.com/micromorph/ratel/-/merge_requests/1164 for more discussion.

Often, the passive outputs of a `CeedOperator` should always be overwritten; e.g., auxiliary data from a residual evaluation used for Jacobian evaluation. Without this interface, one must use `CeedOperatorApply()` even if the desired behavior is to add into the active output vector, resulting in needing an extra scratch vector.