### PR TITLE
Add support for fully assembling operators with multiple active fields with different bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Specifically, directories set with `CeedAddJitSourceRoot(ceed, "foo/bar")` will 
 - Added support to code generation backends `/gpu/cuda/gen` and `/gpu/hip/gen` for operators with both tensor and non-tensor bases.
 - Add `CeedGetGitVersion()` to access the Git commit and dirty state of the repository at build time.
 - Add `CeedGetBuildConfiguration()` to access compilers, flags, and related information about the build environment.
+- Add support for full `CeedOperator` assembly for operators with multiple active fields with different bases for CPU backends and `/gpu/cuda/ref` and `/gpu/hip/gen` backends. 
 
 ### Examples
 

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -367,11 +367,10 @@ static int CeedOperatorBuildKernelFieldData_Cuda_gen(std::ostringstream &code, C
       break;
     case CEED_EVAL_WEIGHT:
       break;  // No action
-      // LCOV_EXCL_START
     case CEED_EVAL_DIV:
     case CEED_EVAL_CURL:
+      data->use_fallback = true;
       break;  // TODO: Not implemented
-              // LCOV_EXCL_STOP
   }
   CeedCallBackend(CeedBasisDestroy(&basis));
   return CEED_ERROR_SUCCESS;
@@ -459,11 +458,10 @@ static int CeedOperatorBuildKernelRestriction_Cuda_gen(std::ostringstream &code,
           data->indices.inputs[i] = (CeedInt *)rstr_data->d_offsets;
           break;
         }
-        // LCOV_EXCL_START
         case CEED_RESTRICTION_ORIENTED:
         case CEED_RESTRICTION_CURL_ORIENTED:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   } else {
@@ -511,11 +509,10 @@ static int CeedOperatorBuildKernelRestriction_Cuda_gen(std::ostringstream &code,
       case CEED_RESTRICTION_POINTS:
         data->indices.outputs[i] = (CeedInt *)rstr_data->d_offsets;
         break;
-      // LCOV_EXCL_START
       case CEED_RESTRICTION_ORIENTED:
       case CEED_RESTRICTION_CURL_ORIENTED:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
   CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
@@ -630,11 +627,10 @@ static int CeedOperatorBuildKernelBasis_Cuda_gen(std::ostringstream &code, CeedO
         }
         break;
       }
-      // LCOV_EXCL_START
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   } else {
     switch (eval_mode) {
@@ -692,10 +688,11 @@ static int CeedOperatorBuildKernelBasis_Cuda_gen(std::ostringstream &code, CeedO
       // LCOV_EXCL_START
       case CEED_EVAL_WEIGHT:
         break;  // Should not occur
+                // LCOV_EXCL_STOP
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
   CeedCallBackend(CeedBasisDestroy(&basis));
@@ -762,11 +759,10 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
         break;
       case CEED_EVAL_WEIGHT:
         break;
-        // LCOV_EXCL_START
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
 
@@ -815,11 +811,10 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
           code << tab << "CeedScalar r_s" << var_suffix << "[1];\n";
           code << tab << "r_s" << var_suffix << "[0] = 1.0;\n";
           break;
-          // LCOV_EXCL_START
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
     code << "\n";
@@ -845,10 +840,11 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
 
@@ -926,11 +922,10 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
           code << tab << "CeedScalar r_s" << var_suffix << "[1];\n";
           code << tab << "r_s" << var_suffix << "[0] = r_q" << var_suffix << "[q];\n";
           break;
-          // LCOV_EXCL_START
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
     code << "\n";
@@ -956,10 +951,11 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   } else {
@@ -1072,10 +1068,11 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   } else if (use_3d_slices) {
@@ -1114,10 +1111,11 @@ static int CeedOperatorBuildKernelQFunction_Cuda_gen(std::ostringstream &code, C
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   }
@@ -1222,6 +1220,13 @@ extern "C" int CeedOperatorBuildKernel_Cuda_gen(CeedOperator op, bool *is_good_b
     CeedCallBackend(CeedOperatorBuildKernelData_Cuda_gen(ceed, num_input_fields, op_input_fields, qf_input_fields, num_output_fields,
                                                          op_output_fields, qf_output_fields, &max_P, &max_P_1d, &Q, &Q_1d, &max_dim, &is_all_tensor,
                                                          &use_3d_slices));
+    if (data->use_fallback) {
+      *is_good_build = false;
+      CeedCallBackend(CeedOperatorSetSetupDone(op));
+      CeedCallBackend(CeedDestroy(&ceed));
+      CeedCallBackend(CeedQFunctionDestroy(&qf));
+      return CEED_ERROR_SUCCESS;
+    }
     data->max_P_1d = is_all_tensor ? max_P_1d : max_P;
   }
   if (is_at_points) {

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -95,7 +95,28 @@ static int CeedOperatorDestroy_Cuda(CeedOperator op) {
     CeedCallCuda(ceed, cudaFree(impl->asmb->d_B_out));
     CeedCallBackend(CeedDestroy(&ceed));
   }
+
   CeedCallBackend(CeedFree(&impl->asmb));
+
+  if (impl->asmb_blocks) {
+    Ceed ceed;
+
+    CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+    for (CeedInt i = 0; i < impl->num_blocks_in; i++) {
+      for (CeedInt j = 0; j < impl->num_blocks_out; j++) {
+        CeedOperatorAssemble_Cuda *asmb = impl->asmb_blocks[i * impl->num_blocks_out + j];
+
+        if (asmb) {
+          CeedCallCuda(ceed, cuModuleUnload(asmb->module));
+          CeedCallCuda(ceed, cudaFree(asmb->d_B_in));
+          CeedCallCuda(ceed, cudaFree(asmb->d_B_out));
+        }
+        CeedCallBackend(CeedFree(&asmb));
+      }
+    }
+    CeedCallBackend(CeedFree(&impl->asmb_blocks));
+    CeedCallBackend(CeedDestroy(&ceed));
+  }
 
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
@@ -1507,6 +1528,119 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda(CeedOperator op,
 //------------------------------------------------------------------------------
 // Single Operator Assembly Setup
 //------------------------------------------------------------------------------
+static int CeedOperatorAssembleSingleBlockSetup_Cuda(CeedOperator op, CeedInt active_input, CeedInt active_output, CeedInt use_ceedsize_idx) {
+  Ceed                ceed;
+  Ceed_Cuda          *cuda_data;
+  CeedInt             num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
+  CeedInt             elem_size_in, num_qpts_in = 0, num_comp_in, elem_size_out, num_qpts_out, num_comp_out;
+  CeedSize            num_output_components;
+  CeedSize            eval_mode_offset_in = 0, eval_mode_offset_out = 0;
+  const CeedScalar   *h_B_in, *h_B_out;
+  CeedElemRestriction rstr_in = NULL, rstr_out = NULL;
+  CeedBasis           basis_in = NULL, basis_out = NULL;
+  CeedOperatorField  *input_fields, *output_fields;
+  CeedOperator_Cuda  *impl;
+
+  CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+  CeedCallBackend(CeedOperatorGetData(op, &impl));
+
+  // Get intput and output fields
+  CeedCallBackend(CeedOperatorGetFields(op, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
+
+  {
+    CeedInt                  num_active_bases_in, *t_num_eval_modes_in, num_active_bases_out, *t_num_eval_modes_out;
+    CeedSize               **eval_modes_offsets_in, **eval_modes_offsets_out;
+    CeedBasis               *active_bases_in, *active_bases_out;
+    CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+    const CeedScalar       **B_mats_in, **B_mats_out;
+    CeedOperatorAssemblyData data;
+
+    CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+    CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &t_num_eval_modes_in, NULL, &eval_modes_offsets_in,
+                                                  &num_active_bases_out, &t_num_eval_modes_out, NULL, &eval_modes_offsets_out,
+                                                  &num_output_components));
+    // Number of elem restrictions is the same as the number of bases
+    CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
+    CeedCall(CeedOperatorAssemblyDataGetBases(data, NULL, &active_bases_in, &B_mats_in, NULL, &active_bases_out, &B_mats_out));
+
+    num_eval_modes_in  = t_num_eval_modes_in[active_input];
+    num_eval_modes_out = t_num_eval_modes_out[active_output];
+    CeedCheck(num_eval_modes_in > 0 && num_eval_modes_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
+
+    if (!impl->asmb_blocks) {
+      CeedCallBackend(CeedCalloc(num_active_bases_in * num_active_bases_out, &impl->asmb_blocks));
+      impl->num_blocks_in  = num_active_bases_in;
+      impl->num_blocks_out = num_active_bases_out;
+    }
+
+    rstr_in              = active_rstrs_in[active_input];
+    basis_in             = active_bases_in[active_input];
+    eval_mode_offset_in  = eval_modes_offsets_in[active_input][0];
+    h_B_in               = B_mats_in[active_input];
+    rstr_out             = active_rstrs_out[active_output];
+    basis_out            = active_bases_out[active_output];
+    eval_mode_offset_out = eval_modes_offsets_out[active_output][0];
+    h_B_out              = B_mats_out[active_output];
+  }
+
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+  if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
+
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+  if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
+  CeedCheck(num_qpts_in == num_qpts_out, ceed, CEED_ERROR_UNSUPPORTED,
+            "Active input and output bases must have the same number of quadrature points");
+
+  CeedCallBackend(CeedCalloc(1, &impl->asmb_blocks[active_input * impl->num_blocks_out + active_output]));
+  CeedOperatorAssemble_Cuda *asmb = impl->asmb_blocks[active_input * impl->num_blocks_out + active_output];
+  asmb->elems_per_block           = 1;
+  asmb->block_size_x              = elem_size_in;
+  asmb->block_size_y              = elem_size_out;
+
+  CeedCallBackend(CeedGetData(ceed, &cuda_data));
+  bool fallback = asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block > cuda_data->device_prop.maxThreadsPerBlock;
+
+  if (fallback) {
+    // Use fallback kernel with 1D threadblock
+    asmb->block_size_y = 1;
+  }
+
+  // Compile kernels
+  const char assembly_kernel_source[] = "// Full assembly source\n#include <ceed/jit-source/cuda/cuda-ref-operator-assemble-block.h>\n";
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
+  CeedCallBackend(CeedCompile_Cuda(ceed, assembly_kernel_source, &asmb->module, 13, "NUM_EVAL_MODES_IN", num_eval_modes_in, "NUM_EVAL_MODES_OUT",
+                                   num_eval_modes_out, "EVAL_MODE_OFFSET_IN", eval_mode_offset_in, "EVAL_MODE_OFFSET_OUT", eval_mode_offset_out,
+                                   "NUM_COMP_IN", num_comp_in, "NUM_COMP_OUT", num_comp_out, "TOTAL_NUM_COMP_OUT", num_output_components,
+                                   "NUM_NODES_IN", elem_size_in, "NUM_NODES_OUT", elem_size_out, "NUM_QPTS", num_qpts_in, "BLOCK_SIZE",
+                                   asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block, "BLOCK_SIZE_Y", asmb->block_size_y,
+                                   "USE_CEEDSIZE", use_ceedsize_idx));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, asmb->module, "LinearAssembleBlock", &asmb->LinearAssemble));
+
+  // Load into B_in, in order that they will be used in eval_modes_in
+  {
+    const CeedInt in_bytes = elem_size_in * num_qpts_in * num_eval_modes_in * sizeof(CeedScalar);
+
+    CeedCallCuda(ceed, cudaMalloc((void **)&asmb->d_B_in, in_bytes));
+    CeedCallCuda(ceed, cudaMemcpy(asmb->d_B_in, h_B_in, in_bytes, cudaMemcpyHostToDevice));
+  }
+
+  // Load into B_out, in order that they will be used in eval_modes_out
+  {
+    const CeedInt out_bytes = elem_size_out * num_qpts_out * num_eval_modes_out * sizeof(CeedScalar);
+
+    CeedCallCuda(ceed, cudaMalloc((void **)&asmb->d_B_out, out_bytes));
+    CeedCallCuda(ceed, cudaMemcpy(asmb->d_B_out, h_B_out, out_bytes, cudaMemcpyHostToDevice));
+  }
+  CeedCallBackend(CeedDestroy(&ceed));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Single Operator Assembly Setup
+//------------------------------------------------------------------------------
 static int CeedOperatorAssembleSingleSetup_Cuda(CeedOperator op, CeedInt use_ceedsize_idx) {
   Ceed                ceed;
   Ceed_Cuda          *cuda_data;
@@ -1702,6 +1836,117 @@ static int CeedOperatorAssembleSingleSetup_Cuda(CeedOperator op, CeedInt use_cee
   CeedCallBackend(CeedBasisDestroy(&basis_in));
   CeedCallBackend(CeedBasisDestroy(&basis_out));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Assemble matrix data for one block of a COO matrix of assembled operator.
+// The sparsity pattern is set by CeedOperatorLinearAssembleSymbolic.
+//------------------------------------------------------------------------------
+static int CeedOperatorAssembleSingleBlock_Cuda(CeedOperator op, CeedInt offset, CeedInt active_input, CeedInt active_output, CeedVector values) {
+  Ceed                ceed;
+  CeedSize            values_length = 0, assembled_qf_length = 0;
+  CeedInt             use_ceedsize_idx = 0, num_elem_in, num_elem_out, elem_size_in, elem_size_out;
+  CeedScalar         *values_array;
+  const CeedScalar   *assembled_qf_array;
+  CeedVector          assembled_qf   = NULL;
+  CeedElemRestriction assembled_rstr = NULL, rstr_in, rstr_out;
+  CeedRestrictionType rstr_type_in, rstr_type_out;
+  const bool         *orients_in = NULL, *orients_out = NULL;
+  const CeedInt8     *curl_orients_in = NULL, *curl_orients_out = NULL;
+  CeedOperator_Cuda  *impl;
+
+  CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+  CeedCallBackend(CeedOperatorGetData(op, &impl));
+
+  // Assemble QFunction
+  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &assembled_rstr, CEED_REQUEST_IMMEDIATE));
+  CeedCallBackend(CeedElemRestrictionDestroy(&assembled_rstr));
+  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
+
+  CeedCallBackend(CeedVectorGetLength(values, &values_length));
+  CeedCallBackend(CeedVectorGetLength(assembled_qf, &assembled_qf_length));
+  if ((values_length > INT_MAX) || (assembled_qf_length > INT_MAX)) use_ceedsize_idx = 1;
+
+  // Setup
+  if (!impl->asmb_blocks || (impl->asmb_blocks && !impl->asmb_blocks[active_input * impl->num_blocks_out + active_output])) {
+    CeedCallBackend(CeedOperatorAssembleSingleBlockSetup_Cuda(op, active_input, active_output, use_ceedsize_idx));
+  }
+  CeedOperatorAssemble_Cuda *asmb = impl->asmb_blocks[active_input * impl->num_blocks_out + active_output];
+
+  assert(asmb != NULL);
+
+  // Assemble element operator
+  CeedCallBackend(CeedVectorGetArray(values, CEED_MEM_DEVICE, &values_array));
+  values_array += offset;
+
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
+
+  rstr_in  = active_rstrs_in[active_input];
+  rstr_out = active_rstrs_out[active_output];
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+
+  CeedCallBackend(CeedElemRestrictionGetType(rstr_in, &rstr_type_in));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_in, CEED_MEM_DEVICE, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_in, CEED_MEM_DEVICE, &curl_orients_in));
+  }
+
+  if (rstr_in != rstr_out) {
+    CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
+    CeedCheck(num_elem_in == num_elem_out, ceed, CEED_ERROR_UNSUPPORTED,
+              "Active input and output operator restrictions must have the same number of elements");
+    CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+
+    CeedCallBackend(CeedElemRestrictionGetType(rstr_out, &rstr_type_out));
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_out, CEED_MEM_DEVICE, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_out, CEED_MEM_DEVICE, &curl_orients_out));
+    }
+  } else {
+    elem_size_out    = elem_size_in;
+    orients_out      = orients_in;
+    curl_orients_out = curl_orients_in;
+  }
+
+  // Compute B^T D B
+  CeedInt shared_mem =
+      ((curl_orients_in || curl_orients_out ? elem_size_in * elem_size_out : 0) + (curl_orients_in ? elem_size_in * asmb->block_size_y : 0)) *
+      sizeof(CeedScalar);
+  CeedInt grid   = CeedDivUpInt(num_elem_in, asmb->elems_per_block);
+  void   *args[] = {(void *)&num_elem_in, &asmb->d_B_in,     &asmb->d_B_out,      &orients_in,  &curl_orients_in,
+                    &orients_out,         &curl_orients_out, &assembled_qf_array, &values_array};
+
+  CeedCallBackend(CeedRunKernelDimShared_Cuda(ceed, asmb->LinearAssemble, NULL, grid, asmb->block_size_x, asmb->block_size_y, asmb->elems_per_block,
+                                              shared_mem, args));
+  CeedCallCuda(ceed, cudaDeviceSynchronize());
+
+  // Restore arrays
+  CeedCallBackend(CeedVectorRestoreArray(values, &values_array));
+  CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
+
+  // Cleanup
+  CeedCallBackend(CeedVectorDestroy(&assembled_qf));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_in, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_in, &curl_orients_in));
+  }
+  if (rstr_in != rstr_out) {
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_out, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_out, &curl_orients_out));
+    }
+  }
+  CeedCallBackend(CeedDestroy(&ceed));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -2090,6 +2335,7 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddPointBlockDiagonal",
                                          CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingle_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingleBlock", CeedOperatorAssembleSingleBlock_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAdd_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Cuda));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/cuda-ref/ceed-cuda-ref-operator.c
+++ b/backends/cuda-ref/ceed-cuda-ref-operator.c
@@ -95,7 +95,28 @@ static int CeedOperatorDestroy_Cuda(CeedOperator op) {
     CeedCallCuda(ceed, cudaFree(impl->asmb->d_B_out));
     CeedCallBackend(CeedDestroy(&ceed));
   }
+
   CeedCallBackend(CeedFree(&impl->asmb));
+
+  if (impl->asmb_blocks) {
+    Ceed ceed;
+
+    CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+    for (CeedInt i = 0; i < impl->num_blocks_in; i++) {
+      for (CeedInt j = 0; j < impl->num_blocks_out; j++) {
+        CeedOperatorAssemble_Cuda *asmb = impl->asmb_blocks[i * impl->num_blocks_out + j];
+
+        if (asmb) {
+          CeedCallCuda(ceed, cuModuleUnload(asmb->module));
+          CeedCallCuda(ceed, cudaFree(asmb->d_B_in));
+          CeedCallCuda(ceed, cudaFree(asmb->d_B_out));
+        }
+        CeedCallBackend(CeedFree(&asmb));
+      }
+    }
+    CeedCallBackend(CeedFree(&impl->asmb_blocks));
+    CeedCallBackend(CeedDestroy(&ceed));
+  }
 
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
@@ -1052,9 +1073,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Cuda(CeedOperator op, 
     CeedInt  strides[3] = {1, num_elem * Q, Q}; /* *NOPAD* */
 
     // Create output restriction
-    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out,
-                                                     (CeedSize)num_active_in * (CeedSize)num_active_out * (CeedSize)num_elem * (CeedSize)Q, strides,
-                                                     rstr));
+    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out, l_size, strides, rstr));
     // Create assembled vector
     CeedCallBackend(CeedVectorCreate(ceed_parent, l_size, assembled));
   }
@@ -1507,6 +1526,139 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda(CeedOperator op,
 //------------------------------------------------------------------------------
 // Single Operator Assembly Setup
 //------------------------------------------------------------------------------
+static int CeedOperatorAssembleSingleBlockSetup_Cuda(CeedOperator op, CeedInt active_input, CeedInt active_output, CeedInt use_ceedsize_idx) {
+  Ceed                     ceed;
+  Ceed_Cuda               *cuda_data;
+  CeedInt                  num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
+  CeedInt                  elem_size_in, num_qpts_in = 0, num_comp_in, elem_size_out, num_qpts_out, num_comp_out;
+  CeedSize                 num_output_components;
+  const CeedScalar        *h_B_in, *h_B_out;
+  CeedElemRestriction      rstr_in = NULL, rstr_out = NULL;
+  CeedBasis                basis_in = NULL, basis_out = NULL;
+  CeedOperatorField       *input_fields, *output_fields;
+  CeedOperator_Cuda       *impl;
+  CeedOperatorAssemblyData data;
+
+  CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+  CeedCallBackend(CeedOperatorGetData(op, &impl));
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+
+  // Get intput and output fields
+  CeedCallBackend(CeedOperatorGetFields(op, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
+
+  {
+    CeedInt              num_active_bases_in, *t_num_eval_modes_in, num_active_bases_out, *t_num_eval_modes_out;
+    CeedBasis           *active_bases_in, *active_bases_out;
+    CeedElemRestriction *active_rstrs_in, *active_rstrs_out;
+    const CeedScalar   **B_mats_in, **B_mats_out;
+
+    CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &t_num_eval_modes_in, NULL, NULL, &num_active_bases_out,
+                                                  &t_num_eval_modes_out, NULL, NULL, &num_output_components));
+    // Number of elem restrictions is the same as the number of bases
+    CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
+    CeedCall(CeedOperatorAssemblyDataGetBases(data, NULL, &active_bases_in, &B_mats_in, NULL, &active_bases_out, &B_mats_out));
+
+    num_eval_modes_in  = t_num_eval_modes_in[active_input];
+    num_eval_modes_out = t_num_eval_modes_out[active_output];
+    CeedCheck(num_eval_modes_in > 0 && num_eval_modes_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
+
+    if (!impl->asmb_blocks) {
+      CeedCallBackend(CeedCalloc(num_active_bases_in * num_active_bases_out, &impl->asmb_blocks));
+      impl->num_blocks_in  = num_active_bases_in;
+      impl->num_blocks_out = num_active_bases_out;
+    }
+
+    rstr_in   = active_rstrs_in[active_input];
+    basis_in  = active_bases_in[active_input];
+    h_B_in    = B_mats_in[active_input];
+    rstr_out  = active_rstrs_out[active_output];
+    basis_out = active_bases_out[active_output];
+    h_B_out   = B_mats_out[active_output];
+  }
+
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+  if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
+
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+  if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
+  CeedCheck(num_qpts_in == num_qpts_out, ceed, CEED_ERROR_UNSUPPORTED,
+            "Active input and output bases must have the same number of quadrature points");
+
+  CeedCallBackend(CeedCalloc(1, &impl->asmb_blocks[active_input * impl->num_blocks_out + active_output]));
+  CeedOperatorAssemble_Cuda *asmb = impl->asmb_blocks[active_input * impl->num_blocks_out + active_output];
+  asmb->elems_per_block           = 1;
+  asmb->block_size_x              = elem_size_in;
+  asmb->block_size_y              = elem_size_out;
+
+  CeedCallBackend(CeedGetData(ceed, &cuda_data));
+  bool fallback = asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block > cuda_data->device_prop.maxThreadsPerBlock;
+
+  if (fallback) {
+    // Use fallback kernel with 1D threadblock
+    asmb->block_size_y = 1;
+  }
+
+  // Compile kernels
+  char *source;
+  {
+    CeedInt    num_eval_modes_in, *t_num_eval_modes_in, num_eval_modes_out, *t_num_eval_modes_out;
+    CeedSize **eval_modes_offsets_in, **eval_modes_offsets_out;
+    char      *eval_mode_offsets_in_str, *eval_mode_offsets_out_str;
+
+    CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, NULL, &t_num_eval_modes_in, NULL, &eval_modes_offsets_in, NULL, &t_num_eval_modes_out, NULL,
+                                                  &eval_modes_offsets_out, NULL));
+    num_eval_modes_in  = t_num_eval_modes_in[active_input];
+    num_eval_modes_out = t_num_eval_modes_out[active_output];
+
+    CeedCallBackend(CeedBuildArrayConstantSize_Cuda(ceed, "EVAL_MODE_OFFSETS_IN", num_eval_modes_in, eval_modes_offsets_in[active_input],
+                                                    &eval_mode_offsets_in_str));
+    CeedCallBackend(CeedBuildArrayConstantSize_Cuda(ceed, "EVAL_MODE_OFFSETS_OUT", num_eval_modes_out, eval_modes_offsets_out[active_output],
+                                                    &eval_mode_offsets_out_str));
+
+    const char     assembly_kernel_source[] = "// Full assembly source\n#include <ceed/jit-source/cuda/cuda-ref-operator-assemble-block.h>\n";
+    const CeedSize len = strlen(assembly_kernel_source) + strlen(eval_mode_offsets_in_str) + strlen(eval_mode_offsets_out_str) + 3;
+
+    CeedCallBackend(CeedCalloc(len, &source));
+    snprintf(source, len, "%s\n%s\n%s", eval_mode_offsets_in_str, eval_mode_offsets_out_str, assembly_kernel_source);
+
+    CeedCallBackend(CeedFree(&eval_mode_offsets_in_str));
+    CeedCallBackend(CeedFree(&eval_mode_offsets_out_str));
+  }
+
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
+  CeedCallBackend(CeedCompile_Cuda(ceed, source, &asmb->module, 11, "NUM_EVAL_MODES_IN", num_eval_modes_in, "NUM_EVAL_MODES_OUT", num_eval_modes_out,
+                                   "NUM_COMP_IN", num_comp_in, "NUM_COMP_OUT", num_comp_out, "TOTAL_NUM_COMP_OUT", num_output_components,
+                                   "NUM_NODES_IN", elem_size_in, "NUM_NODES_OUT", elem_size_out, "NUM_QPTS", num_qpts_in, "BLOCK_SIZE",
+                                   asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block, "BLOCK_SIZE_Y", asmb->block_size_y,
+                                   "USE_CEEDSIZE", use_ceedsize_idx));
+  CeedCallBackend(CeedGetKernel_Cuda(ceed, asmb->module, "LinearAssembleBlock", &asmb->LinearAssemble));
+
+  // Load into B_in, in order that they will be used in eval_modes_in
+  {
+    const CeedInt in_bytes = elem_size_in * num_qpts_in * num_eval_modes_in * sizeof(CeedScalar);
+
+    CeedCallCuda(ceed, cudaMalloc((void **)&asmb->d_B_in, in_bytes));
+    CeedCallCuda(ceed, cudaMemcpy(asmb->d_B_in, h_B_in, in_bytes, cudaMemcpyHostToDevice));
+  }
+
+  // Load into B_out, in order that they will be used in eval_modes_out
+  {
+    const CeedInt out_bytes = elem_size_out * num_qpts_out * num_eval_modes_out * sizeof(CeedScalar);
+
+    CeedCallCuda(ceed, cudaMalloc((void **)&asmb->d_B_out, out_bytes));
+    CeedCallCuda(ceed, cudaMemcpy(asmb->d_B_out, h_B_out, out_bytes, cudaMemcpyHostToDevice));
+  }
+  CeedCallBackend(CeedFree(&source));
+  CeedCallBackend(CeedDestroy(&ceed));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Single Operator Assembly Setup
+//------------------------------------------------------------------------------
 static int CeedOperatorAssembleSingleSetup_Cuda(CeedOperator op, CeedInt use_ceedsize_idx) {
   Ceed                ceed;
   Ceed_Cuda          *cuda_data;
@@ -1702,6 +1854,117 @@ static int CeedOperatorAssembleSingleSetup_Cuda(CeedOperator op, CeedInt use_cee
   CeedCallBackend(CeedBasisDestroy(&basis_in));
   CeedCallBackend(CeedBasisDestroy(&basis_out));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Assemble matrix data for one block of a COO matrix of assembled operator.
+// The sparsity pattern is set by CeedOperatorLinearAssembleSymbolic.
+//------------------------------------------------------------------------------
+static int CeedOperatorAssembleSingleBlock_Cuda(CeedOperator op, CeedInt offset, CeedInt active_input, CeedInt active_output, CeedVector values) {
+  Ceed                ceed;
+  CeedSize            values_length = 0, assembled_qf_length = 0;
+  CeedInt             use_ceedsize_idx = 0, num_elem_in, num_elem_out, elem_size_in, elem_size_out;
+  CeedScalar         *values_array;
+  const CeedScalar   *assembled_qf_array;
+  CeedVector          assembled_qf   = NULL;
+  CeedElemRestriction assembled_rstr = NULL, rstr_in, rstr_out;
+  CeedRestrictionType rstr_type_in, rstr_type_out;
+  const bool         *orients_in = NULL, *orients_out = NULL;
+  const CeedInt8     *curl_orients_in = NULL, *curl_orients_out = NULL;
+  CeedOperator_Cuda  *impl;
+
+  CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+  CeedCallBackend(CeedOperatorGetData(op, &impl));
+
+  // Assemble QFunction
+  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &assembled_rstr, CEED_REQUEST_IMMEDIATE));
+  CeedCallBackend(CeedElemRestrictionDestroy(&assembled_rstr));
+  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
+
+  CeedCallBackend(CeedVectorGetLength(values, &values_length));
+  CeedCallBackend(CeedVectorGetLength(assembled_qf, &assembled_qf_length));
+  if ((values_length > INT_MAX) || (assembled_qf_length > INT_MAX)) use_ceedsize_idx = 1;
+
+  // Setup
+  if (!impl->asmb_blocks || (impl->asmb_blocks && !impl->asmb_blocks[active_input * impl->num_blocks_out + active_output])) {
+    CeedCallBackend(CeedOperatorAssembleSingleBlockSetup_Cuda(op, active_input, active_output, use_ceedsize_idx));
+  }
+  assert(impl->asmb_blocks && impl->asmb_blocks[active_input * impl->num_blocks_out + active_output]);
+  CeedOperatorAssemble_Cuda *asmb = impl->asmb_blocks[active_input * impl->num_blocks_out + active_output];
+
+  assert(asmb != NULL);
+
+  // Assemble element operator
+  CeedCallBackend(CeedVectorGetArray(values, CEED_MEM_DEVICE, &values_array));
+  values_array += offset;
+
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
+
+  rstr_in  = active_rstrs_in[active_input];
+  rstr_out = active_rstrs_out[active_output];
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+
+  CeedCallBackend(CeedElemRestrictionGetType(rstr_in, &rstr_type_in));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_in, CEED_MEM_DEVICE, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_in, CEED_MEM_DEVICE, &curl_orients_in));
+  }
+
+  if (rstr_in != rstr_out) {
+    CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
+    CeedCheck(num_elem_in == num_elem_out, ceed, CEED_ERROR_UNSUPPORTED,
+              "Active input and output operator restrictions must have the same number of elements");
+    CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+
+    CeedCallBackend(CeedElemRestrictionGetType(rstr_out, &rstr_type_out));
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_out, CEED_MEM_DEVICE, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_out, CEED_MEM_DEVICE, &curl_orients_out));
+    }
+  } else {
+    elem_size_out    = elem_size_in;
+    orients_out      = orients_in;
+    curl_orients_out = curl_orients_in;
+  }
+
+  // Compute B^T D B
+  CeedInt shared_mem =
+      ((curl_orients_in || curl_orients_out ? elem_size_in * elem_size_out : 0) + (curl_orients_in ? elem_size_in * asmb->block_size_y : 0)) *
+      sizeof(CeedScalar);
+  CeedInt grid   = CeedDivUpInt(num_elem_in, asmb->elems_per_block);
+  void   *args[] = {(void *)&num_elem_in, &asmb->d_B_in,     &asmb->d_B_out,      &orients_in,  &curl_orients_in,
+                    &orients_out,         &curl_orients_out, &assembled_qf_array, &values_array};
+
+  CeedCallBackend(CeedRunKernelDimShared_Cuda(ceed, asmb->LinearAssemble, NULL, grid, asmb->block_size_x, asmb->block_size_y, asmb->elems_per_block,
+                                              shared_mem, args));
+
+  // Restore arrays
+  CeedCallBackend(CeedVectorRestoreArray(values, &values_array));
+  CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
+
+  // Cleanup
+  CeedCallBackend(CeedVectorDestroy(&assembled_qf));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_in, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_in, &curl_orients_in));
+  }
+  if (rstr_in != rstr_out) {
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_out, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_out, &curl_orients_out));
+    }
+  }
+  CeedCallBackend(CeedDestroy(&ceed));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -2090,6 +2353,7 @@ int CeedOperatorCreate_Cuda(CeedOperator op) {
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddPointBlockDiagonal",
                                          CeedOperatorLinearAssembleAddPointBlockDiagonal_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingle_Cuda));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingleBlock", CeedOperatorAssembleSingleBlock_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAdd_Cuda));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Cuda));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/cuda-ref/ceed-cuda-ref.h
