### PR TITLE
Add chipStar (SPIR-V) support for HIP backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ endif
 ifeq (,$(filter-out undefined default,$(origin ARFLAGS)))
   ARFLAGS = $(if $(DARWIN),cr,crD)
 endif
+# chipStar sets HIP_DIR instead of ROCM_DIR
+ROCM_DIR ?= ${HIP_DIR}
 NVCC ?= $(CUDA_DIR)/bin/nvcc
 NVCC_CXX ?= $(CXX)
 HIPCC ?= $(ROCM_DIR)/bin/hipcc
@@ -88,6 +90,15 @@ ifneq ($(EMSCRIPTEN),)
   EM_LDFLAGS = -s TOTAL_MEMORY=256MB
 endif
 
+# Detect chipStar (SPIR-V HIP) vs AMD ROCm
+HIP_LIB_NAME = amdhip64
+ifneq ($(ROCM_DIR),)
+  ifneq ($(wildcard $(ROCM_DIR)/bin/hipconfig),)
+    ifneq (,$(findstring __HIP_PLATFORM_SPIRV__,$(shell $(ROCM_DIR)/bin/hipconfig 2>/dev/null)))
+      HIP_LIB_NAME = CHIP
+    endif
+  endif
+endif
 # ASAN must be left empty if you don't want to use it
 ASAN ?=
 
@@ -555,16 +566,23 @@ ifneq ($(CUDA_LIB_DIR),)
 endif
 
 # HIP Backends
-HIP_LIB_DIR := $(wildcard $(foreach d,lib lib64,$(ROCM_DIR)/$d/libamdhip64.${SO_EXT}))
+HIP_LIB_DIR := $(wildcard $(foreach d,lib lib64,$(ROCM_DIR)/$d/lib${HIP_LIB_NAME}.${SO_EXT}))
 HIP_LIB_DIR := $(patsubst %/,%,$(dir $(firstword $(HIP_LIB_DIR))))
 HIP_BACKENDS = /gpu/hip/ref /gpu/hip/shared /gpu/hip/gen
 ifneq ($(HIP_LIB_DIR),)
-  HIPCONFIG_CPPFLAGS := $(subst =,,$(shell $(ROCM_DIR)/bin/hipconfig -C))
-  $(hip-all.c:%.c=$(OBJDIR)/%.o) $(hip-all.c:%=%.tidy): CPPFLAGS += $(HIPCONFIG_CPPFLAGS)
-  ifneq ($(CXX), $(HIPCC))
-    $(hip-all.cpp:%.cpp=$(OBJDIR)/%.o) $(hip-all.cpp:%=%.tidy): CPPFLAGS += $(HIPCONFIG_CPPFLAGS)
+  ifeq ($(HIP_LIB_NAME),CHIP)
+    # chipStar hipconfig -C emits clang-only flags; keep only -D/-I/-include for gcc
+    HIPCONFIG_CPPFLAGS := $(shell $(ROCM_DIR)/bin/hipconfig -C)
+    HIPCONFIG_CPPFLAGS_C := $(filter-out --offload% -nohipwrapperinc --hip-path% --target%,$(HIPCONFIG_CPPFLAGS)) -I$(ROCM_DIR)/include
+  else
+    HIPCONFIG_CPPFLAGS := $(subst =,,$(shell $(ROCM_DIR)/bin/hipconfig -C))
+    HIPCONFIG_CPPFLAGS_C := $(HIPCONFIG_CPPFLAGS)
   endif
-  PKG_LIBS += -L$(abspath $(HIP_LIB_DIR)) -lamdhip64 -lhipblas
+  $(hip-all.c:%.c=$(OBJDIR)/%.o) $(hip-all.c:%=%.tidy): CPPFLAGS += $(HIPCONFIG_CPPFLAGS_C)
+  ifneq ($(CXX), $(HIPCC))
+    $(hip-all.cpp:%.cpp=$(OBJDIR)/%.o) $(hip-all.cpp:%=%.tidy): CPPFLAGS += $(HIPCONFIG_CPPFLAGS_C)
+  endif
+  PKG_LIBS += -L$(abspath $(HIP_LIB_DIR)) -l${HIP_LIB_NAME} -lhipblas
   LIBCEED_CONTAINS_CXX = 1
   libceed.c     += $(hip-all.c)
   libceed.cpp   += $(hip-all.cpp)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ The `/gpu/hip/*` backends provide GPU performance strictly using HIP.
 They are based on the `/gpu/cuda/*` backends.
 ROCm version 4.2 or newer is required.
 
+The `/gpu/hip/*` backends can also run on non-AMD GPUs (e.g., Intel) via [chipStar](https://github.com/CHIP-SPV/chipStar), which implements HIP on top of SPIR-V through Level Zero or OpenCL.
+To build against chipStar, set `HIP_DIR` to the chipStar install prefix (in place of `ROCM_DIR`); libCEED's Makefile detects chipStar by inspecting `hipconfig` and automatically enables the required code paths.
+At runtime, chipStar's own environment variables (e.g., `CHIP_BE=level0` or `CHIP_BE=opencl`, `CHIP_DEVICE_TYPE`, `CHIP_PLATFORM`) select the backend and device — see the chipStar documentation for details.
+
 The `/gpu/sycl/*` backends provide GPU performance strictly using SYCL.
 They are based on the `/gpu/cuda/*` and `/gpu/hip/*` backends.
 

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -12,6 +12,7 @@
 #include <ceed/gen-tools.h>
 #include <ceed/jit-tools.h>
 
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Purpose:

Add support for [chipStar](https://github.com/CHIP-SPV/chipStar), enabling libCEED HIP backends (`/gpu/hip/ref`, `/gpu/hip/shared`, `/gpu/hip/gen`) to run on any OpenCL or Level Zero GPU (Intel, etc.) via SPIR-V.

LLM/GenAI Disclosure: Claude Code Opus 4.6 

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.