### PR TITLE
ci - update test suite for parity with Ratel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -797,7 +797,7 @@ NPROC_POOL ?= 1
 export NPROC_POOL
 
 run-% : $(OBJDIR)/%
-	@$(PYTHON) tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) $(<:$(OBJDIR)/%=%)
+	@$(PYTHON) tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) --search '$(subsearch)' $(<:$(OBJDIR)/%=%)
 
 # The test and prove targets can be controlled via pattern searches.  The
 # default is to run tests and those examples that have no external dependencies.
@@ -809,6 +809,7 @@ run-% : $(OBJDIR)/%
 search ?= t ex
 realsearch = $(search:%=%%)
 matched = $(foreach pattern,$(realsearch),$(filter $(OBJDIR)/$(pattern),$(tests) $(allexamples)))
+subsearch ?= .*
 JUNIT_BATCH ?= ''
 
 # Test core libCEED
@@ -823,7 +824,7 @@ ctc-% : $(ctests);@$(foreach tst,$(ctests),$(tst) /cpu/$*;)
 # https://testanything.org/tap-specification.html
 prove : $(matched)
 	$(info Testing backends: $(BACKENDS))
-	$(PROVE) $(PROVE_OPTS) --exec '$(PYTHON) tests/junit.py --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL)' $(matched:$(OBJDIR)/%=%)
+	$(PROVE) $(PROVE_OPTS) --exec '$(PYTHON) tests/junit.py' $(matched:$(OBJDIR)/%=%) :: --mode tap --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) --search '$(subsearch)'
 # Run prove target in parallel
 prv : ;@$(MAKE) $(MFLAGS) V=$(V) prove
 
@@ -831,7 +832,7 @@ prove-all :
 	+$(MAKE) prove realsearch=%
 
 junit-% : $(OBJDIR)/%
-	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) --junit-batch $(JUNIT_BATCH) $(<:$(OBJDIR)/%=%)
+	@printf "  %10s %s\n" TEST $(<:$(OBJDIR)/%=%); $(PYTHON) tests/junit.py --ceed-backends $(BACKENDS) --nproc $(NPROC_TEST) --pool-size $(NPROC_POOL) --search '$(subsearch)' --junit-batch $(JUNIT_BATCH) $(<:$(OBJDIR)/%=%)
 
 junit : $(matched:$(OBJDIR)/%=junit-%)
 

--- a/tests/junit.py
+++ b/tests/junit.py
@@ -27,6 +27,10 @@ def create_argparser() -> argparse.ArgumentParser:
     parser.add_argument('-o', '--output', type=Optional[Path], default=None, help='Output file to write test')
     parser.add_argument('-b', '--junit-batch', type=str, default='', help='Name of JUnit batch for output file')
     parser.add_argument('-np', '--pool-size', type=int, default=1, help='Number of test cases to run in parallel')
+    parser.add_argument('-s', '--search', type=str, default='.*',
+                        help='Search string to filter tests, using `re` package format')
+    parser.add_argument('-v', '--verbose', action='store_true', default=False,
+                        help='print details for all runs, not just failures')
     parser.add_argument('test', help='Test executable', nargs='?')
 
     return parser
@@ -201,7 +205,9 @@ if __name__ == '__main__':
         args.mode,
         args.nproc,
         CeedSuiteSpec(),
-        args.pool_size)
+        args.pool_size,
+        search=args.search,
+        verbose=args.verbose)
 
     # write output and check for failures
     if args.mode is RunMode.JUNIT:

--- a/tests/junit_common.py
+++ b/tests/junit_common.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 import argparse
 import csv
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 import difflib
 from enum import Enum
 from math import isclose
@@ -10,52 +11,75 @@ from pathlib import Path
 import re
 import subprocess
 import multiprocessing as mp
-from itertools import product
 import sys
 import time
