### PR TITLE
SYCL: link libceed.so with SYCLCXX; fix JiT 1-byte heap overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,7 +579,7 @@ ifneq ($(SYCL_DIR),)
   SYCL_LIB_DIR := $(patsubst %/,%,$(dir $(firstword $(SYCL_LIB_DIR))))
 endif
 ifneq ($(SYCL_LIB_DIR),)
-  PKG_LIBS += $(SYCL_FLAG) -lze_loader
+  PKG_LIBS += $(filter -fsycl -fno-sycl-id-queries-fit-in-int,$(SYCLFLAGS)) -lze_loader
   LIBCEED_CONTAINS_CXX = 1
   libceed.sycl  += $(sycl-core.cpp) $(sycl-ref.cpp) $(sycl-shared.cpp) $(sycl-gen.cpp)
   BACKENDS_MAKE += $(SYCL_BACKENDS)
@@ -640,7 +640,12 @@ endif
 
 pkgconfig-libs-private = $(PKG_LIBS)
 ifeq ($(LIBCEED_CONTAINS_CXX),1)
-  $(libceeds) : LINK = $(CXX)
+  ifneq ($(SYCL_LIB_DIR),)
+    $(libceeds) : LINK = $(SYCLCXX)
+    $(libceeds) : CEED_LDFLAGS += $(filter -fsycl -fno-sycl-id-queries-fit-in-int,$(SYCLFLAGS))
+  else
+    $(libceeds) : LINK = $(CXX)
+  endif
   ifeq ($(STATIC),1)
     $(examples) $(tests) : CEED_LDLIBS += $(LIBCXX)
     pkgconfig-libs-private += $(LIBCXX)

--- a/interface/ceed-jit-tools.c
+++ b/interface/ceed-jit-tools.c
@@ -183,10 +183,10 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, C
       const long current_size = strlen(*buffer);
       const long copy_size    = first_hash - &temp_buffer[file_offset] + (is_pragma_once ? 0 : (next_new_line - first_hash + 1));
 
-      CeedCall(CeedRealloc(current_size + copy_size + 1, buffer));
+      CeedCall(CeedRealloc(current_size + copy_size + 2, buffer));
       memcpy(&(*buffer)[current_size], "\n", 2);
       memcpy(&(*buffer)[current_size + 1], &temp_buffer[file_offset], copy_size);
-      memcpy(&(*buffer)[current_size + copy_size], "\0", 1);  // NOLINT
+      memcpy(&(*buffer)[current_size + copy_size + 1], "\0", 1);  // NOLINT
 
       file_offset = strchr(first_hash, '\n') - temp_buffer + 1;
     }
@@ -208,10 +208,10 @@ int CeedLoadSourceToInitializedBuffer(Ceed ceed, const char *source_file_path, C
       const long current_size = strlen(*buffer);
       const long copy_size    = first_hash - &temp_buffer[file_offset];
 
-      CeedCall(CeedRealloc(current_size + copy_size + 1, buffer));
+      CeedCall(CeedRealloc(current_size + copy_size + 2, buffer));
       memcpy(&(*buffer)[current_size], "\n", 2);
       memcpy(&(*buffer)[current_size + 1], &temp_buffer[file_offset], copy_size);
-      memcpy(&(*buffer)[current_size + copy_size], "\0", 1);  // NOLINT
+      memcpy(&(*buffer)[current_size + copy_size + 1], "\0", 1);  // NOLINT
       // -- Load local "header.h"
       char *next_quote        = strchr(first_hash, '"');
       char *next_new_line     = strchr(first_hash, '\n');


### PR DESCRIPTION
## Purpose

Two fixes for SYCL / JiT on Intel oneAPI (e.g. Aurora): link `libceed.so` with the SYCL-aware toolchain when `CC=gcc`, and fix a one-byte heap overflow in `CeedLoadSourceToInitializedBuffer` when JiT source has `#include` at the start of a file (or back-to-back includes), which showed up as heap corruption / `realloc(): invalid pointer` during SYCL JiT.

## 1. `make`: use `SYCLCXX` as linker for `libceed.so` when SYCL is enabled

When `CC=gcc`, `SYCL_FLAG` is empty so the `libceed.so` link step used `g++` without `-fsycl`. The linker does not merge SYCL device sections from `.sycl.cpp` objects, so the shared library only had host stubs and the SYCL backend failed at runtime with errors like **No kernel named …** (e.g. `CeedVectorNorm_Sycl`).

**Change:** If `SYCL_LIB_DIR` is set, link `libceed.so` with `$(SYCLCXX)` (e.g. `icpx`) and add `-fsycl` / `-fno-sycl-id-queries-fit-in-int` to `CEED_LDFLAGS`. **PKG_LIBS:** use `$(filter -fsycl …,$(SYCLFLAGS))` so `ceed.pc` carries `-fsycl` even when `CC` is not Intel.

## 2. `jit-tools`: fix 1-byte heap overflow in `CeedLoadSourceToInitializedBuffer`

On the `#pragma` and `#include` paths the code did `CeedRealloc(current_size + copy_size + 1, …)` but the next line is `memcpy(&(*buffer)[current_size], "\n", 2)`, which writes **two** bytes (the string literal includes the trailing `\0`).

When **`copy_size == 0`** (e.g. the first line of the file is `#include <…>`, or the next preprocessor line is another `#include` so `file_offset` already points at `#`), that allocation is **one byte short** → **heap buffer overflow** (one byte past the end of the `realloc` region).

**Fix:** Allocate `current_size + copy_size + 2` and place the final `'\0'` at `[current_size + copy_size + 1]`, matching the same pattern already used for the “rest of file” tail copy.

### AddressSanitizer repro (pre-fix)

With the buggy `+1` realloc, loading a minimal JiT file whose **first line** is an include, e.g.:

```c
#include <ceed/types.h>
#include <ceed/ceed-f32.h>
```

and calling `CeedLoadSourceToBuffer` under ASAN reports, for example:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 2 at ... thread T0
    #0 memcpy
    #1 CeedLoadSourceToInitializedBuffer .../ceed-jit-tools.c:212
    #2 CeedLoadSourceAndInitializeBuffer
    #3 CeedLoadSourceToBuffer
...
N-byte region [...] allocated by ... CeedReallocArray ... ceed.c:326
```

The fixed code completes successfully for the same input.

## Commits

- `make: use SYCLCXX as linker for libceed.so when SYCL is enabled`
- `jit-tools: fix 1-byte heap overflow in CeedLoadSourceToInitializedBuffer`

## LLM / GenAI disclosure

Pull request description drafted with assistance from an AI coding tool (Cursor). Commits and code changes Claude Opus 4.7