+++ b/backends/cuda-ref/ceed-cuda-ref.h
@@ -132,19 +132,21 @@ typedef struct {
 } CeedOperatorAssemble_Cuda;
 
 typedef struct {
-  bool                      *skip_rstr_in, *skip_rstr_out, *apply_add_basis_out;
-  uint64_t                  *input_states, points_state;  // State tracking for passive inputs
-  CeedVector                *e_vecs_in, *e_vecs_out;
-  CeedVector                *q_vecs_in, *q_vecs_out;
-  CeedInt                    num_inputs, num_outputs;
-  CeedInt                    num_active_in, num_active_out;
-  CeedInt                   *input_field_order, *output_field_order;
-  CeedSize                   max_active_e_vec_len;
-  CeedInt                    max_num_points;
-  CeedInt                   *num_points;
-  CeedVector                *qf_active_in, point_coords_elem;
-  CeedOperatorDiag_Cuda     *diag;
-  CeedOperatorAssemble_Cuda *asmb;
+  bool                       *skip_rstr_in, *skip_rstr_out, *apply_add_basis_out;
+  uint64_t                   *input_states, points_state;  // State tracking for passive inputs
+  CeedVector                 *e_vecs_in, *e_vecs_out;
+  CeedVector                 *q_vecs_in, *q_vecs_out;
+  CeedInt                     num_inputs, num_outputs;
+  CeedInt                     num_active_in, num_active_out;
+  CeedInt                    *input_field_order, *output_field_order;
+  CeedSize                    max_active_e_vec_len;
+  CeedInt                     max_num_points;
+  CeedInt                    *num_points;
+  CeedVector                 *qf_active_in, point_coords_elem;
+  CeedOperatorDiag_Cuda      *diag;
+  CeedOperatorAssemble_Cuda  *asmb;
+  CeedOperatorAssemble_Cuda **asmb_blocks;
+  CeedInt                     num_blocks_in, num_blocks_out;
 } CeedOperator_Cuda;
 
 CEED_INTERN int CeedGetCublasHandle_Cuda(Ceed ceed, cublasHandle_t *handle);

--- a/backends/cuda/ceed-cuda-compile.cpp
+++ b/backends/cuda/ceed-cuda-compile.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdlib>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -418,6 +419,29 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
       // LCOV_EXCL_STOP
     }
   }
+  return CEED_ERROR_SUCCESS;
+}
+
+template <typename ArrayT>
+struct CeedArrayView {
+  const ArrayT *array;
+  CeedInt       size;
+
+  CeedArrayView(const ArrayT *array_, CeedInt size_) : array(array_), size(size_) {}
+};
+
+template <typename OStream, typename ArrayT>
+OStream &operator<<(OStream &ostream, const CeedArrayView<ArrayT> &view) {
+  ostream << "{";
+  for (CeedInt i = 0; i < view.size; i++) ostream << std::setprecision(17) << view.array[i] << (i == view.size - 1 ? "}" : ", ");
+  return ostream;
+}
+
+int CeedBuildArrayConstantSize_Cuda(Ceed ceed, const char *name, CeedInt length, const CeedSize *array, char **line) {
+  std::ostringstream code;
+
+  code << "constexpr CeedSize " << name << "[" << length << "] = " << CeedArrayView<CeedSize>(array, length) << ";";
+  CeedCallBackend(CeedStringAllocCopy(code.str().c_str(), line));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/cuda/ceed-cuda-compile.h
+++ b/backends/cuda/ceed-cuda-compile.h
@@ -12,6 +12,8 @@
 
 static inline CeedInt CeedDivUpInt(CeedInt numerator, CeedInt denominator) { return (numerator + denominator - 1) / denominator; }
 
+CEED_INTERN int CeedBuildArrayConstantSize_Cuda(Ceed ceed, const char *name, CeedInt length, const CeedSize *array, char **line);
+
 CEED_INTERN int CeedCompile_Cuda(Ceed ceed, const char *source, CUmodule *module, const CeedInt num_defines, ...);
 CEED_INTERN int CeedTryCompile_Cuda(Ceed ceed, const char *source, bool *is_compile_good, CUmodule *module, const CeedInt num_defines, ...);
 

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -395,11 +395,10 @@ static int CeedOperatorBuildKernelFieldData_Hip_gen(std::ostringstream &code, Ce
       break;
     case CEED_EVAL_WEIGHT:
       break;  // No action
-      // LCOV_EXCL_START
     case CEED_EVAL_DIV:
     case CEED_EVAL_CURL:
+      data->use_fallback = true;
       break;  // TODO: Not implemented
-              // LCOV_EXCL_STOP
   }
   CeedCallBackend(CeedBasisDestroy(&basis));
   return CEED_ERROR_SUCCESS;
@@ -487,11 +486,10 @@ static int CeedOperatorBuildKernelRestriction_Hip_gen(std::ostringstream &code, 
           data->indices.inputs[i] = (CeedInt *)rstr_data->d_offsets;
           break;
         }
-        // LCOV_EXCL_START
         case CEED_RESTRICTION_ORIENTED:
         case CEED_RESTRICTION_CURL_ORIENTED:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   } else {
@@ -539,11 +537,10 @@ static int CeedOperatorBuildKernelRestriction_Hip_gen(std::ostringstream &code, 
       case CEED_RESTRICTION_POINTS:
         data->indices.outputs[i] = (CeedInt *)rstr_data->d_offsets;
         break;
-      // LCOV_EXCL_START
       case CEED_RESTRICTION_ORIENTED:
       case CEED_RESTRICTION_CURL_ORIENTED:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
   CeedCallBackend(CeedElemRestrictionDestroy(&elem_rstr));
@@ -658,11 +655,10 @@ static int CeedOperatorBuildKernelBasis_Hip_gen(std::ostringstream &code, CeedOp
         }
         break;
       }
-      // LCOV_EXCL_START
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   } else {
     switch (eval_mode) {
@@ -720,10 +716,11 @@ static int CeedOperatorBuildKernelBasis_Hip_gen(std::ostringstream &code, CeedOp
       // LCOV_EXCL_START
       case CEED_EVAL_WEIGHT:
         break;  // Should not occur
+                // LCOV_EXCL_STOP
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
   CeedCallBackend(CeedBasisDestroy(&basis));
@@ -790,11 +787,10 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
         break;
       case CEED_EVAL_WEIGHT:
         break;
-        // LCOV_EXCL_START
       case CEED_EVAL_DIV:
       case CEED_EVAL_CURL:
+        data->use_fallback = true;
         break;  // TODO: Not implemented
-                // LCOV_EXCL_STOP
     }
   }
 
@@ -843,11 +839,10 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
           code << tab << "CeedScalar r_s" << var_suffix << "[1];\n";
           code << tab << "r_s" << var_suffix << "[0] = 1.0;\n";
           break;
-          // LCOV_EXCL_START
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
     code << "\n";
@@ -873,10 +868,11 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
 
@@ -954,11 +950,10 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
           code << tab << "CeedScalar r_s" << var_suffix << "[1];\n";
           code << tab << "r_s" << var_suffix << "[0] = r_q" << var_suffix << "[q];\n";
           break;
-          // LCOV_EXCL_START
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
     code << "\n";
@@ -984,10 +979,11 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   } else {
@@ -1100,10 +1096,11 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   } else if (use_3d_slices) {
@@ -1142,10 +1139,11 @@ static int CeedOperatorBuildKernelQFunction_Hip_gen(std::ostringstream &code, Ce
           // LCOV_EXCL_START
         case CEED_EVAL_WEIGHT:
           break;  // Should not occur
+                  // LCOV_EXCL_STOP
         case CEED_EVAL_DIV:
         case CEED_EVAL_CURL:
+          data->use_fallback = true;
           break;  // TODO: Not implemented
-                  // LCOV_EXCL_STOP
       }
     }
   }
@@ -1249,6 +1247,13 @@ extern "C" int CeedOperatorBuildKernel_Hip_gen(CeedOperator op, bool *is_good_bu
 
     CeedCallBackend(CeedOperatorBuildKernelData_Hip_gen(ceed, num_input_fields, op_input_fields, qf_input_fields, num_output_fields, op_output_fields,
                                                         qf_output_fields, &max_P, &max_P_1d, &Q, &Q_1d, &max_dim, &is_all_tensor, &use_3d_slices));
+    if (data->use_fallback) {
+      *is_good_build = false;
+      CeedCallBackend(CeedOperatorSetSetupDone(op));
+      CeedCallBackend(CeedDestroy(&ceed));
+      CeedCallBackend(CeedQFunctionDestroy(&qf));
+      return CEED_ERROR_SUCCESS;
+    }
     data->max_P_1d = is_all_tensor ? max_P_1d : max_P;
   }
   if (is_at_points) {

--- a/backends/hip-ref/ceed-hip-ref-operator.c
+++ b/backends/hip-ref/ceed-hip-ref-operator.c
@@ -94,7 +94,27 @@ static int CeedOperatorDestroy_Hip(CeedOperator op) {
     CeedCallHip(ceed, hipFree(impl->asmb->d_B_out));
     CeedCallBackend(CeedDestroy(&ceed));
   }
+
   CeedCallBackend(CeedFree(&impl->asmb));
+  if (impl->asmb_blocks) {
+    Ceed ceed;
+
+    CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+    for (CeedInt i = 0; i < impl->num_blocks_in; i++) {
+      for (CeedInt j = 0; j < impl->num_blocks_out; j++) {
+        CeedOperatorAssemble_Hip *asmb = impl->asmb_blocks[i * impl->num_blocks_out + j];
+
+        if (asmb) {
+          CeedCallHip(ceed, hipModuleUnload(asmb->module));
+          CeedCallHip(ceed, hipFree(asmb->d_B_in));
+          CeedCallHip(ceed, hipFree(asmb->d_B_out));
+        }
+        CeedCallBackend(CeedFree(&asmb));
+      }
+    }
+    CeedCallBackend(CeedFree(&impl->asmb_blocks));
+    CeedCallBackend(CeedDestroy(&ceed));
+  }
 
   CeedCallBackend(CeedFree(&impl));
   return CEED_ERROR_SUCCESS;
@@ -1049,9 +1069,7 @@ static inline int CeedOperatorLinearAssembleQFunctionCore_Hip(CeedOperator op, b
     CeedInt  strides[3] = {1, num_elem * Q, Q}; /* *NOPAD* */
 
     // Create output restriction
-    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out,
-                                                     (CeedSize)num_active_in * (CeedSize)num_active_out * (CeedSize)num_elem * (CeedSize)Q, strides,
-                                                     rstr));
+    CeedCallBackend(CeedElemRestrictionCreateStrided(ceed_parent, num_elem, Q, num_active_in * num_active_out, l_size, strides, rstr));
     // Create assembled vector
     CeedCallBackend(CeedVectorCreate(ceed_parent, l_size, assembled));
   }
@@ -1502,6 +1520,139 @@ static int CeedOperatorLinearAssembleAddPointBlockDiagonal_Hip(CeedOperator op, 
 }
 
 //------------------------------------------------------------------------------
+// Single Operator Block Assembly Setup
+//------------------------------------------------------------------------------
+static int CeedOperatorAssembleSingleBlockSetup_Hip(CeedOperator op, CeedInt active_input, CeedInt active_output, CeedInt use_ceedsize_idx) {
+  Ceed                     ceed;
+  Ceed_Hip                *hip_data;
+  CeedInt                  num_input_fields, num_output_fields, num_eval_modes_in = 0, num_eval_modes_out = 0;
+  CeedInt                  elem_size_in, num_qpts_in = 0, num_comp_in, elem_size_out, num_qpts_out, num_comp_out;
+  CeedSize                 num_output_components;
+  const CeedScalar        *h_B_in, *h_B_out;
+  CeedElemRestriction      rstr_in = NULL, rstr_out = NULL;
+  CeedBasis                basis_in = NULL, basis_out = NULL;
+  CeedOperatorField       *input_fields, *output_fields;
+  CeedOperator_Hip        *impl;
+  CeedOperatorAssemblyData data;
+
+  CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+  CeedCallBackend(CeedOperatorGetData(op, &impl));
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+
+  // Get intput and output fields
+  CeedCallBackend(CeedOperatorGetFields(op, &num_input_fields, &input_fields, &num_output_fields, &output_fields));
+
+  {
+    CeedInt              num_active_bases_in, *t_num_eval_modes_in, num_active_bases_out, *t_num_eval_modes_out;
+    CeedBasis           *active_bases_in, *active_bases_out;
+    CeedElemRestriction *active_rstrs_in, *active_rstrs_out;
+    const CeedScalar   **B_mats_in, **B_mats_out;
+
+    CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &t_num_eval_modes_in, NULL, NULL, &num_active_bases_out,
+                                                  &t_num_eval_modes_out, NULL, NULL, &num_output_components));
+    // Number of elem restrictions is the same as the number of bases
+    CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
+    CeedCall(CeedOperatorAssemblyDataGetBases(data, NULL, &active_bases_in, &B_mats_in, NULL, &active_bases_out, &B_mats_out));
+
+    num_eval_modes_in  = t_num_eval_modes_in[active_input];
+    num_eval_modes_out = t_num_eval_modes_out[active_output];
+    CeedCheck(num_eval_modes_in > 0 && num_eval_modes_out > 0, ceed, CEED_ERROR_UNSUPPORTED, "Cannot assemble operator without inputs/outputs");
+
+    if (!impl->asmb_blocks) {
+      CeedCallBackend(CeedCalloc(num_active_bases_in * num_active_bases_out, &impl->asmb_blocks));
+      impl->num_blocks_in  = num_active_bases_in;
+      impl->num_blocks_out = num_active_bases_out;
+    }
+
+    rstr_in   = active_rstrs_in[active_input];
+    basis_in  = active_bases_in[active_input];
+    h_B_in    = B_mats_in[active_input];
+    rstr_out  = active_rstrs_out[active_output];
+    basis_out = active_bases_out[active_output];
+    h_B_out   = B_mats_out[active_output];
+  }
+
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+  if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
+
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+  if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
+  else CeedCallBackend(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
+  CeedCheck(num_qpts_in == num_qpts_out, ceed, CEED_ERROR_UNSUPPORTED,
+            "Active input and output bases must have the same number of quadrature points");
+
+  CeedCallBackend(CeedCalloc(1, &impl->asmb_blocks[active_input * impl->num_blocks_out + active_output]));
+  CeedOperatorAssemble_Hip *asmb = impl->asmb_blocks[active_input * impl->num_blocks_out + active_output];
+  asmb->elems_per_block          = 1;
+  asmb->block_size_x             = elem_size_in;
+  asmb->block_size_y             = elem_size_out;
+
+  CeedCallBackend(CeedGetData(ceed, &hip_data));
+  bool fallback = asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block > hip_data->device_prop.maxThreadsPerBlock;
+
+  if (fallback) {
+    // Use fallback kernel with 1D threadblock
+    asmb->block_size_y = 1;
+  }
+
+  // Compile kernels
+  char *source;
+  {
+    CeedInt    num_eval_modes_in, *t_num_eval_modes_in, num_eval_modes_out, *t_num_eval_modes_out;
+    CeedSize **eval_modes_offsets_in, **eval_modes_offsets_out;
+    char      *eval_mode_offsets_in_str, *eval_mode_offsets_out_str;
+
+    CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, NULL, &t_num_eval_modes_in, NULL, &eval_modes_offsets_in, NULL, &t_num_eval_modes_out, NULL,
+                                                  &eval_modes_offsets_out, NULL));
+    num_eval_modes_in  = t_num_eval_modes_in[active_input];
+    num_eval_modes_out = t_num_eval_modes_out[active_output];
+
+    CeedCallBackend(CeedBuildArrayConstantSize_Hip(ceed, "EVAL_MODE_OFFSETS_IN", num_eval_modes_in, eval_modes_offsets_in[active_input],
+                                                   &eval_mode_offsets_in_str));
+    CeedCallBackend(CeedBuildArrayConstantSize_Hip(ceed, "EVAL_MODE_OFFSETS_OUT", num_eval_modes_out, eval_modes_offsets_out[active_output],
+                                                   &eval_mode_offsets_out_str));
+
+    const char     assembly_kernel_source[] = "// Full assembly source\n#include <ceed/jit-source/hip/hip-ref-operator-assemble-block.h>\n";
+    const CeedSize len = strlen(assembly_kernel_source) + strlen(eval_mode_offsets_in_str) + strlen(eval_mode_offsets_out_str) + 3;
+
+    CeedCallBackend(CeedCalloc(len, &source));
+    snprintf(source, len, "%s\n%s\n%s", eval_mode_offsets_in_str, eval_mode_offsets_out_str, assembly_kernel_source);
+
+    CeedCallBackend(CeedFree(&eval_mode_offsets_in_str));
+    CeedCallBackend(CeedFree(&eval_mode_offsets_out_str));
+  }
+
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
+  CeedCallBackend(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
+  CeedCallBackend(CeedCompile_Hip(ceed, source, &asmb->module, 11, "NUM_EVAL_MODES_IN", num_eval_modes_in, "NUM_EVAL_MODES_OUT", num_eval_modes_out,
+                                  "NUM_COMP_IN", num_comp_in, "NUM_COMP_OUT", num_comp_out, "TOTAL_NUM_COMP_OUT", num_output_components,
+                                  "NUM_NODES_IN", elem_size_in, "NUM_NODES_OUT", elem_size_out, "NUM_QPTS", num_qpts_in, "BLOCK_SIZE",
+                                  asmb->block_size_x * asmb->block_size_y * asmb->elems_per_block, "BLOCK_SIZE_Y", asmb->block_size_y, "USE_CEEDSIZE",
+                                  use_ceedsize_idx));
+  CeedCallBackend(CeedGetKernel_Hip(ceed, asmb->module, "LinearAssembleBlock", &asmb->LinearAssemble));
+
+  // Load into B_in, in order that they will be used in eval_modes_in
+  {
+    const CeedInt in_bytes = elem_size_in * num_qpts_in * num_eval_modes_in * sizeof(CeedScalar);
+
+    CeedCallHip(ceed, hipMalloc((void **)&asmb->d_B_in, in_bytes));
+    CeedCallHip(ceed, hipMemcpy(asmb->d_B_in, h_B_in, in_bytes, hipMemcpyHostToDevice));
+  }
+
+  // Load into B_out, in order that they will be used in eval_modes_out
+  {
+    const CeedInt out_bytes = elem_size_out * num_qpts_out * num_eval_modes_out * sizeof(CeedScalar);
+
+    CeedCallHip(ceed, hipMalloc((void **)&asmb->d_B_out, out_bytes));
+    CeedCallHip(ceed, hipMemcpy(asmb->d_B_out, h_B_out, out_bytes, hipMemcpyHostToDevice));
+  }
+  CeedCallBackend(CeedFree(&source));
+  CeedCallBackend(CeedDestroy(&ceed));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
 // Single Operator Assembly Setup
 //------------------------------------------------------------------------------
 static int CeedOperatorAssembleSingleSetup_Hip(CeedOperator op, CeedInt use_ceedsize_idx) {
@@ -1699,6 +1850,117 @@ static int CeedOperatorAssembleSingleSetup_Hip(CeedOperator op, CeedInt use_ceed
   CeedCallBackend(CeedBasisDestroy(&basis_in));
   CeedCallBackend(CeedBasisDestroy(&basis_out));
   CeedCallBackend(CeedQFunctionDestroy(&qf));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Assemble matrix data for one block of a COO matrix of assembled operator.
+// The sparsity pattern is set by CeedOperatorLinearAssembleSymbolic.
+//------------------------------------------------------------------------------
+static int CeedOperatorAssembleSingleBlock_Hip(CeedOperator op, CeedInt offset, CeedInt active_input, CeedInt active_output, CeedVector values) {
+  Ceed                ceed;
+  CeedSize            values_length = 0, assembled_qf_length = 0;
+  CeedInt             use_ceedsize_idx = 0, num_elem_in, num_elem_out, elem_size_in, elem_size_out;
+  CeedScalar         *values_array;
+  const CeedScalar   *assembled_qf_array;
+  CeedVector          assembled_qf   = NULL;
+  CeedElemRestriction assembled_rstr = NULL, rstr_in, rstr_out;
+  CeedRestrictionType rstr_type_in, rstr_type_out;
+  const bool         *orients_in = NULL, *orients_out = NULL;
+  const CeedInt8     *curl_orients_in = NULL, *curl_orients_out = NULL;
+  CeedOperator_Hip   *impl;
+
+  CeedCallBackend(CeedOperatorGetCeed(op, &ceed));
+  CeedCallBackend(CeedOperatorGetData(op, &impl));
+
+  // Assemble QFunction
+  CeedCallBackend(CeedOperatorLinearAssembleQFunctionBuildOrUpdate(op, &assembled_qf, &assembled_rstr, CEED_REQUEST_IMMEDIATE));
+  CeedCallBackend(CeedElemRestrictionDestroy(&assembled_rstr));
+  CeedCallBackend(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_DEVICE, &assembled_qf_array));
+
+  CeedCallBackend(CeedVectorGetLength(values, &values_length));
+  CeedCallBackend(CeedVectorGetLength(assembled_qf, &assembled_qf_length));
+  if ((values_length > INT_MAX) || (assembled_qf_length > INT_MAX)) use_ceedsize_idx = 1;
+
+  // Setup
+  if (!impl->asmb_blocks || (impl->asmb_blocks && !impl->asmb_blocks[active_input * impl->num_blocks_out + active_output])) {
+    CeedCallBackend(CeedOperatorAssembleSingleBlockSetup_Hip(op, active_input, active_output, use_ceedsize_idx));
+  }
+  assert(impl->asmb_blocks && impl->asmb_blocks[active_input * impl->num_blocks_out + active_output]);
+  CeedOperatorAssemble_Hip *asmb = impl->asmb_blocks[active_input * impl->num_blocks_out + active_output];
+
+  assert(asmb != NULL);
+
+  // Assemble element operator
+  CeedCallBackend(CeedVectorGetArray(values, CEED_MEM_DEVICE, &values_array));
+  values_array += offset;
+
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
+
+  rstr_in  = active_rstrs_in[active_input];
+  rstr_out = active_rstrs_out[active_output];
+  CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
+  CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
+
+  CeedCallBackend(CeedElemRestrictionGetType(rstr_in, &rstr_type_in));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_in, CEED_MEM_DEVICE, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_in, CEED_MEM_DEVICE, &curl_orients_in));
+  }
+
+  if (rstr_in != rstr_out) {
+    CeedCallBackend(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
+    CeedCheck(num_elem_in == num_elem_out, ceed, CEED_ERROR_UNSUPPORTED,
+              "Active input and output operator restrictions must have the same number of elements");
+    CeedCallBackend(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
+
+    CeedCallBackend(CeedElemRestrictionGetType(rstr_out, &rstr_type_out));
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetOrientations(rstr_out, CEED_MEM_DEVICE, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionGetCurlOrientations(rstr_out, CEED_MEM_DEVICE, &curl_orients_out));
+    }
+  } else {
+    elem_size_out    = elem_size_in;
+    orients_out      = orients_in;
+    curl_orients_out = curl_orients_in;
+  }
+
+  // Compute B^T D B
+  CeedInt shared_mem =
+      ((curl_orients_in || curl_orients_out ? elem_size_in * elem_size_out : 0) + (curl_orients_in ? elem_size_in * asmb->block_size_y : 0)) *
+      sizeof(CeedScalar);
+  CeedInt grid   = CeedDivUpInt(num_elem_in, asmb->elems_per_block);
+  void   *args[] = {(void *)&num_elem_in, &asmb->d_B_in,     &asmb->d_B_out,      &orients_in,  &curl_orients_in,
+                    &orients_out,         &curl_orients_out, &assembled_qf_array, &values_array};
+
+  CeedCallBackend(CeedRunKernelDimShared_Hip(ceed, asmb->LinearAssemble, NULL, grid, asmb->block_size_x, asmb->block_size_y, asmb->elems_per_block,
+                                             shared_mem, args));
+
+  // Restore arrays
+  CeedCallBackend(CeedVectorRestoreArray(values, &values_array));
+  CeedCallBackend(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
+
+  // Cleanup
+  CeedCallBackend(CeedVectorDestroy(&assembled_qf));
+  if (rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_in, &orients_in));
+  } else if (rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+    CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_in, &curl_orients_in));
+  }
+  if (rstr_in != rstr_out) {
+    if (rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreOrientations(rstr_out, &orients_out));
+    } else if (rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCallBackend(CeedElemRestrictionRestoreCurlOrientations(rstr_out, &curl_orients_out));
+    }
+  }
+  CeedCallBackend(CeedDestroy(&ceed));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -2089,6 +2351,7 @@ int CeedOperatorCreate_Hip(CeedOperator op) {
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleAddPointBlockDiagonal",
                                          CeedOperatorLinearAssembleAddPointBlockDiagonal_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingle", CeedOperatorAssembleSingle_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "LinearAssembleSingleBlock", CeedOperatorAssembleSingleBlock_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "ApplyAdd", CeedOperatorApplyAdd_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Operator", op, "Destroy", CeedOperatorDestroy_Hip));
   CeedCallBackend(CeedDestroy(&ceed));

