### PR TITLE
at-points - ensure reference point coordinates are always up to date

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -848,12 +848,12 @@ static int CeedOperatorApplyAddAtPoints_Cuda(CeedOperator op, CeedVector in_vec,
   CeedCallBackend(CeedGetWorkVector(ceed, impl->max_active_e_vec_len, &active_e_vec));
 
   // Get point coordinates
-  if (!impl->point_coords_elem) {
+  {
     CeedVector          point_coords = NULL;
     CeedElemRestriction rstr_points  = NULL;
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
-    CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
+    if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
     CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));
@@ -1855,12 +1855,12 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
   }
 
   // Get point coordinates
-  if (!impl->point_coords_elem) {
+  {
     CeedVector          point_coords = NULL;
     CeedElemRestriction rstr_points  = NULL;
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
-    CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
+    if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
     CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -854,7 +854,13 @@ static int CeedOperatorApplyAddAtPoints_Cuda(CeedOperator op, CeedVector in_vec,
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
     if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
-    CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+    {
+      uint64_t state;
+      CeedCallBackend(CeedVectorGetState(point_coords, &state));
+      if (impl->points_state != state) {
+        CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+      }
+    }
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));
   }
@@ -1861,7 +1867,13 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Cuda(CeedOperator op, C
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
     if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
-    CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+    {
+      uint64_t state;
+      CeedCallBackend(CeedVectorGetState(point_coords, &state));
+      if (impl->points_state != state) {
+        CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+      }
+    }
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));
   }

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -133,7 +133,7 @@ typedef struct {
 
 typedef struct {
   bool                      *skip_rstr_in, *skip_rstr_out, *apply_add_basis_out;
-  uint64_t                  *input_states;  // State tracking for passive inputs
+  uint64_t                  *input_states, points_state;  // State tracking for passive inputs
   CeedVector                *e_vecs_in, *e_vecs_out;
   CeedVector                *q_vecs_in, *q_vecs_out;
   CeedInt                    num_inputs, num_outputs;

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -852,7 +852,13 @@ static int CeedOperatorApplyAddAtPoints_Hip(CeedOperator op, CeedVector in_vec, 
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
     if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
-    CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+    {
+      uint64_t state;
+      CeedCallBackend(CeedVectorGetState(point_coords, &state));
+      if (impl->points_state != state) {
+        CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+      }
+    }
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));
   }
@@ -1858,7 +1864,13 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Hip(CeedOperator op, Ce
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
     if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
-    CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+    {
+      uint64_t state;
+      CeedCallBackend(CeedVectorGetState(point_coords, &state));
+      if (impl->points_state != state) {
+        CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
+      }
+    }
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));
   }

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -846,12 +846,12 @@ static int CeedOperatorApplyAddAtPoints_Hip(CeedOperator op, CeedVector in_vec, 
   CeedCallBackend(CeedGetWorkVector(ceed, impl->max_active_e_vec_len, &active_e_vec));
 
   // Get point coordinates
-  if (!impl->point_coords_elem) {
+  {
     CeedVector          point_coords = NULL;
     CeedElemRestriction rstr_points  = NULL;
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
-    CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
+    if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
     CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));
@@ -1852,12 +1852,12 @@ static int CeedOperatorLinearAssembleAddDiagonalAtPoints_Hip(CeedOperator op, Ce
   }
 
   // Get point coordinates
-  if (!impl->point_coords_elem) {
+  {
     CeedVector          point_coords = NULL;
     CeedElemRestriction rstr_points  = NULL;
 
     CeedCallBackend(CeedOperatorAtPointsGetPoints(op, &rstr_points, &point_coords));
-    CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
+    if (!impl->point_coords_elem) CeedCallBackend(CeedElemRestrictionCreateVector(rstr_points, NULL, &impl->point_coords_elem));
     CeedCallBackend(CeedElemRestrictionApply(rstr_points, CEED_NOTRANSPOSE, point_coords, impl->point_coords_elem, request));
     CeedCallBackend(CeedVectorDestroy(&point_coords));
     CeedCallBackend(CeedElemRestrictionDestroy(&rstr_points));

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -138,7 +138,7 @@ typedef struct {
 
 typedef struct {
   bool                     *skip_rstr_in, *skip_rstr_out, *apply_add_basis_out;
-  uint64_t                 *input_states;  // State tracking for passive inputs
+  uint64_t                 *input_states, points_state;  // State tracking for passive inputs
   CeedVector               *e_vecs_in, *e_vecs_out;
   CeedVector               *q_vecs_in, *q_vecs_out;
   CeedInt                   num_inputs, num_outputs;


### PR DESCRIPTION
Minor change to make the behavior of the `cuda/ref` and `hip/ref` operators the same as gen and `/cpu/self/ref` by always applying the reference coordinate element restriction during calls to `OperatorApply`. This allows for in-place updating of reference coordinates without having to change any interfaces. 