### PR TITLE
Operator Name Consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -876,6 +876,7 @@ install : $(libceed) $(OBJDIR)/ceed.pc
 	  "$(includedir)/ceed/jit-source/gallery/" "$(includedir)/ceed/jit-source/magma/"\
 	  "$(includedir)/ceed/jit-source/sycl/" "$(libdir)" "$(pkgconfigdir)")
 	$(INSTALL_DATA) include/ceed/ceed.h "$(DESTDIR)$(includedir)/ceed/"
+	$(INSTALL_DATA) include/ceed/deprecated.h "$(DESTDIR)$(includedir)/ceed/"
 	$(INSTALL_DATA) include/ceed/types.h "$(DESTDIR)$(includedir)/ceed/"
 	$(INSTALL_DATA) include/ceed/ceed-f32.h "$(DESTDIR)$(includedir)/ceed/"
 	$(INSTALL_DATA) include/ceed/ceed-f64.h "$(DESTDIR)$(includedir)/ceed/"

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -1501,7 +1501,7 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda(CeedOperator op,
 //------------------------------------------------------------------------------
 // Single Operator Assembly Setup
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssembleSetup_Cuda(CeedOperator op, CeedInt use_ceedsize_idx) {
+static int CeedOperatorAssembleSingleSetup_Cuda(CeedOperator op, CeedInt use_ceedsize_idx) {
   Ceed                ceed;
   Ceed_Cuda          *cuda_data;
   CeedInt             num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
@@ -1707,7 +1707,7 @@ static int CeedSingleOperatorAssembleSetup_Cuda(CeedOperator op, CeedInt use_cee
 // (could have multiple basis eval modes).
 // TODO: allow multiple active input restrictions/basis objects
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssemble_Cuda(CeedOperator op, CeedInt offset, CeedVector values) {
+static int CeedOperatorAssembleSingle_Cuda(CeedOperator op, CeedInt offset, CeedVector values) {
   Ceed                ceed;
   CeedSize            values_length = 0, assembled_qf_length = 0;
   CeedInt             use_ceedsize_idx = 0, num_elem_in, num_elem_out, elem_size_in, elem_size_out;
@@ -1733,7 +1733,7 @@ static int CeedSingleOperatorAssemble_Cuda(CeedOperator op, CeedInt offset, Ceed
   if ((values_length > INT_MAX) || (assembled_qf_length > INT_MAX)) use_ceedsize_idx = 1;
 
   // Setup
-  if (!impl->asmb) CeedCallBackend(CeedSingleOperatorAssembleSetup_Cuda(op, use_ceedsize_idx));
+  if (!impl->asmb) CeedCallBackend(CeedOperatorAssembleSingleSetup_Cuda(op, use_ceedsize_idx));
   CeedOperatorAssemble_Cuda *asmb = impl->asmb;
 
   assert(asmb != NULL);
@@ -2077,7 +2077,7 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal", CeedOperatorLinearAssembleAddDiagonal_Cuda));
   CeedCallBackend(
       CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddPointBlockDiagonal", CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedSingleOperatorAssemble_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingle_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAdd_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Cuda));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -1498,7 +1498,7 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Hip(CeedOperator op, 
 //------------------------------------------------------------------------------
 // Single Operator Assembly Setup
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceedsize_idx) {
+static int CeedOperatorAssembleSingleSetup_Hip(CeedOperator op, CeedInt use_ceedsize_idx) {
   Ceed                ceed;
   Ceed_Hip           *hip_data;
   CeedInt             num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
@@ -1704,7 +1704,7 @@ static int CeedSingleOperatorAssembleSetup_Hip(CeedOperator op, CeedInt use_ceed
 // (could have multiple basis eval modes).
 // TODO: allow multiple active input restrictions/basis objects
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssemble_Hip(CeedOperator op, CeedInt offset, CeedVector values) {
+static int CeedOperatorAssembleSingle_Hip(CeedOperator op, CeedInt offset, CeedVector values) {
   Ceed                ceed;
   CeedSize            values_length = 0, assembled_qf_length = 0;
   CeedInt             use_ceedsize_idx = 0, num_elem_in, num_elem_out, elem_size_in, elem_size_out;
@@ -1730,7 +1730,7 @@ static int CeedSingleOperatorAssemble_Hip(CeedOperator op, CeedInt offset, CeedV
   if ((values_length > INT_MAX) || (assembled_qf_length > INT_MAX)) use_ceedsize_idx = 1;
 
   // Setup
-  if (!impl->asmb) CeedCallBackend(CeedSingleOperatorAssembleSetup_Hip(op, use_ceedsize_idx));
+  if (!impl->asmb) CeedCallBackend(CeedOperatorAssembleSingleSetup_Hip(op, use_ceedsize_idx));
   CeedOperatorAssemble_Hip *asmb = impl->asmb;
 
   assert(asmb != NULL);
@@ -2076,7 +2076,7 @@ int CeedOperatorCreate_Hip(CeedOperator op) {
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal", CeedOperatorLinearAssembleAddDiagonal_Hip));
   CeedCallBackend(
       CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddPointBlockDiagonal", CeedOperatorLinearAssembleAddPointBlockDiagonal_Hip));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedSingleOperatorAssemble_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingle_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAdd_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Hip));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/ref/ceed-ref-operator.c
+++ b/backends/ref/ceed-ref-operator.c
@@ -1527,7 +1527,7 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Ref(CeedOperator op, Ce
 //------------------------------------------------------------------------------
 // Assemble Operator AtPoints
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssembleAtPoints_Ref(CeedOperator op, CeedInt offset, CeedVector values) {
+static int CeedOperatorAssembleSingleAtPoints_Ref(CeedOperator op, CeedInt offset, CeedVector values) {
   CeedInt             num_points_offset = 0, num_input_fields, num_output_fields, num_elem, num_comp_active = 1;
   CeedScalar         *e_data[2 * CEED_FIELD_MAX] = {0}, *assembled;
   Ceed                ceed;
@@ -1798,7 +1798,7 @@ int CeedOperatorCreateAtPoints_Ref(CeedOperator op) {
   CeedCallBackend(
       CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleQFunctionUpdate", CeedOperatorLinearAssembleQFunctionAtPointsUpdate_Ref));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddDiagonal", CeedOperatorLinearAssembleAddDiagonalAtPoints_Ref));
-  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedSingleOperatorAssembleAtPoints_Ref));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingleAtPoints_Ref));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAddAtPoints_Ref));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Ref));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-operator.sycl.cpp
@@ -997,7 +997,7 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Sycl(CeedOperator op,
 //------------------------------------------------------------------------------
 // Single operator assembly setup
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssembleSetup_Sycl(CeedOperator op) {
+static int CeedOperatorAssembleSingleSetup_Sycl(CeedOperator op) {
   Ceed    ceed;
   CeedInt num_input_fields, num_output_fields, num_eval_mode_in = 0, dim = 1, num_B_in_mats_to_load = 0, size_B_in = 0, num_eval_mode_out = 0,
                                                num_B_out_mats_to_load = 0, size_B_out = 0, num_qpts = 0, elem_size = 0, num_elem, num_comp,
@@ -1337,7 +1337,7 @@ static int CeedOperatorLinearAssembleFallback_Sycl(sycl::queue &sycl_queue, cons
 // input restriction/basis per operator (could have multiple basis eval modes).
 // TODO: allow multiple active input restrictions/basis objects
 //------------------------------------------------------------------------------
-static int CeedSingleOperatorAssemble_Sycl(CeedOperator op, CeedInt offset, CeedVector values) {
+static int CeedOperatorAssembleSingle_Sycl(CeedOperator op, CeedInt offset, CeedVector values) {
   Ceed                ceed;
   Ceed_Sycl          *sycl_data;
   CeedScalar         *values_array;
@@ -1353,7 +1353,7 @@ static int CeedSingleOperatorAssemble_Sycl(CeedOperator op, CeedInt offset, Ceed
 
   // Setup
   if (!impl->asmb) {
-    CeedCallBackend(CeedSingleOperatorAssembleSetup_Sycl(op));
+    CeedCallBackend(CeedOperatorAssembleSingleSetup_Sycl(op));
     assert(impl->asmb != NULL);
   }
 
@@ -1397,7 +1397,7 @@ int CeedOperatorCreate_Sycl(CeedOperator op) {
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Operator", op, "LinearAssembleAddDiagonal", CeedOperatorLinearAssembleAddDiagonal_Sycl));
   CeedCallBackend(
       CeedSetBackendFunctionCpp(ceed, "Operator", op, "LinearAssembleAddPointBlockDiagonal", CeedOperatorLinearAssembleAddPointBlockDiagonal_Sycl));
-  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Operator", op, "LinearAssembleSingle", CeedSingleOperatorAssemble_Sycl));
+  CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingle_Sycl));
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAdd_Sycl));
   CeedCallBackend(CeedSetBackendFunctionCpp(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Sycl));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/doc/sphinx/source/releasenotes.md
+++ b/doc/sphinx/source/releasenotes.md
@@ -15,6 +15,8 @@ On this page we provide a summary of the main API changes, new features and exam
     - Add `CEED_RUNNING_JIT_PASS` compiler definition for wrapping header files that device JiT compilers cannot read
     - Users should now prefer `#include <ceed/types.h>` rather than `#include <ceed.h>` in QFunction source files
 - Require use of `Ceed*Destroy()` on Ceed objects returned from `Ceed*Get*()`.
+- Rename `CeedCompositeOperatorCreate()` to `CeedOperatorCreateComposite()` for uniformity.
+- Rename `CeedCompositeOperator*()` to `CeedOperatorComposite*()` for uniformity.
 
 ### New features
 

--- a/examples/fluids/problems/advection.c
+++ b/examples/fluids/problems/advection.c
@@ -35,7 +35,7 @@ PetscErrorCode CreateKSPMassOperator_AdvectionStabilized(User user, CeedOperator
     CeedOperatorField field;
     PetscInt          sub_op_index = 0;  // will be 0 for the volume op
 
-    PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(user->op_rhs_ctx->op, &sub_ops));
+    PetscCallCeed(ceed, CeedOperatorCompositeGetSubList(user->op_rhs_ctx->op, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
     PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_q, &basis_q, NULL));
 

--- a/examples/fluids/problems/newtonian.c
+++ b/examples/fluids/problems/newtonian.c
@@ -171,7 +171,7 @@ PetscErrorCode CreateKSPMassOperator_NewtonianStabilized(User user, CeedOperator
     CeedOperatorField field;
     PetscInt          sub_op_index = 0;  // will be 0 for the volume op
 
-    PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(user->op_rhs_ctx->op, &sub_ops));
+    PetscCallCeed(ceed, CeedOperatorCompositeGetSubList(user->op_rhs_ctx->op, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
     PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_q, &basis_q, NULL));
 

--- a/examples/fluids/src/differential_filter.c
+++ b/examples/fluids/src/differential_filter.c
@@ -96,7 +96,7 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
     // -- Get Grid anisotropy tensor
     PetscCall(GridAnisotropyTensorCalculateCollocatedVector(ceed, user, ceed_data, &elem_restr_grid_aniso, &grid_aniso_ceed, &num_comp_grid_aniso));
 
-    PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &op_lhs));
+    PetscCallCeed(ceed, CeedOperatorCreateComposite(ceed, &op_lhs));
     for (PetscInt i = 0; i < diff_filter->num_filtered_fields; i++) {
       CeedQFunction       qf_lhs;
       PetscInt            num_comp_filter = diff_filter->num_field_components[i];
@@ -149,7 +149,7 @@ PetscErrorCode DifferentialFilterCreateOperators(Ceed ceed, User user, CeedData 
       PetscCallCeed(ceed, CeedOperatorSetField(op_lhs_sub, "v", elem_restr_filter, basis_filter, CEED_VECTOR_ACTIVE));
       PetscCallCeed(ceed, CeedOperatorSetField(op_lhs_sub, "Grad_v", elem_restr_filter, basis_filter, CEED_VECTOR_ACTIVE));
 
-      PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_lhs, op_lhs_sub));
+      PetscCallCeed(ceed, CeedOperatorCompositeAddSub(op_lhs, op_lhs_sub));
       PetscCallCeed(ceed, CeedElemRestrictionDestroy(&elem_restr_filter));
       PetscCallCeed(ceed, CeedBasisDestroy(&basis_filter));
       PetscCallCeed(ceed, CeedQFunctionDestroy(&qf_lhs));

--- a/examples/fluids/src/mat-ceed.c
+++ b/examples/fluids/src/mat-ceed.c
@@ -406,8 +406,8 @@ PetscErrorCode MatCreateCeed(DM dm_x, DM dm_y, CeedOperator op_mult, CeedOperato
           CeedInt       num_sub_operators;
           CeedOperator *sub_operators;
 
-          PetscCallCeed(ctx->ceed, CeedCompositeOperatorGetNumSub(op_mult, &num_sub_operators));
-          PetscCallCeed(ctx->ceed, CeedCompositeOperatorGetSubList(op_mult, &sub_operators));
+          PetscCallCeed(ctx->ceed, CeedOperatorCompositeGetNumSub(op_mult, &num_sub_operators));
+          PetscCallCeed(ctx->ceed, CeedOperatorCompositeGetSubList(op_mult, &sub_operators));
           for (CeedInt i = 0; i < num_sub_operators; i++) {
             CeedInt                  num_bases, num_comp;
             CeedBasis               *active_bases;

--- a/examples/fluids/src/setuplibceed.c
+++ b/examples/fluids/src/setuplibceed.c
@@ -28,7 +28,7 @@ static PetscErrorCode CreateKSPMassOperator_Unstabilized(User user, CeedOperator
     CeedOperatorField field;
     PetscInt          sub_op_index = 0;  // will be 0 for the volume op
 
-    PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(user->op_rhs_ctx->op, &sub_ops));
+    PetscCallCeed(ceed, CeedOperatorCompositeGetSubList(user->op_rhs_ctx->op, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
     PetscCallCeed(ceed, CeedOperatorFieldGetData(field, NULL, &elem_restr_q, &basis_q, NULL));
 
@@ -134,8 +134,8 @@ static PetscErrorCode AddBCSubOperator(Ceed ceed, DM dm, CeedData ceed_data, DML
   }
 
   // Apply Sub-Operator for Physics
-  PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_apply, op_apply_bc));
-  if (op_apply_bc_jacobian) PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_apply_ijacobian, op_apply_bc_jacobian));
+  PetscCallCeed(ceed, CeedOperatorCompositeAddSub(op_apply, op_apply_bc));
+  if (op_apply_bc_jacobian) PetscCallCeed(ceed, CeedOperatorCompositeAddSub(op_apply_ijacobian, op_apply_bc_jacobian));
 
   PetscCallCeed(ceed, CeedVectorDestroy(&q_data_sur));
   PetscCallCeed(ceed, CeedVectorDestroy(&jac_data_sur));
@@ -197,7 +197,7 @@ static PetscErrorCode AddBCSubOperators(User user, Ceed ceed, DM dm, SimpleBC bc
     PetscInt            sub_op_index = 0;  // will be 0 for the volume op
     CeedElemRestriction elem_restr_q, elem_restr_x;
 
-    PetscCallCeed(ceed, CeedCompositeOperatorGetSubList(op_apply, &sub_ops));
+    PetscCallCeed(ceed, CeedOperatorCompositeGetSubList(op_apply, &sub_ops));
     PetscCallCeed(ceed, CeedOperatorGetFieldByName(sub_ops[sub_op_index], "q", &field));
     PetscCallCeed(ceed, CeedOperatorFieldGetElemRestriction(field, &elem_restr_q));
     PetscCallCeed(ceed, CeedElemRestrictionGetNumComponents(elem_restr_q, &num_comp_q));
@@ -440,8 +440,8 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
   if (!user->phys->implicit) {  // RHS
     CeedOperator op_rhs;
 
-    PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &op_rhs));
-    PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_rhs, op_rhs_vol));
+    PetscCallCeed(ceed, CeedOperatorCreateComposite(ceed, &op_rhs));
+    PetscCallCeed(ceed, CeedOperatorCompositeAddSub(op_rhs, op_rhs_vol));
     PetscCall(AddBCSubOperators(user, ceed, dm, bc, problem, ceed_data, op_rhs, NULL));
 
     PetscCall(OperatorApplyContextCreate(dm, dm, ceed, op_rhs, user->q_ceed, user->g_ceed, user->Q_loc, NULL, &user->op_rhs_ctx));
@@ -456,11 +456,11 @@ PetscErrorCode SetupLibceed(Ceed ceed, CeedData ceed_data, DM dm, User user, App
     CeedOperator op_ijacobian = NULL;
 
     // Create Composite Operaters
-    PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &user->op_ifunction));
-    PetscCallCeed(ceed, CeedCompositeOperatorAddSub(user->op_ifunction, op_ifunction_vol));
+    PetscCallCeed(ceed, CeedOperatorCreateComposite(ceed, &user->op_ifunction));
+    PetscCallCeed(ceed, CeedOperatorCompositeAddSub(user->op_ifunction, op_ifunction_vol));
     if (op_ijacobian_vol) {
-      PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &op_ijacobian));
-      PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_ijacobian, op_ijacobian_vol));
+      PetscCallCeed(ceed, CeedOperatorCreateComposite(ceed, &op_ijacobian));
+      PetscCallCeed(ceed, CeedOperatorCompositeAddSub(op_ijacobian, op_ijacobian_vol));
     }
     PetscCall(AddBCSubOperators(user, ceed, dm, bc, problem, ceed_data, user->op_ifunction, op_ijacobian));
 

--- a/examples/fluids/src/strong_boundary_conditions.c
+++ b/examples/fluids/src/strong_boundary_conditions.c
@@ -104,7 +104,7 @@ PetscErrorCode SetupStrongSTG_Ceed(Ceed ceed, CeedData ceed_data, DM dm, Problem
     PetscCallCeed(ceed, CeedOperatorSetField(op_strong_bc_sub, "q", elem_restr_q_sur, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE));
 
     // -- Add to composite operator
-    PetscCallCeed(ceed, CeedCompositeOperatorAddSub(op_strong_bc, op_strong_bc_sub));
+    PetscCallCeed(ceed, CeedOperatorCompositeAddSub(op_strong_bc, op_strong_bc_sub));
 
     PetscCallCeed(ceed, CeedVectorDestroy(&multiplicity));
     PetscCallCeed(ceed, CeedVectorDestroy(&x_stored));
@@ -168,7 +168,7 @@ PetscErrorCode SetupStrongBC_Ceed(Ceed ceed, CeedData ceed_data, DM dm, User use
     PetscCall(DMRestoreGlobalVector(dm, &global_vec));
   }
 
-  PetscCallCeed(ceed, CeedCompositeOperatorCreate(ceed, &op_strong_bc));
+  PetscCallCeed(ceed, CeedOperatorCreateComposite(ceed, &op_strong_bc));
   {
     PetscBool use_strongstg = PETSC_FALSE;
     PetscCall(PetscOptionsGetBool(NULL, NULL, "-stg_strong", &use_strongstg, NULL));

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -461,9 +461,9 @@ CEED_EXTERN int CeedOperatorReference(CeedOperator op);
 CEED_EXTERN int CeedOperatorGetFallback(CeedOperator op, CeedOperator *op_fallback);
 CEED_EXTERN int CeedOperatorGetFallbackParent(CeedOperator op, CeedOperator *parent);
 CEED_EXTERN int CeedOperatorGetFallbackParentCeed(CeedOperator op, Ceed *parent);
-CEED_EXTERN int CeedOperatorFallbackLinearAssembleQFunctionBuildOrUpdate(CeedOperator op, CeedVector *assembled, CeedElemRestriction *rstr,
+CEED_EXTERN int CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback(CeedOperator op, CeedVector *assembled, CeedElemRestriction *rstr,
                                                                          CeedRequest *request);
-CEED_INTERN int CeedSingleOperatorAssemble(CeedOperator op, CeedInt offset, CeedVector values);
+CEED_INTERN int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector values);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
 CEED_INTERN int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A, const CeedScalar *mat_B, CeedScalar *mat_C, CeedInt m, CeedInt n,

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -409,7 +409,7 @@ CEED_EXTERN int CeedQFunctionContextDestroy(CeedQFunctionContext *ctx);
 
 CEED_EXTERN int CeedOperatorCreate(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, CeedQFunction dqfT, CeedOperator *op);
 CEED_EXTERN int CeedOperatorCreateAtPoints(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, CeedQFunction dqfT, CeedOperator *op);
-CEED_EXTERN int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op);
+CEED_EXTERN int CeedOperatorCreateComposite(Ceed ceed, CeedOperator *op);
 CEED_EXTERN int CeedOperatorReferenceCopy(CeedOperator op, CeedOperator *op_copy);
 CEED_EXTERN int CeedOperatorSetField(CeedOperator op, const char *field_name, CeedElemRestriction rstr, CeedBasis basis, CeedVector vec);
 CEED_EXTERN int CeedOperatorGetFields(CeedOperator op, CeedInt *num_input_fields, CeedOperatorField **input_fields, CeedInt *num_output_fields,
@@ -418,10 +418,10 @@ CEED_EXTERN int CeedOperatorGetFields(CeedOperator op, CeedInt *num_input_fields
 CEED_EXTERN int  CeedOperatorAtPointsSetPoints(CeedOperator op, CeedElemRestriction rstr_points, CeedVector point_coords);
 CEED_EXTERN int  CeedOperatorAtPointsGetPoints(CeedOperator op, CeedElemRestriction *rstr_points, CeedVector *point_coords);
 CEED_EXTERN int  CeedOperatorIsAtPoints(CeedOperator op, bool *is_at_points);
-CEED_EXTERN int  CeedCompositeOperatorAddSub(CeedOperator composite_op, CeedOperator sub_op);
-CEED_EXTERN int  CeedCompositeOperatorGetNumSub(CeedOperator op, CeedInt *num_suboperators);
-CEED_EXTERN int  CeedCompositeOperatorGetSubList(CeedOperator op, CeedOperator **sub_operators);
-CEED_EXTERN int  CeedCompositeOperatorGetSubByName(CeedOperator op, const char *op_name, CeedOperator *sub_op);
+CEED_EXTERN int  CeedOperatorCompositeAddSub(CeedOperator composite_op, CeedOperator sub_op);
+CEED_EXTERN int  CeedOperatorCompositeGetNumSub(CeedOperator op, CeedInt *num_suboperators);
+CEED_EXTERN int  CeedOperatorCompositeGetSubList(CeedOperator op, CeedOperator **sub_operators);
+CEED_EXTERN int  CeedOperatorCompositeGetSubByName(CeedOperator op, const char *op_name, CeedOperator *sub_op);
 CEED_EXTERN int  CeedOperatorCheckReady(CeedOperator op);
 CEED_EXTERN int  CeedOperatorGetActiveVectorLengths(CeedOperator op, CeedSize *input_size, CeedSize *output_size);
 CEED_EXTERN int  CeedOperatorSetQFunctionAssemblyReuse(CeedOperator op, bool reuse_assembly_data);
@@ -436,7 +436,7 @@ CEED_EXTERN int  CeedOperatorLinearAssembleAddPointBlockDiagonal(CeedOperator op
 CEED_EXTERN int  CeedOperatorLinearAssemblePointBlockDiagonalSymbolic(CeedOperator op, CeedSize *num_entries, CeedInt **rows, CeedInt **cols);
 CEED_EXTERN int  CeedOperatorLinearAssembleSymbolic(CeedOperator op, CeedSize *num_entries, CeedInt **rows, CeedInt **cols);
 CEED_EXTERN int  CeedOperatorLinearAssemble(CeedOperator op, CeedVector values);
-CEED_EXTERN int  CeedCompositeOperatorGetMultiplicity(CeedOperator op, CeedInt num_skip_indices, CeedInt *skip_indices, CeedVector mult);
+CEED_EXTERN int  CeedOperatorCompositeGetMultiplicity(CeedOperator op, CeedInt num_skip_indices, CeedInt *skip_indices, CeedVector mult);
 CEED_EXTERN int  CeedOperatorMultigridLevelCreate(CeedOperator op_fine, CeedVector p_mult_fine, CeedElemRestriction rstr_coarse,
                                                   CeedBasis basis_coarse, CeedOperator *op_coarse, CeedOperator *op_prolong,
                                                   CeedOperator *op_restrict);
@@ -472,6 +472,14 @@ CEED_EXTERN int  CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector
 CEED_EXTERN int  CeedOperatorApplyAddActive(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
 CEED_EXTERN int  CeedOperatorAssemblyDataStrip(CeedOperator op);
 CEED_EXTERN int  CeedOperatorDestroy(CeedOperator *op);
+
+// Compatibility with previous composite CeedOperator naming
+#define CeedCompositeOperatorCreate(a, b) CeedOperatorCreateComposite(a, b)
+#define CeedCompositeOperatorAddSub(a, b) CeedOperatorCompositeAddSub(a, b)
+#define CeedCompositeOperatorGetNumSub(a, b) CeedOperatorCompositeGetNumSub(a, b)
+#define CeedCompositeOperatorGetSubList(a, b) CeedOperatorCompositeGetSubList(a, b)
+#define CeedCompositeOperatorGetSubByName(a, b) CeedOperatorCompositeGetSubByName(a, b, c)
+#define CeedCompositeOperatorGetMultiplicity(a, b, c, d) CeedOperatorCompositeGetMultiplicity(a, b, c, d)
 
 CEED_EXTERN int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOperatorField *op_field);
 CEED_EXTERN int CeedOperatorFieldGetName(CeedOperatorField op_field, const char **field_name);

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -474,12 +474,7 @@ CEED_EXTERN int  CeedOperatorAssemblyDataStrip(CeedOperator op);
 CEED_EXTERN int  CeedOperatorDestroy(CeedOperator *op);
 
 // Compatibility with previous composite CeedOperator naming
-#define CeedCompositeOperatorCreate(a, b) CeedOperatorCreateComposite(a, b)
-#define CeedCompositeOperatorAddSub(a, b) CeedOperatorCompositeAddSub(a, b)
-#define CeedCompositeOperatorGetNumSub(a, b) CeedOperatorCompositeGetNumSub(a, b)
-#define CeedCompositeOperatorGetSubList(a, b) CeedOperatorCompositeGetSubList(a, b)
-#define CeedCompositeOperatorGetSubByName(a, b) CeedOperatorCompositeGetSubByName(a, b, c)
-#define CeedCompositeOperatorGetMultiplicity(a, b, c, d) CeedOperatorCompositeGetMultiplicity(a, b, c, d)
+#include "deprecated.h"
 
 CEED_EXTERN int CeedOperatorGetFieldByName(CeedOperator op, const char *field_name, CeedOperatorField *op_field);
 CEED_EXTERN int CeedOperatorFieldGetName(CeedOperatorField op_field, const char **field_name);

--- a/include/ceed/deprecated.h
+++ b/include/ceed/deprecated.h
@@ -1,0 +1,38 @@
+/// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and other CEED contributors.
+/// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+///
+/// SPDX-License-Identifier: BSD-2-Clause
+///
+/// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Public header for user and utility components of libCEED
+#pragma once
+
+#if __STDC_VERSION__ >= 202311L
+#define DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define DEPRECATED(msg)
+#endif
+
+// Compatibility with previous composite CeedOperator naming
+DEPRECATED("Use CeedOperatorCreateComposite()")
+static inline int CeedCompositeOperatorCreate(Ceed a, CeedOperator *b) { return CeedOperatorCreateComposite(a, b); }
+DEPRECATED("Use CeedOperatorCompositeAddSub()")
+static inline int CeedCompositeOperatorAddSub(CeedOperator a, CeedOperator b) { return CeedOperatorCompositeAddSub(a, b); }
+DEPRECATED("Use CeedOperatorCompositeGetNumSub()")
+static inline int CeedCompositeOperatorGetNumSub(CeedOperator a, CeedInt *b) { return CeedOperatorCompositeGetNumSub(a, b); }
+DEPRECATED("Use CeedOperatorCompositeGetSubList()")
+static inline int CeedCompositeOperatorGetSubList(CeedOperator a, CeedOperator **b) { return CeedOperatorCompositeGetSubList(a, b); }
+DEPRECATED("Use CeedCompositeOperatorGetSubByName()")
+static inline int CeedCompositeOperatorGetSubByName(CeedOperator a, const char *b, CeedOperator *c) {
+  return CeedOperatorCompositeGetSubByName(a, b, c);
+}
+DEPRECATED("Use CeedOperatorCompositeGetMultiplicity()")
+static inline int CeedCompositeOperatorGetMultiplicity(CeedOperator a, CeedInt b, CeedInt *c, CeedVector d) {
+  return CeedOperatorCompositeGetMultiplicity(a, b, c, d);
+}
+
+#undef DEPRECATED

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -951,8 +951,8 @@ CEED_EXTERN void fCeedOperatorCreate(int *ceed, int *qf, int *dqf, int *dqfT, in
   CeedOperator_n++;
 }
 
-#define fCeedCompositeOperatorCreate FORTRAN_NAME(ceedcompositeoperatorcreate, CEEDCOMPOSITEOPERATORCREATE)
-CEED_EXTERN void fCeedCompositeOperatorCreate(int *ceed, int *op, int *err) {
+#define fCeedOperatorCreateComposite FORTRAN_NAME(ceedoperatorcreatecomposite, CEEDOPERATORCREATECOMPOSITE)
+CEED_EXTERN void fCeedOperatorCreateComposite(int *ceed, int *op, int *err) {
   if (CeedOperator_count == CeedOperator_count_max) {
     CeedOperator_count_max += CeedOperator_count_max / 2 + 1;
     CeedRealloc(CeedOperator_count_max, &CeedOperator_dict);
@@ -960,7 +960,7 @@ CEED_EXTERN void fCeedCompositeOperatorCreate(int *ceed, int *op, int *err) {
 
   CeedOperator *op_ = &CeedOperator_dict[CeedOperator_count];
 
-  *err = CeedCompositeOperatorCreate(Ceed_dict[*ceed], op_);
+  *err = CeedOperatorCreateComposite(Ceed_dict[*ceed], op_);
   if (*err) return;
   *op = CeedOperator_count++;
   CeedOperator_n++;
@@ -1003,12 +1003,12 @@ CEED_EXTERN void fCeedOperatorSetField(int *op, const char *field_name, int *r, 
   *err = CeedOperatorSetField(op_, field_name_c, r_, b_, v_);
 }
 
-#define fCeedCompositeOperatorAddSub FORTRAN_NAME(ceedcompositeoperatoraddsub, CEEDCOMPOSITEOPERATORADDSUB)
-CEED_EXTERN void fCeedCompositeOperatorAddSub(int *compositeop, int *subop, int *err) {
+#define fCeedOperatorCompositeAddSub FORTRAN_NAME(ceedoperatorcompositeaddsub, CEEDOPERATORCOMPOSITEADDSUB)
+CEED_EXTERN void fCeedOperatorCompositeAddSub(int *compositeop, int *subop, int *err) {
   CeedOperator compositeop_ = CeedOperator_dict[*compositeop];
   CeedOperator subop_       = CeedOperator_dict[*subop];
 
-  *err = CeedCompositeOperatorAddSub(compositeop_, subop_);
+  *err = CeedOperatorCompositeAddSub(compositeop_, subop_);
 }
 
 #define fCeedOperatorSetName FORTRAN_NAME(ceedoperatorsetname, CEEDOPERATORSETNAME)

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -376,8 +376,8 @@ static int CeedOperatorContextSetGeneric(CeedOperator op, CeedContextFieldLabel 
     CeedInt       num_sub;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_sub));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_sub));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     CeedCheck(num_sub == field_label->num_sub_labels, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
               "Composite operator modified after ContextFieldLabel created");
 
@@ -443,8 +443,8 @@ static int CeedOperatorContextGetGenericRead(CeedOperator op, CeedContextFieldLa
     CeedInt       num_sub;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_sub));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_sub));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     CeedCheck(num_sub == field_label->num_sub_labels, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
               "Composite operator modified after ContextFieldLabel created");
 
@@ -506,8 +506,8 @@ static int CeedOperatorContextRestoreGenericRead(CeedOperator op, CeedContextFie
     CeedInt       num_sub;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_sub));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_sub));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     CeedCheck(num_sub == field_label->num_sub_labels, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
               "Composite operator modified after ContextFieldLabel created");
 
@@ -831,13 +831,13 @@ int CeedOperatorCreateAtPoints(Ceed ceed, CeedQFunction qf, CeedQFunction dqf, C
 
   @ref User
  */
-int CeedCompositeOperatorCreate(Ceed ceed, CeedOperator *op) {
+int CeedOperatorCreateComposite(Ceed ceed, CeedOperator *op) {
   if (!ceed->CompositeOperatorCreate) {
     Ceed delegate;
 
     CeedCall(CeedGetObjectDelegate(ceed, &delegate, "Operator"));
     if (delegate) {
-      CeedCall(CeedCompositeOperatorCreate(delegate, op));
+      CeedCall(CeedOperatorCreateComposite(delegate, op));
       CeedCall(CeedDestroy(&delegate));
       return CEED_ERROR_SUCCESS;
     }
@@ -1263,7 +1263,7 @@ int CeedOperatorFieldGetData(CeedOperatorField op_field, const char **field_name
 
   @ref User
  */
-int CeedCompositeOperatorAddSub(CeedOperator composite_op, CeedOperator sub_op) {
+int CeedOperatorCompositeAddSub(CeedOperator composite_op, CeedOperator sub_op) {
   bool is_immutable;
 
   CeedCheck(composite_op->is_composite, CeedOperatorReturnCeed(composite_op), CEED_ERROR_MINOR, "CeedOperator is not a composite operator");
@@ -1303,7 +1303,7 @@ int CeedCompositeOperatorAddSub(CeedOperator composite_op, CeedOperator sub_op) 
 
   @ref Backend
 **/
-int CeedCompositeOperatorGetNumSub(CeedOperator op, CeedInt *num_suboperators) {
+int CeedOperatorCompositeGetNumSub(CeedOperator op, CeedInt *num_suboperators) {
   bool is_composite;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
@@ -1322,7 +1322,7 @@ int CeedCompositeOperatorGetNumSub(CeedOperator op, CeedInt *num_suboperators) {
 
   @ref Backend
 **/
-int CeedCompositeOperatorGetSubList(CeedOperator op, CeedOperator **sub_operators) {
+int CeedOperatorCompositeGetSubList(CeedOperator op, CeedOperator **sub_operators) {
   bool is_composite;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
@@ -1346,7 +1346,7 @@ int CeedCompositeOperatorGetSubList(CeedOperator op, CeedOperator **sub_operator
 
   @ref Advanced
 **/
-int CeedCompositeOperatorGetSubByName(CeedOperator op, const char *op_name, CeedOperator *sub_op) {
+int CeedOperatorCompositeGetSubByName(CeedOperator op, const char *op_name, CeedOperator *sub_op) {
   bool          is_composite;
   CeedInt       num_sub_ops;
   CeedOperator *sub_ops;
@@ -1354,8 +1354,8 @@ int CeedCompositeOperatorGetSubByName(CeedOperator op, const char *op_name, Ceed
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
   CeedCheck(is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_MINOR, "Only defined for a composite operator");
   *sub_op = NULL;
-  CeedCall(CeedCompositeOperatorGetNumSub(op, &num_sub_ops));
-  CeedCall(CeedCompositeOperatorGetSubList(op, &sub_ops));
+  CeedCall(CeedOperatorCompositeGetNumSub(op, &num_sub_ops));
+  CeedCall(CeedOperatorCompositeGetSubList(op, &sub_ops));
   for (CeedInt i = 0; i < num_sub_ops; i++) {
     if (sub_ops[i]->name && !strcmp(op_name, sub_ops[i]->name)) {
       *sub_op = sub_ops[i];
@@ -1386,7 +1386,7 @@ int CeedOperatorCheckReady(CeedOperator op) {
   if (is_composite) {
     CeedInt num_suboperators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
     if (!num_suboperators) {
       // Empty operator setup
       op->input_size  = 0;
@@ -1394,7 +1394,7 @@ int CeedOperatorCheckReady(CeedOperator op) {
     } else {
       CeedOperator *sub_operators;
 
-      CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+      CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
       for (CeedInt i = 0; i < num_suboperators; i++) {
         CeedCall(CeedOperatorCheckReady(sub_operators[i]));
       }
@@ -1448,8 +1448,8 @@ int CeedOperatorGetActiveVectorLengths(CeedOperator op, CeedSize *input_size, Ce
     CeedInt       num_suboperators;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     for (CeedInt i = 0; i < num_suboperators; i++) {
       CeedSize sub_input_size, sub_output_size;
 
@@ -1516,8 +1516,8 @@ int CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(CeedOperator op, bool needs
     CeedInt       num_suboperators;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     for (CeedInt i = 0; i < num_suboperators; i++) {
       CeedCall(CeedOperatorSetQFunctionAssemblyDataUpdateNeeded(sub_operators[i], needs_data_update));
     }
@@ -1599,8 +1599,8 @@ static int CeedOperatorView_Core(CeedOperator op, FILE *stream, bool is_full) {
     CeedInt       num_suboperators;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     fprintf(stream, "Composite CeedOperator%s%s\n", has_name ? " - " : "", has_name ? name : "");
 
     for (CeedInt i = 0; i < num_suboperators; i++) {
@@ -1729,9 +1729,9 @@ int CeedOperatorGetFlopsEstimate(CeedOperator op, CeedSize *flops) {
   if (is_composite) {
     CeedInt num_suboperators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
     CeedOperator *sub_operators;
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
 
     // FLOPs for each suboperator
     for (CeedInt i = 0; i < num_suboperators; i++) {
@@ -1906,8 +1906,8 @@ int CeedOperatorGetContextFieldLabel(CeedOperator op, const char *field_name, Ce
     CeedContextFieldLabel new_field_label;
 
     CeedCall(CeedCalloc(1, &new_field_label));
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_sub));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_sub));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     CeedCall(CeedCalloc(num_sub, &new_field_label->sub_labels));
     new_field_label->num_sub_labels = num_sub;
 
@@ -2209,8 +2209,8 @@ int CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedReq
       CeedInt       num_suboperators;
       CeedOperator *sub_operators;
 
-      CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
-      CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+      CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+      CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
       for (CeedInt i = 0; i < num_suboperators; i++) {
         CeedCall(CeedOperatorApplyAdd(sub_operators[i], in, out, request));
       }
@@ -2250,8 +2250,8 @@ int CeedOperatorApplyAddActive(CeedOperator op, CeedVector in, CeedVector out, C
     CeedInt       num_suboperators;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
 
     // Zero all output vectors
     for (CeedInt i = 0; i < num_suboperators; i++) {
@@ -2308,8 +2308,8 @@ int CeedOperatorAssemblyDataStrip(CeedOperator op) {
     CeedInt       num_suboperators;
     CeedOperator *sub_operators;
 
-    CeedCall(CeedCompositeOperatorGetNumSub(op, &num_suboperators));
-    CeedCall(CeedCompositeOperatorGetSubList(op, &sub_operators));
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
     for (CeedInt i = 0; i < num_suboperators; i++) {
       CeedCall(CeedQFunctionAssemblyDataDestroy(&sub_operators[i]->qf_assembled));
       CeedCall(CeedOperatorAssemblyDataDestroy(&sub_operators[i]->op_assembled));

--- a/julia/LibCEED.jl/src/Operator.jl
+++ b/julia/LibCEED.jl/src/Operator.jl
@@ -69,11 +69,11 @@ collection `ops`.
 """
 function create_composite_operator(c::Ceed, ops)
     ref = Ref{C.CeedOperator}()
-    C.CeedCompositeOperatorCreate(c[], ref)
+    C.CeedOperatorCreateComposite(c[], ref)
     comp_op = Operator(ref, QFunctionNone(), QFunctionNone(), QFunctionNone())
     comp_op.sub_ops = ops
     for op ∈ ops
-        C.CeedCompositeOperatorAddSub(comp_op[], op[])
+        C.CeedOperatorCompositeAddSub(comp_op[], op[])
     end
     comp_op
 end

--- a/julia/LibCEED.jl/src/generated/libceed_bindings.jl
+++ b/julia/LibCEED.jl/src/generated/libceed_bindings.jl
@@ -658,8 +658,8 @@ function CeedOperatorCreate(ceed, qf, dqf, dqfT, op)
     ccall((:CeedOperatorCreate, libceed), Cint, (Ceed, CeedQFunction, CeedQFunction, CeedQFunction, Ptr{CeedOperator}), ceed, qf, dqf, dqfT, op)
 end
 
-function CeedCompositeOperatorCreate(ceed, op)
-    ccall((:CeedCompositeOperatorCreate, libceed), Cint, (Ceed, Ptr{CeedOperator}), ceed, op)
+function CeedOperatorCreateComposite(ceed, op)
+    ccall((:CeedOperatorCreateComposite, libceed), Cint, (Ceed, Ptr{CeedOperator}), ceed, op)
 end
 
 function CeedOperatorReferenceCopy(op, op_copy)
@@ -674,16 +674,16 @@ function CeedOperatorGetFields(op, num_input_fields, input_fields, num_output_fi
     ccall((:CeedOperatorGetFields, libceed), Cint, (CeedOperator, Ptr{CeedInt}, Ptr{Ptr{CeedOperatorField}}, Ptr{CeedInt}, Ptr{Ptr{CeedOperatorField}}), op, num_input_fields, input_fields, num_output_fields, output_fields)
 end
 
-function CeedCompositeOperatorAddSub(composite_op, sub_op)
-    ccall((:CeedCompositeOperatorAddSub, libceed), Cint, (CeedOperator, CeedOperator), composite_op, sub_op)
+function CeedOperatorCompositeAddSub(composite_op, sub_op)
+    ccall((:CeedOperatorCompositeAddSub, libceed), Cint, (CeedOperator, CeedOperator), composite_op, sub_op)
 end
 
-function CeedCompositeOperatorGetNumSub(op, num_suboperators)
-    ccall((:CeedCompositeOperatorGetNumSub, libceed), Cint, (CeedOperator, Ptr{CeedInt}), op, num_suboperators)
+function CeedOperatorCompositeGetNumSub(op, num_suboperators)
+    ccall((:CeedOperatorCompositeGetNumSub, libceed), Cint, (CeedOperator, Ptr{CeedInt}), op, num_suboperators)
 end
 
-function CeedCompositeOperatorGetSubList(op, sub_operators)
-    ccall((:CeedCompositeOperatorGetSubList, libceed), Cint, (CeedOperator, Ptr{Ptr{CeedOperator}}), op, sub_operators)
+function CeedOperatorCompositeGetSubList(op, sub_operators)
+    ccall((:CeedOperatorCompositeGetSubList, libceed), Cint, (CeedOperator, Ptr{Ptr{CeedOperator}}), op, sub_operators)
 end
 
 function CeedOperatorCheckReady(op)
@@ -738,8 +738,8 @@ function CeedOperatorLinearAssemble(op, values)
     ccall((:CeedOperatorLinearAssemble, libceed), Cint, (CeedOperator, CeedVector), op, values)
 end
 
-function CeedCompositeOperatorGetMultiplicity(op, num_skip_indices, skip_indices, mult)
-    ccall((:CeedCompositeOperatorGetMultiplicity, libceed), Cint, (CeedOperator, CeedInt, Ptr{CeedInt}, CeedVector), op, num_skip_indices, skip_indices, mult)
+function CeedOperatorCompositeGetMultiplicity(op, num_skip_indices, skip_indices, mult)
+    ccall((:CeedOperatorCompositeGetMultiplicity, libceed), Cint, (CeedOperator, CeedInt, Ptr{CeedInt}, CeedVector), op, num_skip_indices, skip_indices, mult)
 end
 
 function CeedOperatorMultigridLevelCreate(op_fine, p_mult_fine, rstr_coarse, basis_coarse, op_coarse, op_prolong, op_restrict)

--- a/julia/LibCEED.jl/test/rundevtests.jl
+++ b/julia/LibCEED.jl/test/rundevtests.jl
@@ -8,4 +8,36 @@ function checkoutput(str, fname)
     return true
 end
 
-@testset "LibCEED Development Tests" begin end
+@testset "LibCEED Development Tests" begin
+    @testset "Operator" begin
+        c = Ceed()
+        @interior_qf id = (
+            c,
+            (input, :in, EVAL_INTERP),
+            (output, :out, EVAL_INTERP),
+            begin
+                output[] = input
+            end,
+        )
+        b = create_tensor_h1_lagrange_basis(c, 3, 1, 3, 3, GAUSS_LOBATTO)
+        n = getnumnodes(b)
+        offsets = Vector{CeedInt}(0:n-1)
+        r = create_elem_restriction(c, 1, n, 1, 1, n, offsets)
+        op = Operator(
+            c;
+            qf=id,
+            fields=[
+                (:input, r, b, CeedVectorActive()),
+                (:output, r, b, CeedVectorActive()),
+            ],
+        )
+
+        v = rand(CeedScalar, n)
+        v1 = CeedVector(c, v)
+        v2 = CeedVector(c, n)
+
+        comp_op = create_composite_operator(c, [op])
+        apply!(comp_op, v1, v2)
+        @test @witharray_read(a1 = v1, @witharray_read(a2 = v2, a1 == a2))
+    end
+end

--- a/julia/LibCEED.jl/test/runtests.jl
+++ b/julia/LibCEED.jl/test/runtests.jl
@@ -256,10 +256,6 @@ else
             LibCEED.assemble_add_diagonal!(op, diag_vector)
             @test @witharray(a = diag_vector, a == fill(1.0, n))
 
-            comp_op = create_composite_operator(c, [op])
-            apply!(comp_op, v1, v2)
-            @test @witharray_read(a1 = v1, @witharray_read(a2 = v2, a1 == a2))
-
             @test showstr(op) == """
                 CeedOperator
                   1 elements with 27 quadrature points each

--- a/python/build_ceed_cffi.py
+++ b/python/build_ceed_cffi.py
@@ -34,6 +34,7 @@ for header_path in ["include/ceed/types.h", "include/ceed/ceed.h"]:
         lines += [line.strip() for line in f if
                   not (line.startswith("#") and not line.startswith("#include")) and
                   not line.startswith("  static") and
+                  not line.startswith("#include \"deprecated.h\"") and
                   not line.startswith("  CEED_QFUNCTION_ATTR") and
                   "CeedErrorImpl" not in line and
                   "const char *, ...);" not in line and

--- a/python/ceed_operator.py
+++ b/python/ceed_operator.py
@@ -331,7 +331,7 @@ class CompositeOperator(_OperatorBase):
         # Reference to Ceed
         self._ceed = ceed
         # libCEED call
-        err_code = lib.CeedCompositeOperatorCreate(
+        err_code = lib.CeedOperatorCreateComposite(
             self._ceed._pointer[0], self._pointer)
         self._ceed._check_error(err_code)
 
@@ -343,7 +343,7 @@ class CompositeOperator(_OperatorBase):
              subop: sub-operator Operator"""
 
         # libCEED call
-        err_code = lib.CeedCompositeOperatorAddSub(
+        err_code = lib.CeedOperatorCompositeAddSub(
             self._pointer[0], subop._pointer[0])
         self._ceed._check_error(err_code)
 

--- a/rust/libceed/src/operator.rs
+++ b/rust/libceed/src/operator.rs
@@ -2119,7 +2119,7 @@ impl<'a> CompositeOperator<'a> {
     // Constructor
     pub fn create(ceed: &crate::Ceed) -> crate::Result<Self> {
         let mut ptr = std::ptr::null_mut();
-        ceed.check_error(unsafe { bind_ceed::CeedCompositeOperatorCreate(ceed.ptr, &mut ptr) })?;
+        ceed.check_error(unsafe { bind_ceed::CeedOperatorCreateComposite(ceed.ptr, &mut ptr) })?;
         Ok(Self {
             op_core: OperatorCore {
                 ptr,
@@ -2401,7 +2401,7 @@ impl<'a> CompositeOperator<'a> {
     #[allow(unused_mut)]
     pub fn sub_operator(mut self, subop: &Operator) -> crate::Result<Self> {
         self.op_core.check_error(unsafe {
-            bind_ceed::CeedCompositeOperatorAddSub(self.op_core.ptr, subop.op_core.ptr)
+            bind_ceed::CeedOperatorCompositeAddSub(self.op_core.ptr, subop.op_core.ptr)
         })?;
         Ok(self)
     }

--- a/tests/t520-operator-f.f90
+++ b/tests/t520-operator-f.f90
@@ -211,13 +211,13 @@
      & buhex,ceed_vector_active,err)
 
 ! Composite Operators
-      call ceedcompositeoperatorcreate(ceed,op_setup,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
+      call ceedoperatorcreatecomposite(ceed,op_setup,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuptet,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuphex,err)
 
-      call ceedcompositeoperatorcreate(ceed,op_mass,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masstet,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
+      call ceedoperatorcreatecomposite(ceed,op_mass,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masstet,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masshex,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,ceed_vector_none,&

--- a/tests/t520-operator.c
+++ b/tests/t520-operator.c
@@ -159,25 +159,25 @@ int main(int argc, char **argv) {
 
   // Set up Composite Operators
   // -- Create
-  CeedCompositeOperatorCreate(ceed, &op_setup);
+  CeedOperatorCreateComposite(ceed, &op_setup);
   // -- Add SubOperators
-  CeedCompositeOperatorAddSub(op_setup, op_setup_tet);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_hex);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_tet);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_hex);
 
   // -- Create
-  CeedCompositeOperatorCreate(ceed, &op_mass);
+  CeedOperatorCreateComposite(ceed, &op_mass);
   // -- Add SubOperators
-  CeedCompositeOperatorAddSub(op_mass, op_mass_tet);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_hex);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_tet);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_hex);
 
-  {  // Test CeedCompositeOperatorGetSubByName
+  {  // Test CeedOperatorCompositeGetSubByName
     CeedOperator op_byname;
 
-    CeedCompositeOperatorGetSubByName(op_mass, "mass hex", &op_byname);
-    if (op_byname != op_mass_hex) printf("CeedCompositeOperatorGetSubByName returned incorrect Sub Operator");
+    CeedOperatorCompositeGetSubByName(op_mass, "mass hex", &op_byname);
+    if (op_byname != op_mass_hex) printf("CeedOperatorCompositeGetSubByName returned incorrect Sub Operator");
 
-    CeedCompositeOperatorGetSubByName(op_mass, "asdf", &op_byname);
-    if (op_byname != NULL) printf("CeedCompositeOperatorGetSubByName returned non-NULL for non-existent Sub Operator");
+    CeedOperatorCompositeGetSubByName(op_mass, "asdf", &op_byname);
+    if (op_byname != NULL) printf("CeedOperatorCompositeGetSubByName returned non-NULL for non-existent Sub Operator");
   }
 
   // Apply Setup Operator

--- a/tests/t521-operator-f.f90
+++ b/tests/t521-operator-f.f90
@@ -213,13 +213,13 @@
      & buhex,ceed_vector_active,err)
 
 ! Composite Operators
-      call ceedcompositeoperatorcreate(ceed,op_setup,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
+      call ceedoperatorcreatecomposite(ceed,op_setup,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuptet,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuphex,err)
 
-      call ceedcompositeoperatorcreate(ceed,op_mass,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masstet,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
+      call ceedoperatorcreatecomposite(ceed,op_mass,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masstet,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masshex,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,ceed_vector_none,&

--- a/tests/t521-operator.c
+++ b/tests/t521-operator.c
@@ -156,13 +156,13 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_mass_hex, "v", elem_restriction_u_hex, basis_u_hex, CEED_VECTOR_ACTIVE);
 
   // Composite Operators
-  CeedCompositeOperatorCreate(ceed, &op_setup);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_tet);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_hex);
+  CeedOperatorCreateComposite(ceed, &op_setup);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_tet);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_hex);
 
-  CeedCompositeOperatorCreate(ceed, &op_mass);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_tet);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_hex);
+  CeedOperatorCreateComposite(ceed, &op_mass);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_tet);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_hex);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, x, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);

--- a/tests/t522-operator-f.f90
+++ b/tests/t522-operator-f.f90
@@ -215,13 +215,13 @@
      & buhex,ceed_vector_active,err)
 
 ! Composite Operators
-      call ceedcompositeoperatorcreate(ceed,op_setup,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
+      call ceedoperatorcreatecomposite(ceed,op_setup,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuptet,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuphex,err)
 
-      call ceedcompositeoperatorcreate(ceed,op_diff,err)
-      call ceedcompositeoperatoraddsub(op_diff,op_difftet,err)
-      call ceedcompositeoperatoraddsub(op_diff,op_diffhex,err)
+      call ceedoperatorcreatecomposite(ceed,op_diff,err)
+      call ceedoperatorcompositeaddsub(op_diff,op_difftet,err)
+      call ceedoperatorcompositeaddsub(op_diff,op_diffhex,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,ceed_vector_none,&

--- a/tests/t522-operator.c
+++ b/tests/t522-operator.c
@@ -159,13 +159,13 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_diff_hex, "v", elem_restriction_u_hex, basis_u_hex, CEED_VECTOR_ACTIVE);
 
   // Composite Operators
-  CeedCompositeOperatorCreate(ceed, &op_setup);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_tet);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_hex);
+  CeedOperatorCreateComposite(ceed, &op_setup);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_tet);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_hex);
 
-  CeedCompositeOperatorCreate(ceed, &op_diff);
-  CeedCompositeOperatorAddSub(op_diff, op_diff_tet);
-  CeedCompositeOperatorAddSub(op_diff, op_diff_hex);
+  CeedOperatorCreateComposite(ceed, &op_diff);
+  CeedOperatorCompositeAddSub(op_diff, op_diff_tet);
+  CeedOperatorCompositeAddSub(op_diff, op_diff_hex);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, x, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);

--- a/tests/t523-operator-f.f90
+++ b/tests/t523-operator-f.f90
@@ -205,15 +205,15 @@
      & buhex,ceed_vector_active,err)
 
 ! Composite Operators
-      call ceedcompositeoperatorcreate(ceed,op_setup,err)
+      call ceedoperatorcreatecomposite(ceed,op_setup,err)
       call ceedoperatorsetname(op_setup,'setup',err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuptet,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuphex,err)
 
-      call ceedcompositeoperatorcreate(ceed,op_mass,err)
+      call ceedoperatorcreatecomposite(ceed,op_mass,err)
       call ceedoperatorsetname(op_mass,'mass',err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masstet,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masstet,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masshex,err)
 
 ! View
       call ceedoperatorview(op_setup,err)

--- a/tests/t523-operator.c
+++ b/tests/t523-operator.c
@@ -150,18 +150,18 @@ int main(int argc, char **argv) {
 
   // Set up Composite Operators
   // -- Create
-  CeedCompositeOperatorCreate(ceed, &op_setup);
+  CeedOperatorCreateComposite(ceed, &op_setup);
   CeedOperatorSetName(op_setup, "setup");
   // -- Add SubOperators
-  CeedCompositeOperatorAddSub(op_setup, op_setup_tet);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_hex);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_tet);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_hex);
 
   // -- Create
-  CeedCompositeOperatorCreate(ceed, &op_mass);
+  CeedOperatorCreateComposite(ceed, &op_mass);
   CeedOperatorSetName(op_mass, "mass");
   // -- Add SubOperators
-  CeedCompositeOperatorAddSub(op_mass, op_mass_tet);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_hex);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_tet);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_hex);
 
   // View
   CeedOperatorViewTerse(op_setup, stdout);

--- a/tests/t524-operator-f.f90
+++ b/tests/t524-operator-f.f90
@@ -215,13 +215,13 @@
      & buhex,ceed_vector_active,err)
 
 ! Composite Operators
-      call ceedcompositeoperatorcreate(ceed,op_setup,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuptet,err)
-      call ceedcompositeoperatoraddsub(op_setup,op_setuphex,err)
+      call ceedoperatorcreatecomposite(ceed,op_setup,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuptet,err)
+      call ceedoperatorcompositeaddsub(op_setup,op_setuphex,err)
 
-      call ceedcompositeoperatorcreate(ceed,op_mass,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masstet,err)
-      call ceedcompositeoperatoraddsub(op_mass,op_masshex,err)
+      call ceedoperatorcreatecomposite(ceed,op_mass,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masstet,err)
+      call ceedoperatorcompositeaddsub(op_mass,op_masshex,err)
 
 ! Apply Setup Operator
       call ceedoperatorapply(op_setup,x,ceed_vector_none,&

--- a/tests/t524-operator.c
+++ b/tests/t524-operator.c
@@ -155,13 +155,13 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_mass_hex, "v", elem_restriction_u_hex, basis_u_hex, CEED_VECTOR_ACTIVE);
 
   // Composite Operators
-  CeedCompositeOperatorCreate(ceed, &op_setup);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_tet);
-  CeedCompositeOperatorAddSub(op_setup, op_setup_hex);
+  CeedOperatorCreateComposite(ceed, &op_setup);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_tet);
+  CeedOperatorCompositeAddSub(op_setup, op_setup_hex);
 
-  CeedCompositeOperatorCreate(ceed, &op_mass);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_tet);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_hex);
+  CeedOperatorCreateComposite(ceed, &op_mass);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_tet);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_hex);
 
   // Apply Setup Operator
   CeedOperatorApply(op_setup, x, CEED_VECTOR_NONE, CEED_REQUEST_IMMEDIATE);

--- a/tests/t525-operator.c
+++ b/tests/t525-operator.c
@@ -73,9 +73,9 @@ int main(int argc, char **argv) {
   CeedOperatorCreate(ceed, qf_sub_2, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_sub_2);
 
   // Composite operator
-  CeedCompositeOperatorCreate(ceed, &op_composite);
-  CeedCompositeOperatorAddSub(op_composite, op_sub_1);
-  CeedCompositeOperatorAddSub(op_composite, op_sub_2);
+  CeedOperatorCreateComposite(ceed, &op_composite);
+  CeedOperatorCompositeAddSub(op_composite, op_sub_1);
+  CeedOperatorCompositeAddSub(op_composite, op_sub_2);
 
   // Check setting field in context of single sub-operator for composite operator
   CeedOperatorGetContextFieldLabel(op_composite, "time", &time_label);

--- a/tests/t526-operator.c
+++ b/tests/t526-operator.c
@@ -114,10 +114,10 @@ int main(int argc, char **argv) {
 
   // Set up Composite Operator
   // -- Create
-  CeedCompositeOperatorCreate(ceed, &op_mass);
+  CeedOperatorCreateComposite(ceed, &op_mass);
   // -- Add SubOperators
-  CeedCompositeOperatorAddSub(op_mass, op_mass_tet);
-  CeedCompositeOperatorAddSub(op_mass, op_mass_hex);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_tet);
+  CeedOperatorCompositeAddSub(op_mass, op_mass_hex);
 
   // Estimate FLOPs
   CeedQFunctionSetUserFlopsEstimate(qf_mass, 1);

--- a/tests/t538-operator.c
+++ b/tests/t538-operator.c
@@ -104,9 +104,9 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_diff, "dv", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
 
   // Composite operator
-  CeedCompositeOperatorCreate(ceed, &op_apply);
-  CeedCompositeOperatorAddSub(op_apply, op_mass);
-  CeedCompositeOperatorAddSub(op_apply, op_diff);
+  CeedOperatorCreateComposite(ceed, &op_apply);
+  CeedOperatorCompositeAddSub(op_apply, op_mass);
+  CeedOperatorCompositeAddSub(op_apply, op_diff);
 
   // Assemble diagonal
   CeedVectorCreate(ceed, num_dofs, &assembled);

--- a/tests/t554-operator.c
+++ b/tests/t554-operator.c
@@ -33,10 +33,10 @@ int main(int argc, char **argv) {
   CeedVectorCreate(ceed, num_comp * num_dofs_u_fine, &v_fine);
 
   // Composite operators
-  CeedCompositeOperatorCreate(ceed, &op_mass_coarse);
-  CeedCompositeOperatorCreate(ceed, &op_mass_fine);
-  CeedCompositeOperatorCreate(ceed, &op_prolong);
-  CeedCompositeOperatorCreate(ceed, &op_restrict);
+  CeedOperatorCreateComposite(ceed, &op_mass_coarse);
+  CeedOperatorCreateComposite(ceed, &op_mass_fine);
+  CeedOperatorCreateComposite(ceed, &op_prolong);
+  CeedOperatorCreateComposite(ceed, &op_restrict);
 
   // Setup fine suboperators
   for (CeedInt i = 0; i < num_sub_ops; i++) {
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
     CeedOperatorApply(sub_op_setup, x, q_data, CEED_REQUEST_IMMEDIATE);
 
     // -- Composite operators
-    CeedCompositeOperatorAddSub(op_mass_fine, sub_op_mass_fine);
+    CeedOperatorCompositeAddSub(op_mass_fine, sub_op_mass_fine);
 
     // -- Cleanup
     CeedVectorDestroy(&q_data);
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
 
   // Scale for suboperator multiplicity
   CeedVectorCreate(ceed, num_comp * num_dofs_u_fine, &p_mult_fine);
-  CeedCompositeOperatorGetMultiplicity(op_mass_fine, 0, NULL, p_mult_fine);
+  CeedOperatorCompositeGetMultiplicity(op_mass_fine, 0, NULL, p_mult_fine);
 
   // Setup coarse and prolong/restriction suboperators
   for (CeedInt i = 0; i < num_sub_ops; i++) {
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
     CeedOperator       *sub_ops_mass_fine, sub_op_mass_coarse, sub_op_prolong, sub_op_restrict;
 
     // -- Fine grid operator
-    CeedCompositeOperatorGetSubList(op_mass_fine, &sub_ops_mass_fine);
+    CeedOperatorCompositeGetSubList(op_mass_fine, &sub_ops_mass_fine);
 
     // -- Restrictions
     CeedInt offset = num_elem_sub * i * (p_coarse - 1);
@@ -145,9 +145,9 @@ int main(int argc, char **argv) {
                                      &sub_op_prolong, &sub_op_restrict);
 
     // -- Composite operators
-    CeedCompositeOperatorAddSub(op_mass_coarse, sub_op_mass_coarse);
-    CeedCompositeOperatorAddSub(op_prolong, sub_op_prolong);
-    CeedCompositeOperatorAddSub(op_restrict, sub_op_restrict);
+    CeedOperatorCompositeAddSub(op_mass_coarse, sub_op_mass_coarse);
+    CeedOperatorCompositeAddSub(op_prolong, sub_op_prolong);
+    CeedOperatorCompositeAddSub(op_restrict, sub_op_restrict);
 
     // -- Cleanup
     CeedElemRestrictionDestroy(&elem_restriction_u_coarse);

--- a/tests/t565-operator.c
+++ b/tests/t565-operator.c
@@ -107,9 +107,9 @@ int main(int argc, char **argv) {
   CeedOperatorSetField(op_diff, "dv", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
 
   // Composite operator
-  CeedCompositeOperatorCreate(ceed, &op_apply);
-  CeedCompositeOperatorAddSub(op_apply, op_mass);
-  CeedCompositeOperatorAddSub(op_apply, op_diff);
+  CeedOperatorCreateComposite(ceed, &op_apply);
+  CeedOperatorCompositeAddSub(op_apply, op_mass);
+  CeedOperatorCompositeAddSub(op_apply, op_diff);
 
   // Fully assemble operator
   CeedSize   num_entries;


### PR DESCRIPTION
We have `CeedBasisCreateH1` and similar for almost all objects. I'm not sure why we treat `CeedCompositeOperatorCreate` differently?