--- a/backends/hip-ref/ceed-hip-ref.h
+++ b/backends/hip-ref/ceed-hip-ref.h
@@ -137,19 +137,21 @@ typedef struct {
 } CeedOperatorAssemble_Hip;
 
 typedef struct {
-  bool                     *skip_rstr_in, *skip_rstr_out, *apply_add_basis_out;
-  uint64_t                 *input_states, points_state;  // State tracking for passive inputs
-  CeedVector               *e_vecs_in, *e_vecs_out;
-  CeedVector               *q_vecs_in, *q_vecs_out;
-  CeedInt                   num_inputs, num_outputs;
-  CeedInt                   num_active_in, num_active_out;
-  CeedInt                  *input_field_order, *output_field_order;
-  CeedSize                  max_active_e_vec_len;
-  CeedInt                   max_num_points;
-  CeedInt                  *num_points;
-  CeedVector               *qf_active_in, point_coords_elem;
-  CeedOperatorDiag_Hip     *diag;
-  CeedOperatorAssemble_Hip *asmb;
+  bool                      *skip_rstr_in, *skip_rstr_out, *apply_add_basis_out;
+  uint64_t                  *input_states, points_state;  // State tracking for passive inputs
+  CeedVector                *e_vecs_in, *e_vecs_out;
+  CeedVector                *q_vecs_in, *q_vecs_out;
+  CeedInt                    num_inputs, num_outputs;
+  CeedInt                    num_active_in, num_active_out;
+  CeedInt                   *input_field_order, *output_field_order;
+  CeedSize                   max_active_e_vec_len;
+  CeedInt                    max_num_points;
+  CeedInt                   *num_points;
+  CeedVector                *qf_active_in, point_coords_elem;
+  CeedOperatorDiag_Hip      *diag;
+  CeedOperatorAssemble_Hip  *asmb;
+  CeedOperatorAssemble_Hip **asmb_blocks;
+  CeedInt                    num_blocks_in, num_blocks_out;
 } CeedOperator_Hip;
 
 CEED_INTERN int CeedGetHipblasHandle_Hip(Ceed ceed, hipblasHandle_t *handle);

--- a/backends/hip/ceed-hip-compile.cpp
+++ b/backends/hip/ceed-hip-compile.cpp
@@ -11,6 +11,7 @@
 #include <ceed/backend.h>
 #include <ceed/jit-source/hip/hip-chipstar.h>
 #include <ceed/jit-tools.h>
+#include <iomanip>
 #include <stdarg.h>
 #include <string.h>
 #include <hip/hiprtc.h>
@@ -197,6 +198,29 @@ static int CeedCompileCore_Hip(Ceed ceed, const char *source, const bool throw_e
   CeedCallHiprtc(ceed, hiprtcDestroyProgram(&prog));
   CeedCallHip(ceed, hipModuleLoadData(module, ptx));
   CeedCallBackend(CeedFree(&ptx));
+  return CEED_ERROR_SUCCESS;
+}
+
+template <typename ArrayT>
+struct CeedArrayView {
+  const ArrayT *array;
+  CeedInt       size;
+
+  CeedArrayView(const ArrayT *array_, CeedInt size_) : array(array_), size(size_) {}
+};
+
+template <typename OStream, typename ArrayT>
+OStream &operator<<(OStream &ostream, const CeedArrayView<ArrayT> &view) {
+  ostream << "{";
+  for (CeedInt i = 0; i < view.size; i++) ostream << std::setprecision(17) << view.array[i] << (i == view.size - 1 ? "}" : ", ");
+  return ostream;
+}
+
+int CeedBuildArrayConstantSize_Hip(Ceed ceed, const char *name, CeedInt length, const CeedSize *array, char **line) {
+  std::ostringstream code;
+
+  code << "constexpr CeedSize " << name << "[" << length << "] = " << CeedArrayView<CeedSize>(array, length) << ";";
+  CeedCallBackend(CeedStringAllocCopy(code.str().c_str(), line));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/hip/ceed-hip-compile.h
+++ b/backends/hip/ceed-hip-compile.h
@@ -12,6 +12,8 @@
 
 static inline CeedInt CeedDivUpInt(CeedInt numerator, CeedInt denominator) { return (numerator + denominator - 1) / denominator; }
 
+CEED_INTERN int CeedBuildArrayConstantSize_Hip(Ceed ceed, const char *name, CeedInt length, const CeedSize *array, char **line);
+
 CEED_INTERN int CeedCompile_Hip(Ceed ceed, const char *source, hipModule_t *module, const CeedInt num_defines, ...);
 CEED_INTERN int CeedTryCompile_Hip(Ceed ceed, const char *source, bool *is_compile_good, hipModule_t *module, const CeedInt num_defines, ...);
 

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -359,6 +359,7 @@ struct CeedOperator_private {
   int (*LinearAssembleSymbolic)(CeedOperator, CeedSize *, CeedInt **, CeedInt **);
   int (*LinearAssemble)(CeedOperator, CeedVector);
   int (*LinearAssembleSingle)(CeedOperator, CeedInt, CeedVector);
+  int (*LinearAssembleSingleBlock)(CeedOperator, CeedInt, CeedInt, CeedInt, CeedVector);
   int (*CreateFDMElementInverse)(CeedOperator, CeedOperator *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);

--- a/include/ceed-impl.h
+++ b/include/ceed-impl.h
@@ -332,6 +332,7 @@ struct CeedQFunctionAssemblyData_private {
   bool                is_setup;
   bool                reuse_data;
   bool                needs_data_update;
+  bool                is_block_assembling;
   CeedVector          vec;
   CeedElemRestriction rstr;
 };
@@ -359,6 +360,7 @@ struct CeedOperator_private {
   int (*LinearAssembleSymbolic)(CeedOperator, CeedSize *, CeedInt **, CeedInt **);
   int (*LinearAssemble)(CeedOperator, CeedVector);
   int (*LinearAssembleSingle)(CeedOperator, CeedInt, CeedVector);
+  int (*LinearAssembleSingleBlock)(CeedOperator, CeedInt, CeedInt, CeedInt, CeedVector);
   int (*CreateFDMElementInverse)(CeedOperator, CeedOperator *, CeedRequest *);
   int (*Apply)(CeedOperator, CeedVector, CeedVector, CeedRequest *);
   int (*ApplyComposite)(CeedOperator, CeedVector, CeedVector, CeedRequest *);

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -474,7 +474,7 @@ CEED_EXTERN int CeedOperatorGetFallbackParent(CeedOperator op, CeedOperator *par
 CEED_EXTERN int CeedOperatorGetFallbackParentCeed(CeedOperator op, Ceed *parent);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback(CeedOperator op, CeedVector *assembled, CeedElemRestriction *rstr,
                                                                          CeedRequest *request);
-CEED_INTERN int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector values);
+CEED_INTERN int CeedOperatorAssembleSingle(CeedOperator op, CeedSize offset, CeedVector values);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
 CEED_INTERN int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A, const CeedScalar *mat_B, CeedScalar *mat_C, CeedInt m, CeedInt n,

--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -436,6 +436,7 @@ CEED_EXTERN int CeedQFunctionAssemblyDataSetUpdateNeeded(CeedQFunctionAssemblyDa
 CEED_EXTERN int CeedQFunctionAssemblyDataIsUpdateNeeded(CeedQFunctionAssemblyData data, bool *is_update_needed);
 CEED_EXTERN int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQFunctionAssemblyData *data_copy);
 CEED_EXTERN int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_setup);
+CEED_EXTERN int CeedQFunctionAssemblyDataSetBlockAssembling(CeedQFunctionAssemblyData data, bool is_block_assembling);
 CEED_EXTERN int CeedQFunctionAssemblyDataSetObjects(CeedQFunctionAssemblyData data, CeedVector vec, CeedElemRestriction rstr);
 CEED_EXTERN int CeedQFunctionAssemblyDataGetObjects(CeedQFunctionAssemblyData data, CeedVector *vec, CeedElemRestriction *rstr);
 CEED_EXTERN int CeedQFunctionAssemblyDataDestroy(CeedQFunctionAssemblyData *data);
@@ -474,7 +475,7 @@ CEED_EXTERN int CeedOperatorGetFallbackParent(CeedOperator op, CeedOperator *par
 CEED_EXTERN int CeedOperatorGetFallbackParentCeed(CeedOperator op, Ceed *parent);
 CEED_EXTERN int CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback(CeedOperator op, CeedVector *assembled, CeedElemRestriction *rstr,
                                                                          CeedRequest *request);
-CEED_INTERN int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector values);
+CEED_INTERN int CeedOperatorAssembleSingle(CeedOperator op, CeedSize offset, CeedVector values);
 CEED_EXTERN int CeedOperatorSetSetupDone(CeedOperator op);
 
 CEED_INTERN int CeedMatrixMatrixMultiply(Ceed ceed, const CeedScalar *mat_A, const CeedScalar *mat_B, CeedScalar *mat_C, CeedInt m, CeedInt n,

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-block.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-block.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Internal header for CUDA operator block assembly
+#include <ceed/types.h>
+
+#if USE_CEEDSIZE
+typedef CeedSize IndexType;
+#else
+typedef CeedInt IndexType;
+#endif
+
+//------------------------------------------------------------------------------
+// Matrix assembly kernel
+//------------------------------------------------------------------------------
+extern "C" __launch_bounds__(BLOCK_SIZE) __global__
+    void LinearAssembleBlock(const CeedInt num_elem, const CeedScalar *B_in, const CeedScalar *B_out, const bool *orients_in,
+                             const CeedInt8 *curl_orients_in, const bool *orients_out, const CeedInt8 *curl_orients_out,
+                             const CeedScalar *__restrict__ qf_array, CeedScalar *__restrict__ values_array) {
+  extern __shared__ CeedScalar s_CT[];
+  CeedScalar                  *s_C = &s_CT[NUM_NODES_OUT * NUM_NODES_IN];
+
+  const int l = threadIdx.x;  // The output column index of each B^T D B operation
+                              // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
+
+  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: e,
+  // comp_in, comp_out, node_row, node_col
+  const IndexType comp_out_stride = NUM_NODES_OUT * NUM_NODES_IN;
+  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP_OUT;
+  const IndexType e_stride        = comp_in_stride * NUM_COMP_IN;
+
+  // Strides for QF array, slowest --> fastest: e_in, comp_in, e_out, comp_out, e, q
+  const IndexType q_e_stride             = NUM_QPTS;
+  const IndexType q_comp_out_stride      = num_elem * q_e_stride;
+  const IndexType q_eval_mode_out_stride = q_comp_out_stride * NUM_COMP_OUT;
+  const IndexType q_comp_in_stride       = q_eval_mode_out_stride * NUM_EVAL_MODES_OUT;
+  const IndexType q_eval_mode_in_stride  = q_comp_in_stride * NUM_COMP_IN;
+
+  // Loop over each element (if necessary)
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NUM_COMP_IN; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NUM_COMP_OUT; comp_out++) {
+        for (IndexType n = threadIdx.y; n < NUM_NODES_OUT; n += BLOCK_SIZE_Y) {
+          CeedScalar result = 0.0;
+
+          for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
+            for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+              const IndexType row_offset = EVAL_MODE_OFFSETS_IN[e_in] + comp_in;
+              const IndexType col_offset = EVAL_MODE_OFFSETS_OUT[e_out] + comp_out;
+              const IndexType comp_index = row_offset * TOTAL_NUM_COMP_OUT + col_offset;
+
+              // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+              for (IndexType q = 0; q < NUM_QPTS; q++) {
+                const CeedSize b_out_index = (e_out + q * NUM_EVAL_MODES_OUT) * NUM_NODES_OUT + n;
+                const CeedSize b_in_index  = (e_in + q * NUM_EVAL_MODES_IN) * NUM_NODES_IN + l;
+                result += B_out[b_out_index] * qf_array[comp_index * q_comp_out_stride + q_e_stride * e + q] * B_in[b_in_index];
+              }
+            }  // end of out eval mode
+          }  // end of in eval mode
+          if (orients_in) {
+            result *= orients_in[NUM_NODES_IN * e + l] ? -1.0 : 1.0;
+          }
+          if (orients_out) {
+            result *= orients_out[NUM_NODES_OUT * e + n] ? -1.0 : 1.0;
+          }
+          if (!curl_orients_in && !curl_orients_out) {
+            const IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * n + l;
+
+            values_array[val_index] = result;
+          } else if (curl_orients_in) {
+            s_C[NUM_NODES_IN * threadIdx.y + l] = result;
+            __syncthreads();
+            s_CT[NUM_NODES_IN * n + l] =
+                (l > 0 ? s_C[NUM_NODES_IN * threadIdx.y + l - 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l - 1] : 0.0) +
+                s_C[NUM_NODES_IN * threadIdx.y + l] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 1] +
+                (l < (NUM_NODES_IN - 1) ? s_C[NUM_NODES_IN * threadIdx.y + l + 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 3] : 0.0);
+          } else {
+            s_CT[NUM_NODES_IN * n + l] = result;
+          }
+        }  // end of loop over element node index, n
+        if (curl_orients_in || curl_orients_out) {
+          // Compute and store the final T^T (B^T D B T) using the fully computed C T product in shared memory
+          if (curl_orients_out) __syncthreads();
+          for (IndexType n = threadIdx.y; n < NUM_NODES_OUT; n += BLOCK_SIZE_Y) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * n + l;
+
+            if (curl_orients_out) {
+              values_array[val_index] =
+                  (n > 0 ? s_CT[NUM_NODES_IN * (n - 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n - 1] : 0.0) +
+                  s_CT[NUM_NODES_IN * n + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n + 1] +
+                  (n < (NUM_NODES_OUT - 1) ? s_CT[NUM_NODES_IN * (n + 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n + 3] : 0.0);
+            } else {
+              values_array[val_index] = s_CT[NUM_NODES_IN * n + l];
+            }
+          }  // end of loop over element node index, n
+        }
+      }  // end of out component
+    }  // end of in component
+  }  // end of element loop
+}

--- a/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-block.h
+++ b/include/ceed/jit-source/cuda/cuda-ref-operator-assemble-block.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Internal header for CUDA operator full assembly
+#include <ceed/types.h>
+
+#if USE_CEEDSIZE
+typedef CeedSize IndexType;
+#else
+typedef CeedInt IndexType;
+#endif
+
+//------------------------------------------------------------------------------
+// Matrix assembly kernel
+//------------------------------------------------------------------------------
+extern "C" __launch_bounds__(BLOCK_SIZE) __global__
+    void LinearAssembleBlock(const CeedInt num_elem, const CeedScalar *B_in, const CeedScalar *B_out, const bool *orients_in,
+                             const CeedInt8 *curl_orients_in, const bool *orients_out, const CeedInt8 *curl_orients_out,
+                             const CeedScalar *__restrict__ qf_array, CeedScalar *__restrict__ values_array) {
+  extern __shared__ CeedScalar s_CT[];
+  CeedScalar                  *s_C = &s_CT[NUM_NODES_OUT * NUM_NODES_IN];
+
+  const int l = threadIdx.x;  // The output column index of each B^T D B operation
+                              // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
+
+  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: e,
+  // comp_in, comp_out, node_row, node_col
+  const IndexType comp_out_stride = NUM_NODES_OUT * NUM_NODES_IN;
+  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP_OUT;
+  const IndexType e_stride        = comp_in_stride * NUM_COMP_IN;
+
+  // Strides for QF array, slowest --> fastest: e_in, comp_in, e_out, comp_out, e, q
+  const IndexType q_e_stride             = NUM_QPTS;
+  const IndexType q_comp_out_stride      = num_elem * q_e_stride;
+  const IndexType q_eval_mode_out_stride = q_comp_out_stride * NUM_COMP_OUT;
+  const IndexType q_comp_in_stride       = q_eval_mode_out_stride * NUM_EVAL_MODES_OUT;
+  const IndexType q_eval_mode_in_stride  = q_comp_in_stride * NUM_COMP_IN;
+
+  // Loop over each element (if necessary)
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NUM_COMP_IN; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NUM_COMP_OUT; comp_out++) {
+        for (IndexType n = threadIdx.y; n < NUM_NODES_OUT; n += BLOCK_SIZE_Y) {
+          CeedScalar result = 0.0;
+
+          for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
+            for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+              const IndexType row_offset = EVAL_MODE_OFFSET_IN + e_in * NUM_COMP_IN + comp_in;
+              const IndexType col_offset = EVAL_MODE_OFFSET_OUT + e_out * NUM_COMP_OUT + comp_out;
+              const IndexType comp_index = row_offset * TOTAL_NUM_COMP_OUT + col_offset;
+
+              // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+              for (IndexType q = 0; q < NUM_QPTS; q++) {
+                const CeedSize b_out_index = (e_out + q * NUM_EVAL_MODES_OUT) * NUM_NODES_OUT + n;
+                const CeedSize b_in_index  = (e_in + q * NUM_EVAL_MODES_IN) * NUM_NODES_IN + l;
+                result += B_out[b_out_index] * qf_array[comp_index * q_comp_out_stride + q_e_stride * e + q] * B_in[b_in_index];
+              }
+            }  // end of out eval mode
+          }  // end of in eval mode
+          if (orients_in) {
+            result *= orients_in[NUM_NODES_IN * e + l] ? -1.0 : 1.0;
+          }
+          if (orients_out) {
+            result *= orients_out[NUM_NODES_OUT * e + n] ? -1.0 : 1.0;
+          }
+          if (!curl_orients_in && !curl_orients_out) {
+            const IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * n + l;
+
+            values_array[val_index] = result;
+          } else if (curl_orients_in) {
+            s_C[NUM_NODES_IN * threadIdx.y + l] = result;
+            __syncthreads();
+            s_CT[NUM_NODES_IN * n + l] =
+                (l > 0 ? s_C[NUM_NODES_IN * threadIdx.y + l - 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l - 1] : 0.0) +
+                s_C[NUM_NODES_IN * threadIdx.y + l] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 1] +
+                (l < (NUM_NODES_IN - 1) ? s_C[NUM_NODES_IN * threadIdx.y + l + 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 3] : 0.0);
+          } else {
+            s_CT[NUM_NODES_IN * n + l] = result;
+          }
+        }  // end of loop over element node index, n
+        if (curl_orients_in || curl_orients_out) {
+          // Compute and store the final T^T (B^T D B T) using the fully computed C T product in shared memory
+          if (curl_orients_out) __syncthreads();
+          for (IndexType n = threadIdx.y; n < NUM_NODES_OUT; n += BLOCK_SIZE_Y) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * n + l;
+
+            if (curl_orients_out) {
+              values_array[val_index] =
+                  (n > 0 ? s_CT[NUM_NODES_IN * (n - 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n - 1] : 0.0) +
+                  s_CT[NUM_NODES_IN * n + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n + 1] +
+                  (n < (NUM_NODES_OUT - 1) ? s_CT[NUM_NODES_IN * (n + 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n + 3] : 0.0);
+            } else {
+              values_array[val_index] = s_CT[NUM_NODES_IN * n + l];
+            }
+          }  // end of loop over element node index, n
+        }
+      }  // end of out component
+    }  // end of in component
+  }  // end of element loop
+}

