### PR TITLE
atpoints - fix insidious memory bug

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-restriction.c
+++ b/backends/cuda-ref/ceed-cuda-ref-restriction.c
@@ -550,7 +550,7 @@ int CeedElemRestrictionCreate_Cuda(CeedMemType mem_type, CeedCopyMode copy_mode,
     CeedCallBackend(CeedMalloc(num_elem, &points_per_elem));
     for (CeedInt i = 0; i < num_elem; i++) {
       CeedInt num_points = offsets[i + 1] - offsets[i];
-      CeedInt last_point = offsets[offsets[i]] * num_comp;
+      CeedInt last_point = 0;
 
       points_per_elem[i] = num_points;
       at_points_size += num_points;

--- a/backends/hip-ref/ceed-hip-ref-restriction.c
+++ b/backends/hip-ref/ceed-hip-ref-restriction.c
@@ -551,7 +551,7 @@ int CeedElemRestrictionCreate_Hip(CeedMemType mem_type, CeedCopyMode copy_mode, 
     CeedCallBackend(CeedMalloc(num_elem, &points_per_elem));
     for (CeedInt i = 0; i < num_elem; i++) {
       CeedInt num_points = offsets[i + 1] - offsets[i];
-      CeedInt last_point = offsets[offsets[i]] * num_comp;
+      CeedInt last_point = 0;
 
       points_per_elem[i] = num_points;
       at_points_size += num_points;


### PR DESCRIPTION
My prior fix to the padded indices had one issue: it didn't work correctly if the cells at the end of the list were empty. This fixes that bug, which caused memory faults, by using the index `0` for padding empty cells. This index is as valid as any index can be and should prevent my head from hurting so bad. 