### PR TITLE
vec: Check length >= 0

### DIFF
--- a/interface/ceed-vector.c
+++ b/interface/ceed-vector.c
@@ -159,6 +159,7 @@ int CeedVectorReference(CeedVector vec) {
   @ref User
 **/
 int CeedVectorCreate(Ceed ceed, CeedSize length, CeedVector *vec) {
+  CeedCheck(length >= 0, ceed, CEED_ERROR_UNSUPPORTED, "CeedVector must have length >= 0, recieved %" CeedSize_FMT, length);
   if (!ceed->VectorCreate) {
     Ceed delegate;
 


### PR DESCRIPTION
Verify that the length of a CeedVector is non-negative on `CeedVectorCreate()`.

Closes #1892 