### PR TITLE
python - remove license classifier (deprecated in later python versions)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ classifiers = """
 Development Status :: 4 - Beta
 Intended Audience :: Developers
 Intended Audience :: Science/Research
-License :: OSI Approved :: BSD License
 Operating System :: POSIX
 Programming Language :: C
 Programming Language :: C++


### PR DESCRIPTION
Removes deprecated license classifier, as license is otherwise specified.