--- a/include/ceed/jit-source/hip/hip-ref-operator-assemble-block.h
+++ b/include/ceed/jit-source/hip/hip-ref-operator-assemble-block.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Internal header for HIP operator block assembly
+#include <ceed/types.h>
+
+#if USE_CEEDSIZE
+typedef CeedSize IndexType;
+#else
+typedef CeedInt IndexType;
+#endif
+
+//------------------------------------------------------------------------------
+// Matrix assembly kernel
+//------------------------------------------------------------------------------
+extern "C" __launch_bounds__(BLOCK_SIZE) __global__
+    void LinearAssembleBlock(const CeedInt num_elem, const CeedScalar *B_in, const CeedScalar *B_out, const bool *orients_in,
+                             const CeedInt8 *curl_orients_in, const bool *orients_out, const CeedInt8 *curl_orients_out,
+                             const CeedScalar *__restrict__ qf_array, CeedScalar *__restrict__ values_array) {
+  extern __shared__ CeedScalar s_CT[];
+  CeedScalar                  *s_C = &s_CT[NUM_NODES_OUT * NUM_NODES_IN];
+
+  const int l = threadIdx.x;  // The output column index of each B^T D B operation
+                              // such that we have (Bout^T)_ij D_jk Bin_kl = C_il
+
+  // Strides for final output ordering, determined by the reference (interface) implementation of the symbolic assembly, slowest --> fastest: e,
+  // comp_in, comp_out, node_row, node_col
+  const IndexType comp_out_stride = NUM_NODES_OUT * NUM_NODES_IN;
+  const IndexType comp_in_stride  = comp_out_stride * NUM_COMP_OUT;
+  const IndexType e_stride        = comp_in_stride * NUM_COMP_IN;
+
+  // Strides for QF array, slowest --> fastest: e_in, comp_in, e_out, comp_out, e, q
+  const IndexType q_e_stride             = NUM_QPTS;
+  const IndexType q_comp_out_stride      = num_elem * q_e_stride;
+  const IndexType q_eval_mode_out_stride = q_comp_out_stride * NUM_COMP_OUT;
+  const IndexType q_comp_in_stride       = q_eval_mode_out_stride * NUM_EVAL_MODES_OUT;
+  const IndexType q_eval_mode_in_stride  = q_comp_in_stride * NUM_COMP_IN;
+
+  // Loop over each element (if necessary)
+  for (IndexType e = blockIdx.x * blockDim.z + threadIdx.z; e < num_elem; e += gridDim.x * blockDim.z) {
+    for (IndexType comp_in = 0; comp_in < NUM_COMP_IN; comp_in++) {
+      for (IndexType comp_out = 0; comp_out < NUM_COMP_OUT; comp_out++) {
+        for (IndexType n = threadIdx.y; n < NUM_NODES_OUT; n += BLOCK_SIZE_Y) {
+          CeedScalar result = 0.0;
+
+          for (IndexType e_in = 0; e_in < NUM_EVAL_MODES_IN; e_in++) {
+            for (IndexType e_out = 0; e_out < NUM_EVAL_MODES_OUT; e_out++) {
+              const IndexType row_offset = EVAL_MODE_OFFSETS_IN[e_in] + comp_in;
+              const IndexType col_offset = EVAL_MODE_OFFSETS_OUT[e_out] + comp_out;
+              const IndexType comp_index = row_offset * TOTAL_NUM_COMP_OUT + col_offset;
+
+              // Perform the B^T D B operation for this 'chunk' of D (the qf_array)
+              for (IndexType q = 0; q < NUM_QPTS; q++) {
+                const CeedSize b_out_index = (e_out + q * NUM_EVAL_MODES_OUT) * NUM_NODES_OUT + n;
+                const CeedSize b_in_index  = (e_in + q * NUM_EVAL_MODES_IN) * NUM_NODES_IN + l;
+                result += B_out[b_out_index] * qf_array[comp_index * q_comp_out_stride + q_e_stride * e + q] * B_in[b_in_index];
+              }
+            }  // end of out eval mode
+          }  // end of in eval mode
+          if (orients_in) {
+            result *= orients_in[NUM_NODES_IN * e + l] ? -1.0 : 1.0;
+          }
+          if (orients_out) {
+            result *= orients_out[NUM_NODES_OUT * e + n] ? -1.0 : 1.0;
+          }
+          if (!curl_orients_in && !curl_orients_out) {
+            const IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * n + l;
+
+            values_array[val_index] = result;
+          } else if (curl_orients_in) {
+            s_C[NUM_NODES_IN * threadIdx.y + l] = result;
+            __syncthreads();
+            s_CT[NUM_NODES_IN * n + l] =
+                (l > 0 ? s_C[NUM_NODES_IN * threadIdx.y + l - 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l - 1] : 0.0) +
+                s_C[NUM_NODES_IN * threadIdx.y + l] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 1] +
+                (l < (NUM_NODES_IN - 1) ? s_C[NUM_NODES_IN * threadIdx.y + l + 1] * curl_orients_in[3 * NUM_NODES_IN * e + 3 * l + 3] : 0.0);
+          } else {
+            s_CT[NUM_NODES_IN * n + l] = result;
+          }
+        }  // end of loop over element node index, n
+        if (curl_orients_in || curl_orients_out) {
+          // Compute and store the final T^T (B^T D B T) using the fully computed C T product in shared memory
+          if (curl_orients_out) __syncthreads();
+          for (IndexType n = threadIdx.y; n < NUM_NODES_OUT; n += BLOCK_SIZE_Y) {
+            IndexType val_index = e_stride * e + comp_in_stride * comp_in + comp_out_stride * comp_out + NUM_NODES_IN * n + l;
+
+            if (curl_orients_out) {
+              values_array[val_index] =
+                  (n > 0 ? s_CT[NUM_NODES_IN * (n - 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n - 1] : 0.0) +
+                  s_CT[NUM_NODES_IN * n + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n + 1] +
+                  (n < (NUM_NODES_OUT - 1) ? s_CT[NUM_NODES_IN * (n + 1) + l] * curl_orients_out[3 * NUM_NODES_OUT * e + 3 * n + 3] : 0.0);
+            } else {
+              values_array[val_index] = s_CT[NUM_NODES_IN * n + l];
+            }
+          }  // end of loop over element node index, n
+        }
+      }  // end of out component
+    }  // end of in component
+  }  // end of element loop
+}

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -438,6 +438,117 @@ static inline int CeedOperatorLinearAssembleAddDiagonalComposite(CeedOperator op
 }
 
 /**
+  @brief Count number of entries for assembled `CeedOperator`
+
+  @param[in]  op              `CeedOperator` to assemble
+  @param[in]  active_rstr_in  `CeedElemRestriction` for this block input field
+  @param[in]  active_rstr_out `CeedElemRestriction` for this block output field
+  @param[out] num_entries     Number of entries in assembled representation
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Utility
+**/
+static int CeedOperatorAssemblyCountEntriesSingleBlock(CeedOperator op, CeedElemRestriction active_rstr_in, CeedElemRestriction active_rstr_out,
+                                                       CeedSize *num_entries) {
+  bool    is_composite;
+  CeedInt num_elem_in, elem_size_in, num_comp_in, num_elem_out, elem_size_out, num_comp_out;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  CeedCheck(!is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+
+  CeedCall(CeedElemRestrictionGetNumElements(active_rstr_in, &num_elem_in));
+  CeedCall(CeedElemRestrictionGetElementSize(active_rstr_in, &elem_size_in));
+  CeedCall(CeedElemRestrictionGetNumComponents(active_rstr_in, &num_comp_in));
+  if (active_rstr_in != active_rstr_out) {
+    CeedCall(CeedElemRestrictionGetNumElements(active_rstr_out, &num_elem_out));
+    CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+              "Active input and output operator restrictions must have the same number of elements."
+              " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
+              num_elem_in, num_elem_out);
+    CeedCall(CeedElemRestrictionGetElementSize(active_rstr_out, &elem_size_out));
+    CeedCall(CeedElemRestrictionGetNumComponents(active_rstr_out, &num_comp_out));
+  } else {
+    num_elem_out  = num_elem_in;
+    elem_size_out = elem_size_in;
+    num_comp_out  = num_comp_in;
+  }
+  *num_entries = (CeedSize)elem_size_in * num_comp_in * elem_size_out * num_comp_out * num_elem_in;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Count number of entries for assembled `CeedOperator`
+
+  @param[in]  op          `CeedOperator` to assemble
+  @param[out] num_entries Number of entries in assembled representation
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Utility
+**/
+static int CeedOperatorAssemblyCountEntriesSingle(CeedOperator op, CeedSize *num_entries) {
+  bool                     is_composite;
+  CeedInt                  num_active_in, num_active_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  CeedCheck(!is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, &num_active_in, &active_rstrs_in, &num_active_out, &active_rstrs_out));
+
+  // Sum entries for each pair of input/output restrictions (block of full matrix)
+  *num_entries = 0;
+  for (CeedInt i = 0; i < num_active_in; i++) {
+    for (CeedInt j = 0; j < num_active_out; j++) {
+      CeedSize num_entries_block;
+
+      CeedCall(CeedOperatorAssemblyCountEntriesSingleBlock(op, active_rstrs_in[i], active_rstrs_out[j], &num_entries_block));
+      *num_entries += num_entries_block;
+    }
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Count number of entries for assembled `CeedOperator`
+
+  @param[in]  op          `CeedOperator` to assemble
+  @param[out] num_entries Number of entries in assembled representation
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Utility
+**/
+int CeedOperatorLinearAssembleGetNumEntries(CeedOperator op, CeedSize *num_entries) {
+  bool is_composite;
+
+  CeedCall(CeedOperatorCheckReady(op));
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+
+  if (is_composite) {
+    CeedInt       num_suboperators;
+    CeedOperator *sub_operators;
+
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
+
+    *num_entries = 0;
+    for (CeedInt k = 0; k < num_suboperators; ++k) {
+      CeedSize single_entries;
+
+      CeedCall(CeedOperatorAssemblyCountEntriesSingle(sub_operators[k], &single_entries));
+      *num_entries += single_entries;
+    }
+  } else {
+    CeedCall(CeedOperatorAssemblyCountEntriesSingle(op, num_entries));
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Build nonzero pattern for non-composite CeedOperator`.
 
   Users should generally use @ref CeedOperatorLinearAssembleSymbolic().
@@ -451,7 +562,8 @@ static inline int CeedOperatorLinearAssembleAddDiagonalComposite(CeedOperator op
 
   @ref Developer
 **/
-static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedInt offset, CeedInt *rows, CeedInt *cols) {
+static int CeedOperatorAssembleSymbolicSingleBlock(CeedOperator op, CeedSize offset, CeedElemRestriction elem_rstr_in,
+                                                   CeedElemRestriction elem_rstr_out, CeedInt *rows, CeedInt *cols) {
   Ceed                ceed;
   bool                is_composite;
   CeedSize            num_nodes_in, num_nodes_out, local_num_entries, count = 0;
@@ -460,14 +572,14 @@ static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedInt offset, C
   CeedScalar         *array;
   const CeedScalar   *elem_dof_a_in, *elem_dof_a_out;
   CeedVector          index_vec_in, index_vec_out, elem_dof_in, elem_dof_out;
-  CeedElemRestriction elem_rstr_in, elem_rstr_out, index_elem_rstr_in, index_elem_rstr_out;
+  CeedElemRestriction index_elem_rstr_in, index_elem_rstr_out;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
   CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCheck(!is_composite, ceed, CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
 
   CeedCall(CeedOperatorGetActiveVectorLengths(op, &num_nodes_in, &num_nodes_out));
-  CeedCall(CeedOperatorGetActiveElemRestrictions(op, &elem_rstr_in, &elem_rstr_out));
+  // CeedCall(CeedOperatorGetActiveElemRestrictions(op, &elem_rstr_in, &elem_rstr_out));
   CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_in, &num_elem_in));
   CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_in, &elem_size_in));
   CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_in, &num_comp_in));
@@ -545,8 +657,48 @@ static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedInt offset, C
     CeedCall(CeedVectorRestoreArrayRead(elem_dof_out, &elem_dof_a_out));
     CeedCall(CeedVectorDestroy(&elem_dof_out));
   }
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_in));
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_out));
+  CeedCall(CeedDestroy(&ceed));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Build nonzero pattern for non-composite CeedOperator`.
+
+  Users should generally use @ref CeedOperatorLinearAssembleSymbolic().
+
+  @param[in]  op     `CeedOperator` to assemble nonzero pattern
+  @param[in]  offset Offset for number of entries
+  @param[out] rows   Row number for each entry
+  @param[out] cols   Column number for each entry
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Developer
+**/
+static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedSize offset, CeedInt *rows, CeedInt *cols) {
+  Ceed                     ceed;
+  bool                     is_composite;
+  CeedInt                  num_active_in, num_active_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
+  CeedCheck(!is_composite, ceed, CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, &num_active_in, &active_rstrs_in, &num_active_out, &active_rstrs_out));
+
+  // Sum entries for each pair of input/output restrictions (block of full matrix)
+  for (CeedInt i = 0; i < num_active_in; i++) {
+    for (CeedInt j = 0; j < num_active_out; j++) {
+      CeedSize num_entries_block;
+
+      CeedCall(CeedOperatorAssembleSymbolicSingleBlock(op, offset, active_rstrs_in[i], active_rstrs_out[j], rows, cols));
+      CeedCall(CeedOperatorAssemblyCountEntriesSingleBlock(op, active_rstrs_in[i], active_rstrs_out[j], &num_entries_block));
+      offset += num_entries_block;
+    }
+  }
   CeedCall(CeedDestroy(&ceed));
   return CEED_ERROR_SUCCESS;
 }
@@ -668,7 +820,7 @@ int CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback(CeedOperator op, Ce
 
   @ref Developer
 **/
-int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector values) {
+int CeedOperatorAssembleSingleBlock(CeedOperator op, CeedInt offset, CeedInt active_input, CeedInt active_output, CeedVector values) {
   bool is_composite, is_at_points;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
@@ -682,9 +834,9 @@ int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector value
     if (num_elem == 0) return CEED_ERROR_SUCCESS;
   }
 
-  if (op->LinearAssembleSingle) {
+  if (op->LinearAssembleSingleBlock) {
     // Backend version
-    CeedCall(op->LinearAssembleSingle(op, offset, values));
+    CeedCall(op->LinearAssembleSingleBlock(op, offset, active_input, active_output, values));
     return CEED_ERROR_SUCCESS;
   } else {
     // Operator fallback
@@ -693,7 +845,7 @@ int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector value
     CeedDebug(CeedOperatorReturnCeed(op), "\nFalling back for CeedOperatorAssembleSingle\n");
     CeedCall(CeedOperatorGetFallback(op, &op_fallback));
     if (op_fallback) {
-      CeedCall(CeedOperatorAssembleSingle(op_fallback, offset, values));
+      CeedCall(CeedOperatorAssembleSingleBlock(op_fallback, offset, active_input, active_output, values));
       return CEED_ERROR_SUCCESS;
     }
   }
@@ -714,281 +866,294 @@ int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector value
   CeedCall(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_HOST, &assembled_qf_array));
 
   // Get assembly data
-  CeedInt                  num_elem_in, elem_size_in, num_comp_in, num_qpts_in;
-  CeedInt                  num_elem_out, elem_size_out, num_comp_out, num_qpts_out;
   CeedSize                 local_num_entries, count = 0;
-  const CeedEvalMode     **eval_modes_in, **eval_modes_out;
   CeedInt                  num_active_bases_in, *num_eval_modes_in, num_active_bases_out, *num_eval_modes_out;
-  CeedBasis               *active_bases_in, *active_bases_out, basis_in, basis_out;
-  const CeedScalar       **B_mats_in, **B_mats_out, *B_mat_in, *B_mat_out;
-  CeedElemRestriction      elem_rstr_in, elem_rstr_out;
-  CeedRestrictionType      elem_rstr_type_in, elem_rstr_type_out;
-  const bool              *elem_rstr_orients_in = NULL, *elem_rstr_orients_out = NULL;
-  const CeedInt8          *elem_rstr_curl_orients_in = NULL, *elem_rstr_curl_orients_out = NULL;
+  CeedSize                 num_output_components, **eval_modes_offsets_in, **eval_modes_offsets_out;
+  CeedBasis               *active_bases_in, *active_bases_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  const CeedScalar       **B_mats_in, **B_mats_out;
   CeedOperatorAssemblyData data;
 
   CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
-  CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &num_eval_modes_in, &eval_modes_in, NULL, &num_active_bases_out,
-                                                &num_eval_modes_out, &eval_modes_out, NULL, NULL));
+  CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &num_eval_modes_in, NULL, &eval_modes_offsets_in, &num_active_bases_out,
+                                                &num_eval_modes_out, NULL, &eval_modes_offsets_out, &num_output_components));
+  // Number of elem restrictions is the same as the number of bases
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
 
-  CeedCheck(num_active_bases_in == 1 && num_active_bases_out == 1, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-            "Cannot assemble operator with multiple active bases");
+  // CeedCheck(num_active_bases_in == 1 && num_active_bases_out == 1, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+  //           "Cannot assemble operator with multiple active bases");
   CeedCheck(num_eval_modes_in[0] > 0 && num_eval_modes_out[0] > 0, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
             "Cannot assemble operator without inputs/outputs");
 
   CeedCall(CeedOperatorAssemblyDataGetBases(data, NULL, &active_bases_in, &B_mats_in, NULL, &active_bases_out, &B_mats_out));
-  CeedCall(CeedOperatorGetActiveElemRestrictions(op, &elem_rstr_in, &elem_rstr_out));
-  basis_in  = active_bases_in[0];
-  basis_out = active_bases_out[0];
-  B_mat_in  = B_mats_in[0];
-  B_mat_out = B_mats_out[0];
 
-  CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_in, &num_elem_in));
-  CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_in, &elem_size_in));
-  CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_in, &num_comp_in));
-  if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
-  else CeedCall(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
+  // Assemble single block (active_out, active_in)
+  {
+    CeedInt             num_elem_in, elem_size_in, num_comp_in, num_qpts_in;
+    CeedInt             num_elem_out, elem_size_out, num_comp_out, num_qpts_out;
+    CeedElemRestriction elem_rstr_in = active_rstrs_in[active_input], elem_rstr_out = active_rstrs_out[active_output];
+    CeedBasis           basis_in = active_bases_in[active_input], basis_out = active_bases_out[active_output];
+    const CeedScalar   *B_mat_in = B_mats_in[active_input], *B_mat_out = B_mats_out[active_output];
+    CeedRestrictionType elem_rstr_type_in, elem_rstr_type_out;
+    const bool         *elem_rstr_orients_in = NULL, *elem_rstr_orients_out = NULL;
+    const CeedInt8     *elem_rstr_curl_orients_in = NULL, *elem_rstr_curl_orients_out = NULL;
 
-  CeedCall(CeedElemRestrictionGetType(elem_rstr_in, &elem_rstr_type_in));
-  if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
-    CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_orients_in));
-  } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
-    CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_curl_orients_in));
-  }
+    CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_in, &num_elem_in));
+    CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_in, &elem_size_in));
+    CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_in, &num_comp_in));
+    if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
+    else CeedCall(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
 
-  if (elem_rstr_in != elem_rstr_out) {
-    CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_out, &num_elem_out));
-    CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-              "Active input and output operator restrictions must have the same number of elements."
-              " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
-              num_elem_in, num_elem_out);
-    CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_out, &elem_size_out));
-    CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_out, &num_comp_out));
-    if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
-    else CeedCall(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
-    CeedCheck(num_qpts_in == num_qpts_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-              "Active input and output bases must have the same number of quadrature points."
-              " Input has %" CeedInt_FMT " points; output has %" CeedInt_FMT "points.",
-              num_qpts_in, num_qpts_out);
-
-    CeedCall(CeedElemRestrictionGetType(elem_rstr_out, &elem_rstr_type_out));
-    if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
-      CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_orients_out));
-    } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
-      CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_curl_orients_out));
+    CeedCall(CeedElemRestrictionGetType(elem_rstr_in, &elem_rstr_type_in));
+    if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+      CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_orients_in));
+    } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_curl_orients_in));
     }
-  } else {
-    num_elem_out  = num_elem_in;
-    elem_size_out = elem_size_in;
-    num_comp_out  = num_comp_in;
-    num_qpts_out  = num_qpts_in;
 
-    elem_rstr_orients_out      = elem_rstr_orients_in;
-    elem_rstr_curl_orients_out = elem_rstr_curl_orients_in;
-  }
-  local_num_entries = (CeedSize)elem_size_out * num_comp_out * elem_size_in * num_comp_in * num_elem_in;
+    if (elem_rstr_in != elem_rstr_out) {
+      CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_out, &num_elem_out));
+      CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+                "Active input and output operator restrictions must have the same number of elements."
+                " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
+                num_elem_in, num_elem_out);
+      CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_out, &elem_size_out));
+      CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_out, &num_comp_out));
+      if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
+      else CeedCall(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
+      CeedCheck(num_qpts_in == num_qpts_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+                "Active input and output bases must have the same number of quadrature points."
+                " Input has %" CeedInt_FMT " points; output has %" CeedInt_FMT "points.",
+                num_qpts_in, num_qpts_out);
 
-  // Loop over elements and put in data structure
-  // We store B_mat_in, B_mat_out, BTD, elem_mat in row-major order
-  CeedTensorContract contract;
-  CeedScalar        *vals, *BTD_mat = NULL, *elem_mat = NULL, *elem_mat_b = NULL;
+      CeedCall(CeedElemRestrictionGetType(elem_rstr_out, &elem_rstr_type_out));
+      if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+        CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_orients_out));
+      } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+        CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_curl_orients_out));
+      }
+    } else {
+      num_elem_out  = num_elem_in;
+      elem_size_out = elem_size_in;
+      num_comp_out  = num_comp_in;
+      num_qpts_out  = num_qpts_in;
 
-  CeedCall(CeedBasisGetTensorContract(basis_in, &contract));
-  CeedCall(CeedCalloc(elem_size_out * num_qpts_in * num_eval_modes_in[0], &BTD_mat));
-  CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat));
-  if (elem_rstr_curl_orients_in || elem_rstr_curl_orients_out) CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat_b));
+      elem_rstr_orients_out      = elem_rstr_orients_in;
+      elem_rstr_curl_orients_out = elem_rstr_curl_orients_in;
+    }
+    local_num_entries = (CeedSize)elem_size_out * num_comp_out * elem_size_in * num_comp_in * num_elem_in;
+    // Loop over elements and put in data structure
+    // We store B_mat_in, B_mat_out, BTD, elem_mat in row-major order
+    CeedTensorContract contract;
+    CeedScalar        *vals, *BTD_mat = NULL, *elem_mat = NULL, *elem_mat_b = NULL;
 
-  CeedCall(CeedVectorGetArray(values, CEED_MEM_HOST, &vals));
-  for (CeedSize e = 0; e < num_elem_in; e++) {
-    for (CeedInt comp_in = 0; comp_in < num_comp_in; comp_in++) {
-      for (CeedInt comp_out = 0; comp_out < num_comp_out; comp_out++) {
-        // Compute B^T*D
-        for (CeedSize n = 0; n < elem_size_out; n++) {
-          for (CeedSize q = 0; q < num_qpts_in; q++) {
-            for (CeedInt e_in = 0; e_in < num_eval_modes_in[0]; e_in++) {
-              const CeedSize btd_index = n * (num_qpts_in * num_eval_modes_in[0]) + q * num_eval_modes_in[0] + e_in;
-              CeedScalar     sum       = 0.0;
+    CeedCall(CeedBasisGetTensorContract(basis_in, &contract));
+    CeedCall(CeedCalloc(elem_size_out * num_qpts_in * num_eval_modes_in[active_input], &BTD_mat));
+    CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat));
+    if (elem_rstr_curl_orients_in || elem_rstr_curl_orients_out) CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat_b));
 
-              for (CeedInt e_out = 0; e_out < num_eval_modes_out[0]; e_out++) {
-                const CeedSize b_out_index     = (q * num_eval_modes_out[0] + e_out) * elem_size_out + n;
-                const CeedSize eval_mode_index = ((e_in * num_comp_in + comp_in) * num_eval_modes_out[0] + e_out) * num_comp_out + comp_out;
-                const CeedSize qf_index        = q * layout_qf[0] + eval_mode_index * layout_qf[1] + e * layout_qf[2];
+    CeedCall(CeedVectorGetArray(values, CEED_MEM_HOST, &vals));
+    for (CeedSize e = 0; e < num_elem_in; e++) {
+      for (CeedInt comp_in = 0; comp_in < num_comp_in; comp_in++) {
+        for (CeedInt comp_out = 0; comp_out < num_comp_out; comp_out++) {
+          // Compute B^T*D
+          for (CeedSize n = 0; n < elem_size_out; n++) {
+            for (CeedSize q = 0; q < num_qpts_in; q++) {
+              for (CeedInt e_in = 0; e_in < num_eval_modes_in[active_input]; e_in++) {
+                const CeedSize btd_index = n * (num_qpts_in * num_eval_modes_in[active_input]) + q * num_eval_modes_in[active_input] + e_in;
+                CeedScalar     sum       = 0.0;
 
-                sum += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
+                for (CeedInt e_out = 0; e_out < num_eval_modes_out[active_output]; e_out++) {
+                  const CeedSize b_out_index     = (q * num_eval_modes_out[active_output] + e_out) * elem_size_out + n;
+                  const CeedSize row_offset      = eval_modes_offsets_in[active_input][e_in] + comp_in;
+                  const CeedSize eval_mode_index = row_offset * num_output_components + eval_modes_offsets_out[active_output][e_out] + comp_out;
+                  const CeedSize qf_index        = q * layout_qf[0] + eval_mode_index * layout_qf[1] + e * layout_qf[2];
+
+                  sum += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
+                }
+                BTD_mat[btd_index] = sum;
               }
-              BTD_mat[btd_index] = sum;
             }
           }
-        }
 
-        // Form element matrix itself (for each block component)
-        if (contract) {
-          CeedCall(CeedTensorContractApply(contract, 1, num_qpts_in * num_eval_modes_in[0], elem_size_in, elem_size_out, BTD_mat, CEED_NOTRANSPOSE,
-                                           false, B_mat_in, elem_mat));
-        } else {
-          Ceed ceed;
+          // Form element matrix itself (for each block component)
+          if (contract) {
+            CeedCall(CeedTensorContractApply(contract, 1, num_qpts_in * num_eval_modes_in[active_input], elem_size_in, elem_size_out, BTD_mat,
+                                             CEED_NOTRANSPOSE, false, B_mat_in, elem_mat));
+          } else {
+            Ceed ceed;
 
-          CeedCall(CeedOperatorGetCeed(op, &ceed));
-          CeedCall(CeedMatrixMatrixMultiply(ceed, BTD_mat, B_mat_in, elem_mat, elem_size_out, elem_size_in, num_qpts_in * num_eval_modes_in[0]));
-          CeedCall(CeedDestroy(&ceed));
-        }
+            CeedCall(CeedOperatorGetCeed(op, &ceed));
+            CeedCall(CeedMatrixMatrixMultiply(ceed, BTD_mat, B_mat_in, elem_mat, elem_size_out, elem_size_in,
+                                              num_qpts_in * num_eval_modes_in[active_input]));
+            CeedCall(CeedDestroy(&ceed));
+          }
 
-        // Transform the element matrix if required
-        if (elem_rstr_orients_out) {
-          const bool *elem_orients = &elem_rstr_orients_out[e * elem_size_out];
+          // Transform the element matrix if required
+          if (elem_rstr_orients_out) {
+            const bool *elem_orients = &elem_rstr_orients_out[e * elem_size_out];
 
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              const double orient = elem_orients[i] ? -1.0 : 1.0;
+
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] *= orient;
+              }
+            }
+          } else if (elem_rstr_curl_orients_out) {
+            const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_out[e * 3 * elem_size_out];
+
+            // T^T*(B^T*D*B)
+            memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] =
+                    elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * i + 1] +
+                    (i > 0 ? elem_mat_b[(i - 1) * elem_size_in + j] * elem_curl_orients[3 * i - 1] : 0.0) +
+                    (i < elem_size_out - 1 ? elem_mat_b[(i + 1) * elem_size_in + j] * elem_curl_orients[3 * i + 3] : 0.0);
+              }
+            }
+          }
+          if (elem_rstr_orients_in) {
+            const bool *elem_orients = &elem_rstr_orients_in[e * elem_size_in];
+
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] *= elem_orients[j] ? -1.0 : 1.0;
+              }
+            }
+          } else if (elem_rstr_curl_orients_in) {
+            const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_in[e * 3 * elem_size_in];
+
+            // (B^T*D*B)*T
+            memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] = elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * j + 1] +
+                                                 (j > 0 ? elem_mat_b[i * elem_size_in + j - 1] * elem_curl_orients[3 * j - 1] : 0.0) +
+                                                 (j < elem_size_in - 1 ? elem_mat_b[i * elem_size_in + j + 1] * elem_curl_orients[3 * j + 3] : 0.0);
+              }
+            }
+          }
+
+          // Put element matrix in coordinate data structure
           for (CeedInt i = 0; i < elem_size_out; i++) {
-            const double orient = elem_orients[i] ? -1.0 : 1.0;
-
             for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] *= orient;
+              vals[offset + count] = elem_mat[i * elem_size_in + j];
+              count++;
             }
-          }
-        } else if (elem_rstr_curl_orients_out) {
-          const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_out[e * 3 * elem_size_out];
-
-          // T^T*(B^T*D*B)
-          memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
-          for (CeedInt i = 0; i < elem_size_out; i++) {
-            for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] = elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * i + 1] +
-                                               (i > 0 ? elem_mat_b[(i - 1) * elem_size_in + j] * elem_curl_orients[3 * i - 1] : 0.0) +
-                                               (i < elem_size_out - 1 ? elem_mat_b[(i + 1) * elem_size_in + j] * elem_curl_orients[3 * i + 3] : 0.0);
-            }
-          }
-        }
-        if (elem_rstr_orients_in) {
-          const bool *elem_orients = &elem_rstr_orients_in[e * elem_size_in];
-
-          for (CeedInt i = 0; i < elem_size_out; i++) {
-            for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] *= elem_orients[j] ? -1.0 : 1.0;
-            }
-          }
-        } else if (elem_rstr_curl_orients_in) {
-          const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_in[e * 3 * elem_size_in];
-
-          // (B^T*D*B)*T
-          memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
-          for (CeedInt i = 0; i < elem_size_out; i++) {
-            for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] = elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * j + 1] +
-                                               (j > 0 ? elem_mat_b[i * elem_size_in + j - 1] * elem_curl_orients[3 * j - 1] : 0.0) +
-                                               (j < elem_size_in - 1 ? elem_mat_b[i * elem_size_in + j + 1] * elem_curl_orients[3 * j + 3] : 0.0);
-            }
-          }
-        }
-
-        // Put element matrix in coordinate data structure
-        for (CeedInt i = 0; i < elem_size_out; i++) {
-          for (CeedInt j = 0; j < elem_size_in; j++) {
-            vals[offset + count] = elem_mat[i * elem_size_in + j];
-            count++;
           }
         }
       }
     }
-  }
-  CeedCheck(count == local_num_entries, CeedOperatorReturnCeed(op), CEED_ERROR_MAJOR, "Error computing entries");
-  CeedCall(CeedVectorRestoreArray(values, &vals));
+    CeedCheck(count == local_num_entries, CeedOperatorReturnCeed(op), CEED_ERROR_MAJOR, "Error computing entries");
+    CeedCall(CeedVectorRestoreArray(values, &vals));
 
-  // Cleanup
-  CeedCall(CeedFree(&BTD_mat));
-  CeedCall(CeedFree(&elem_mat));
-  CeedCall(CeedFree(&elem_mat_b));
-  if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
-    CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_in, &elem_rstr_orients_in));
-  } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
-    CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_in, &elem_rstr_curl_orients_in));
-  }
-  if (elem_rstr_in != elem_rstr_out) {
-    if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
-      CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_out, &elem_rstr_orients_out));
-    } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
-      CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_out, &elem_rstr_curl_orients_out));
+    // Cleanup
+    CeedCall(CeedFree(&BTD_mat));
+    CeedCall(CeedFree(&elem_mat));
+    CeedCall(CeedFree(&elem_mat_b));
+    if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+      CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_in, &elem_rstr_orients_in));
+    } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_in, &elem_rstr_curl_orients_in));
+    }
+    if (elem_rstr_in != elem_rstr_out) {
+      if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+        CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_out, &elem_rstr_orients_out));
+      } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+        CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_out, &elem_rstr_curl_orients_out));
+      }
     }
   }
   CeedCall(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
   CeedCall(CeedVectorDestroy(&assembled_qf));
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_in));
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_out));
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Count number of entries for assembled `CeedOperator`
+  @brief Assemble nonzero entries for non-composite `CeedOperator`.
 
-  @param[in]  op          `CeedOperator` to assemble
-  @param[out] num_entries Number of entries in assembled representation
+  Users should generally use @ref CeedOperatorLinearAssemble().
+
+  @param[in]  op     `CeedOperator` to assemble
+  @param[in]  offset Offset for number of entries
+  @param[out] values Values to assemble into matrix
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref Utility
+  @ref Developer
 **/