-from typing import Optional, Tuple, List, Callable
+from typing import Optional, Tuple, List, Dict, Callable, Iterable, get_origin
+import shutil
 
 sys.path.insert(0, str(Path(__file__).parent / "junit-xml"))
 from junit_xml import TestCase, TestSuite, to_xml_report_string  # nopep8
+
+
+class ParseError(RuntimeError):
+    """A custom exception for failed parsing."""
+
+    def __init__(self, message):
+        super().__init__(message)
 
 
 class CaseInsensitiveEnumAction(argparse.Action):
     """Action to convert input values to lower case prior to converting to an Enum type"""
 
     def __init__(self, option_strings, dest, type, default, **kwargs):
-        if not (issubclass(type, Enum) and issubclass(type, str)):
-            raise ValueError(f"{type} must be a StrEnum or str and Enum")
+        if not issubclass(type, Enum):
+            raise ValueError(f"{type} must be an Enum")
         # store provided enum type
         self.enum_type = type
-        if isinstance(default, str):
+        if isinstance(default, self.enum_type):
+            pass
+        elif isinstance(default, str):
             default = self.enum_type(default.lower())
-        else:
+        elif isinstance(default, Iterable):
             default = [self.enum_type(v.lower()) for v in default]
+        else:
+            raise argparse.ArgumentTypeError("Invalid value type, must be str or iterable")
         # prevent automatic type conversion
         super().__init__(option_strings, dest, default=default, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        if isinstance(values, str):
+        if isinstance(values, self.enum_type):
+            pass
+        elif isinstance(values, str):
             values = self.enum_type(values.lower())
-        else:
+        elif isinstance(values, Iterable):
             values = [self.enum_type(v.lower()) for v in values]
+        else:
+            raise argparse.ArgumentTypeError("Invalid value type, must be str or iterable")
         setattr(namespace, self.dest, values)
 
 
 @dataclass
 class TestSpec:
     """Dataclass storing information about a single test case"""
-    name: str
+    name: str = field(default_factory=str)
+    csv_rtol: float = -1
+    csv_ztol: float = -1
+    cgns_tol: float = -1
     only: List = field(default_factory=list)
     args: List = field(default_factory=list)
+    key_values: Dict = field(default_factory=dict)
 
 
-class RunMode(str, Enum):
+class RunMode(Enum):
     """Enumeration of run modes, either `RunMode.TAP` or `RunMode.JUNIT`"""
-    __str__ = str.__str__
-    __format__ = str.__format__
-    TAP: str = 'tap'
-    JUNIT: str = 'junit'
+    TAP = 'tap'
+    JUNIT = 'junit'
+
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return self.value
 
 
 class SuiteSpec(ABC):
@@ -98,6 +122,11 @@ class SuiteSpec(ABC):
         raise NotImplementedError
 
     @property
+    def test_failure_artifacts_path(self) -> Path:
+        """Path to test failure artifacts"""
+        return Path('build') / 'test_failure_artifacts'
+
+    @property
     def cgns_tol(self):
         """Absolute tolerance for CGNS diff"""
         return getattr(self, '_cgns_tol', 1.0e-12)
@@ -107,15 +136,24 @@ class SuiteSpec(ABC):
         self._cgns_tol = val
 
     @property
-    def diff_csv_kwargs(self):
+    def csv_ztol(self):
         """Keyword arguments to be passed to diff_csv()"""
-        return getattr(self, '_diff_csv_kwargs', {})
+        return getattr(self, '_csv_ztol', 3e-10)
 
-    @diff_csv_kwargs.setter
-    def diff_csv_kwargs(self, val):
-        self._diff_csv_kwargs = val
+    @csv_ztol.setter
+    def csv_ztol(self, val):
+        self._csv_ztol = val
 
-    def post_test_hook(self, test: str, spec: TestSpec) -> None:
+    @property
+    def csv_rtol(self):
+        """Keyword arguments to be passed to diff_csv()"""
+        return getattr(self, '_csv_rtol', 1e-6)
+
+    @csv_rtol.setter
+    def csv_rtol(self, val):
+        self._csv_rtol = val
+
+    def post_test_hook(self, test: str, spec: TestSpec, backend: str) -> None:
         """Function callback ran after each test case
 
         Args:
@@ -219,6 +257,39 @@ def startswith_any(base: str, prefixes: List[str]) -> bool:
     return any((base.startswith(prefix) for prefix in prefixes))
 
 
+def find_matching(line: str, open: str = '(', close: str = ')') -> Tuple[int, int]:
+    """Find the start and end positions of the first outer paired delimeters
+
+    Args:
+        line (str): Line to search
+        open (str, optional): Opening delimiter, must be different than `close`. Defaults to '('.
+        close (str, optional): Closing delimeter, must be different than `open`. Defaults to ')'.
+
+    Raises:
+        RuntimeError: If open or close is not a single character
+        RuntimeError: If open and close are the same characters
+
+    Returns:
+        Tuple[int]: If matching delimeters are found, return indices in `list`. Otherwise, return end < start.
+    """
+    if len(open) != 1 or len(close) != 1:
+        raise RuntimeError("`open` and `close` must be single characters")
+    if open == close:
+        raise RuntimeError("`open` and `close` must be different characters")
+    start: int = line.find(open)
+    if start < 0:
+        return -1, -1
+    count: int = 1
+    for i in range(start + 1, len(line)):
+        if line[i] == open:
+            count += 1
+        if line[i] == close:
+            count -= 1
+            if count == 0:
+                return start, i
+    return start, -1
+
+
 def parse_test_line(line: str) -> TestSpec:
     """Parse a single line of TESTARGS and CLI arguments into a `TestSpec` object
 
@@ -228,18 +299,58 @@ def parse_test_line(line: str) -> TestSpec:
     Returns:
         TestSpec: Parsed specification of test case
     """
-    args: List[str] = re.findall("(?:\".*?\"|\\S)+", line.strip())
-    if args[0] == 'TESTARGS':
-        return TestSpec(name='', args=args[1:])
-    raw_test_args: str = args[0][args[0].index('TESTARGS(') + 9:args[0].rindex(')')]
-    # transform 'name="myname",only="serial,int32"' into {'name': 'myname', 'only': 'serial,int32'}
-    test_args: dict = dict([''.join(t).split('=') for t in re.findall(r"""([^,=]+)(=)"([^"]*)\"""", raw_test_args)])
-    name: str = test_args.get('name', '')
-    constraints: List[str] = test_args['only'].split(',') if 'only' in test_args else []
-    if len(args) > 1:
-        return TestSpec(name=name, only=constraints, args=args[1:])
-    else:
-        return TestSpec(name=name, only=constraints)
+    test_fields = fields(TestSpec)
+    field_names = [f.name for f in test_fields]
+    known: Dict = dict()
+    other: Dict = dict()
+    if line[0] == "(":
+        # have key/value pairs to parse
+        start, end = find_matching(line)
+        if end < start:
+            raise ParseError(f"Mismatched parentheses in TESTCASE: {line}")
+
+        keyvalues_str = line[start:end + 1]
+        keyvalues_pattern = re.compile(r'''
+            (?:\(\s*|\s*,\s*)   # start with open parentheses or comma, no capture
+            ([A-Za-z]+[\w\-]+)  # match key starting with alpha, containing alphanumeric, _, or -; captured as Group 1
+            \s*=\s*             # key is followed by = (whitespace ignored)
+            (?:                 # uncaptured group for OR
+              "((?:[^"]|\\")+)" #   match quoted value (any internal " must be escaped as \"); captured as Group 2
+            | ([^=]+)           #   OR match unquoted value (no equals signs allowed); captured as Group 3
+            )                   # end uncaptured group for OR
+            \s*(?=,|\))         # lookahead for either next comma or closing parentheses
+        ''', re.VERBOSE)
+
+        for match in re.finditer(keyvalues_pattern, keyvalues_str):
+            if not match:  # empty
+                continue
+            key = match.group(1)
+            value = match.group(2) if match.group(2) else match.group(3)
+            try:
+                index = field_names.index(key)
+                if key == "only":  # weird bc only is a list
+                    value = [constraint.strip() for constraint in value.split(',')]
+                try:
+                    # TODO: stop supporting python <=3.8
+                    known[key] = test_fields[index].type(value)  # type: ignore
+                except TypeError:
+                    # TODO: this is still liable to fail for complex types
+                    known[key] = get_origin(test_fields[index].type)(value)  # type: ignore
+            except ValueError:
+                other[key] = value
+
+        line = line[end + 1:]
+
+    args_pattern = re.compile(r'''
+        \s+(            # remove leading space
+            (?:"[^"]+") # match quoted CLI option
+          | (?:[\S]+)   # match anything else that is space separated
+        )
+    ''', re.VERBOSE)
+    args: List[str] = re.findall(args_pattern, line)
+    for k, v in other.items():
+        print(f"warning, unknown TESTCASE option for test '{known['name']}': {k}={v}")
+    return TestSpec(**known, key_values=other, args=args)
 
 
 def get_test_args(source_file: Path) -> List[TestSpec]:
@@ -266,20 +377,20 @@ def get_test_args(source_file: Path) -> List[TestSpec]:
     else:
         raise RuntimeError(f'Unrecognized extension for file: {source_file}')
 
-    return [parse_test_line(line.strip(comment_str))
+    return [parse_test_line(line.strip(comment_str).removeprefix("TESTARGS"))
             for line in source_file.read_text().splitlines()
             if line.startswith(f'{comment_str}TESTARGS')] or [TestSpec('', args=['{ceed_resource}'])]
 
 
-def diff_csv(test_csv: Path, true_csv: Path, zero_tol: float = 3e-10, rel_tol: float = 1e-2,
+def diff_csv(test_csv: Path, true_csv: Path, zero_tol: float, rel_tol: float,
              comment_str: str = '#', comment_func: Optional[Callable[[str, str], Optional[str]]] = None) -> str:
     """Compare CSV results against an expected CSV file with tolerances
 
     Args:
         test_csv (Path): Path to output CSV results
         true_csv (Path): Path to expected CSV results
