### PR TITLE
dealii - use /cpu/self as default

### DIFF
--- a/examples/deal.II/bps.cc
+++ b/examples/deal.II/bps.cc
@@ -61,7 +61,7 @@ struct Parameters
   unsigned int n_global_refinements = 1;
   unsigned int fe_degree            = 2;
   bool         print_timings        = true;
-  std::string  libCEED_resource      = "/cpu/self/avx/blocked";
+  std::string  libCEED_resource      = "/cpu/self";
 
   bool
   parse(int argc, char *argv[])


### PR DESCRIPTION
Minor change - we usually set the default resource as `/cpu/self`, which resolves to what is usually the fastest CPU backend installed