### PR TITLE
Fix gcc `-march=native` for arm mac

### DIFF
--- a/.github/workflows/c-fortran-test-linux-osx.yml
+++ b/.github/workflows/c-fortran-test-linux-osx.yml
@@ -12,29 +12,36 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15]
         compiler: [gcc, clang]
-        exclude:
-          # "gcc" on macOS is a symlink to Apple Clang, same as "clang"
-          - os: macos-15
-            compiler: gcc
         include:
-          # macOS: test with real GCC (not Apple Clang symlink)
           - os: macos-15
-            compiler: gcc-15
-          # macOS: test with Homebrew LLVM
-          - os: macos-15
-            compiler: llvm
+            compiler: apple-clang
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Environment setup
       uses: actions/checkout@v4
-    - name: Set LLVM compiler path
-      if: matrix.compiler == 'llvm'
-      run: echo "CC=$(brew --prefix llvm@18)/bin/clang" >> $GITHUB_ENV
     - name: Set compiler
-      if: matrix.compiler != 'llvm'
-      run: echo "CC=${{ matrix.compiler }}" >> $GITHUB_ENV
+      run: |
+        case "${{ matrix.compiler }}" in
+          gcc)
+            if [[ "${{ matrix.os }}" == macos-* ]]; then
+              echo "CC=gcc-15" >> $GITHUB_ENV
+            else
+              echo "CC=gcc" >> $GITHUB_ENV
+            fi
+            ;;
+          clang)
+            if [[ "${{ matrix.os }}" == macos-* ]]; then
+              echo "CC=$(brew --prefix llvm@18)/bin/clang" >> $GITHUB_ENV
+            else
+              echo "CC=clang" >> $GITHUB_ENV
+            fi
+            ;;
+          apple-clang)
+            echo "CC=clang" >> $GITHUB_ENV
+            ;;
+        esac
     - name: Show compiler version
       run: $CC --version | head -1
     - name: Build and test libCEED

--- a/.github/workflows/c-fortran-test-linux-osx.yml
+++ b/.github/workflows/c-fortran-test-linux-osx.yml
@@ -12,15 +12,33 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15]
         compiler: [gcc, clang]
+        exclude:
+          # "gcc" on macOS is a symlink to Apple Clang, same as "clang"
+          - os: macos-15
+            compiler: gcc
+        include:
+          # macOS: test with real GCC (not Apple Clang symlink)
+          - os: macos-15
+            compiler: gcc-15
+          # macOS: test with Homebrew LLVM
+          - os: macos-15
+            compiler: llvm
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Environment setup
       uses: actions/checkout@v4
+    - name: Set LLVM compiler path
+      if: matrix.compiler == 'llvm'
+      run: echo "CC=$(brew --prefix llvm@18)/bin/clang" >> $GITHUB_ENV
+    - name: Set compiler
+      if: matrix.compiler != 'llvm'
+      run: echo "CC=${{ matrix.compiler }}" >> $GITHUB_ENV
+    - name: Show compiler version
+      run: $CC --version | head -1
     - name: Build and test libCEED
       env:
-        CC: ${{ matrix.compiler }}
         FC: gfortran-14
       run: |
         make info

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,12 @@ CC_VENDOR := $(subst (GCC),gcc,$(subst icc_orig,icc,$(CC_VENDOR)))
 CC_VENDOR := $(if $(filter cc,$(CC_VENDOR)),gcc,$(CC_VENDOR))
 FC_VENDOR := $(if $(FC),$(firstword $(filter GNU ifort ifx XL,$(shell $(FC) --version 2>&1 || $(FC) -qversion))))
 
+# Host architecture for setting appropriate flags
+UNAME_M := $(shell uname -m)
+
 # Default extra flags by vendor
-MARCHFLAG.gcc           := -march=native
+# GCC: use -march=native only on x86 (where -mcpu doesn't exist); use -mcpu=native elsewhere
+MARCHFLAG.gcc           := $(if $(filter x86_64 i%86,$(UNAME_M)),-march=native,-mcpu=native)
 MARCHFLAG.clang         := $(MARCHFLAG.gcc)
 MARCHFLAG.icc           :=
 MARCHFLAG.oneAPI        := $(MARCHFLAG.clang)


### PR DESCRIPTION
 When building with spack on ARM (Apple Silicon), GCC's `-march=native` fails:

```
  cc1: error: unknown value 'apple-m1' for '-march'
  cc1: note: valid arguments are: armv8-a armv8.1-a ... native
  cc1: note: did you mean '-mcpu=apple-m1'?
```

This occurs because spack's compiler wrapper causes `-march=native` to resolve to CPU names like `apple-m1`, but GCC's `-march` doesn't accept CPU names on ARM—only `-mcpu` does. Fix by detecting architecture via `uname -m` and using `-mcpu=native` on non-x86 platforms.

Reproducer with spack on macOS ARM:

```bash
mkdir test && cd test
echo 'spack:
  specs:
  - libceed@develop %gcc' > spack.yaml
spack env activate .
spack install
```

Also changes the macos CI to use gcc/clang from homebrew, as `gcc` `clang` are aliases for apple-clang.