-static int CeedOperatorAssemblyCountEntriesSingle(CeedOperator op, CeedSize *num_entries) {
-  bool                is_composite;
-  CeedInt             num_elem_in, elem_size_in, num_comp_in, num_elem_out, elem_size_out, num_comp_out;
-  CeedElemRestriction rstr_in, rstr_out;
+int CeedOperatorAssembleSingle(CeedOperator op, CeedSize offset, CeedVector values) {
+  bool is_composite, is_at_points;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
   CeedCheck(!is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
 
-  CeedCall(CeedOperatorGetActiveElemRestrictions(op, &rstr_in, &rstr_out));
-  CeedCall(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
-  CeedCall(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
-  CeedCall(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
-  if (rstr_in != rstr_out) {
-    CeedCall(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
-    CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-              "Active input and output operator restrictions must have the same number of elements."
-              " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
-              num_elem_in, num_elem_out);
-    CeedCall(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
-    CeedCall(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
-  } else {
-    num_elem_out  = num_elem_in;
-    elem_size_out = elem_size_in;
-    num_comp_out  = num_comp_in;
+  // Early exit for empty operator
+  {
+    CeedInt num_elem = 0;
+
+    CeedCall(CeedOperatorGetNumElements(op, &num_elem));
+    if (num_elem == 0) return CEED_ERROR_SUCCESS;
   }
-  CeedCall(CeedElemRestrictionDestroy(&rstr_in));
-  CeedCall(CeedElemRestrictionDestroy(&rstr_out));
-  *num_entries = (CeedSize)elem_size_in * num_comp_in * elem_size_out * num_comp_out * num_elem_in;
-  return CEED_ERROR_SUCCESS;
-}
 
-/**
-  @brief Count number of entries for assembled `CeedOperator`
+  // Check for multiple active elem restrictions
+  CeedInt                  num_active_rstr_in, num_active_rstr_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
 
-  @param[in]  op          `CeedOperator` to assemble
-  @param[out] num_entries Number of entries in assembled representation
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, &num_active_rstr_in, &active_rstrs_in, &num_active_rstr_out, &active_rstrs_out));
 
-  @return An error code: 0 - success, otherwise - failure
+  const bool multiple_active_rstr = num_active_rstr_in > 1 || num_active_rstr_out > 1;
 
-  @ref Utility
-**/
-int CeedOperatorLinearAssembleGetNumEntries(CeedOperator op, CeedSize *num_entries) {
-  bool is_composite;
+  if (multiple_active_rstr) {
+    if (!op->LinearAssembleSingleBlock) {
+      // Operator fallback
+      CeedOperator op_fallback;
 
-  CeedCall(CeedOperatorCheckReady(op));
-  CeedCall(CeedOperatorIsComposite(op, &is_composite));
-
-  if (is_composite) {
-    CeedInt       num_suboperators;
-    CeedOperator *sub_operators;
-
-    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
-    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
-
-    *num_entries = 0;
-    for (CeedInt k = 0; k < num_suboperators; ++k) {
-      CeedSize single_entries;
-
-      CeedCall(CeedOperatorAssemblyCountEntriesSingle(sub_operators[k], &single_entries));
-      *num_entries += single_entries;
+      CeedDebug(CeedOperatorReturnCeed(op), "\nFalling back for CeedOperatorAssembleSingle\n");
+      CeedCall(CeedOperatorGetFallback(op, &op_fallback));
+      if (op_fallback) {
+        CeedCall(CeedOperatorAssembleSingle(op_fallback, offset, values));
+        return CEED_ERROR_SUCCESS;
+      }
     }
+
+    // Assemble QFunction for each block
+    for (CeedInt i = 0; i < num_active_rstr_in; i++) {
+      for (CeedInt j = 0; j < num_active_rstr_out; j++) {
+        CeedSize num_entries_block;
+
+        CeedCall(CeedOperatorAssembleSingleBlock(op, offset, i, j, values));
+        CeedCall(CeedOperatorAssemblyCountEntriesSingleBlock(op, active_rstrs_in[i], active_rstrs_out[j], &num_entries_block));
+        offset += num_entries_block;
+      }
+    }
+    return CEED_ERROR_SUCCESS;
+  } else if (op->LinearAssembleSingle) {
+    // Backend version
+    CeedCall(op->LinearAssembleSingle(op, offset, values));
+    return CEED_ERROR_SUCCESS;
   } else {
-    CeedCall(CeedOperatorAssemblyCountEntriesSingle(op, num_entries));
+    // Operator fallback
+    CeedOperator op_fallback;
+
+    CeedDebug(CeedOperatorReturnCeed(op), "\nFalling back for CeedOperatorAssembleSingle\n");
+    CeedCall(CeedOperatorGetFallback(op, &op_fallback));
+    if (op_fallback) {
+      CeedCall(CeedOperatorAssembleSingle(op_fallback, offset, values));
+      return CEED_ERROR_SUCCESS;
+    }
   }
+
+  CeedCall(CeedOperatorIsAtPoints(op, &is_at_points));
+  CeedCheck(!is_at_points, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+            "Backend does not implement CeedOperatorLinearAssemble for AtPoints operator");
+
+  // Assemble QFunction for 0 0 block
+  CeedCall(CeedOperatorAssembleSingleBlock(op, offset, 0, 0, values));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed-preconditioning.c
+++ b/interface/ceed-preconditioning.c
@@ -438,6 +438,117 @@ static inline int CeedOperatorLinearAssembleAddDiagonalComposite(CeedOperator op
 }
 
 /**
+  @brief Count number of entries for assembled `CeedOperator`
+
+  @param[in]  op              `CeedOperator` to assemble
+  @param[in]  active_rstr_in  `CeedElemRestriction` for this block input field
+  @param[in]  active_rstr_out `CeedElemRestriction` for this block output field
+  @param[out] num_entries     Number of entries in assembled representation
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Utility
+**/
+static int CeedOperatorAssemblyCountEntriesSingleBlock(CeedOperator op, CeedElemRestriction active_rstr_in, CeedElemRestriction active_rstr_out,
+                                                       CeedSize *num_entries) {
+  bool    is_composite;
+  CeedInt num_elem_in, elem_size_in, num_comp_in, num_elem_out, elem_size_out, num_comp_out;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  CeedCheck(!is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+
+  CeedCall(CeedElemRestrictionGetNumElements(active_rstr_in, &num_elem_in));
+  CeedCall(CeedElemRestrictionGetElementSize(active_rstr_in, &elem_size_in));
+  CeedCall(CeedElemRestrictionGetNumComponents(active_rstr_in, &num_comp_in));
+  if (active_rstr_in != active_rstr_out) {
+    CeedCall(CeedElemRestrictionGetNumElements(active_rstr_out, &num_elem_out));
+    CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+              "Active input and output operator restrictions must have the same number of elements."
+              " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
+              num_elem_in, num_elem_out);
+    CeedCall(CeedElemRestrictionGetElementSize(active_rstr_out, &elem_size_out));
+    CeedCall(CeedElemRestrictionGetNumComponents(active_rstr_out, &num_comp_out));
+  } else {
+    num_elem_out  = num_elem_in;
+    elem_size_out = elem_size_in;
+    num_comp_out  = num_comp_in;
+  }
+  *num_entries = (CeedSize)elem_size_in * num_comp_in * elem_size_out * num_comp_out * num_elem_in;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Count number of entries for assembled `CeedOperator`
+
+  @param[in]  op          `CeedOperator` to assemble
+  @param[out] num_entries Number of entries in assembled representation
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Utility
+**/
+static int CeedOperatorAssemblyCountEntriesSingle(CeedOperator op, CeedSize *num_entries) {
+  bool                     is_composite;
+  CeedInt                  num_active_in, num_active_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  CeedCheck(!is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, &num_active_in, &active_rstrs_in, &num_active_out, &active_rstrs_out));
+
+  // Sum entries for each pair of input/output restrictions (block of full matrix)
+  *num_entries = 0;
+  for (CeedInt i = 0; i < num_active_in; i++) {
+    for (CeedInt j = 0; j < num_active_out; j++) {
+      CeedSize num_entries_block;
+
+      CeedCall(CeedOperatorAssemblyCountEntriesSingleBlock(op, active_rstrs_in[i], active_rstrs_out[j], &num_entries_block));
+      *num_entries += num_entries_block;
+    }
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Count number of entries for assembled `CeedOperator`
+
+  @param[in]  op          `CeedOperator` to assemble
+  @param[out] num_entries Number of entries in assembled representation
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Utility
+**/
+int CeedOperatorLinearAssembleGetNumEntries(CeedOperator op, CeedSize *num_entries) {
+  bool is_composite;
+
+  CeedCall(CeedOperatorCheckReady(op));
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+
+  if (is_composite) {
+    CeedInt       num_suboperators;
+    CeedOperator *sub_operators;
+
+    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
+    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
+
+    *num_entries = 0;
+    for (CeedInt k = 0; k < num_suboperators; ++k) {
+      CeedSize single_entries;
+
+      CeedCall(CeedOperatorAssemblyCountEntriesSingle(sub_operators[k], &single_entries));
+      *num_entries += single_entries;
+    }
+  } else {
+    CeedCall(CeedOperatorAssemblyCountEntriesSingle(op, num_entries));
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
   @brief Build nonzero pattern for non-composite `CeedOperator`.
 
   Users should generally use @ref CeedOperatorLinearAssembleSymbolic().
@@ -451,7 +562,8 @@ static inline int CeedOperatorLinearAssembleAddDiagonalComposite(CeedOperator op
 
   @ref Developer
 **/
-static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedInt offset, CeedInt *rows, CeedInt *cols) {
+static int CeedOperatorAssembleSymbolicSingleBlock(CeedOperator op, CeedSize offset, CeedElemRestriction elem_rstr_in,
+                                                   CeedElemRestriction elem_rstr_out, CeedInt *rows, CeedInt *cols) {
   Ceed                ceed;
   bool                is_composite;
   CeedSize            num_nodes_in, num_nodes_out, local_num_entries, count = 0;
@@ -460,14 +572,13 @@ static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedInt offset, C
   CeedScalar         *array;
   const CeedScalar   *elem_dof_a_in, *elem_dof_a_out;
   CeedVector          index_vec_in, index_vec_out, elem_dof_in, elem_dof_out;
-  CeedElemRestriction elem_rstr_in, elem_rstr_out, index_elem_rstr_in, index_elem_rstr_out;
+  CeedElemRestriction index_elem_rstr_in, index_elem_rstr_out;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
   CeedCall(CeedOperatorGetCeed(op, &ceed));
   CeedCheck(!is_composite, ceed, CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
 
   CeedCall(CeedOperatorGetActiveVectorLengths(op, &num_nodes_in, &num_nodes_out));
-  CeedCall(CeedOperatorGetActiveElemRestrictions(op, &elem_rstr_in, &elem_rstr_out));
   CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_in, &num_elem_in));
   CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_in, &elem_size_in));
   CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_in, &num_comp_in));
@@ -545,8 +656,48 @@ static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedInt offset, C
     CeedCall(CeedVectorRestoreArrayRead(elem_dof_out, &elem_dof_a_out));
     CeedCall(CeedVectorDestroy(&elem_dof_out));
   }
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_in));
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_out));
+  CeedCall(CeedDestroy(&ceed));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Build nonzero pattern for non-composite CeedOperator`.
+
+  Users should generally use @ref CeedOperatorLinearAssembleSymbolic().
+
+  @param[in]  op     `CeedOperator` to assemble nonzero pattern
+  @param[in]  offset Offset for number of entries
+  @param[out] rows   Row number for each entry
+  @param[out] cols   Column number for each entry
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Developer
+**/
+static int CeedOperatorAssembleSymbolicSingle(CeedOperator op, CeedSize offset, CeedInt *rows, CeedInt *cols) {
+  Ceed                     ceed;
+  bool                     is_composite;
+  CeedInt                  num_active_in, num_active_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData data;
+
+  CeedCall(CeedOperatorIsComposite(op, &is_composite));
+  CeedCall(CeedOperatorGetCeed(op, &ceed));
+  CeedCheck(!is_composite, ceed, CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
+
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, &num_active_in, &active_rstrs_in, &num_active_out, &active_rstrs_out));
+
+  // Sum entries for each pair of input/output restrictions (block of full matrix)
+  for (CeedInt i = 0; i < num_active_in; i++) {
+    for (CeedInt j = 0; j < num_active_out; j++) {
+      CeedSize num_entries_block;
+
+      CeedCall(CeedOperatorAssembleSymbolicSingleBlock(op, offset, active_rstrs_in[i], active_rstrs_out[j], rows, cols));
+      CeedCall(CeedOperatorAssemblyCountEntriesSingleBlock(op, active_rstrs_in[i], active_rstrs_out[j], &num_entries_block));
+      offset += num_entries_block;
+    }
+  }
   CeedCall(CeedDestroy(&ceed));
   return CEED_ERROR_SUCCESS;
 }
@@ -668,7 +819,7 @@ int CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback(CeedOperator op, Ce
 
   @ref Developer
 **/
-int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector values) {
+int CeedOperatorAssembleSingleBlock(CeedOperator op, CeedInt offset, CeedInt active_input, CeedInt active_output, CeedVector values) {
   bool is_composite, is_at_points;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
@@ -682,9 +833,9 @@ int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector value
     if (num_elem == 0) return CEED_ERROR_SUCCESS;
   }
 
-  if (op->LinearAssembleSingle) {
+  if (op->LinearAssembleSingleBlock) {
     // Backend version
-    CeedCall(op->LinearAssembleSingle(op, offset, values));
+    CeedCall(op->LinearAssembleSingleBlock(op, offset, active_input, active_output, values));
     return CEED_ERROR_SUCCESS;
   } else {
     // Operator fallback
@@ -693,7 +844,7 @@ int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector value
     CeedDebug(CeedOperatorReturnCeed(op), "\nFalling back for CeedOperatorAssembleSingle\n");
     CeedCall(CeedOperatorGetFallback(op, &op_fallback));
     if (op_fallback) {
-      CeedCall(CeedOperatorAssembleSingle(op_fallback, offset, values));
+      CeedCall(CeedOperatorAssembleSingleBlock(op_fallback, offset, active_input, active_output, values));
       return CEED_ERROR_SUCCESS;
     }
   }
@@ -714,281 +865,296 @@ int CeedOperatorAssembleSingle(CeedOperator op, CeedInt offset, CeedVector value
   CeedCall(CeedVectorGetArrayRead(assembled_qf, CEED_MEM_HOST, &assembled_qf_array));
 
   // Get assembly data
-  CeedInt                  num_elem_in, elem_size_in, num_comp_in, num_qpts_in;
-  CeedInt                  num_elem_out, elem_size_out, num_comp_out, num_qpts_out;
   CeedSize                 local_num_entries, count = 0;
-  const CeedEvalMode     **eval_modes_in, **eval_modes_out;
   CeedInt                  num_active_bases_in, *num_eval_modes_in, num_active_bases_out, *num_eval_modes_out;
-  CeedBasis               *active_bases_in, *active_bases_out, basis_in, basis_out;
-  const CeedScalar       **B_mats_in, **B_mats_out, *B_mat_in, *B_mat_out;
-  CeedElemRestriction      elem_rstr_in, elem_rstr_out;
-  CeedRestrictionType      elem_rstr_type_in, elem_rstr_type_out;
-  const bool              *elem_rstr_orients_in = NULL, *elem_rstr_orients_out = NULL;
-  const CeedInt8          *elem_rstr_curl_orients_in = NULL, *elem_rstr_curl_orients_out = NULL;
+  CeedSize                 num_output_components, **eval_modes_offsets_in, **eval_modes_offsets_out;
+  CeedBasis               *active_bases_in, *active_bases_out;
+  CeedElemRestriction     *active_rstrs_in, *active_rstrs_out;
+  const CeedScalar       **B_mats_in, **B_mats_out;
   CeedOperatorAssemblyData data;
 
   CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
-  CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &num_eval_modes_in, &eval_modes_in, NULL, &num_active_bases_out,
-                                                &num_eval_modes_out, &eval_modes_out, NULL, NULL));
+  CeedCall(CeedOperatorAssemblyDataGetEvalModes(data, &num_active_bases_in, &num_eval_modes_in, NULL, &eval_modes_offsets_in, &num_active_bases_out,
+                                                &num_eval_modes_out, NULL, &eval_modes_offsets_out, &num_output_components));
+  // Number of elem restrictions is the same as the number of bases
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, NULL, &active_rstrs_in, NULL, &active_rstrs_out));
 
-  CeedCheck(num_active_bases_in == 1 && num_active_bases_out == 1, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-            "Cannot assemble operator with multiple active bases");
   CeedCheck(num_eval_modes_in[0] > 0 && num_eval_modes_out[0] > 0, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
             "Cannot assemble operator without inputs/outputs");
 
   CeedCall(CeedOperatorAssemblyDataGetBases(data, NULL, &active_bases_in, &B_mats_in, NULL, &active_bases_out, &B_mats_out));
-  CeedCall(CeedOperatorGetActiveElemRestrictions(op, &elem_rstr_in, &elem_rstr_out));
-  basis_in  = active_bases_in[0];
-  basis_out = active_bases_out[0];
-  B_mat_in  = B_mats_in[0];
-  B_mat_out = B_mats_out[0];
 
-  CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_in, &num_elem_in));
-  CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_in, &elem_size_in));
-  CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_in, &num_comp_in));
-  if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
-  else CeedCall(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
+  // Assemble single block (active_out, active_in)
+  {
+    CeedInt             num_elem_in, elem_size_in, num_comp_in, num_qpts_in;
+    CeedInt             num_elem_out, elem_size_out, num_comp_out, num_qpts_out;
+    CeedElemRestriction elem_rstr_in = active_rstrs_in[active_input], elem_rstr_out = active_rstrs_out[active_output];
+    CeedBasis           basis_in = active_bases_in[active_input], basis_out = active_bases_out[active_output];
+    const CeedScalar   *B_mat_in = B_mats_in[active_input], *B_mat_out = B_mats_out[active_output];
+    CeedRestrictionType elem_rstr_type_in, elem_rstr_type_out;
+    const bool         *elem_rstr_orients_in = NULL, *elem_rstr_orients_out = NULL;
+    const CeedInt8     *elem_rstr_curl_orients_in = NULL, *elem_rstr_curl_orients_out = NULL;
 
-  CeedCall(CeedElemRestrictionGetType(elem_rstr_in, &elem_rstr_type_in));
-  if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
-    CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_orients_in));
-  } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
-    CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_curl_orients_in));
-  }
+    CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_in, &num_elem_in));
+    CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_in, &elem_size_in));
+    CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_in, &num_comp_in));
+    if (basis_in == CEED_BASIS_NONE) num_qpts_in = elem_size_in;
+    else CeedCall(CeedBasisGetNumQuadraturePoints(basis_in, &num_qpts_in));
 
-  if (elem_rstr_in != elem_rstr_out) {
-    CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_out, &num_elem_out));
-    CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-              "Active input and output operator restrictions must have the same number of elements."
-              " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
-              num_elem_in, num_elem_out);
-    CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_out, &elem_size_out));
-    CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_out, &num_comp_out));
-    if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
-    else CeedCall(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
-    CeedCheck(num_qpts_in == num_qpts_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-              "Active input and output bases must have the same number of quadrature points."
-              " Input has %" CeedInt_FMT " points; output has %" CeedInt_FMT "points.",
-              num_qpts_in, num_qpts_out);
-
-    CeedCall(CeedElemRestrictionGetType(elem_rstr_out, &elem_rstr_type_out));
-    if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
-      CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_orients_out));
-    } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
-      CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_curl_orients_out));
+    CeedCall(CeedElemRestrictionGetType(elem_rstr_in, &elem_rstr_type_in));
+    if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+      CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_orients_in));
+    } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_in, CEED_MEM_HOST, &elem_rstr_curl_orients_in));
     }
-  } else {
-    num_elem_out  = num_elem_in;
-    elem_size_out = elem_size_in;
-    num_comp_out  = num_comp_in;
-    num_qpts_out  = num_qpts_in;
 
-    elem_rstr_orients_out      = elem_rstr_orients_in;
-    elem_rstr_curl_orients_out = elem_rstr_curl_orients_in;
-  }
-  local_num_entries = (CeedSize)elem_size_out * num_comp_out * elem_size_in * num_comp_in * num_elem_in;
+    if (elem_rstr_in != elem_rstr_out) {
+      CeedCall(CeedElemRestrictionGetNumElements(elem_rstr_out, &num_elem_out));
+      CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+                "Active input and output operator restrictions must have the same number of elements."
+                " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
+                num_elem_in, num_elem_out);
+      CeedCall(CeedElemRestrictionGetElementSize(elem_rstr_out, &elem_size_out));
+      CeedCall(CeedElemRestrictionGetNumComponents(elem_rstr_out, &num_comp_out));
+      if (basis_out == CEED_BASIS_NONE) num_qpts_out = elem_size_out;
+      else CeedCall(CeedBasisGetNumQuadraturePoints(basis_out, &num_qpts_out));
+      CeedCheck(num_qpts_in == num_qpts_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+                "Active input and output bases must have the same number of quadrature points."
+                " Input has %" CeedInt_FMT " points; output has %" CeedInt_FMT "points.",
+                num_qpts_in, num_qpts_out);
 
-  // Loop over elements and put in data structure
-  // We store B_mat_in, B_mat_out, BTD, elem_mat in row-major order
-  CeedTensorContract contract;
-  CeedScalar        *vals, *BTD_mat = NULL, *elem_mat = NULL, *elem_mat_b = NULL;
+      CeedCall(CeedElemRestrictionGetType(elem_rstr_out, &elem_rstr_type_out));
+      if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+        CeedCall(CeedElemRestrictionGetOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_orients_out));
+      } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+        CeedCall(CeedElemRestrictionGetCurlOrientations(elem_rstr_out, CEED_MEM_HOST, &elem_rstr_curl_orients_out));
+      }
+    } else {
+      num_elem_out  = num_elem_in;
+      elem_size_out = elem_size_in;
+      num_comp_out  = num_comp_in;
+      num_qpts_out  = num_qpts_in;
 
-  CeedCall(CeedBasisGetTensorContract(basis_in, &contract));
-  CeedCall(CeedCalloc(elem_size_out * num_qpts_in * num_eval_modes_in[0], &BTD_mat));
-  CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat));
-  if (elem_rstr_curl_orients_in || elem_rstr_curl_orients_out) CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat_b));
+      elem_rstr_orients_out      = elem_rstr_orients_in;
+      elem_rstr_curl_orients_out = elem_rstr_curl_orients_in;
+    }
+    local_num_entries = (CeedSize)elem_size_out * num_comp_out * elem_size_in * num_comp_in * num_elem_in;
+    // Loop over elements and put in data structure
+    // We store B_mat_in, B_mat_out, BTD, elem_mat in row-major order
+    CeedTensorContract contract;
+    CeedScalar        *vals, *BTD_mat = NULL, *elem_mat = NULL, *elem_mat_b = NULL;
 
-  CeedCall(CeedVectorGetArray(values, CEED_MEM_HOST, &vals));
-  for (CeedSize e = 0; e < num_elem_in; e++) {
-    for (CeedInt comp_in = 0; comp_in < num_comp_in; comp_in++) {
-      for (CeedInt comp_out = 0; comp_out < num_comp_out; comp_out++) {
-        // Compute B^T*D
-        for (CeedSize n = 0; n < elem_size_out; n++) {
-          for (CeedSize q = 0; q < num_qpts_in; q++) {
-            for (CeedInt e_in = 0; e_in < num_eval_modes_in[0]; e_in++) {
-              const CeedSize btd_index = n * (num_qpts_in * num_eval_modes_in[0]) + q * num_eval_modes_in[0] + e_in;
-              CeedScalar     sum       = 0.0;
+    CeedCall(CeedBasisGetTensorContract(basis_in, &contract));
+    CeedCall(CeedCalloc(elem_size_out * num_qpts_in * num_eval_modes_in[active_input], &BTD_mat));
+    CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat));
+    if (elem_rstr_curl_orients_in || elem_rstr_curl_orients_out) CeedCall(CeedCalloc(elem_size_out * elem_size_in, &elem_mat_b));
 
-              for (CeedInt e_out = 0; e_out < num_eval_modes_out[0]; e_out++) {
-                const CeedSize b_out_index     = (q * num_eval_modes_out[0] + e_out) * elem_size_out + n;
-                const CeedSize eval_mode_index = ((e_in * num_comp_in + comp_in) * num_eval_modes_out[0] + e_out) * num_comp_out + comp_out;
-                const CeedSize qf_index        = q * layout_qf[0] + eval_mode_index * layout_qf[1] + e * layout_qf[2];
+    CeedCall(CeedVectorGetArray(values, CEED_MEM_HOST, &vals));
+    for (CeedSize e = 0; e < num_elem_in; e++) {
+      for (CeedInt comp_in = 0; comp_in < num_comp_in; comp_in++) {
+        for (CeedInt comp_out = 0; comp_out < num_comp_out; comp_out++) {
+          // Compute B^T*D
+          for (CeedSize n = 0; n < elem_size_out; n++) {
+            for (CeedSize q = 0; q < num_qpts_in; q++) {
+              for (CeedInt e_in = 0; e_in < num_eval_modes_in[active_input]; e_in++) {
+                const CeedSize btd_index = n * (num_qpts_in * num_eval_modes_in[active_input]) + q * num_eval_modes_in[active_input] + e_in;
+                CeedScalar     sum       = 0.0;
 
-                sum += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
+                for (CeedInt e_out = 0; e_out < num_eval_modes_out[active_output]; e_out++) {
+                  const CeedSize b_out_index     = (q * num_eval_modes_out[active_output] + e_out) * elem_size_out + n;
+                  const CeedSize row_offset      = eval_modes_offsets_in[active_input][e_in] + comp_in;
+                  const CeedSize eval_mode_index = row_offset * num_output_components + eval_modes_offsets_out[active_output][e_out] + comp_out;
+                  const CeedSize qf_index        = q * layout_qf[0] + eval_mode_index * layout_qf[1] + e * layout_qf[2];
+
+                  sum += B_mat_out[b_out_index] * assembled_qf_array[qf_index];
+                }
+                BTD_mat[btd_index] = sum;
               }
-              BTD_mat[btd_index] = sum;
             }
           }
-        }
 
-        // Form element matrix itself (for each block component)
-        if (contract) {
-          CeedCall(CeedTensorContractApply(contract, 1, num_qpts_in * num_eval_modes_in[0], elem_size_in, elem_size_out, BTD_mat, CEED_NOTRANSPOSE,
-                                           false, B_mat_in, elem_mat));
-        } else {
-          Ceed ceed;
+          // Form element matrix itself (for each block component)
+          if (contract) {
+            CeedCall(CeedTensorContractApply(contract, 1, num_qpts_in * num_eval_modes_in[active_input], elem_size_in, elem_size_out, BTD_mat,
+                                             CEED_NOTRANSPOSE, false, B_mat_in, elem_mat));
+          } else {
+            Ceed ceed;
 
-          CeedCall(CeedOperatorGetCeed(op, &ceed));
-          CeedCall(CeedMatrixMatrixMultiply(ceed, BTD_mat, B_mat_in, elem_mat, elem_size_out, elem_size_in, num_qpts_in * num_eval_modes_in[0]));
-          CeedCall(CeedDestroy(&ceed));
-        }
+            CeedCall(CeedOperatorGetCeed(op, &ceed));
+            CeedCall(CeedMatrixMatrixMultiply(ceed, BTD_mat, B_mat_in, elem_mat, elem_size_out, elem_size_in,
+                                              num_qpts_in * num_eval_modes_in[active_input]));
+            CeedCall(CeedDestroy(&ceed));
+          }
 
-        // Transform the element matrix if required
-        if (elem_rstr_orients_out) {
-          const bool *elem_orients = &elem_rstr_orients_out[e * elem_size_out];
+          // Transform the element matrix if required
+          if (elem_rstr_orients_out) {
+            const bool *elem_orients = &elem_rstr_orients_out[e * elem_size_out];
 
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              const double orient = elem_orients[i] ? -1.0 : 1.0;
+
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] *= orient;
+              }
+            }
+          } else if (elem_rstr_curl_orients_out) {
+            const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_out[e * 3 * elem_size_out];
+
+            // T^T*(B^T*D*B)
+            memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] =
+                    elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * i + 1] +
+                    (i > 0 ? elem_mat_b[(i - 1) * elem_size_in + j] * elem_curl_orients[3 * i - 1] : 0.0) +
+                    (i < elem_size_out - 1 ? elem_mat_b[(i + 1) * elem_size_in + j] * elem_curl_orients[3 * i + 3] : 0.0);
+              }
+            }
+          }
+          if (elem_rstr_orients_in) {
+            const bool *elem_orients = &elem_rstr_orients_in[e * elem_size_in];
+
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] *= elem_orients[j] ? -1.0 : 1.0;
+              }
+            }
+          } else if (elem_rstr_curl_orients_in) {
+            const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_in[e * 3 * elem_size_in];
+
+            // (B^T*D*B)*T
+            memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
+            for (CeedInt i = 0; i < elem_size_out; i++) {
+              for (CeedInt j = 0; j < elem_size_in; j++) {
+                elem_mat[i * elem_size_in + j] = elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * j + 1] +
+                                                 (j > 0 ? elem_mat_b[i * elem_size_in + j - 1] * elem_curl_orients[3 * j - 1] : 0.0) +
+                                                 (j < elem_size_in - 1 ? elem_mat_b[i * elem_size_in + j + 1] * elem_curl_orients[3 * j + 3] : 0.0);
+              }
+            }
+          }
+
+          // Put element matrix in coordinate data structure
           for (CeedInt i = 0; i < elem_size_out; i++) {
-            const double orient = elem_orients[i] ? -1.0 : 1.0;
-
             for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] *= orient;
+              vals[offset + count] = elem_mat[i * elem_size_in + j];
+              count++;
             }
-          }
-        } else if (elem_rstr_curl_orients_out) {
-          const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_out[e * 3 * elem_size_out];
-
-          // T^T*(B^T*D*B)
-          memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
-          for (CeedInt i = 0; i < elem_size_out; i++) {
-            for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] = elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * i + 1] +
-                                               (i > 0 ? elem_mat_b[(i - 1) * elem_size_in + j] * elem_curl_orients[3 * i - 1] : 0.0) +
-                                               (i < elem_size_out - 1 ? elem_mat_b[(i + 1) * elem_size_in + j] * elem_curl_orients[3 * i + 3] : 0.0);
-            }
-          }
-        }
-        if (elem_rstr_orients_in) {
-          const bool *elem_orients = &elem_rstr_orients_in[e * elem_size_in];
-
-          for (CeedInt i = 0; i < elem_size_out; i++) {
-            for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] *= elem_orients[j] ? -1.0 : 1.0;
-            }
-          }
-        } else if (elem_rstr_curl_orients_in) {
-          const CeedInt8 *elem_curl_orients = &elem_rstr_curl_orients_in[e * 3 * elem_size_in];
-
-          // (B^T*D*B)*T
-          memcpy(elem_mat_b, elem_mat, elem_size_out * elem_size_in * sizeof(CeedScalar));
-          for (CeedInt i = 0; i < elem_size_out; i++) {
-            for (CeedInt j = 0; j < elem_size_in; j++) {
-              elem_mat[i * elem_size_in + j] = elem_mat_b[i * elem_size_in + j] * elem_curl_orients[3 * j + 1] +
-                                               (j > 0 ? elem_mat_b[i * elem_size_in + j - 1] * elem_curl_orients[3 * j - 1] : 0.0) +
-                                               (j < elem_size_in - 1 ? elem_mat_b[i * elem_size_in + j + 1] * elem_curl_orients[3 * j + 3] : 0.0);
-            }
-          }
-        }
-
-        // Put element matrix in coordinate data structure
-        for (CeedInt i = 0; i < elem_size_out; i++) {
-          for (CeedInt j = 0; j < elem_size_in; j++) {
-            vals[offset + count] = elem_mat[i * elem_size_in + j];
-            count++;
           }
         }
       }
     }
-  }
-  CeedCheck(count == local_num_entries, CeedOperatorReturnCeed(op), CEED_ERROR_MAJOR, "Error computing entries");
-  CeedCall(CeedVectorRestoreArray(values, &vals));
+    CeedCheck(count == local_num_entries, CeedOperatorReturnCeed(op), CEED_ERROR_MAJOR, "Error computing entries");
+    CeedCall(CeedVectorRestoreArray(values, &vals));
 
-  // Cleanup
-  CeedCall(CeedFree(&BTD_mat));
-  CeedCall(CeedFree(&elem_mat));
-  CeedCall(CeedFree(&elem_mat_b));
-  if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
-    CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_in, &elem_rstr_orients_in));
-  } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
-    CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_in, &elem_rstr_curl_orients_in));
-  }
-  if (elem_rstr_in != elem_rstr_out) {
-    if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
-      CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_out, &elem_rstr_orients_out));
-    } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
-      CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_out, &elem_rstr_curl_orients_out));
+    // Cleanup
+    CeedCall(CeedFree(&BTD_mat));
+    CeedCall(CeedFree(&elem_mat));
+    CeedCall(CeedFree(&elem_mat_b));
+    if (elem_rstr_type_in == CEED_RESTRICTION_ORIENTED) {
+      CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_in, &elem_rstr_orients_in));
+    } else if (elem_rstr_type_in == CEED_RESTRICTION_CURL_ORIENTED) {
+      CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_in, &elem_rstr_curl_orients_in));
+    }
+    if (elem_rstr_in != elem_rstr_out) {
+      if (elem_rstr_type_out == CEED_RESTRICTION_ORIENTED) {
+        CeedCall(CeedElemRestrictionRestoreOrientations(elem_rstr_out, &elem_rstr_orients_out));
+      } else if (elem_rstr_type_out == CEED_RESTRICTION_CURL_ORIENTED) {
+        CeedCall(CeedElemRestrictionRestoreCurlOrientations(elem_rstr_out, &elem_rstr_curl_orients_out));
+      }
     }
   }
   CeedCall(CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array));
   CeedCall(CeedVectorDestroy(&assembled_qf));
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_in));
-  CeedCall(CeedElemRestrictionDestroy(&elem_rstr_out));
   return CEED_ERROR_SUCCESS;
 }
 
 /**
-  @brief Count number of entries for assembled `CeedOperator`
+  @brief Assemble nonzero entries for non-composite `CeedOperator`.
 
-  @param[in]  op          `CeedOperator` to assemble
-  @param[out] num_entries Number of entries in assembled representation
+  Users should generally use @ref CeedOperatorLinearAssemble().
+
+  @param[in]  op     `CeedOperator` to assemble
+  @param[in]  offset Offset for number of entries
+  @param[out] values Values to assemble into matrix
 
   @return An error code: 0 - success, otherwise - failure
 
-  @ref Utility
+  @ref Developer
 **/
-static int CeedOperatorAssemblyCountEntriesSingle(CeedOperator op, CeedSize *num_entries) {
-  bool                is_composite;
-  CeedInt             num_elem_in, elem_size_in, num_comp_in, num_elem_out, elem_size_out, num_comp_out;
-  CeedElemRestriction rstr_in, rstr_out;
+int CeedOperatorAssembleSingle(CeedOperator op, CeedSize offset, CeedVector values) {
+  bool is_composite, is_at_points;
 
   CeedCall(CeedOperatorIsComposite(op, &is_composite));
   CeedCheck(!is_composite, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED, "Composite operator not supported");
 
-  CeedCall(CeedOperatorGetActiveElemRestrictions(op, &rstr_in, &rstr_out));
-  CeedCall(CeedElemRestrictionGetNumElements(rstr_in, &num_elem_in));
-  CeedCall(CeedElemRestrictionGetElementSize(rstr_in, &elem_size_in));
-  CeedCall(CeedElemRestrictionGetNumComponents(rstr_in, &num_comp_in));
-  if (rstr_in != rstr_out) {
-    CeedCall(CeedElemRestrictionGetNumElements(rstr_out, &num_elem_out));
-    CeedCheck(num_elem_in == num_elem_out, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
-              "Active input and output operator restrictions must have the same number of elements."
-              " Input has %" CeedInt_FMT " elements; output has %" CeedInt_FMT "elements.",
-              num_elem_in, num_elem_out);
-    CeedCall(CeedElemRestrictionGetElementSize(rstr_out, &elem_size_out));
-    CeedCall(CeedElemRestrictionGetNumComponents(rstr_out, &num_comp_out));
-  } else {
-    num_elem_out  = num_elem_in;
-    elem_size_out = elem_size_in;
-    num_comp_out  = num_comp_in;
+  // Early exit for empty operator
+  {
+    CeedInt num_elem = 0;
+
+    CeedCall(CeedOperatorGetNumElements(op, &num_elem));
+    if (num_elem == 0) return CEED_ERROR_SUCCESS;
   }
-  CeedCall(CeedElemRestrictionDestroy(&rstr_in));
-  CeedCall(CeedElemRestrictionDestroy(&rstr_out));
-  *num_entries = (CeedSize)elem_size_in * num_comp_in * elem_size_out * num_comp_out * num_elem_in;
-  return CEED_ERROR_SUCCESS;
-}
 
-/**
-  @brief Count number of entries for assembled `CeedOperator`
+  // Check for multiple active elem restrictions
+  CeedInt                   num_active_rstr_in, num_active_rstr_out;
+  CeedElemRestriction      *active_rstrs_in, *active_rstrs_out;
+  CeedOperatorAssemblyData  data;
+  CeedQFunctionAssemblyData qf_data;
 
-  @param[in]  op          `CeedOperator` to assemble
-  @param[out] num_entries Number of entries in assembled representation
+  CeedCall(CeedOperatorGetOperatorAssemblyData(op, &data));
+  CeedCall(CeedOperatorGetQFunctionAssemblyData(op, &qf_data));
+  CeedCall(CeedOperatorAssemblyDataGetElemRestrictions(data, &num_active_rstr_in, &active_rstrs_in, &num_active_rstr_out, &active_rstrs_out));
 
-  @return An error code: 0 - success, otherwise - failure
+  const bool multiple_active_rstr = num_active_rstr_in > 1 || num_active_rstr_out > 1;
 
-  @ref Utility
-**/
-int CeedOperatorLinearAssembleGetNumEntries(CeedOperator op, CeedSize *num_entries) {
-  bool is_composite;
+  if (multiple_active_rstr) {
+    if (!op->LinearAssembleSingleBlock) {
+      // Operator fallback
+      CeedOperator op_fallback;
 
-  CeedCall(CeedOperatorCheckReady(op));
-  CeedCall(CeedOperatorIsComposite(op, &is_composite));
-
-  if (is_composite) {
-    CeedInt       num_suboperators;
-    CeedOperator *sub_operators;
-
-    CeedCall(CeedOperatorCompositeGetNumSub(op, &num_suboperators));
-    CeedCall(CeedOperatorCompositeGetSubList(op, &sub_operators));
-
-    *num_entries = 0;
-    for (CeedInt k = 0; k < num_suboperators; ++k) {
-      CeedSize single_entries;
-
-      CeedCall(CeedOperatorAssemblyCountEntriesSingle(sub_operators[k], &single_entries));
-      *num_entries += single_entries;
+      CeedDebug(CeedOperatorReturnCeed(op), "\nFalling back for CeedOperatorAssembleSingle\n");
+      CeedCall(CeedOperatorGetFallback(op, &op_fallback));
+      if (op_fallback) {
+        CeedCall(CeedOperatorAssembleSingle(op_fallback, offset, values));
+        return CEED_ERROR_SUCCESS;
+      }
     }
+
+    // Assemble QFunction for each block
+    for (CeedInt i = 0; i < num_active_rstr_in; i++) {
+      for (CeedInt j = 0; j < num_active_rstr_out; j++) {
+        CeedSize num_entries_block;
+
+        CeedCall(CeedOperatorAssembleSingleBlock(op, offset, i, j, values));
+        CeedCall(CeedQFunctionAssemblyDataSetBlockAssembling(qf_data, true));
+        CeedCall(CeedOperatorAssemblyCountEntriesSingleBlock(op, active_rstrs_in[i], active_rstrs_out[j], &num_entries_block));
+        offset += num_entries_block;
+      }
+    }
+    CeedCall(CeedQFunctionAssemblyDataSetBlockAssembling(qf_data, false));
+    return CEED_ERROR_SUCCESS;
+  } else if (op->LinearAssembleSingle) {
+    // Backend version
+    CeedCall(op->LinearAssembleSingle(op, offset, values));
+    return CEED_ERROR_SUCCESS;
   } else {
-    CeedCall(CeedOperatorAssemblyCountEntriesSingle(op, num_entries));
+    // Operator fallback
+    CeedOperator op_fallback;
+
+    CeedDebug(CeedOperatorReturnCeed(op), "\nFalling back for CeedOperatorAssembleSingle\n");
+    CeedCall(CeedOperatorGetFallback(op, &op_fallback));
+    if (op_fallback) {
+      CeedCall(CeedOperatorAssembleSingle(op_fallback, offset, values));
+      return CEED_ERROR_SUCCESS;
+    }
   }
+
+  CeedCall(CeedOperatorIsAtPoints(op, &is_at_points));
+  CeedCheck(!is_at_points, CeedOperatorReturnCeed(op), CEED_ERROR_UNSUPPORTED,
+            "Backend does not implement CeedOperatorLinearAssemble for AtPoints operator");
+
+  // Assemble QFunction for 0 0 block
+  CeedCall(CeedOperatorAssembleSingleBlock(op, offset, 0, 0, values));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -1484,7 +1650,8 @@ int CeedQFunctionAssemblyDataSetUpdateNeeded(CeedQFunctionAssemblyData data, boo
   @ref Backend
 **/
 int CeedQFunctionAssemblyDataIsUpdateNeeded(CeedQFunctionAssemblyData data, bool *is_update_needed) {
-  *is_update_needed = !data->reuse_data || data->needs_data_update;
+  // Only reassemble between blocks if explicitly marked as needing update
+  *is_update_needed = data->is_block_assembling ? data->needs_data_update : (!data->reuse_data || data->needs_data_update);
   return CEED_ERROR_SUCCESS;
 }
 
@@ -1522,6 +1689,21 @@ int CeedQFunctionAssemblyDataReferenceCopy(CeedQFunctionAssemblyData data, CeedQ
 **/
 int CeedQFunctionAssemblyDataIsSetup(CeedQFunctionAssemblyData data, bool *is_setup) {
   *is_setup = data->is_setup;
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Mark `CeedQFunctionAssemblyData` as being between block assembly, preventing recomputing for each block
+
+  @param[in,out] data                `CeedQFunctionAssemblyData` to mark
+  @param[in]     is_block_assembling Boolean flag indicating if the data is being used for multiple blocks
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionAssemblyDataSetBlockAssembling(CeedQFunctionAssemblyData data, bool is_block_assembling) {
+  data->is_block_assembling = is_block_assembling;
   return CEED_ERROR_SUCCESS;
 }
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1350,6 +1350,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
       CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSymbolic),
       CEED_FTABLE_ENTRY(CeedOperator, LinearAssemble),
       CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSingle),
+      CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSingleBlock),
       CEED_FTABLE_ENTRY(CeedOperator, CreateFDMElementInverse),
       CEED_FTABLE_ENTRY(CeedOperator, Apply),
       CEED_FTABLE_ENTRY(CeedOperator, ApplyComposite),

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1351,6 +1351,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
       CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSymbolic),
       CEED_FTABLE_ENTRY(CeedOperator, LinearAssemble),
       CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSingle),
+      CEED_FTABLE_ENTRY(CeedOperator, LinearAssembleSingleBlock),
       CEED_FTABLE_ENTRY(CeedOperator, CreateFDMElementInverse),
       CEED_FTABLE_ENTRY(CeedOperator, Apply),
       CEED_FTABLE_ENTRY(CeedOperator, ApplyComposite),

--- a/tests/t571-operator.c
+++ b/tests/t571-operator.c
@@ -1,0 +1,208 @@
+/// @file
+/// Test full assembly of multi-basis asymmetric mass-like operator
+/// \test Test full assembly of multi-basis asymmetric mass-like operator
+#include "t571-operator.h"
+
+#include <ceed.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  Ceed                ceed;
+  CeedElemRestriction elem_restriction_x, elem_restriction_u, elem_restriction_p, elem_restriction_q_data;
+  CeedBasis           basis_x, basis_u, basis_p;
+  CeedQFunction       qf_setup, qf_mass;
+  CeedOperator        op_setup, op_mass;
+  CeedVector          q_data, x, u, v;
+  CeedInt             p_u = 3, p_p = 2, q = 3, dim = 2, num_comp_u = 3, num_comp_p = 2;
+  CeedInt             n_x = 3, n_y = 2;
+  CeedInt             num_elem   = n_x * n_y;
+  CeedInt             num_dofs_u = (n_x * (p_u - 1) + 1) * (n_y * (p_u - 1) + 1), num_dofs_p = (n_x * (p_p - 1) + 1) * (n_y * (p_p - 1) + 1),
+          num_qpts = num_elem * q * q;
+  CeedInt    ind_x[num_elem * p_u * p_u], ind_p[num_elem * p_p * p_p];
+  CeedInt    l_size = num_comp_u * num_dofs_u + num_comp_p * num_dofs_p;
+  CeedScalar assembled_values[l_size * l_size];
+  CeedScalar assembled_true[l_size * l_size];
+
+  CeedInit(argv[1], &ceed);
+
+  // Vectors
+  CeedVectorCreate(ceed, dim * num_dofs_u, &x);
+  {
+    CeedScalar x_array[dim * num_dofs_u];
+
+    for (CeedInt i = 0; i < n_x * (p_u - 1) + 1; i++) {
+      for (CeedInt j = 0; j < n_y * (p_u - 1) + 1; j++) {
+        x_array[i + j * (n_x * 2 + 1) + 0 * num_dofs_u] = (CeedScalar)i / (n_x * (p_u - 1));
+        x_array[i + j * (n_x * 2 + 1) + 1 * num_dofs_u] = (CeedScalar)j / (n_y * (p_u - 1));
+      }
+    }
+    CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
+  }
+  CeedVectorCreate(ceed, l_size, &u);
+  CeedVectorCreate(ceed, l_size, &v);
+  CeedVectorCreate(ceed, num_qpts, &q_data);
+
+  // Restrictions
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p_u - 1) + row * (n_x * (p_u - 1) + 1) * (p_u - 1);
+    for (CeedInt j = 0; j < p_u; j++) {
+      for (CeedInt k = 0; k < p_u; k++) ind_x[p_u * (p_u * i + k) + j] = offset + k * p_u + j;
+    }
+  }
+  const CeedInt offset_p = num_comp_u * num_dofs_u;
+
+  for (CeedInt k = 0; k < num_elem; k++) {
+    CeedInt col, row, offset;
+
+    col    = k % n_x;
+    row    = k / n_x;
+    offset = col * (p_p - 1) + row * (n_x * (p_p - 1) + 1) * (p_p - 1);
+    // Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
+    for (CeedInt j = 0; j < p_p; j++) {
+      for (CeedInt i = 0; i < p_p; i++) ind_p[k * p_p * p_p + (p_p * i + j)] = offset + i * p_p + j + offset_p;
+    }
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, dim, num_dofs_u, dim * num_dofs_u, CEED_MEM_HOST, CEED_USE_POINTER, ind_x,
+                            &elem_restriction_x);
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, num_comp_u, num_dofs_u, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restriction_u);
+  CeedElemRestrictionCreate(ceed, num_elem, p_p * p_p, num_comp_p, num_dofs_p, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_p, &elem_restriction_p);
+
+  CeedInt strides_q_data[3] = {1, q * q * num_elem, q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, 1, num_qpts * 1, strides_q_data, &elem_restriction_q_data);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, p_u, q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_u, p_u, q, CEED_GAUSS, &basis_u);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_p, p_p, q, CEED_GAUSS, &basis_p);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "qdata", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, multi_basis, multi_basis_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "qdata", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "du", num_comp_u, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_mass, "dp", num_comp_p, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "dv", num_comp_u, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "dq", num_comp_p, CEED_EVAL_INTERP);
+
+  Context_t            context = {num_comp_u, num_comp_p};
+  CeedQFunctionContext ctx;
+
+  CeedQFunctionContextCreate(ceed, &ctx);
+  CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES, sizeof(Context_t), &context);
+  CeedQFunctionSetContext(qf_mass, ctx);
+  CeedQFunctionContextDestroy(&ctx);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_mass);
+  CeedOperatorSetField(op_mass, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_mass, "du", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "dp", elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "dv", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass, "dq", elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, x, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fuly assemble operator
+  CeedSize   num_entries;
+  CeedInt   *rows;
+  CeedInt   *cols;
+  CeedVector assembled;
+
+  for (CeedInt k = 0; k < l_size * l_size; k++) {
+    assembled_values[k] = 0.0;
+    assembled_true[k]   = 0.0;
+  }
+  CeedOperatorLinearAssembleSymbolic(op_mass, &num_entries, &rows, &cols);
+  CeedVectorCreate(ceed, num_entries, &assembled);
+  CeedOperatorLinearAssemble(op_mass, assembled);
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries; k++) assembled_values[rows[k] * l_size + cols[k]] += assembled_array[k];
+    CeedVectorRestoreArrayRead(assembled, &assembled_array);
+  }
+
+  // Manually assemble operator
+  CeedInt old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < l_size; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_mass, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < l_size; i++) assembled_true[i * l_size + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+
+  // Check output
+  for (CeedInt i = 0; i < l_size; i++) {
+    for (CeedInt j = 0; j < l_size; j++) {
+      const CeedScalar assembled_value      = assembled_values[i * l_size + j];
+      const CeedScalar assembled_true_value = assembled_true[i * l_size + j];
+      const CeedScalar error                = fabs(assembled_value - assembled_true_value) / (fmax(fabs(assembled_true_value), 1.0));
+
+      if (!(error < 100. * CEED_EPSILON)) {
+        // LCOV_EXCL_START
+        const CeedInt node_out = (i < num_comp_u * num_dofs_u) ? i % num_dofs_u : (i - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_out = (i < num_comp_u * num_dofs_u) ? i / num_dofs_u : (i - num_comp_u * num_dofs_u) / num_dofs_p;
+        const CeedInt node_in  = (j < num_comp_u * num_dofs_u) ? j % num_dofs_u : (j - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_in  = (j < num_comp_u * num_dofs_u) ? j / num_dofs_u : (j - num_comp_u * num_dofs_u) / num_dofs_p;
+
+        printf("[(%s, %" CeedInt_FMT ", %" CeedInt_FMT "), (%s, %" CeedInt_FMT ", %" CeedInt_FMT ")] Error in assembly: %g != %g (error: %g)\n",
+               (i < num_comp_u * num_dofs_u ? "u" : "p"), node_out, comp_out, (j < num_comp_u * num_dofs_u ? "u" : "p"), node_in, comp_in,
+               assembled_value, assembled_true_value, error);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&u);
+  CeedVectorDestroy(&v);
+  CeedVectorDestroy(&assembled);
+  CeedElemRestrictionDestroy(&elem_restriction_u);
+  CeedElemRestrictionDestroy(&elem_restriction_p);
+  CeedElemRestrictionDestroy(&elem_restriction_x);
+  CeedElemRestrictionDestroy(&elem_restriction_q_data);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_p);
+  CeedBasisDestroy(&basis_x);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t571-operator.h
+++ b/tests/t571-operator.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#include <ceed/types.h>
+
+typedef struct {
+  CeedInt num_comp_u;
+  CeedInt num_comp_p;
+} Context_t;
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  const CeedScalar *weight = in[0], *J = in[1];
+  CeedScalar       *rho = out[0];
+  for (CeedInt i = 0; i < Q; i++) {
+    rho[i] = weight[i] * (J[i + Q * 0] * J[i + Q * 3] - J[i + Q * 1] * J[i + Q * 2]);
+  }
+  return 0;
+}
+
+CEED_QFUNCTION(multi_basis)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  const CeedScalar(*q_data)        = (const CeedScalar(*))in[0];
+  const CeedScalar(*u)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*p)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];
+  CeedScalar(*v)[CEED_Q_VLA]       = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  CeedScalar(*q)[CEED_Q_VLA]       = (CeedScalar(*)[CEED_Q_VLA])out[1];
+
+  const Context_t *context = (Context_t *)ctx;
+
+  for (CeedInt i = 0; i < Q; i++) {
+    CeedScalar mass_u = 0;
+    for (CeedInt j = 0; j < context->num_comp_u; j++) {
+      v[j][i] = q_data[i] * u[j][i];
+      mass_u += v[j][i];
+    }
+    for (CeedInt j = 0; j < context->num_comp_p; j++) {
+      q[j][i] = q_data[i] * p[j][i] + (j + 1) * mass_u;
+    }
+  }
+  return 0;
+}

--- a/tests/t572-operator.c
+++ b/tests/t572-operator.c
@@ -1,0 +1,209 @@
+/// @file
+/// Test full assembly of multi-basis asymmetric Poisson-like operator
+/// \test Test full assembly of multi-basis asymmetric Poisson-like operator
+#include "t572-operator.h"
+
+#include <ceed.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  Ceed                ceed;
+  CeedElemRestriction elem_restriction_x, elem_restriction_u, elem_restriction_p, elem_restriction_q_data;
+  CeedBasis           basis_x, basis_u, basis_p;
+  CeedQFunction       qf_setup, qf_diff;
+  CeedOperator        op_setup, op_diff;
+  CeedVector          q_data, x, u, v;
+  CeedInt             p_u = 3, p_p = 2, q = 3, dim = 2, num_comp_u = 3, num_comp_p = 2;
+  CeedInt             n_x = 3, n_y = 2;
+  CeedInt             q_data_size = dim * (dim + 1) / 2;
+  CeedInt             num_elem    = n_x * n_y;
+  CeedInt             num_dofs_u = (n_x * (p_u - 1) + 1) * (n_y * (p_u - 1) + 1), num_dofs_p = (n_x * (p_p - 1) + 1) * (n_y * (p_p - 1) + 1),
+          num_qpts = num_elem * q * q;
+  CeedInt    ind_x[num_elem * p_u * p_u], ind_p[num_elem * p_p * p_p];
+  CeedInt    l_size = num_comp_u * num_dofs_u + num_comp_p * num_dofs_p;
+  CeedScalar assembled_values[l_size * l_size];
+  CeedScalar assembled_true[l_size * l_size];
+
+  CeedInit(argv[1], &ceed);
+
+  // Vectors
+  CeedVectorCreate(ceed, dim * num_dofs_u, &x);
+  {
+    CeedScalar x_array[dim * num_dofs_u];
+
+    for (CeedInt i = 0; i < n_x * (p_u - 1) + 1; i++) {
+      for (CeedInt j = 0; j < n_y * (p_u - 1) + 1; j++) {
+        x_array[i + j * (n_x * 2 + 1) + 0 * num_dofs_u] = (CeedScalar)i / (n_x * (p_u - 1));
+        x_array[i + j * (n_x * 2 + 1) + 1 * num_dofs_u] = (CeedScalar)j / (n_y * (p_u - 1));
+      }
+    }
+    CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
+  }
+  CeedVectorCreate(ceed, l_size, &u);
+  CeedVectorCreate(ceed, l_size, &v);
+  CeedVectorCreate(ceed, num_qpts * q_data_size, &q_data);
+
+  // Restrictions
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p_u - 1) + row * (n_x * (p_u - 1) + 1) * (p_u - 1);
+    for (CeedInt j = 0; j < p_u; j++) {
+      for (CeedInt k = 0; k < p_u; k++) ind_x[p_u * (p_u * i + k) + j] = offset + k * p_u + j;
+    }
+  }
+  const CeedInt offset_p = num_comp_u * num_dofs_u;
+
+  for (CeedInt k = 0; k < num_elem; k++) {
+    CeedInt col, row, offset;
+
+    col    = k % n_x;
+    row    = k / n_x;
+    offset = col * (p_p - 1) + row * (n_x * (p_p - 1) + 1) * (p_p - 1);
+    // Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
+    for (CeedInt j = 0; j < p_p; j++) {
+      for (CeedInt i = 0; i < p_p; i++) ind_p[k * p_p * p_p + (p_p * i + j)] = offset + i * p_p + j + offset_p;
+    }
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, dim, num_dofs_u, dim * num_dofs_u, CEED_MEM_HOST, CEED_USE_POINTER, ind_x,
+                            &elem_restriction_x);
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, num_comp_u, num_dofs_u, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restriction_u);
+  CeedElemRestrictionCreate(ceed, num_elem, p_p * p_p, num_comp_p, num_dofs_p, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_p, &elem_restriction_p);
+
+  CeedInt strides_q_data[3] = {1, q * q * num_elem, q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, q_data_size, num_qpts * q_data_size, strides_q_data, &elem_restriction_q_data);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, p_u, q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_u, p_u, q, CEED_GAUSS, &basis_u);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_p, p_p, q, CEED_GAUSS, &basis_p);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "qdata", q_data_size, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, multi_basis_diff, multi_basis_diff_loc, &qf_diff);
+  CeedQFunctionAddInput(qf_diff, "qdata", q_data_size, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_diff, "du", num_comp_u * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_diff, "dp", num_comp_p * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_diff, "dv", num_comp_u * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_diff, "dq", num_comp_p * dim, CEED_EVAL_GRAD);
+
+  Context_t            context = {num_comp_u, num_comp_p};
+  CeedQFunctionContext ctx;
+
+  CeedQFunctionContextCreate(ceed, &ctx);
+  CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES, sizeof(Context_t), &context);
+  CeedQFunctionSetContext(qf_diff, ctx);
+  CeedQFunctionContextDestroy(&ctx);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_diff);
+  CeedOperatorSetField(op_diff, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_diff, "du", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dp", elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dv", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dq", elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, x, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fuly assemble operator
+  CeedSize   num_entries;
+  CeedInt   *rows;
+  CeedInt   *cols;
+  CeedVector assembled;
+
+  for (CeedInt k = 0; k < l_size * l_size; k++) {
+    assembled_values[k] = 0.0;
+    assembled_true[k]   = 0.0;
+  }
+  CeedOperatorLinearAssembleSymbolic(op_diff, &num_entries, &rows, &cols);
+  CeedVectorCreate(ceed, num_entries, &assembled);
+  CeedOperatorLinearAssemble(op_diff, assembled);
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries; k++) assembled_values[rows[k] * l_size + cols[k]] += assembled_array[k];
+    CeedVectorRestoreArrayRead(assembled, &assembled_array);
+  }
+
+  // Manually assemble operator
+  CeedInt old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < l_size; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_diff, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < l_size; i++) assembled_true[i * l_size + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+
+  // Check output
+  for (CeedInt i = 0; i < l_size; i++) {
+    for (CeedInt j = 0; j < l_size; j++) {
+      const CeedScalar assembled_value      = assembled_values[i * l_size + j];
+      const CeedScalar assembled_true_value = assembled_true[i * l_size + j];
+      const CeedScalar error                = fabs(assembled_value - assembled_true_value) / (fmax(fabs(assembled_true_value), 1.0));
+
+      if (!(error < 1000. * CEED_EPSILON)) {
+        // LCOV_EXCL_START
+        const CeedInt node_out = (i < num_comp_u * num_dofs_u) ? i % num_dofs_u : (i - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_out = (i < num_comp_u * num_dofs_u) ? i / num_dofs_u : (i - num_comp_u * num_dofs_u) / num_dofs_p;
+        const CeedInt node_in  = (j < num_comp_u * num_dofs_u) ? j % num_dofs_u : (j - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_in  = (j < num_comp_u * num_dofs_u) ? j / num_dofs_u : (j - num_comp_u * num_dofs_u) / num_dofs_p;
+
+        printf("[(%s, %" CeedInt_FMT ", %" CeedInt_FMT "), (%s, %" CeedInt_FMT ", %" CeedInt_FMT ")] Error in assembly: %g != %g (error: %g)\n",
+               (i < num_comp_u * num_dofs_u ? "u" : "p"), node_out, comp_out, (j < num_comp_u * num_dofs_u ? "u" : "p"), node_in, comp_in,
+               assembled_value, assembled_true_value, error);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&u);
+  CeedVectorDestroy(&v);
+  CeedVectorDestroy(&assembled);
+  CeedElemRestrictionDestroy(&elem_restriction_p);
+  CeedElemRestrictionDestroy(&elem_restriction_u);
+  CeedElemRestrictionDestroy(&elem_restriction_x);
+  CeedElemRestrictionDestroy(&elem_restriction_q_data);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_p);
+  CeedBasisDestroy(&basis_x);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_diff);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_diff);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t572-operator.c
+++ b/tests/t572-operator.c
@@ -1,0 +1,209 @@
+/// @file
+/// Test full assembly of multi-basis asymmetric Poisson-like operator
+/// \test Test full assembly of multi-basis asymmetric Poisson-like operator
+#include "t572-operator.h"
+
+#include <ceed.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  Ceed                ceed;
+  CeedElemRestriction elem_restriction_x, elem_restriction_u, elem_restriction_p, elem_restriction_q_data;
+  CeedBasis           basis_x, basis_u, basis_p;
+  CeedQFunction       qf_setup, qf_diff;
+  CeedOperator        op_setup, op_diff;
+  CeedVector          q_data, x, u, v;
+  CeedInt             p_u = 3, p_p = 2, q = 3, dim = 2, num_comp_u = 3, num_comp_p = 2;
+  CeedInt             n_x = 3, n_y = 2;
+  CeedInt             q_data_size = dim * (dim + 1) / 2;
+  CeedInt             num_elem    = n_x * n_y;
+  CeedInt             num_dofs_u = (n_x * (p_u - 1) + 1) * (n_y * (p_u - 1) + 1), num_dofs_p = (n_x * (p_p - 1) + 1) * (n_y * (p_p - 1) + 1),
+          num_qpts = num_elem * q * q;
+  CeedInt    ind_x[num_elem * p_u * p_u], ind_p[num_elem * p_p * p_p];
+  CeedInt    l_size = num_comp_u * num_dofs_u + num_comp_p * num_dofs_p;
+  CeedScalar assembled_values[l_size * l_size];
+  CeedScalar assembled_true[l_size * l_size];
+
+  CeedInit(argv[1], &ceed);
+
+  // Vectors
+  CeedVectorCreate(ceed, dim * num_dofs_u, &x);
+  {
+    CeedScalar x_array[dim * num_dofs_u];
+
+    for (CeedInt i = 0; i < n_x * (p_u - 1) + 1; i++) {
+      for (CeedInt j = 0; j < n_y * (p_u - 1) + 1; j++) {
+        x_array[i + j * (n_x * 2 + 1) + 0 * num_dofs_u] = (CeedScalar)i / (n_x * (p_u - 1));
+        x_array[i + j * (n_x * 2 + 1) + 1 * num_dofs_u] = (CeedScalar)j / (n_y * (p_u - 1));
+      }
+    }
+    CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
+  }
+  CeedVectorCreate(ceed, l_size, &u);
+  CeedVectorCreate(ceed, l_size, &v);
+  CeedVectorCreate(ceed, num_qpts * q_data_size, &q_data);
+
+  // Restrictions
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p_u - 1) + row * (n_x * (p_u - 1) + 1) * (p_u - 1);
+    for (CeedInt j = 0; j < p_u; j++) {
+      for (CeedInt k = 0; k < p_u; k++) ind_x[p_u * (p_u * i + k) + j] = offset + k * p_u + j;
+    }
+  }
+  const CeedInt offset_p = num_comp_u * num_dofs_u;
+
+  for (CeedInt k = 0; k < num_elem; k++) {
+    CeedInt col, row, offset;
+
+    col    = k % n_x;
+    row    = k / n_x;
+    offset = col * (p_p - 1) + row * (n_x * (p_p - 1) + 1) * (p_p - 1);
+    // Data for node i, component j, element k can be found in the L-vector at index offsets[i + k*elem_size] + j*comp_stride.
+    for (CeedInt j = 0; j < p_p; j++) {
+      for (CeedInt i = 0; i < p_p; i++) ind_p[k * p_p * p_p + (p_p * i + j)] = offset + i * p_p + j + offset_p;
+    }
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, dim, num_dofs_u, dim * num_dofs_u, CEED_MEM_HOST, CEED_USE_POINTER, ind_x,
+                            &elem_restriction_x);
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, num_comp_u, num_dofs_u, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restriction_u);
+  CeedElemRestrictionCreate(ceed, num_elem, p_p * p_p, num_comp_p, num_dofs_p, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_p, &elem_restriction_p);
+
+  CeedInt strides_q_data[3] = {1, q * q * num_elem, q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, q_data_size, num_qpts * q_data_size, strides_q_data, &elem_restriction_q_data);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, p_u, q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_u, p_u, q, CEED_GAUSS, &basis_u);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_p, p_p, q, CEED_GAUSS, &basis_p);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "qdata", q_data_size, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, multi_basis_diff, multi_basis_diff_loc, &qf_diff);
+  CeedQFunctionAddInput(qf_diff, "qdata", q_data_size, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_diff, "du", num_comp_u * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_diff, "dp", num_comp_p * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_diff, "dq", num_comp_p * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_diff, "dv", num_comp_u * dim, CEED_EVAL_GRAD);
+
+  Context_t            context = {num_comp_u, num_comp_p};
+  CeedQFunctionContext ctx;
+
+  CeedQFunctionContextCreate(ceed, &ctx);
+  CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES, sizeof(Context_t), &context);
+  CeedQFunctionSetContext(qf_diff, ctx);
+  CeedQFunctionContextDestroy(&ctx);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_diff);
+  CeedOperatorSetField(op_diff, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_diff, "du", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dp", elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dq", elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_diff, "dv", elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, x, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fuly assemble operator
+  CeedSize   num_entries;
+  CeedInt   *rows;
+  CeedInt   *cols;
+  CeedVector assembled;
+
+  for (CeedInt k = 0; k < l_size * l_size; k++) {
+    assembled_values[k] = 0.0;
+    assembled_true[k]   = 0.0;
+  }
+  CeedOperatorLinearAssembleSymbolic(op_diff, &num_entries, &rows, &cols);
+  CeedVectorCreate(ceed, num_entries, &assembled);
+  CeedOperatorLinearAssemble(op_diff, assembled);
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries; k++) assembled_values[rows[k] * l_size + cols[k]] += assembled_array[k];
+    CeedVectorRestoreArrayRead(assembled, &assembled_array);
+  }
+
+  // Manually assemble operator
+  CeedInt old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < l_size; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_diff, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < l_size; i++) assembled_true[i * l_size + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+
+  // Check output
+  for (CeedInt i = 0; i < l_size; i++) {
+    for (CeedInt j = 0; j < l_size; j++) {
+      const CeedScalar assembled_value      = assembled_values[i * l_size + j];
+      const CeedScalar assembled_true_value = assembled_true[i * l_size + j];
+      const CeedScalar error                = fabs(assembled_value - assembled_true_value) / (fmax(fabs(assembled_true_value), 1.0));
+
+      if (!(error < 1000. * CEED_EPSILON)) {
+        // LCOV_EXCL_START
+        const CeedInt node_out = (i < num_comp_u * num_dofs_u) ? i % num_dofs_u : (i - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_out = (i < num_comp_u * num_dofs_u) ? i / num_dofs_u : (i - num_comp_u * num_dofs_u) / num_dofs_p;
+        const CeedInt node_in  = (j < num_comp_u * num_dofs_u) ? j % num_dofs_u : (j - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_in  = (j < num_comp_u * num_dofs_u) ? j / num_dofs_u : (j - num_comp_u * num_dofs_u) / num_dofs_p;
+
+        printf("[(%s, %" CeedInt_FMT ", %" CeedInt_FMT "), (%s, %" CeedInt_FMT ", %" CeedInt_FMT ")] Error in assembly: %g != %g (error: %g)\n",
+               (i < num_comp_u * num_dofs_u ? "u" : "p"), node_out, comp_out, (j < num_comp_u * num_dofs_u ? "u" : "p"), node_in, comp_in,
+               assembled_value, assembled_true_value, error);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows);
+  free(cols);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&u);
+  CeedVectorDestroy(&v);
+  CeedVectorDestroy(&assembled);
+  CeedElemRestrictionDestroy(&elem_restriction_p);
+  CeedElemRestrictionDestroy(&elem_restriction_u);
+  CeedElemRestrictionDestroy(&elem_restriction_x);
+  CeedElemRestrictionDestroy(&elem_restriction_q_data);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_p);
+  CeedBasisDestroy(&basis_x);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_diff);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_diff);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t572-operator.h
+++ b/tests/t572-operator.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#include <ceed/types.h>
+
+typedef struct {
+  CeedInt num_comp_u;
+  CeedInt num_comp_p;
+} Context_t;
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
+  // the symmetric part of the result.
+
+  // in[0] is quadrature weights, size (Q)
+  // in[1] is Jacobians with shape [2, nc=2, Q]
+  const CeedScalar *weight = in[0];
+  const CeedScalar *J      = in[1];
+
+  // out[0] is qdata, size (Q)
+  CeedScalar(*q_data)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+
+  // Quadrature point loop
+  for (CeedInt i = 0; i < Q; i++) {
+    // J: 0 2   qd: 0 2   adj(J):  J22 -J12
+    //    1 3       2 1           -J21  J11
+    const CeedScalar J11 = J[i + Q * 0];
+    const CeedScalar J21 = J[i + Q * 1];
+    const CeedScalar J12 = J[i + Q * 2];
+    const CeedScalar J22 = J[i + Q * 3];
+    const CeedScalar w   = weight[i] / (J11 * J22 - J21 * J12);
+    q_data[0][i]         = w * (J12 * J12 + J22 * J22);
+    q_data[1][i]         = w * (J11 * J11 + J21 * J21);
+    q_data[2][i]         = -w * (J11 * J12 + J21 * J22);
+  }
+
+  return 0;
+}
+
+CEED_QFUNCTION(multi_basis_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  // in[0] is quadrature data, size (3*Q)
+  // in[1] is gradient u, shape [2, nc_u, Q]
+  // in[2] is gradient p, shape [2, nc_p, Q]
+  const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
+  const CeedScalar *du                  = in[1];
+  const CeedScalar *dp                  = in[2];
+
+  // out[0] is output to multiply against gradient q, shape [2, nc_p, Q]
+  // out[1] is output to multiply against gradient v, shape [2, nc_u, Q]
+  CeedScalar *dq = out[0];
+  CeedScalar *dv = out[1];
+
+  const Context_t *context = (Context_t *)ctx;
+
+  // Quadrature point loop
+  for (CeedInt i = 0; i < Q; i++) {
+    // Component loop
+    for (CeedInt c = 0; c < context->num_comp_u; c++) {
+      const CeedScalar du0                        = du[i + c * Q + context->num_comp_u * Q * 0];
+      const CeedScalar du1                        = du[i + c * Q + context->num_comp_u * Q * 1];
+      dv[i + c * Q + context->num_comp_u * Q * 0] = q_data[0][i] * du0 + q_data[2][i] * du1;
+      dv[i + c * Q + context->num_comp_u * Q * 1] = q_data[2][i] * du0 + q_data[1][i] * du1;
+    }
+
+    for (CeedInt c = 0; c < context->num_comp_p; c++) {
+      const CeedScalar dp0                        = dp[i + c * Q + context->num_comp_p * Q * 0];
+      const CeedScalar dp1                        = dp[i + c * Q + context->num_comp_p * Q * 1];
+      dq[i + c * Q + context->num_comp_p * Q * 0] = q_data[0][i] * dp0 + q_data[2][i] * dp1;
+      dq[i + c * Q + context->num_comp_p * Q * 1] = q_data[2][i] * dp0 + q_data[1][i] * dp1;
+    }
+    // Add artificial, asymmetric coupling terms to test block assembly
+    dv[i + 0 * Q + context->num_comp_u * Q * 1] += dq[i + (context->num_comp_p - 1) * Q + context->num_comp_p * Q * 0];
+    dq[i] += dv[i + (context->num_comp_u - 1) * Q + context->num_comp_u * Q * 1];
+  }
+  return 0;
+}

--- a/tests/t572-operator.h
+++ b/tests/t572-operator.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+#include <ceed/types.h>
+
+typedef struct {
+  CeedInt num_comp_u;
+  CeedInt num_comp_p;
+} Context_t;
+
+CEED_QFUNCTION(setup)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
+  // the symmetric part of the result.
+
+  // in[0] is quadrature weights, size (Q)
+  // in[1] is Jacobians with shape [2, nc=2, Q]
+  const CeedScalar *weight = in[0];
+  const CeedScalar *J      = in[1];
+
+  // out[0] is qdata, size (Q)
+  CeedScalar(*q_data)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[0];
+
+  // Quadrature point loop
+  for (CeedInt i = 0; i < Q; i++) {
+    // J: 0 2   qd: 0 2   adj(J):  J22 -J12
+    //    1 3       2 1           -J21  J11
+    const CeedScalar J11 = J[i + Q * 0];
+    const CeedScalar J21 = J[i + Q * 1];
+    const CeedScalar J12 = J[i + Q * 2];
+    const CeedScalar J22 = J[i + Q * 3];
+    const CeedScalar w   = weight[i] / (J11 * J22 - J21 * J12);
+    q_data[0][i]         = w * (J12 * J12 + J22 * J22);
+    q_data[1][i]         = w * (J11 * J11 + J21 * J21);
+    q_data[2][i]         = -w * (J11 * J12 + J21 * J22);
+  }
+
+  return 0;
+}
+
+CEED_QFUNCTION(multi_basis_diff)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
+  // in[0] is quadrature data, size (3*Q)
+  // in[1] is gradient u, shape [2, nc_u, Q]
+  // in[2] is gradient p, shape [2, nc_p, Q]
+  const CeedScalar(*q_data)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[0];
+  const CeedScalar *du                  = in[1];
+  const CeedScalar *dp                  = in[2];
+
+  // out[0] is output to multiply against gradient v, shape [2, nc_u, Q]
+  // out[1] is output to multiply against gradient q, shape [2, nc_p, Q]
+  CeedScalar *dv = out[0];
+  CeedScalar *dq = out[1];
+
+  const Context_t *context = (Context_t *)ctx;
+
+  // Quadrature point loop
+  for (CeedInt i = 0; i < Q; i++) {
+    // Component loop
+    for (CeedInt c = 0; c < context->num_comp_u; c++) {
+      const CeedScalar du0                        = du[i + c * Q + context->num_comp_u * Q * 0];
+      const CeedScalar du1                        = du[i + c * Q + context->num_comp_u * Q * 1];
+      dv[i + c * Q + context->num_comp_u * Q * 0] = q_data[0][i] * du0 + q_data[2][i] * du1;
+      dv[i + c * Q + context->num_comp_u * Q * 1] = q_data[2][i] * du0 + q_data[1][i] * du1;
+    }
+
+    for (CeedInt c = 0; c < context->num_comp_p; c++) {
+      const CeedScalar dp0                        = dp[i + c * Q + context->num_comp_p * Q * 0];
+      const CeedScalar dp1                        = dp[i + c * Q + context->num_comp_p * Q * 1];
+      dq[i + c * Q + context->num_comp_p * Q * 0] = q_data[0][i] * dp0 + q_data[2][i] * dp1;
+      dq[i + c * Q + context->num_comp_p * Q * 1] = q_data[2][i] * dp0 + q_data[1][i] * dp1;
+    }
+    // Add artificial, asymmetric coupling terms to test block assembly
+    dv[i + 0 * Q + context->num_comp_u * Q * 1] += dq[i + (context->num_comp_p - 1) * Q + context->num_comp_p * Q * 0];
+    dq[i] += dv[i + (context->num_comp_u - 1) * Q + context->num_comp_u * Q * 1];
+  }
+  return 0;
+}

--- a/tests/t573-operator.c
+++ b/tests/t573-operator.c
@@ -1,0 +1,214 @@
+/// @file
+/// Test assembly of operator for operator with multiple active bases
+/// \test Test assembly of operator for operator with multiple active bases
+#include "t539-operator.h"
+
+#include <ceed.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  Ceed                ceed;
+  CeedElemRestriction elem_restriction_x, elem_restriction_u_0, elem_restriction_u_1, elem_restr_q_data_mass, elem_restr_q_data_diff;
+  CeedBasis           basis_x, basis_u_0, basis_u_1;
+  CeedQFunction       qf_setup_mass, qf_setup_diff, qf_apply;
+  CeedOperator        op_setup_mass, op_setup_diff, op_apply;
+  CeedVector          q_data_mass, q_data_diff, x, assembled, u, v;
+  CeedInt             p_0 = 2, p_1 = 3, q = 4, dim = 2, num_comp_0 = 2, num_comp_1 = 1;
+  CeedInt             n_x = 1, n_y = 2, num_elem = n_x * n_y;
+  CeedInt             num_dofs_0 = (n_x * (p_0 - 1) + 1) * (n_y * (p_0 - 1) + 1), num_dofs_1 = (n_x * (p_1 - 1) + 1) * (n_y * (p_1 - 1) + 1);
+  CeedInt             num_qpts = num_elem * q * q;
+  CeedInt             ind_u_0[num_elem * p_0 * p_0], ind_u_1[num_elem * p_1 * p_1];
+  CeedInt             l_size = num_comp_0 * num_dofs_0 + num_comp_1 * num_dofs_1;
+  CeedScalar          assembled_values[l_size * l_size];
+  CeedScalar          assembled_true[l_size * l_size];
+
+  CeedInit(argv[1], &ceed);
+
+  // Vectors
+  CeedVectorCreate(ceed, dim * num_dofs_0, &x);
+  {
+    CeedScalar x_array[dim * num_dofs_0];
+
+    for (CeedInt i = 0; i < n_x * (p_0 - 1) + 1; i++) {
+      for (CeedInt j = 0; j < n_y * (p_0 - 1) + 1; j++) {
+        x_array[i + j * (n_x * (p_0 - 1) + 1) + 0 * num_dofs_0] = (CeedScalar)i / ((p_0 - 1) * n_x);
+        x_array[i + j * (n_x * (p_0 - 1) + 1) + 1 * num_dofs_0] = (CeedScalar)j / ((p_0 - 1) * n_y);
+      }
+    }
+    CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
+  }
+  CeedVectorCreate(ceed, num_comp_0 * num_dofs_0 + num_comp_1 * num_dofs_1, &u);
+  CeedVectorCreate(ceed, num_comp_0 * num_dofs_0 + num_comp_1 * num_dofs_1, &v);
+  CeedVectorCreate(ceed, num_qpts, &q_data_mass);
+  CeedVectorCreate(ceed, num_qpts * dim * (dim + 1) / 2, &q_data_diff);
+
+  // Restrictions
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p_0 - 1) + row * (n_x * (p_0 - 1) + 1) * (p_0 - 1);
+    for (CeedInt j = 0; j < p_0; j++) {
+      for (CeedInt k = 0; k < p_0; k++) ind_u_0[p_0 * (p_0 * i + k) + j] = offset + k * (n_x * (p_0 - 1) + 1) + j;
+    }
+    offset = col * (p_1 - 1) + row * (n_x * (p_1 - 1) + 1) * (p_1 - 1) + num_dofs_0 * num_comp_0;
+    for (CeedInt j = 0; j < p_1; j++) {
+      for (CeedInt k = 0; k < p_1; k++) ind_u_1[p_1 * (p_1 * i + k) + j] = offset + k * (n_x * (p_1 - 1) + 1) + j;
+    }
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, p_0 * p_0, dim, num_dofs_0, dim * num_dofs_0, CEED_MEM_HOST, CEED_USE_POINTER, ind_u_0,
+                            &elem_restriction_x);
+  CeedElemRestrictionCreate(ceed, num_elem, p_0 * p_0, num_comp_0, num_dofs_0, num_comp_0 * num_dofs_0 + num_comp_1 * num_dofs_1, CEED_MEM_HOST,
+                            CEED_USE_POINTER, ind_u_0, &elem_restriction_u_0);
+  CeedElemRestrictionCreate(ceed, num_elem, p_1 * p_1, num_comp_1, num_dofs_1, num_comp_0 * num_dofs_0 + num_comp_1 * num_dofs_1, CEED_MEM_HOST,
+                            CEED_USE_POINTER, ind_u_1, &elem_restriction_u_1);
+
+  CeedInt strides_q_data_mass[3] = {1, q * q, q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, 1, num_qpts, strides_q_data_mass, &elem_restr_q_data_mass);
+
+  CeedInt strides_q_data_diff[3] = {1, q * q, dim * (dim + 1) / 2 * q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, dim * (dim + 1) / 2, dim * (dim + 1) / 2 * num_qpts, strides_q_data_diff,
+                                   &elem_restr_q_data_diff);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, p_0, q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_0, p_0, q, CEED_GAUSS, &basis_u_0);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_1, p_1, q, CEED_GAUSS, &basis_u_1);
+
+  // QFunction - setup mass
+  CeedQFunctionCreateInteriorByName(ceed, "Mass2DBuild", &qf_setup_mass);
+
+  // Operator - setup mass
+  CeedOperatorCreate(ceed, qf_setup_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup_mass);
+  CeedOperatorSetField(op_setup_mass, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_mass, "weights", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_mass, "qdata", elem_restr_q_data_mass, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  // QFunction - setup diffusion
+  CeedQFunctionCreateInteriorByName(ceed, "Poisson2DBuild", &qf_setup_diff);
+
+  // Operator - setup diffusion
+  CeedOperatorCreate(ceed, qf_setup_diff, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup_diff);
+  CeedOperatorSetField(op_setup_diff, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup_diff, "weights", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup_diff, "qdata", elem_restr_q_data_diff, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operators
+  CeedOperatorApply(op_setup_mass, x, q_data_mass, CEED_REQUEST_IMMEDIATE);
+  CeedOperatorApply(op_setup_diff, x, q_data_diff, CEED_REQUEST_IMMEDIATE);
+
+  // QFunction - apply
+  CeedQFunctionCreateInterior(ceed, 1, apply, apply_loc, &qf_apply);
+  CeedQFunctionAddInput(qf_apply, "du_0", num_comp_0 * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddInput(qf_apply, "mass qdata", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_apply, "diff qdata", dim * (dim + 1) / 2, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_apply, "u_0", num_comp_0, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_apply, "u_1", num_comp_1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "v_0", num_comp_0, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "v_1", num_comp_1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_apply, "dv_0", num_comp_0 * dim, CEED_EVAL_GRAD);
+
+  // Operator - apply
+  CeedOperatorCreate(ceed, qf_apply, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_apply);
+  CeedOperatorSetField(op_apply, "du_0", elem_restriction_u_0, basis_u_0, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "mass qdata", elem_restr_q_data_mass, CEED_BASIS_NONE, q_data_mass);
+  CeedOperatorSetField(op_apply, "diff qdata", elem_restr_q_data_diff, CEED_BASIS_NONE, q_data_diff);
+  CeedOperatorSetField(op_apply, "u_0", elem_restriction_u_0, basis_u_0, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "u_1", elem_restriction_u_1, basis_u_1, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "v_0", elem_restriction_u_0, basis_u_0, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "v_1", elem_restriction_u_1, basis_u_1, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_apply, "dv_0", elem_restriction_u_0, basis_u_0, CEED_VECTOR_ACTIVE);
+
+  // Fuly assemble operator
+  CeedSize num_entries;
+  CeedInt *rows;
+  CeedInt *cols;
+
+  for (CeedInt k = 0; k < l_size * l_size; k++) {
+    assembled_values[k] = 0.0;
+    assembled_true[k]   = 0.0;
+  }
+  CeedOperatorLinearAssembleSymbolic(op_apply, &num_entries, &rows, &cols);
+  CeedVectorCreate(ceed, num_entries, &assembled);
+  CeedOperatorLinearAssemble(op_apply, assembled);
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries; k++) assembled_values[rows[k] * l_size + cols[k]] += assembled_array[k];
+    CeedVectorRestoreArrayRead(assembled, &assembled_array);
+  }
+
+  // Manually assemble operator
+  CeedInt old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < l_size; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_apply, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < l_size; i++) assembled_true[i * l_size + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+
+  // Check output
+  for (CeedInt i = 0; i < l_size; i++) {
+    for (CeedInt j = 0; j < l_size; j++) {
+      const CeedScalar assembled_value      = assembled_values[i * l_size + j];
+      const CeedScalar assembled_true_value = assembled_true[i * l_size + j];
+      const CeedScalar error                = fabs(assembled_value - assembled_true_value) / (fmax(fabs(assembled_true_value), 1.0));
+
+      if (!(error < 1000. * CEED_EPSILON)) {
+        // LCOV_EXCL_START
+        const CeedInt node_out = (i < num_comp_0 * num_dofs_0) ? i % num_dofs_0 : (i - num_comp_0 * num_dofs_0) % num_dofs_0;
+        const CeedInt comp_out = (i < num_comp_0 * num_dofs_0) ? i / num_dofs_0 : (i - num_comp_0 * num_dofs_0) / num_dofs_0;
+        const CeedInt node_in  = (j < num_comp_0 * num_dofs_0) ? j % num_dofs_0 : (j - num_comp_0 * num_dofs_0) % num_dofs_0;
+        const CeedInt comp_in  = (j < num_comp_0 * num_dofs_0) ? j / num_dofs_0 : (j - num_comp_0 * num_dofs_0) / num_dofs_0;
+
+        printf("[(%s, %" CeedInt_FMT ", %" CeedInt_FMT "), (%s, %" CeedInt_FMT ", %" CeedInt_FMT ")] Error in assembly: %g != %g (error: %g)\n",
+               (i < num_comp_0 * num_dofs_0 ? "0" : "1"), node_out, comp_out, (j < num_comp_0 * num_dofs_0 ? "0" : "1"), node_in, comp_in,
+               assembled_value, assembled_true_value, error);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Cleanup
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&assembled);
+  free(rows);
+  free(cols);
+  CeedVectorDestroy(&u);
+  CeedVectorDestroy(&v);
+  CeedVectorDestroy(&q_data_mass);
+  CeedVectorDestroy(&q_data_diff);
+  CeedElemRestrictionDestroy(&elem_restriction_x);
+  CeedElemRestrictionDestroy(&elem_restriction_u_0);
+  CeedElemRestrictionDestroy(&elem_restriction_u_1);
+  CeedElemRestrictionDestroy(&elem_restr_q_data_mass);
+  CeedElemRestrictionDestroy(&elem_restr_q_data_diff);
+  CeedBasisDestroy(&basis_x);
+  CeedBasisDestroy(&basis_u_0);
+  CeedBasisDestroy(&basis_u_1);
+  CeedQFunctionDestroy(&qf_setup_mass);
+  CeedQFunctionDestroy(&qf_setup_diff);
+  CeedQFunctionDestroy(&qf_apply);
+  CeedOperatorDestroy(&op_setup_mass);
+  CeedOperatorDestroy(&op_setup_diff);
+  CeedOperatorDestroy(&op_apply);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t574-operator.c
+++ b/tests/t574-operator.c
@@ -1,0 +1,307 @@
+/// @file
+/// Test full assembly of multi-basis asymmetric mass-like operator with oriented and curl-oriented element restrictions
+/// \test Test full assembly of multi-basis asymmetric mass-like operator with oriented and curl-oriented element restrictions
+#include "t571-operator.h"
+
+#include <ceed.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  Ceed                ceed;
+  CeedElemRestriction elem_restriction_x, elem_restriction_q_data;
+  CeedElemRestriction oriented_elem_restriction_u, curl_oriented_elem_restriction_u;
+  CeedElemRestriction oriented_elem_restriction_p, curl_oriented_elem_restriction_p;
+  CeedBasis           basis_x, basis_u, basis_p;
+  CeedQFunction       qf_setup, qf_mass;
+  CeedOperator        op_setup, op_mass_oriented, op_mass_curl_oriented;
+  CeedVector          q_data, x, u, v;
+  CeedInt             p_u = 3, p_p = 2, q = 4, dim = 2;
+  CeedInt             n_x = 1, n_y = 1;
+  CeedInt             num_elem   = n_x * n_y;
+  CeedInt             num_comp_u = 1, num_comp_p = 1;  // Must be 1
+  CeedInt             num_dofs_u = (n_x * (p_u - 1) + 1) * (n_y * (p_u - 1) + 1), num_dofs_p = (n_x * (p_p - 1) + 1) * (n_y * (p_p - 1) + 1),
+          num_qpts = num_elem * q * q;
+  CeedInt    ind_x[num_elem * p_u * p_u], ind_p[num_elem * p_p * p_p];
+  CeedInt    l_size = num_comp_u * num_dofs_u + num_comp_p * num_dofs_p;
+  bool       orients_u[num_elem * p_u * p_u], orients_p[num_elem * p_p * p_p];
+  CeedInt8   curl_orients_u[3 * num_elem * p_u * p_u], curl_orients_p[3 * num_elem * p_p * p_p];
+  CeedScalar assembled_values_oriented[l_size * l_size];
+  CeedScalar assembled_values_curl_oriented[l_size * l_size];
+  CeedScalar assembled_true[l_size * l_size];
+
+  CeedInit(argv[1], &ceed);
+
+  // Vectors
+  CeedVectorCreate(ceed, dim * num_dofs_u, &x);
+  {
+    CeedScalar x_array[dim * num_dofs_u];
+
+    for (CeedInt i = 0; i < n_x * (p_u - 1) + 1; i++) {
+      for (CeedInt j = 0; j < n_y * (p_u - 1) + 1; j++) {
+        x_array[i + j * (n_x * 2 + 1) + 0 * num_dofs_u] = (CeedScalar)i / (n_x * (p_u - 1));
+        x_array[i + j * (n_x * 2 + 1) + 1 * num_dofs_u] = (CeedScalar)j / (n_y * (p_u - 1));
+      }
+    }
+    CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
+  }
+  CeedVectorCreate(ceed, l_size, &u);
+  CeedVectorCreate(ceed, l_size, &v);
+  CeedVectorCreate(ceed, num_qpts, &q_data);
+
+  // Restrictions
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p_u - 1) + row * (n_x * (p_u - 1) + 1) * (p_u - 1);
+    for (CeedInt j = 0; j < p_u; j++) {
+      for (CeedInt k = 0; k < p_u; k++) {
+        bool normal = !((j % 2 > 0 && k % 2 == 0) || (j % 2 == 0 && k % 2 > 0));
+
+        ind_x[p_u * (p_u * i + k) + j]                    = offset + k * p_u + j;
+        orients_u[p_u * (p_u * i + k) + j]                = !normal;
+        curl_orients_u[3 * (p_u * (p_u * i + k) + j) + 0] = j % 2 > 0 && k % 2 == 0 ? -1 : 0;
+        curl_orients_u[3 * (p_u * (p_u * i + k) + j) + 1] = normal ? 1 : 0;
+        curl_orients_u[3 * (p_u * (p_u * i + k) + j) + 2] = j % 2 == 0 && k % 2 > 0 ? -1 : 0;
+      }
+    }
+  }
+  const CeedInt offset_p = num_comp_u * num_dofs_u;
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p_p - 1) + row * (n_x * (p_p - 1) + 1) * (p_p - 1);
+    for (CeedInt j = 0; j < p_p; j++) {
+      for (CeedInt k = 0; k < p_p; k++) {
+        bool normal = !((j % 2 > 0 && k % 2 == 0) || (j % 2 == 0 && k % 2 > 0));
+
+        ind_p[p_p * (p_p * i + k) + j]                    = offset + k * p_p + j + offset_p;
+        orients_p[p_p * (p_p * i + k) + j]                = !normal;
+        curl_orients_p[3 * (p_p * (p_p * i + k) + j) + 0] = j % 2 == 0 && k % 2 > 0 ? -1 : 0;
+        curl_orients_p[3 * (p_p * (p_p * i + k) + j) + 1] = normal ? 1 : 0;
+        curl_orients_p[3 * (p_p * (p_p * i + k) + j) + 2] = j % 2 > 0 && k % 2 == 0 ? -1 : 0;
+      }
+    }
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, p_u * p_u, dim, num_dofs_u, dim * num_dofs_u, CEED_MEM_HOST, CEED_USE_POINTER, ind_x,
+                            &elem_restriction_x);
+  CeedElemRestrictionCreateOriented(ceed, num_elem, p_u * p_u, num_comp_u, num_dofs_u, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, orients_u,
+                                    &oriented_elem_restriction_u);
+  CeedElemRestrictionCreateCurlOriented(ceed, num_elem, p_u * p_u, num_comp_u, num_dofs_u, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_x,
+                                        curl_orients_u, &curl_oriented_elem_restriction_u);
+
+  CeedElemRestrictionCreateOriented(ceed, num_elem, p_p * p_p, num_comp_p, num_dofs_p, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_p, orients_p,
+                                    &oriented_elem_restriction_p);
+  CeedElemRestrictionCreateCurlOriented(ceed, num_elem, p_p * p_p, num_comp_p, num_dofs_p, l_size, CEED_MEM_HOST, CEED_USE_POINTER, ind_p,
+                                        curl_orients_p, &curl_oriented_elem_restriction_p);
+
+  CeedInt strides_q_data[3] = {1, q * q * num_elem, q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, 1, num_qpts * 1, strides_q_data, &elem_restriction_q_data);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, p_u, q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_u, p_u, q, CEED_GAUSS, &basis_u);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, num_comp_p, p_p, q, CEED_GAUSS, &basis_p);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "qdata", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, multi_basis, multi_basis_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "qdata", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", num_comp_u, CEED_EVAL_INTERP);
+  CeedQFunctionAddInput(qf_mass, "p", num_comp_p, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", num_comp_u, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "q", num_comp_p, CEED_EVAL_INTERP);
+
+  Context_t            context = {num_comp_u, num_comp_p};
+  CeedQFunctionContext ctx;
+
+  CeedQFunctionContextCreate(ceed, &ctx);
+  CeedQFunctionContextSetData(ctx, CEED_MEM_HOST, CEED_COPY_VALUES, sizeof(Context_t), &context);
+  CeedQFunctionSetContext(qf_mass, ctx);
+  CeedQFunctionContextDestroy(&ctx);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_mass_oriented);
+  CeedOperatorSetField(op_mass_oriented, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_mass_oriented, "u", oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_oriented, "p", oriented_elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_oriented, "v", oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_oriented, "q", oriented_elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_mass_curl_oriented);
+  CeedOperatorSetField(op_mass_curl_oriented, "qdata", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_mass_curl_oriented, "u", curl_oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_curl_oriented, "p", curl_oriented_elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_curl_oriented, "v", curl_oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_curl_oriented, "q", curl_oriented_elem_restriction_p, basis_p, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, x, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fully assemble operators
+  CeedSize   num_entries_oriented, num_entries_curl_oriented;
+  CeedInt   *rows_oriented, *rows_curl_oriented;
+  CeedInt   *cols_oriented, *cols_curl_oriented;
+  CeedVector assembled_oriented, assembled_curl_oriented;
+
+  for (CeedInt k = 0; k < l_size * l_size; ++k) {
+    assembled_values_oriented[k]      = 0.0;
+    assembled_values_curl_oriented[k] = 0.0;
+  }
+  CeedOperatorLinearAssembleSymbolic(op_mass_oriented, &num_entries_oriented, &rows_oriented, &cols_oriented);
+  CeedOperatorLinearAssembleSymbolic(op_mass_curl_oriented, &num_entries_curl_oriented, &rows_curl_oriented, &cols_curl_oriented);
+  CeedVectorCreate(ceed, num_entries_oriented, &assembled_oriented);
+  CeedVectorCreate(ceed, num_entries_curl_oriented, &assembled_curl_oriented);
+  CeedOperatorLinearAssemble(op_mass_oriented, assembled_oriented);
+  CeedOperatorLinearAssemble(op_mass_curl_oriented, assembled_curl_oriented);
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled_oriented, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries_oriented; ++k) {
+      assembled_values_oriented[rows_oriented[k] * l_size + cols_oriented[k]] += assembled_array[k];
+    }
+    CeedVectorRestoreArrayRead(assembled_oriented, &assembled_array);
+  }
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled_curl_oriented, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries_curl_oriented; ++k) {
+      assembled_values_curl_oriented[rows_curl_oriented[k] * l_size + cols_curl_oriented[k]] += assembled_array[k];
+    }
+    CeedVectorRestoreArrayRead(assembled_curl_oriented, &assembled_array);
+  }
+
+  // Manually assemble oriented operator
+  CeedInt old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < l_size; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_mass_oriented, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < l_size; i++) assembled_true[i * l_size + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+
+  // Check output
+  for (CeedInt i = 0; i < l_size; i++) {
+    for (CeedInt j = 0; j < l_size; j++) {
+      const CeedScalar assembled_value      = assembled_values_oriented[i * l_size + j];
+      const CeedScalar assembled_true_value = assembled_true[i * l_size + j];
+      const CeedScalar error                = fabs(assembled_value - assembled_true_value) / (fmax(fabs(assembled_true_value), 1.0));
+
+      if (!(error < 100. * CEED_EPSILON)) {
+        // LCOV_EXCL_START
+        const CeedInt node_out = (i < num_comp_u * num_dofs_u) ? i % num_dofs_u : (i - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_out = (i < num_comp_u * num_dofs_u) ? i / num_dofs_u : (i - num_comp_u * num_dofs_u) / num_dofs_p;
+        const CeedInt node_in  = (j < num_comp_u * num_dofs_u) ? j % num_dofs_u : (j - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_in  = (j < num_comp_u * num_dofs_u) ? j / num_dofs_u : (j - num_comp_u * num_dofs_u) / num_dofs_p;
+
+        printf("[(%s, %" CeedInt_FMT ", %" CeedInt_FMT "), (%s, %" CeedInt_FMT ", %" CeedInt_FMT
+               ")] Error in oriented assembly: %g != %g (error: %g)\n",
+               (i < num_comp_u * num_dofs_u ? "u" : "p"), node_out, comp_out, (j < num_comp_u * num_dofs_u ? "u" : "p"), node_in, comp_in,
+               assembled_value, assembled_true_value, error);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Manually assemble curl-oriented operator
+  old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < l_size; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_mass_curl_oriented, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < l_size; i++) assembled_true[i * l_size + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+  for (CeedInt i = 0; i < l_size; i++) {
+    for (CeedInt j = 0; j < l_size; j++) {
+      const CeedScalar assembled_value      = assembled_values_curl_oriented[i * l_size + j];
+      const CeedScalar assembled_true_value = assembled_true[i * l_size + j];
+      const CeedScalar error                = fabs(assembled_value - assembled_true_value) / (fmax(fabs(assembled_true_value), 1.0));
+
+      if (!(error < 100. * CEED_EPSILON)) {
+        // LCOV_EXCL_START
+        const CeedInt node_out = (i < num_comp_u * num_dofs_u) ? i % num_dofs_u : (i - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_out = (i < num_comp_u * num_dofs_u) ? i / num_dofs_u : (i - num_comp_u * num_dofs_u) / num_dofs_p;
+        const CeedInt node_in  = (j < num_comp_u * num_dofs_u) ? j % num_dofs_u : (j - num_comp_u * num_dofs_u) % num_dofs_p;
+        const CeedInt comp_in  = (j < num_comp_u * num_dofs_u) ? j / num_dofs_u : (j - num_comp_u * num_dofs_u) / num_dofs_p;
+
+        printf("[(%s, %" CeedInt_FMT ", %" CeedInt_FMT "), (%s, %" CeedInt_FMT ", %" CeedInt_FMT
+               ")] Error in curl-oriented assembly: %g != %g (error: %g)\n",
+               (i < num_comp_u * num_dofs_u ? "u" : "p"), node_out, comp_out, (j < num_comp_u * num_dofs_u ? "u" : "p"), node_in, comp_in,
+               assembled_value, assembled_true_value, error);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows_oriented);
+  free(cols_oriented);
+  free(rows_curl_oriented);
+  free(cols_curl_oriented);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&u);
+  CeedVectorDestroy(&v);
+  CeedVectorDestroy(&assembled_oriented);
+  CeedVectorDestroy(&assembled_curl_oriented);
+  CeedElemRestrictionDestroy(&oriented_elem_restriction_u);
+  CeedElemRestrictionDestroy(&curl_oriented_elem_restriction_u);
+  CeedElemRestrictionDestroy(&oriented_elem_restriction_p);
+  CeedElemRestrictionDestroy(&curl_oriented_elem_restriction_p);
+  CeedElemRestrictionDestroy(&elem_restriction_x);
+  CeedElemRestrictionDestroy(&elem_restriction_q_data);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_p);
+  CeedBasisDestroy(&basis_x);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass_oriented);
+  CeedOperatorDestroy(&op_mass_curl_oriented);
+  CeedDestroy(&ceed);
+  return 0;
+}

--- a/tests/t584-operator.c
+++ b/tests/t584-operator.c
@@ -1,0 +1,239 @@
+/// @file
+/// Test full assembly of mass matrix operator with non-trivial oriented and curl-oriented element restrictions (see t560)
+/// \test Test full assembly of mass matrix operator with non-trivial oriented and curl-oriented element restrictions
+#include <ceed.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "t510-operator.h"
+
+int main(int argc, char **argv) {
+  Ceed                ceed;
+  CeedElemRestriction elem_restriction_x, elem_restriction_q_data;
+  CeedElemRestriction oriented_elem_restriction_u, curl_oriented_elem_restriction_u;
+  CeedBasis           basis_x, basis_u;
+  CeedQFunction       qf_setup, qf_mass;
+  CeedOperator        op_setup, op_mass_oriented, op_mass_curl_oriented;
+  CeedVector          q_data, x, u, v;
+  CeedInt             p = 2, q = 4, dim = 2;
+  CeedInt             n_x = 3, n_y = 2;
+  CeedInt             num_elem = n_x * n_y;
+  CeedInt             num_dofs = (n_x * 2 + 1) * (n_y * 2 + 1), num_qpts = num_elem * q * q;
+  CeedInt             ind_x[num_elem * p * p];
+  bool                orients_u[num_elem * p * p];
+  CeedInt8            curl_orients_u[3 * num_elem * p * p];
+  CeedScalar          assembled_true[num_dofs * num_dofs];
+  CeedScalar          assembled_values_oriented[num_dofs * num_dofs];
+  CeedScalar          assembled_values_curl_oriented[num_dofs * num_dofs];
+
+  CeedInit(argv[1], &ceed);
+
+  // Vectors
+  CeedVectorCreate(ceed, dim * num_dofs, &x);
+  {
+    CeedScalar x_array[dim * num_dofs];
+
+    for (CeedInt i = 0; i < n_x * 2 + 1; i++) {
+      for (CeedInt j = 0; j < n_y * 2 + 1; j++) {
+        x_array[i + j * (n_x * 2 + 1) + 0 * num_dofs] = (CeedScalar)i / (2 * n_x);
+        x_array[i + j * (n_x * 2 + 1) + 1 * num_dofs] = (CeedScalar)j / (2 * n_y);
+      }
+    }
+    CeedVectorSetArray(x, CEED_MEM_HOST, CEED_COPY_VALUES, x_array);
+  }
+  CeedVectorCreate(ceed, num_dofs, &u);
+  CeedVectorCreate(ceed, num_dofs, &v);
+  CeedVectorCreate(ceed, num_qpts, &q_data);
+
+  // Restrictions
+  // Restrictions
+  for (CeedInt i = 0; i < num_elem; i++) {
+    CeedInt col, row, offset;
+
+    col    = i % n_x;
+    row    = i / n_x;
+    offset = col * (p - 1) + row * (n_x * (p - 1) + 1) * (p - 1);
+    for (CeedInt j = 0; j < p; j++) {
+      for (CeedInt k = 0; k < p; k++) {
+        ind_x[p * (p * i + k) + j]                    = offset + k * p + j;
+        orients_u[p * (p * i + k) + j]                = false;
+        bool normal                                   = !((j % 2 > 0 && k % 2 == 0) || (j % 2 == 0 && k % 2 > 0));
+        curl_orients_u[3 * (p * (p * i + k) + j) + 0] = j % 2 > 0 && k % 2 == 0 ? -1 : 0;
+        curl_orients_u[3 * (p * (p * i + k) + j) + 1] = normal ? 1 : 0;
+        curl_orients_u[3 * (p * (p * i + k) + j) + 2] = j % 2 == 0 && k % 2 > 0 ? -1 : 0;
+      }
+    }
+  }
+  CeedElemRestrictionCreate(ceed, num_elem, p * p, dim, num_dofs, dim * num_dofs, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, &elem_restriction_x);
+  CeedElemRestrictionCreateOriented(ceed, num_elem, p * p, 1, num_dofs, num_dofs, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, orients_u,
+                                    &oriented_elem_restriction_u);
+  CeedElemRestrictionCreateCurlOriented(ceed, num_elem, p * p, 1, num_dofs, num_dofs, CEED_MEM_HOST, CEED_USE_POINTER, ind_x, curl_orients_u,
+                                        &curl_oriented_elem_restriction_u);
+
+  CeedInt strides_q_data[3] = {1, q * q, q * q};
+  CeedElemRestrictionCreateStrided(ceed, num_elem, q * q, 1, num_qpts, strides_q_data, &elem_restriction_q_data);
+
+  // Bases
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, dim, p, q, CEED_GAUSS, &basis_x);
+  CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, p, q, CEED_GAUSS, &basis_u);
+
+  // QFunctions
+  CeedQFunctionCreateInterior(ceed, 1, setup, setup_loc, &qf_setup);
+  CeedQFunctionAddInput(qf_setup, "weight", 1, CEED_EVAL_WEIGHT);
+  CeedQFunctionAddInput(qf_setup, "dx", dim * dim, CEED_EVAL_GRAD);
+  CeedQFunctionAddOutput(qf_setup, "rho", 1, CEED_EVAL_NONE);
+
+  CeedQFunctionCreateInterior(ceed, 1, mass, mass_loc, &qf_mass);
+  CeedQFunctionAddInput(qf_mass, "rho", 1, CEED_EVAL_NONE);
+  CeedQFunctionAddInput(qf_mass, "u", 1, CEED_EVAL_INTERP);
+  CeedQFunctionAddOutput(qf_mass, "v", 1, CEED_EVAL_INTERP);
+
+  // Operators
+  CeedOperatorCreate(ceed, qf_setup, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_setup);
+  CeedOperatorSetField(op_setup, "weight", CEED_ELEMRESTRICTION_NONE, basis_x, CEED_VECTOR_NONE);
+  CeedOperatorSetField(op_setup, "dx", elem_restriction_x, basis_x, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_setup, "rho", elem_restriction_q_data, CEED_BASIS_NONE, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_mass_oriented);
+  CeedOperatorSetField(op_mass_oriented, "rho", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_mass_oriented, "u", oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_oriented, "v", oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+
+  CeedOperatorCreate(ceed, qf_mass, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE, &op_mass_curl_oriented);
+  CeedOperatorSetField(op_mass_curl_oriented, "rho", elem_restriction_q_data, CEED_BASIS_NONE, q_data);
+  CeedOperatorSetField(op_mass_curl_oriented, "u", curl_oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+  CeedOperatorSetField(op_mass_curl_oriented, "v", curl_oriented_elem_restriction_u, basis_u, CEED_VECTOR_ACTIVE);
+
+  // Apply Setup Operator
+  CeedOperatorApply(op_setup, x, q_data, CEED_REQUEST_IMMEDIATE);
+
+  // Fully assemble operators
+  CeedSize   num_entries_oriented, num_entries_curl_oriented;
+  CeedInt   *rows_oriented, *rows_curl_oriented;
+  CeedInt   *cols_oriented, *cols_curl_oriented;
+  CeedVector assembled_oriented, assembled_curl_oriented;
+
+  for (CeedInt k = 0; k < num_dofs * num_dofs; ++k) {
+    assembled_values_oriented[k]      = 0.0;
+    assembled_values_curl_oriented[k] = 0.0;
+  }
+  CeedOperatorLinearAssembleSymbolic(op_mass_oriented, &num_entries_oriented, &rows_oriented, &cols_oriented);
+  CeedOperatorLinearAssembleSymbolic(op_mass_curl_oriented, &num_entries_curl_oriented, &rows_curl_oriented, &cols_curl_oriented);
+  CeedVectorCreate(ceed, num_entries_oriented, &assembled_oriented);
+  CeedVectorCreate(ceed, num_entries_curl_oriented, &assembled_curl_oriented);
+  CeedOperatorLinearAssemble(op_mass_oriented, assembled_oriented);
+  CeedOperatorLinearAssemble(op_mass_curl_oriented, assembled_curl_oriented);
+
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled_oriented, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries_oriented; ++k) {
+      assembled_values_oriented[rows_oriented[k] * num_dofs + cols_oriented[k]] += assembled_array[k];
+    }
+    CeedVectorRestoreArrayRead(assembled_oriented, &assembled_array);
+  }
+  {
+    const CeedScalar *assembled_array;
+
+    CeedVectorGetArrayRead(assembled_curl_oriented, CEED_MEM_HOST, &assembled_array);
+    for (CeedInt k = 0; k < num_entries_curl_oriented; ++k) {
+      assembled_values_curl_oriented[rows_curl_oriented[k] * num_dofs + cols_curl_oriented[k]] += assembled_array[k];
+    }
+    CeedVectorRestoreArrayRead(assembled_curl_oriented, &assembled_array);
+  }
+
+  // Manually assemble oriented operator
+  CeedInt old_index = -1;
+
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < num_dofs; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_mass_oriented, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < num_dofs; i++) assembled_true[i * num_dofs + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+
+  // Check output
+  for (CeedInt i = 0; i < num_dofs; i++) {
+    for (CeedInt j = 0; j < num_dofs; j++) {
+      if (fabs(assembled_values_oriented[i * num_dofs + j] - assembled_true[i * num_dofs + j]) > 100. * CEED_EPSILON) {
+        // LCOV_EXCL_START
+        printf("[%" CeedInt_FMT ", %" CeedInt_FMT "] Error in oriented assembly: %f != %f\n", i, j, assembled_values_oriented[i * num_dofs + j],
+               assembled_true[i * num_dofs + j]);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Manually assemble curl-oriented operator
+  old_index = -1;
+  CeedVectorSetValue(u, 0.0);
+  for (CeedInt j = 0; j < num_dofs; j++) {
+    CeedScalar       *u_array;
+    const CeedScalar *v_array;
+
+    // Set input
+    CeedVectorGetArray(u, CEED_MEM_HOST, &u_array);
+    u_array[j] = 1.0;
+    if (j > 0) u_array[old_index] = 0.0;
+    old_index = j;
+    CeedVectorRestoreArray(u, &u_array);
+
+    // Compute effect of DoF ind
+    CeedOperatorApply(op_mass_curl_oriented, u, v, CEED_REQUEST_IMMEDIATE);
+
+    CeedVectorGetArrayRead(v, CEED_MEM_HOST, &v_array);
+    for (CeedInt i = 0; i < num_dofs; i++) assembled_true[i * num_dofs + j] = v_array[i];
+    CeedVectorRestoreArrayRead(v, &v_array);
+  }
+  // Check output
+  for (CeedInt i = 0; i < num_dofs; i++) {
+    for (CeedInt j = 0; j < num_dofs; j++) {
+      if (fabs(assembled_values_curl_oriented[i * num_dofs + j] - assembled_true[i * num_dofs + j]) > 100. * CEED_EPSILON) {
+        // LCOV_EXCL_START
+        printf("[%" CeedInt_FMT ", %" CeedInt_FMT "] Error in curl-oriented assembly: %f != %f\n", i, j,
+               assembled_values_curl_oriented[i * num_dofs + j], assembled_true[i * num_dofs + j]);
+        // LCOV_EXCL_STOP
+      }
+    }
+  }
+
+  // Cleanup
+  free(rows_oriented);
+  free(cols_oriented);
+  free(rows_curl_oriented);
+  free(cols_curl_oriented);
+  CeedVectorDestroy(&x);
+  CeedVectorDestroy(&u);
+  CeedVectorDestroy(&v);
+  CeedVectorDestroy(&q_data);
+  CeedVectorDestroy(&assembled_oriented);
+  CeedVectorDestroy(&assembled_curl_oriented);
+  CeedElemRestrictionDestroy(&oriented_elem_restriction_u);
+  CeedElemRestrictionDestroy(&curl_oriented_elem_restriction_u);
+  CeedElemRestrictionDestroy(&elem_restriction_x);
+  CeedElemRestrictionDestroy(&elem_restriction_q_data);
+  CeedBasisDestroy(&basis_u);
+  CeedBasisDestroy(&basis_x);
+  CeedQFunctionDestroy(&qf_setup);
+  CeedQFunctionDestroy(&qf_mass);
+  CeedOperatorDestroy(&op_setup);
+  CeedOperatorDestroy(&op_mass_oriented);
+  CeedOperatorDestroy(&op_mass_curl_oriented);
+  CeedDestroy(&ceed);
+  return 0;
+}


### PR DESCRIPTION
Purpose:

Adds support for assembling matrices with >2 active fields that use different bases. This is useful for assembling mixed problems, Lagrange multipliers, etc. without the need for PCFieldSplit. FieldSplit may still be better for a lot of problems, but this is useful for many applications.

LLM/GenAI Disclosure:

None