-        zero_tol (float, optional): Tolerance below which values are considered to be zero. Defaults to 3e-10.
-        rel_tol (float, optional): Relative tolerance for comparing non-zero values. Defaults to 1e-2.
+        zero_tol (float): Tolerance below which values are considered to be zero.
+        rel_tol (float): Relative tolerance for comparing non-zero values.
         comment_str (str, optional): String to denoting commented line
         comment_func (Callable, optional): Function to determine if test and true line are different
 
@@ -317,6 +428,10 @@ def diff_csv(test_csv: Path, true_csv: Path, zero_tol: float = 3e-10, rel_tol: f
 
     test_reader: csv.DictReader = csv.DictReader(test_lines)
     true_reader: csv.DictReader = csv.DictReader(true_lines)
+    if not test_reader.fieldnames:
+        return f'No CSV columns found in test output {test_csv}'
+    if not true_reader.fieldnames:
+        return f'No CSV columns found in test source {true_csv}'
     if test_reader.fieldnames != true_reader.fieldnames:
         return ''.join(difflib.unified_diff([f'{test_lines[0]}\n'], [f'{true_lines[0]}\n'],
                        tofile='found CSV columns', fromfile='expected CSV columns'))
@@ -344,13 +459,13 @@ def diff_csv(test_csv: Path, true_csv: Path, zero_tol: float = 3e-10, rel_tol: f
     return '\n'.join(diff_lines)
 
 
-def diff_cgns(test_cgns: Path, true_cgns: Path, cgns_tol: float = 1e-12) -> str:
+def diff_cgns(test_cgns: Path, true_cgns: Path, cgns_tol: float) -> str:
     """Compare CGNS results against an expected CGSN file with tolerance
 
     Args:
         test_cgns (Path): Path to output CGNS file
         true_cgns (Path): Path to expected CGNS file
-        cgns_tol (float, optional): Tolerance for comparing floating-point values
+        cgns_tol (float): Tolerance for comparing floating-point values
 
     Returns:
         str: Diff output between result and expected CGNS files
@@ -367,32 +482,60 @@ def diff_cgns(test_cgns: Path, true_cgns: Path, cgns_tol: float = 1e-12) -> str:
     return proc.stderr.decode('utf-8') + proc.stdout.decode('utf-8')
 
 
+def diff_ascii(test_file: Path, true_file: Path, backend: str) -> str:
+    """Compare ASCII results against an expected ASCII file
+
+    Args:
+        test_file (Path): Path to output ASCII file
+        true_file (Path): Path to expected ASCII file
+
+    Returns:
+        str: Diff output between result and expected ASCII files
+    """
+    tmp_backend: str = backend.replace('/', '-')
+    true_str: str = true_file.read_text().replace('{ceed_resource}', tmp_backend)
+    diff = list(difflib.unified_diff(test_file.read_text().splitlines(keepends=True),
+                                     true_str.splitlines(keepends=True),
+                                     fromfile=str(test_file),
+                                     tofile=str(true_file)))
+    return ''.join(diff)
+
+
 def test_case_output_string(test_case: TestCase, spec: TestSpec, mode: RunMode,
-                            backend: str, test: str, index: int) -> str:
+                            backend: str, test: str, index: int, verbose: bool) -> str:
     output_str = ''
     if mode is RunMode.TAP:
         # print incremental output if TAP mode
         if test_case.is_skipped():
             output_str += f'    ok {index} - {spec.name}, {backend} # SKIP {test_case.skipped[0]["message"]}\n'
         elif test_case.is_failure() or test_case.is_error():
-            output_str += f'    not ok {index} - {spec.name}, {backend}\n'
+            output_str += f'    not ok {index} - {spec.name}, {backend} ({test_case.elapsed_sec} s)\n'
         else:
-            output_str += f'    ok {index} - {spec.name}, {backend}\n'
-        output_str += f'      ---\n'
-        if spec.only:
-            output_str += f'      only: {",".join(spec.only)}\n'
-        output_str += f'      args: {test_case.args}\n'
-        if test_case.is_error():
-            output_str += f'      error: {test_case.errors[0]["message"]}\n'
-        if test_case.is_failure():
-            output_str += f'      num_failures: {len(test_case.failures)}\n'
-            for i, failure in enumerate(test_case.failures):
-                output_str += f'      failure_{i}: {failure["message"]}\n'
-                output_str += f'        message: {failure["message"]}\n'
-                if failure["output"]:
-                    out = failure["output"].strip().replace('\n', '\n          ')
-                    output_str += f'        output: |\n          {out}\n'
-        output_str += f'      ...\n'
+            output_str += f'    ok {index} - {spec.name}, {backend} ({test_case.elapsed_sec} s)\n'
+        if test_case.is_failure() or test_case.is_error() or verbose:
+            output_str += f'      ---\n'
+            if spec.only:
+                output_str += f'      only: {",".join(spec.only)}\n'
+            output_str += f'      args: {test_case.args}\n'
+            if spec.csv_ztol > 0:
+                output_str += f'      csv_ztol: {spec.csv_ztol}\n'
+            if spec.csv_rtol > 0:
+                output_str += f'      csv_rtol: {spec.csv_rtol}\n'
+            if spec.cgns_tol > 0:
+                output_str += f'      cgns_tol: {spec.cgns_tol}\n'
+            for k, v in spec.key_values.items():
+                output_str += f'      {k}: {v}\n'
+            if test_case.is_error():
+                output_str += f'      error: {test_case.errors[0]["message"]}\n'
+            if test_case.is_failure():
+                output_str += f'      failures:\n'
+                for i, failure in enumerate(test_case.failures):
+                    output_str += f'        -\n'
+                    output_str += f'          message: {failure["message"]}\n'
+                    if failure["output"]:
+                        out = failure["output"].strip().replace('\n', '\n            ')
+                        output_str += f'          output: |\n            {out}\n'
+            output_str += f'      ...\n'
     else:
         # print error or failure information if JUNIT mode
         if test_case.is_error() or test_case.is_failure():
@@ -408,8 +551,20 @@ def test_case_output_string(test_case: TestCase, spec: TestSpec, mode: RunMode,
     return output_str
 
 
+def save_failure_artifact(suite_spec: SuiteSpec, file: Path) -> Path:
+    """Attach a file to a test case
+
+    Args:
+        test_case (TestCase): Test case to attach the file to
+        file (Path): Path to the file to attach
+    """
+    save_path: Path = suite_spec.test_failure_artifacts_path / file.name
+    shutil.copyfile(file, save_path)
+    return save_path
+
+
 def run_test(index: int, test: str, spec: TestSpec, backend: str,
-             mode: RunMode, nproc: int, suite_spec: SuiteSpec) -> TestCase:
+             mode: RunMode, nproc: int, suite_spec: SuiteSpec, verbose: bool = False) -> TestCase:
     """Run a single test case and backend combination
 
     Args:
@@ -420,6 +575,7 @@ def run_test(index: int, test: str, spec: TestSpec, backend: str,
         mode (RunMode): Output mode
         nproc (int): Number of MPI processes to use when running test case
         suite_spec (SuiteSpec): Specification of test suite
+        verbose (bool, optional): Print detailed output for all runs, not just failures. Defaults to False.
 
     Returns:
         TestCase: Test case result
@@ -438,7 +594,7 @@ def run_test(index: int, test: str, spec: TestSpec, backend: str,
         run_args = ['mpiexec', '-n', f'{nproc}', *run_args]
 
     # run test
-    skip_reason: str = suite_spec.check_pre_skip(test, spec, backend, nproc)
+    skip_reason: Optional[str] = suite_spec.check_pre_skip(test, spec, backend, nproc)
     if skip_reason:
         test_case: TestCase = TestCase(f'{test}, "{spec.name}", n{nproc}, {backend}',
                                        elapsed_sec=0,
@@ -464,19 +620,23 @@ def run_test(index: int, test: str, spec: TestSpec, backend: str,
                              allow_multiple_subelements=True,
                              category=spec.name,)
         ref_csvs: List[Path] = []
+        ref_ascii: List[Path] = []
         output_files: List[str] = [arg for arg in run_args if 'ascii:' in arg]
         if output_files:
-            ref_csvs = [suite_spec.get_output_path(test, file.split(':')[1]) for file in output_files]
+            ref_csvs = [suite_spec.get_output_path(test, file.split(':')[1])
+                        for file in output_files if file.endswith('.csv')]
+            ref_ascii = [suite_spec.get_output_path(test, file.split(':')[1])
+                         for file in output_files if not file.endswith('.csv')]
         ref_cgns: List[Path] = []
         output_files = [arg for arg in run_args if 'cgns:' in arg]
         if output_files:
             ref_cgns = [suite_spec.get_output_path(test, file.split('cgns:')[-1]) for file in output_files]
         ref_stdout: Path = suite_spec.get_output_path(test, test + '.out')
-        suite_spec.post_test_hook(test, spec)
+        suite_spec.post_test_hook(test, spec, backend)
 
     # check allowed failures
     if not test_case.is_skipped() and test_case.stderr:
-        skip_reason: str = suite_spec.check_post_skip(test, spec, backend, test_case.stderr)
+        skip_reason: Optional[str] = suite_spec.check_post_skip(test, spec, backend, test_case.stderr)
         if skip_reason:
             test_case.add_skipped_info(skip_reason)
 
@@ -507,39 +667,67 @@ def run_test(index: int, test: str, spec: TestSpec, backend: str,
         # expected CSV output
         for ref_csv in ref_csvs:
             csv_name = ref_csv.name
+            out_file = Path.cwd() / csv_name
             if not ref_csv.is_file():
                 # remove _{ceed_backend} from path name
                 ref_csv = (ref_csv.parent / ref_csv.name.rsplit('_', 1)[0]).with_suffix('.csv')
             if not ref_csv.is_file():
                 test_case.add_failure_info('csv', output=f'{ref_csv} not found')
-            elif not (Path.cwd() / csv_name).is_file():
-                test_case.add_failure_info('csv', output=f'{csv_name} not found')
+            elif not out_file.is_file():
+                test_case.add_failure_info('csv', output=f'{out_file} not found')
             else:
-                diff: str = diff_csv(Path.cwd() / csv_name, ref_csv, **suite_spec.diff_csv_kwargs)
+                csv_ztol: float = spec.csv_ztol if spec.csv_ztol > 0 else suite_spec.csv_ztol
+                csv_rtol: float = spec.csv_rtol if spec.csv_rtol > 0 else suite_spec.csv_rtol
+                diff = diff_csv(out_file, ref_csv, zero_tol=csv_ztol, rel_tol=csv_rtol)
                 if diff:
-                    test_case.add_failure_info('csv', output=diff)
+                    save_path: Path = suite_spec.test_failure_artifacts_path / csv_name
+                    shutil.move(out_file, save_path)
+                    test_case.add_failure_info(f'csv: {save_path}', output=diff)
                 else:
-                    (Path.cwd() / csv_name).unlink()
+                    out_file.unlink()
         # expected CGNS output
         for ref_cgn in ref_cgns:
             cgn_name = ref_cgn.name
+            out_file = Path.cwd() / cgn_name
             if not ref_cgn.is_file():
                 # remove _{ceed_backend} from path name
                 ref_cgn = (ref_cgn.parent / ref_cgn.name.rsplit('_', 1)[0]).with_suffix('.cgns')
             if not ref_cgn.is_file():
                 test_case.add_failure_info('cgns', output=f'{ref_cgn} not found')
-            elif not (Path.cwd() / cgn_name).is_file():
-                test_case.add_failure_info('csv', output=f'{cgn_name} not found')
+            elif not out_file.is_file():
+                test_case.add_failure_info('cgns', output=f'{out_file} not found')
             else:
-                diff = diff_cgns(Path.cwd() / cgn_name, ref_cgn, cgns_tol=suite_spec.cgns_tol)
+                cgns_tol = spec.cgns_tol if spec.cgns_tol > 0 else suite_spec.cgns_tol
+                diff = diff_cgns(out_file, ref_cgn, cgns_tol=cgns_tol)
                 if diff:
-                    test_case.add_failure_info('cgns', output=diff)
+                    save_path: Path = suite_spec.test_failure_artifacts_path / cgn_name
+                    shutil.move(out_file, save_path)
+                    test_case.add_failure_info(f'cgns: {save_path}', output=diff)
                 else:
-                    (Path.cwd() / cgn_name).unlink()
+                    out_file.unlink()
+        # expected ASCII output
+        for ref_file in ref_ascii:
+            ref_name = ref_file.name
+            out_file = Path.cwd() / ref_name
+            if not ref_file.is_file():
+                # remove _{ceed_backend} from path name
+                ref_file = (ref_file.parent / ref_file.name.rsplit('_', 1)[0]).with_suffix(ref_file.suffix)
+            if not ref_file.is_file():
+                test_case.add_failure_info('ascii', output=f'{ref_file} not found')
+            elif not out_file.is_file():
+                test_case.add_failure_info('ascii', output=f'{out_file} not found')
+            else:
+                diff = diff_ascii(out_file, ref_file, backend)
+                if diff:
+                    save_path: Path = suite_spec.test_failure_artifacts_path / ref_name
+                    shutil.move(out_file, save_path)
+                    test_case.add_failure_info(f'ascii: {save_path}', output=diff)
+                else:
+                    out_file.unlink()
 
     # store result
     test_case.args = ' '.join(str(arg) for arg in run_args)
-    output_str = test_case_output_string(test_case, spec, mode, backend, test, index)
+    output_str = test_case_output_string(test_case, spec, mode, backend, test, index, verbose)
 
     return test_case, output_str
 
@@ -553,7 +741,7 @@ def init_process():
 
 
 def run_tests(test: str, ceed_backends: List[str], mode: RunMode, nproc: int,
-              suite_spec: SuiteSpec, pool_size: int = 1) -> TestSuite:
+              suite_spec: SuiteSpec, pool_size: int = 1, search: str = ".*", verbose: bool = False) -> TestSuite:
     """Run all test cases for `test` with each of the provided `ceed_backends`
 
     Args:
@@ -563,18 +751,23 @@ def run_tests(test: str, ceed_backends: List[str], mode: RunMode, nproc: int,
         nproc (int): Number of MPI processes to use when running each test case
         suite_spec (SuiteSpec): Object defining required methods for running tests
         pool_size (int, optional): Number of processes to use when running tests in parallel. Defaults to 1.
+        search (str, optional): Regular expression used to match tests. Defaults to ".*".
+        verbose (bool, optional): Print detailed output for all runs, not just failures. Defaults to False.
 
     Returns:
         TestSuite: JUnit `TestSuite` containing results of all test cases
     """
-    test_specs: List[TestSpec] = get_test_args(suite_spec.get_source_path(test))
+    test_specs: List[TestSpec] = [
+        t for t in get_test_args(suite_spec.get_source_path(test)) if re.search(search, t.name, re.IGNORECASE)
+    ]
+    suite_spec.test_failure_artifacts_path.mkdir(parents=True, exist_ok=True)
     if mode is RunMode.TAP:
         print('TAP version 13')
         print(f'1..{len(test_specs)}')
 
     with mp.Pool(processes=pool_size, initializer=init_process) as pool:
-        async_outputs: List[List[mp.AsyncResult]] = [
-            [pool.apply_async(run_test, (i, test, spec, backend, mode, nproc, suite_spec))
+        async_outputs: List[List[mp.pool.AsyncResult]] = [
+            [pool.apply_async(run_test, (i, test, spec, backend, mode, nproc, suite_spec, verbose))
              for (i, backend) in enumerate(ceed_backends, start=1)]
             for spec in test_specs
         ]
@@ -607,7 +800,7 @@ def write_junit_xml(test_suite: TestSuite, output_file: Optional[Path], batch: s
         output_file (Optional[Path]): Path to output file, or `None` to generate automatically as `build/{test_suite.name}{batch}.junit`
         batch (str): Name of JUnit batch, defaults to empty string
     """
-    output_file: Path = output_file or Path('build') / (f'{test_suite.name}{batch}.junit')
+    output_file = output_file or Path('build') / (f'{test_suite.name}{batch}.junit')
     output_file.write_text(to_xml_report_string([test_suite]))
 
 


### PR DESCRIPTION
Adds `make test subsearch="..."`, where `subsearch` is interpreted as a regular expression used to filter test cases by name.

Lots of people have asked for this, it wasn't too bad to add in.

Also, adds some useful output (timing, better error formatting) to TAP.

I used that output to shorten some excessively long tests (>30 s).

The parsing for arguments to TESTCASE(...) are far more robust
- quotation marks are now optional and can be escaped as `\"`
- there can be spaces after the commas separating arguments
- parentheses are allowed, so long as they match
- the only disallowed character is `=` when quotation marks aren't used, otherwise it's fine

The arguments `cgns_tol`, `csv_rtol`, and `csv_ztol` are now supported for per-test case tolerance settings.