### PR TITLE
Don't use JiT options that chipStar cannot process

### DIFF
--- a/backends/hip/ceed-hip-compile.cpp
+++ b/backends/hip/ceed-hip-compile.cpp
@@ -9,6 +9,7 @@
 
 #include <ceed.h>
 #include <ceed/backend.h>
+#include <ceed/jit-source/hip/hip-chipstar.h>
 #include <ceed/jit-tools.h>
 #include <stdarg.h>
 #include <string.h>
@@ -37,7 +38,6 @@ static int CeedCompileCore_Hip(Ceed ceed, const char *source, const bool throw_e
                                const CeedInt num_defines, va_list args) {
   size_t                 ptx_size;
   char                  *ptx;
-  const int              num_opts            = 4;
   CeedInt                num_jit_source_dirs = 0, num_jit_defines = 0;
   const char           **opts;
   int                    runtime_version;
@@ -77,14 +77,26 @@ static int CeedCompileCore_Hip(Ceed ceed, const char *source, const bool throw_e
   code << "#include <ceed/jit-source/hip/hip-jit.h>\n\n";
 
   // Non-macro options
+#if CEED_HIP_USE_CHIPSTAR
+  const int num_opts = 1;
+
+  CeedCallBackend(CeedCalloc(num_opts, &opts));
+  opts[0] = "-DCEED_RUNNING_JIT_PASS=1";
+#else
+  const int num_opts = 4;
+
   CeedCallBackend(CeedCalloc(num_opts, &opts));
   opts[0] = "-default-device";
-  CeedCallBackend(CeedGetData(ceed, (void **)&ceed_data));
-  CeedCallHip(ceed, hipGetDeviceProperties(&prop, ceed_data->device_id));
-  std::string arch_arg = "--gpu-architecture=" + std::string(prop.gcnArchName);
-  opts[1]              = arch_arg.c_str();
-  opts[2]              = "-munsafe-fp-atomics";
-  opts[3]              = "-DCEED_RUNNING_JIT_PASS=1";
+  {
+    CeedCallBackend(CeedGetData(ceed, (void **)&ceed_data));
+    CeedCallHip(ceed, hipGetDeviceProperties(&prop, ceed_data->device_id));
+    std::string arch_arg = "--gpu-architecture=" + std::string(prop.gcnArchName);
+
+    opts[1] = arch_arg.c_str();
+  }
+  opts[2] = "-munsafe-fp-atomics";
+  opts[3] = "-DCEED_RUNNING_JIT_PASS=1";
+#endif
   // Additional include dirs
   {
     const char **jit_source_dirs;

--- a/include/ceed/jit-source/hip/hip-chipstar.h
+++ b/include/ceed/jit-source/hip/hip-chipstar.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC and other CEED contributors.
+// All Rights Reserved. See the top-level LICENSE and NOTICE files for details.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This file is part of CEED:  http://github.com/ceed
+
+/// @file
+/// Internal header for HIP chipStar detection
+
+// If we are using Chipstar, then we have to ensure all threads have the same workloads
+//   and hit __syncthreads() at the same places/number of times
+#ifdef __HIP_PLATFORM_SPIRV__
+#define CEED_HIP_USE_CHIPSTAR true
+#else
+#define CEED_HIP_USE_CHIPSTAR false
+#endif

--- a/include/ceed/jit-source/hip/hip-jit.h
+++ b/include/ceed/jit-source/hip/hip-jit.h
@@ -13,12 +13,5 @@
 #define CeedPragmaSIMD
 #define CEED_Q_VLA 1
 
-// If we are using Chipstar, then we have to ensure all threads have the same workloads
-//   and hit __syncthreads() at the same places/number of times
-#ifdef __HIP_PLATFORM_SPIRV__
-#define CEED_HIP_USE_CHIPSTAR true
-#else
-#define CEED_HIP_USE_CHIPSTAR false
-#endif
-
+#include "hip-chipstar.h"
 #include "hip-types.h"


### PR DESCRIPTION
Purpose:

Update the HIP backend JiT so that we don't process options chipStar cannot use.

See also #1942 

Closes: #N/A

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
