### PR TITLE
sycl: fix several correctness bugs in sycl-ref backend

### DIFF
--- a/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
@@ -109,9 +109,10 @@ static int CeedBasisApplyInterp_Sycl(sycl::queue &sycl_queue, const SyclModule_t
         CeedInt post = 1;
 
         for (CeedInt d = 0; d < dim; d++) {
-          // Use older version of sycl workgroup barrier for performance reasons
-          // Can be updated in future to align with SYCL2020 spec if performance bottleneck is removed
-          // sycl::group_barrier(work_group);
+          // Full work-group barrier with local-only fence: s_buffer_1/2 are SLM
+          // (local_accessor), so local_space is sufficient and avoids the cost of
+          // a global memory fence. Do not replace with a sub-group barrier —
+          // work_group_size (= Q) can exceed the hardware sub-group size.
           work_item.barrier(sycl::access::fence_space::local_space);
 
           pre /= P;
@@ -210,9 +211,7 @@ static int CeedBasisApplyGrad_Sycl(sycl::queue &sycl_queue, const SyclModule_t &
           CeedScalar       *cur_v = v + elem * v_stride + dim_1 * v_dim_stride + comp * v_comp_stride;
 
           for (CeedInt dim_2 = 0; dim_2 < dim; dim_2++) {
-            // Use older version of sycl workgroup barrier for performance reasons
-            // Can be updated in future to align with SYCL2020 spec if performance bottleneck is removed
-            // sycl::group_barrier(work_group);
+            // Full work-group barrier with local-only fence: see interp kernel comment.
             work_item.barrier(sycl::access::fence_space::local_space);
 
             pre /= P;

--- a/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
@@ -97,6 +97,10 @@ static int CeedBasisApplyInterp_Sycl(sycl::queue &sycl_queue, const SyclModule_t
         const CeedScalar *cur_u = u + elem * u_stride + comp * u_comp_stride;
         CeedScalar       *cur_v = v + elem * v_stride + comp * v_comp_stride;
 
+        // Prevent race: idle work items (i >= writeLen) must not overwrite
+        // s_buffer_1 while active work items still read it from the previous comp.
+        sycl::group_barrier(work_group);
+
         for (CeedInt k = i; k < u_size; k += group_size) {
           s_buffer_1[k] = cur_u[k];
         }

--- a/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-ref-basis.sycl.cpp
@@ -211,7 +211,10 @@ static int CeedBasisApplyGrad_Sycl(sycl::queue &sycl_queue, const SyclModule_t &
           CeedScalar       *cur_v = v + elem * v_stride + dim_1 * v_dim_stride + comp * v_comp_stride;
 
           for (CeedInt dim_2 = 0; dim_2 < dim; dim_2++) {
-            // Full work-group barrier with local-only fence: see interp kernel comment.
+            // Full work-group barrier with local-only fence: s_buffer_1/2 are SLM
+            // (local_accessor), so local_space is sufficient and avoids the cost of
+            // a global memory fence. Do not replace with a sub-group barrier —
+            // work_group_size (= Q) can exceed the hardware sub-group size.
             work_item.barrier(sycl::access::fence_space::local_space);
 
             pre /= P;

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -690,10 +690,14 @@ static int CeedVectorDestroy_Sycl(const CeedVector vec) {
   CeedCallBackend(CeedVectorGetData(vec, &impl));
   CeedCallBackend(CeedGetData(ceed, &data));
 
-  // Wait for all work to finish before freeing memory
-  CeedCallSycl(ceed, data->sycl_queue.wait_and_throw());
-  CeedCallSycl(ceed, sycl::free(impl->d_array_owned, data->sycl_context));
-  CeedCallSycl(ceed, sycl::free(impl->reduction_norm, data->sycl_context));
+  // data may be NULL if CeedDestroy_Sycl already ran (work vectors are destroyed
+  // after the backend Destroy callback). When NULL, the SYCL context destructor
+  // already waited for pending work and freed context-owned USM allocations.
+  if (data) {
+    CeedCallSycl(ceed, data->sycl_queue.wait_and_throw());
+    if (impl->d_array_owned) CeedCallSycl(ceed, sycl::free(impl->d_array_owned, data->sycl_context));
+    if (impl->reduction_norm) CeedCallSycl(ceed, sycl::free(impl->reduction_norm, data->sycl_context));
+  }
 
   CeedCallBackend(CeedFree(&impl->h_array_owned));
   CeedCallBackend(CeedFree(&impl));

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -690,14 +690,9 @@ static int CeedVectorDestroy_Sycl(const CeedVector vec) {
   CeedCallBackend(CeedVectorGetData(vec, &impl));
   CeedCallBackend(CeedGetData(ceed, &data));
 
-  // data may be NULL if CeedDestroy_Sycl already ran (work vectors are destroyed
-  // after the backend Destroy callback). When NULL, the SYCL context destructor
-  // already waited for pending work and freed context-owned USM allocations.
-  if (data) {
-    CeedCallSycl(ceed, data->sycl_queue.wait_and_throw());
-    if (impl->d_array_owned) CeedCallSycl(ceed, sycl::free(impl->d_array_owned, data->sycl_context));
-    if (impl->reduction_norm) CeedCallSycl(ceed, sycl::free(impl->reduction_norm, data->sycl_context));
-  }
+  CeedCallSycl(ceed, data->sycl_queue.wait_and_throw());
+  if (impl->d_array_owned) CeedCallSycl(ceed, sycl::free(impl->d_array_owned, data->sycl_context));
+  if (impl->reduction_norm) CeedCallSycl(ceed, sycl::free(impl->reduction_norm, data->sycl_context));
 
   CeedCallBackend(CeedFree(&impl->h_array_owned));
   CeedCallBackend(CeedFree(&impl));

--- a/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
+++ b/backends/sycl-ref/ceed-sycl-vector.sycl.cpp
@@ -691,8 +691,8 @@ static int CeedVectorDestroy_Sycl(const CeedVector vec) {
   CeedCallBackend(CeedGetData(ceed, &data));
 
   CeedCallSycl(ceed, data->sycl_queue.wait_and_throw());
-  if (impl->d_array_owned) CeedCallSycl(ceed, sycl::free(impl->d_array_owned, data->sycl_context));
-  if (impl->reduction_norm) CeedCallSycl(ceed, sycl::free(impl->reduction_norm, data->sycl_context));
+  CeedCallSycl(ceed, sycl::free(impl->d_array_owned, data->sycl_context));
+  CeedCallSycl(ceed, sycl::free(impl->reduction_norm, data->sycl_context));
 
   CeedCallBackend(CeedFree(&impl->h_array_owned));
   CeedCallBackend(CeedFree(&impl));

--- a/backends/sycl/ceed-sycl-common.sycl.cpp
+++ b/backends/sycl/ceed-sycl-common.sycl.cpp
@@ -82,14 +82,10 @@ int CeedDestroy_Sycl(Ceed ceed) {
   Ceed_Sycl *data;
 
   CeedCallBackend(CeedGetData(ceed, &data));
-  // Explicitly call C++ destructors before freeing: CeedCalloc allocates without
-  // constructors, so we must destruct manually. The queue destructor waits for
-  // pending work, ensuring GPU operations complete before memory is freed.
+  // CeedCalloc allocates without calling constructors; explicitly run destructors
+  // before freeing so the sycl::queue destructor waits for pending GPU work.
   data->~Ceed_Sycl();
   CeedCallBackend(CeedFree(&data));
-  // Null out ceed->data so CeedVectorDestroy_Sycl can detect Ceed is already torn down.
-  // CeedWorkVectorsDestroy runs after this callback, so vectors must guard against NULL.
-  CeedCallBackend(CeedSetData(ceed, NULL));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl/ceed-sycl-common.sycl.cpp
+++ b/backends/sycl/ceed-sycl-common.sycl.cpp
@@ -82,7 +82,14 @@ int CeedDestroy_Sycl(Ceed ceed) {
   Ceed_Sycl *data;
 
   CeedCallBackend(CeedGetData(ceed, &data));
+  // Explicitly call C++ destructors before freeing: CeedCalloc allocates without
+  // constructors, so we must destruct manually. The queue destructor waits for
+  // pending work, ensuring GPU operations complete before memory is freed.
+  data->~Ceed_Sycl();
   CeedCallBackend(CeedFree(&data));
+  // Null out ceed->data so CeedVectorDestroy_Sycl can detect Ceed is already torn down.
+  // CeedWorkVectorsDestroy runs after this callback, so vectors must guard against NULL.
+  CeedCallBackend(CeedSetData(ceed, NULL));
   return CEED_ERROR_SUCCESS;
 }
 

--- a/backends/sycl/ceed-sycl-compile.sycl.cpp
+++ b/backends/sycl/ceed-sycl-compile.sycl.cpp
@@ -130,6 +130,24 @@ int CeedBuildModule_Sycl(Ceed ceed, const std::string &kernel_source, SyclModule
   CeedCallBackend(CeedGetData(ceed, &data));
   CeedCallBackend(CeedJitAddDefinitions_Sycl(ceed, kernel_source, jit_source, constants));
   CeedCallBackend(CeedJitGetFlags_Sycl(flags));
+  // Add JIT source root directories as -I include paths (matches CUDA/HIP behavior)
+  {
+    const char **jit_source_dirs;
+    CeedInt      num_jit_source_dirs;
+
+    CeedCallBackend(CeedGetJitSourceRoots(ceed, &num_jit_source_dirs, &jit_source_dirs));
+    for (CeedInt i = 0; i < num_jit_source_dirs; i++) flags.push_back(std::string("-I") + jit_source_dirs[i]);
+    CeedCallBackend(CeedRestoreJitSourceRoots(ceed, &jit_source_dirs));
+  }
+  // Add user JIT defines as -D flags
+  {
+    const char **jit_defines;
+    CeedInt      num_jit_defines;
+
+    CeedCallBackend(CeedGetJitDefines(ceed, &num_jit_defines, &jit_defines));
+    for (CeedInt i = 0; i < num_jit_defines; i++) flags.push_back(std::string("-D") + jit_defines[i]);
+    CeedCallBackend(CeedRestoreJitDefines(ceed, &jit_defines));
+  }
   CeedCallBackend(CeedJitCompileSource_Sycl(ceed, data->sycl_device, jit_source, il_binary, flags));
   CeedCallBackend(CeedLoadModule_Sycl(ceed, data->sycl_context, data->sycl_device, il_binary, sycl_module));
   return CEED_ERROR_SUCCESS;

--- a/backends/sycl/ceed-sycl-compile.sycl.cpp
+++ b/backends/sycl/ceed-sycl-compile.sycl.cpp
@@ -60,8 +60,26 @@ static int CeedJitAddDefinitions_Sycl(Ceed ceed, const std::string &kernel_sourc
 //------------------------------------------------------------------------------
 // TODO: Add architecture flags, optimization flags
 //------------------------------------------------------------------------------
-static inline int CeedJitGetFlags_Sycl(std::vector<std::string> &flags) {
+static inline int CeedJitGetFlags_Sycl(Ceed ceed, std::vector<std::string> &flags) {
   flags = {std::string("-cl-std=CL3.0"), std::string("-Dint32_t=int"), std::string("-DCEED_RUNNING_JIT_PASS=1")};
+  // Add JIT source root directories as -I include paths
+  {
+    const char **jit_source_dirs;
+    CeedInt      num_jit_source_dirs;
+
+    CeedCallBackend(CeedGetJitSourceRoots(ceed, &num_jit_source_dirs, &jit_source_dirs));
+    for (CeedInt i = 0; i < num_jit_source_dirs; i++) flags.push_back(std::string("-I") + jit_source_dirs[i]);
+    CeedCallBackend(CeedRestoreJitSourceRoots(ceed, &jit_source_dirs));
+  }
+  // Add user JIT defines as -D flags
+  {
+    const char **jit_defines;
+    CeedInt      num_jit_defines;
+
+    CeedCallBackend(CeedGetJitDefines(ceed, &num_jit_defines, &jit_defines));
+    for (CeedInt i = 0; i < num_jit_defines; i++) flags.push_back(std::string("-D") + jit_defines[i]);
+    CeedCallBackend(CeedRestoreJitDefines(ceed, &jit_defines));
+  }
   return CEED_ERROR_SUCCESS;
 }
 
@@ -129,25 +147,7 @@ int CeedBuildModule_Sycl(Ceed ceed, const std::string &kernel_source, SyclModule
 
   CeedCallBackend(CeedGetData(ceed, &data));
   CeedCallBackend(CeedJitAddDefinitions_Sycl(ceed, kernel_source, jit_source, constants));
-  CeedCallBackend(CeedJitGetFlags_Sycl(flags));
-  // Add JIT source root directories as -I include paths (matches CUDA/HIP behavior)
-  {
-    const char **jit_source_dirs;
-    CeedInt      num_jit_source_dirs;
-
-    CeedCallBackend(CeedGetJitSourceRoots(ceed, &num_jit_source_dirs, &jit_source_dirs));
-    for (CeedInt i = 0; i < num_jit_source_dirs; i++) flags.push_back(std::string("-I") + jit_source_dirs[i]);
-    CeedCallBackend(CeedRestoreJitSourceRoots(ceed, &jit_source_dirs));
-  }
-  // Add user JIT defines as -D flags
-  {
-    const char **jit_defines;
-    CeedInt      num_jit_defines;
-
-    CeedCallBackend(CeedGetJitDefines(ceed, &num_jit_defines, &jit_defines));
-    for (CeedInt i = 0; i < num_jit_defines; i++) flags.push_back(std::string("-D") + jit_defines[i]);
-    CeedCallBackend(CeedRestoreJitDefines(ceed, &jit_defines));
-  }
+  CeedCallBackend(CeedJitGetFlags_Sycl(ceed, flags));
   CeedCallBackend(CeedJitCompileSource_Sycl(ceed, data->sycl_device, jit_source, il_binary, flags));
   CeedCallBackend(CeedLoadModule_Sycl(ceed, data->sycl_context, data->sycl_device, il_binary, sycl_module));
   return CEED_ERROR_SUCCESS;

--- a/examples/ceed/ex1-volume-f-c.h
+++ b/examples/ceed/ex1-volume-f-c.h
@@ -9,7 +9,7 @@
 
 /// libCEED Q-function for building quadrature data for a mass operator
 CEED_QFUNCTION(build_mass)(void *ctx, const CeedInt Q, const CeedScalar *const *in, CeedScalar *const *out) {
-  long long int *build_data = (long long int *)ctx;
+  const long *build_data = (const long *)ctx;
 
   // in[0] is Jacobians with shape [dim, dim, Q]
   // in[1] is quadrature weights with shape [1, Q]

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1679,6 +1679,8 @@ int CeedDestroy(Ceed *ceed) {
     CeedCall(CeedFree(&(*ceed)->obj_delegates));
   }
 
+  CeedCall(CeedWorkVectorsDestroy(*ceed));
+
   if ((*ceed)->Destroy) CeedCall((*ceed)->Destroy(*ceed));
 
   for (CeedInt i = 0; i < (*ceed)->num_jit_source_roots; i++) {
@@ -1699,7 +1701,6 @@ int CeedDestroy(Ceed *ceed) {
   CeedCall(CeedFree(&(*ceed)->f_offsets));
   CeedCall(CeedFree(&(*ceed)->resource));
   CeedCall(CeedDestroy(&(*ceed)->op_fallback_ceed));
-  CeedCall(CeedWorkVectorsDestroy(*ceed));
   CeedCall(CeedObjectDestroy_Private(&(*ceed)->obj));
   CeedCall(CeedFree(ceed));
   return CEED_ERROR_SUCCESS;


### PR DESCRIPTION
Purpose:

Fix several correctness and stability bugs in the SYCL backend, discovered and verified on Intel Arc A770 (oneAPI 2025.0.4) and Intel Ponte Vecchio / Aurora (oneAPI 2025.3.2).

**`interface: destroy work vectors before backend Destroy callback`**
Work vectors are CeedVectors backed by backend-allocated memory (USM on SYCL). `CeedWorkVectorsDestroy` was previously called after the backend's own `Destroy` callback, so `CeedVectorDestroy` ran with a freed backend data pointer. Move `CeedWorkVectorsDestroy` before `(*ceed)->Destroy` so the backend context is still valid when work vectors are cleaned up. Fixes t130, t131.

**`sycl: remove NULL guard workaround in CeedVectorDestroy_Sycl`**
Consequence of the ordering fix above. `CeedVectorDestroy_Sycl` no longer needs a NULL check on `ceed->data`, and `CeedDestroy_Sycl` no longer needs `CeedSetData(ceed, NULL)`.

**`sycl-ref: fix s_buffer_1 race in interp comp loop for TRANSPOSE direction`**
In `CeedBasisApplyInterp_Sycl`, work items with `i >= writeLen` skip the output write loop and immediately load the next component's data into `s_buffer_1`. Meanwhile work items with `i < writeLen` are still reading `s_buffer_1` for the current component's contraction. This race only manifests in the TRANSPOSE direction where `writeLen = P_1d < group_size = Q_1d`. Fixed by adding a work-group barrier at the top of each comp loop iteration.

**`sycl: pass JIT source roots as -I and defines as -D to ocloc`**
The SYCL backend was not forwarding `CeedGetJitSourceRoots` as `-I` flags or `CeedGetJitDefines` as `-D` flags to ocloc, unlike the CUDA and HIP backends. This caused compilation failures for user QFunctions that use angle-bracket includes or custom defines. Fixes t406.

**`examples: use long instead of long long int for OpenCL C compatibility`**
IGC v2.30.1 crashes when processing SPIR-V containing a 64-bit switch statement generated from `long long int`. `long` is also 64-bit in OpenCL C and matches the Fortran `integer*8` type used in the corresponding `ex1-volume-f.h`, so this is semantics-preserving and avoids the IGC bug. Fixes ex1-volume-f subtests 1-3.

## Test results — Intel Ponte Vecchio / Aurora (oneAPI 2025.3.2)

`make prove BACKENDS='/gpu/sycl/ref'`

**Before (upstream/main):** `Files=257, Tests=284, Result: FAIL`
```
Test Summary Report
-------------------
t406-qfunction        (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
t130-vector           (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
t131-vector           (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
ex1-volume-f          (Wstat: 0 Tests: 6 Failed: 3)
  Failed tests:  1-3
```

**After (sycl-fixes):** `Files=257, Tests=284, Result: PASS`

Note: the comp-loop race fix (`s_buffer_1` race in TRANSPOSE) addresses a non-deterministic correctness bug — wrong numerical results when `writeLen < group_size` — that does not produce a consistent test failure but was confirmed via bisection on Aurora.

<details>
<summary>Full make prove output — before (upstream/main)</summary>

```
=== Running tests for /gpu/sycl/ref (before PR) ===
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
make: 'lib' with optional backends: /gpu/sycl/ref
      LINK.c build/t000-ceed
      LINK.c build/t001-ceed
      LINK.c build/t002-ceed
      LINK.c build/t003-ceed
      LINK.c build/t004-ceed
      LINK.c build/t005-ceed
      LINK.c build/t006-ceed
      LINK.c build/t007-ceed
      LINK.c build/t008-ceed
      LINK.c build/t009-ceed
      LINK.c build/t010-config
      LINK.c build/t100-vector
      LINK.c build/t101-vector
      LINK.c build/t102-vector
      LINK.c build/t103-vector
      LINK.c build/t104-vector
      LINK.c build/t105-vector
      LINK.c build/t106-vector
      LINK.c build/t107-vector
      LINK.c build/t108-vector
      LINK.c build/t109-vector
      LINK.c build/t110-vector
      LINK.c build/t111-vector
      LINK.c build/t112-vector
      LINK.c build/t113-vector
      LINK.c build/t114-vector
      LINK.c build/t115-vector
      LINK.c build/t116-vector
      LINK.c build/t117-vector
      LINK.c build/t118-vector
      LINK.c build/t119-vector
      LINK.c build/t120-vector
      LINK.c build/t121-vector
      LINK.c build/t122-vector
      LINK.c build/t123-vector
      LINK.c build/t124-vector
      LINK.c build/t125-vector
      LINK.c build/t126-vector
      LINK.c build/t127-vector
      LINK.c build/t128-vector
      LINK.c build/t130-vector
      LINK.c build/t131-vector
      LINK.c build/t200-elemrestriction
      LINK.c build/t201-elemrestriction
      LINK.c build/t202-elemrestriction
      LINK.c build/t203-elemrestriction
      LINK.c build/t204-elemrestriction
      LINK.c build/t205-elemrestriction
      LINK.c build/t206-elemrestriction
      LINK.c build/t207-elemrestriction
      LINK.c build/t208-elemrestriction
      LINK.c build/t209-elemrestriction
      LINK.c build/t210-elemrestriction
      LINK.c build/t211-elemrestriction
      LINK.c build/t212-elemrestriction
      LINK.c build/t213-elemrestriction
      LINK.c build/t214-elemrestriction
      LINK.c build/t215-elemrestriction
      LINK.c build/t216-elemrestriction
      LINK.c build/t217-elemrestriction
      LINK.c build/t218-elemrestriction
      LINK.c build/t219-elemrestriction
      LINK.c build/t220-elemrestriction
      LINK.c build/t230-elemrestriction
      LINK.c build/t231-elemrestriction
      LINK.c build/t232-elemrestriction
      LINK.c build/t233-elemrestriction
      LINK.c build/t234-elemrestriction
      LINK.c build/t300-basis
      LINK.c build/t301-basis
      LINK.c build/t302-basis
      LINK.c build/t303-basis
      LINK.c build/t304-basis
      LINK.c build/t305-basis
      LINK.c build/t306-basis
      LINK.c build/t307-basis
      LINK.c build/t310-basis
      LINK.c build/t311-basis
      LINK.c build/t312-basis
      LINK.c build/t313-basis
      LINK.c build/t314-basis
      LINK.c build/t315-basis
      LINK.c build/t316-basis
      LINK.c build/t317-basis
      LINK.c build/t318-basis
      LINK.c build/t319-basis
      LINK.c build/t320-basis
      LINK.c build/t321-basis
      LINK.c build/t322-basis
      LINK.c build/t323-basis
      LINK.c build/t324-basis
      LINK.c build/t325-basis
      LINK.c build/t330-basis
      LINK.c build/t331-basis
      LINK.c build/t332-basis
      LINK.c build/t340-basis
      LINK.c build/t341-basis
      LINK.c build/t342-basis
      LINK.c build/t350-basis
      LINK.c build/t351-basis
      LINK.c build/t352-basis
      LINK.c build/t353-basis
      LINK.c build/t354-basis
      LINK.c build/t355-basis
      LINK.c build/t356-basis
      LINK.c build/t357-basis
      LINK.c build/t360-basis
      LINK.c build/t361-basis
      LINK.c build/t362-basis
      LINK.c build/t363-basis
      LINK.c build/t364-basis
      LINK.c build/t365-basis
      LINK.c build/t400-qfunction
      LINK.c build/t401-qfunction
      LINK.c build/t402-qfunction
      LINK.c build/t403-qfunction
      LINK.c build/t404-qfunction
      LINK.c build/t405-qfunction
      LINK.c build/t406-qfunction
      LINK.c build/t407-qfunction
      LINK.c build/t408-qfunction
      LINK.c build/t409-qfunction
      LINK.c build/t410-qfunction
      LINK.c build/t411-qfunction
      LINK.c build/t412-qfunction
      LINK.c build/t413-qfunction
      LINK.c build/t414-qfunction
      LINK.c build/t415-qfunction
      LINK.c build/t500-operator
      LINK.c build/t501-operator
      LINK.c build/t502-operator
      LINK.c build/t503-operator
      LINK.c build/t504-operator
      LINK.c build/t505-operator
      LINK.c build/t506-operator
      LINK.c build/t507-operator
      LINK.c build/t508-operator
      LINK.c build/t509-operator
      LINK.c build/t510-operator
      LINK.c build/t511-operator
      LINK.c build/t520-operator
      LINK.c build/t521-operator
      LINK.c build/t522-operator
      LINK.c build/t523-operator
      LINK.c build/t524-operator
      LINK.c build/t525-operator
      LINK.c build/t526-operator
      LINK.c build/t530-operator
      LINK.c build/t531-operator
      LINK.c build/t532-operator
      LINK.c build/t533-operator
      LINK.c build/t534-operator
      LINK.c build/t535-operator
      LINK.c build/t536-operator
      LINK.c build/t537-operator
      LINK.c build/t538-operator
      LINK.c build/t539-operator
      LINK.c build/t540-operator
      LINK.c build/t541-operator
      LINK.c build/t550-operator
      LINK.c build/t551-operator
      LINK.c build/t552-operator
      LINK.c build/t553-operator
      LINK.c build/t554-operator
      LINK.c build/t560-operator
      LINK.c build/t561-operator
      LINK.c build/t562-operator
      LINK.c build/t563-operator
      LINK.c build/t564-operator
      LINK.c build/t565-operator
      LINK.c build/t566-operator
      LINK.c build/t567-operator
      LINK.c build/t568-operator
      LINK.c build/t569-operator
      LINK.c build/t570-operator
      LINK.c build/t580-operator
      LINK.c build/t581-operator
      LINK.c build/t582-operator
      LINK.c build/t583-operator
      LINK.c build/t590-operator
      LINK.c build/t591-operator
      LINK.c build/t592-operator
      LINK.c build/t593-operator
      LINK.c build/t594-operator
      LINK.c build/t595-operator
      LINK.c build/t596-operator
      LINK.c build/t597-operator
      LINK.c build/t598-operator
      LINK.c build/t599-operator
      LINK.F build/t000-ceed-f
      LINK.F build/t001-ceed-f
      LINK.F build/t003-ceed-f
      LINK.F build/t004-ceed-f
      LINK.F build/t100-vector-f
      LINK.F build/t101-vector-f
      LINK.F build/t102-vector-f
      LINK.F build/t103-vector-f
      LINK.F build/t104-vector-f
      LINK.F build/t105-vector-f
      LINK.F build/t106-vector-f
      LINK.F build/t107-vector-f
      LINK.F build/t108-vector-f
      LINK.F build/t109-vector-f
      LINK.F build/t119-vector-f
      LINK.F build/t124-vector-f
      LINK.F build/t200-elemrestriction-f
      LINK.F build/t201-elemrestriction-f
      LINK.F build/t202-elemrestriction-f
      LINK.F build/t208-elemrestriction-f
      LINK.F build/t209-elemrestriction-f
      LINK.F build/t210-elemrestriction-f
      LINK.F build/t211-elemrestriction-f
      LINK.F build/t212-elemrestriction-f
      LINK.F build/t300-basis-f
      LINK.F build/t302-basis-f
      LINK.F build/t306-basis-f
      LINK.F build/t313-basis-f
      LINK.F build/t314-basis-f
      LINK.F build/t320-basis-f
      LINK.F build/t322-basis-f
      LINK.F build/t323-basis-f
      LINK.F build/t400-qfunction-f
      LINK.F build/t401-qfunction-f
      LINK.F build/t402-qfunction-f
      LINK.F build/t410-qfunction-f
      LINK.F build/t411-qfunction-f
      LINK.F build/t412-qfunction-f
      LINK.F build/t413-qfunction-f
      LINK.F build/t500-operator-f
      LINK.F build/t501-operator-f
      LINK.F build/t502-operator-f
      LINK.F build/t503-operator-f
      LINK.F build/t504-operator-f
      LINK.F build/t505-operator-f
      LINK.F build/t506-operator-f
      LINK.F build/t510-operator-f
      LINK.F build/t511-operator-f
      LINK.F build/t520-operator-f
      LINK.F build/t521-operator-f
      LINK.F build/t522-operator-f
      LINK.F build/t523-operator-f
      LINK.F build/t524-operator-f
      LINK.F build/t530-operator-f
      LINK.F build/t531-operator-f
      LINK.F build/t532-operator-f
      LINK.F build/t533-operator-f
      LINK.F build/t534-operator-f
      LINK.F build/t535-operator-f
      LINK.F build/t536-operator-f
      LINK.F build/t540-operator-f
      LINK.F build/t550-operator-f
      LINK.F build/t552-operator-f
      LINK.F build/t553-operator-f
      LINK.c build/ex1-volume
      LINK.c build/ex2-surface
      LINK.c build/ex3-volume
      LINK.F build/ex1-volume-f
Testing backends: /gpu/sycl/ref
prove -j 208 --exec '/opt/aurora/25.190.0/oneapi/intel-conda-miniforge/bin/python3 tests/junit.py' t000-ceed t001-ceed t002-ceed t003-ceed t004-ceed t005-ceed t006-ceed t007-ceed t008-ceed t009-ceed t010-config t100-vector t101-vector t102-vector t103-vector t104-vector t105-vector t106-vector t107-vector t108-vector t109-vector t110-vector t111-vector t112-vector t113-vector t114-vector t115-vector t116-vector t117-vector t118-vector t119-vector t120-vector t121-vector t122-vector t123-vector t124-vector t125-vector t126-vector t127-vector t128-vector t130-vector t131-vector t200-elemrestriction t201-elemrestriction t202-elemrestriction t203-elemrestriction t204-elemrestriction t205-elemrestriction t206-elemrestriction t207-elemrestriction t208-elemrestriction t209-elemrestriction t210-elemrestriction t211-elemrestriction t212-elemrestriction t213-elemrestriction t214-elemrestriction t215-elemrestriction t216-elemrestriction t217-elemrestriction t218-elemrestriction t219-elemrestriction t220-elemrestriction t230-elemrestriction t231-elemrestriction t232-elemrestriction t233-elemrestriction t234-elemrestriction t300-basis t301-basis t302-basis t303-basis t304-basis t305-basis t306-basis t307-basis t310-basis t311-basis t312-basis t313-basis t314-basis t315-basis t316-basis t317-basis t318-basis t319-basis t320-basis t321-basis t322-basis t323-basis t324-basis t325-basis t330-basis t331-basis t332-basis t340-basis t341-basis t342-basis t350-basis t351-basis t352-basis t353-basis t354-basis t355-basis t356-basis t357-basis t360-basis t361-basis t362-basis t363-basis t364-basis t365-basis t400-qfunction t401-qfunction t402-qfunction t403-qfunction t404-qfunction t405-qfunction t406-qfunction t407-qfunction t408-qfunction t409-qfunction t410-qfunction t411-qfunction t412-qfunction t413-qfunction t414-qfunction t415-qfunction t500-operator t501-operator t502-operator t503-operator t504-operator t505-operator t506-operator t507-operator t508-operator t509-operator t510-operator t511-operator t520-operator t521-operator t522-operator t523-operator t524-operator t525-operator t526-operator t530-operator t531-operator t532-operator t533-operator t534-operator t535-operator t536-operator t537-operator t538-operator t539-operator t540-operator t541-operator t550-operator t551-operator t552-operator t553-operator t554-operator t560-operator t561-operator t562-operator t563-operator t564-operator t565-operator t566-operator t567-operator t568-operator t569-operator t570-operator t580-operator t581-operator t582-operator t583-operator t590-operator t591-operator t592-operator t593-operator t594-operator t595-operator t596-operator t597-operator t598-operator t599-operator t000-ceed-f t001-ceed-f t003-ceed-f t004-ceed-f t100-vector-f t101-vector-f t102-vector-f t103-vector-f t104-vector-f t105-vector-f t106-vector-f t107-vector-f t108-vector-f t109-vector-f t119-vector-f t124-vector-f t200-elemrestriction-f t201-elemrestriction-f t202-elemrestriction-f t208-elemrestriction-f t209-elemrestriction-f t210-elemrestriction-f t211-elemrestriction-f t212-elemrestriction-f t300-basis-f t302-basis-f t306-basis-f t313-basis-f t314-basis-f t320-basis-f t322-basis-f t323-basis-f t400-qfunction-f t401-qfunction-f t402-qfunction-f t410-qfunction-f t411-qfunction-f t412-qfunction-f t413-qfunction-f t500-operator-f t501-operator-f t502-operator-f t503-operator-f t504-operator-f t505-operator-f t506-operator-f t510-operator-f t511-operator-f t520-operator-f t521-operator-f t522-operator-f t523-operator-f t524-operator-f t530-operator-f t531-operator-f t532-operator-f t533-operator-f t534-operator-f t535-operator-f t536-operator-f t540-operator-f t550-operator-f t552-operator-f t553-operator-f ex1-volume ex2-surface ex3-volume ex1-volume-f :: --mode tap --ceed-backends /gpu/sycl/ref --nproc 1 --pool-size 1 --search '.*'
t000-ceed ............... ok
t001-ceed ............... ok
t002-ceed ............... ok
t006-ceed ............... ok
t007-ceed ............... ok
t008-ceed ............... ok
t009-ceed ............... ok
t010-config ............. ok
t102-vector ............. ok
t110-vector ............. ok
t112-vector ............. ok
t113-vector ............. ok
t111-vector ............. ok
t114-vector ............. ok
t115-vector ............. ok
t116-vector ............. ok
t117-vector ............. ok
t118-vector ............. ok
t203-elemrestriction .... ok
t301-basis .............. ok
t303-basis .............. ok
t304-basis .............. ok
t305-basis .............. ok
t306-basis .............. ok
t220-elemrestriction .... ok
t231-elemrestriction .... ok
t004-ceed ............... ok
t128-vector ............. ok
t217-elemrestriction .... ok
t003-ceed ............... ok
t211-elemrestriction .... ok
t321-basis .............. ok
t205-elemrestriction .... ok
t234-elemrestriction .... ok
t207-elemrestriction .... ok
t322-basis .............. ok
t219-elemrestriction .... ok
t402-qfunction .......... ok
t216-elemrestriction .... ok
t580-operator ........... ok
t106-vector-f ........... ok
t363-basis .............. ok
t233-elemrestriction .... ok
t004-ceed-f ............. ok
t324-basis .............. ok
t209-elemrestriction .... ok
t320-basis .............. ok
t215-elemrestriction .... ok
t406-qfunction .......... 
Failed 1/1 subtests 
t000-ceed-f ............. ok
t403-qfunction .......... ok
t208-elemrestriction .... ok
t101-vector-f ........... ok
t401-qfunction .......... ok
t210-elemrestriction .... ok
t206-elemrestriction .... ok
t300-basis .............. ok
t125-vector ............. ok
t232-elemrestriction .... ok
t525-operator ........... ok
t100-vector-f ........... ok
t341-basis .............. ok
t213-elemrestriction .... ok
t127-vector ............. ok
t342-basis .............. ok
t104-vector ............. ok
t583-operator ........... ok
t330-basis .............. ok
t582-operator ........... ok
t103-vector ............. ok
t412-qfunction .......... ok
t003-ceed-f ............. ok
t599-operator ........... ok
t202-elemrestriction-f .. ok
t597-operator ........... ok
t210-elemrestriction-f .. ok
t508-operator ........... ok
t413-qfunction .......... ok
t218-elemrestriction .... ok
t592-operator ........... ok
t400-qfunction .......... ok
t350-basis .............. ok
t362-basis .............. ok
t323-basis-f ............ ok
t130-vector ............. 
Failed 1/1 subtests 
t409-qfunction .......... ok
t307-basis .............. ok
t509-operator ........... ok
t320-basis-f ............ ok
t109-vector ............. ok
t302-basis .............. ok
t360-basis .............. ok
t230-elemrestriction .... ok
t355-basis .............. ok
t201-elemrestriction .... ok
t107-vector ............. ok
t212-elemrestriction-f .. ok
t331-basis .............. ok
t200-elemrestriction-f .. ok
t108-vector ............. ok
t501-operator ........... ok
t119-vector-f ........... ok
t581-operator ........... ok
t503-operator ........... ok
t102-vector-f ........... ok
t200-elemrestriction .... ok
t106-vector ............. ok
t126-vector ............. ok
t593-operator ........... ok
t212-elemrestriction .... ok
t107-vector-f ........... ok
t211-elemrestriction-f .. ok
t536-operator ........... ok
t001-ceed-f ............. ok
t208-elemrestriction-f .. ok
t408-qfunction .......... ok
t120-vector ............. ok
t214-elemrestriction .... ok
t407-qfunction .......... ok
t122-vector ............. ok
t507-operator ........... ok
t311-basis .............. ok
t100-vector ............. ok
t402-qfunction-f ........ ok
t202-elemrestriction .... ok
t109-vector-f ........... ok
t005-ceed ............... ok
t119-vector ............. ok
t404-qfunction .......... ok
t590-operator ........... ok
t340-basis .............. ok
t121-vector ............. ok
t123-vector ............. ok
t317-basis .............. ok
t124-vector ............. ok
t410-qfunction .......... ok
t108-vector-f ........... ok
t124-vector-f ........... ok
t103-vector-f ........... ok
t413-qfunction-f ........ ok
t332-basis .............. ok
t591-operator ........... ok
t594-operator ........... ok
t105-vector ............. ok
t104-vector-f ........... ok
t598-operator ........... ok
t596-operator ........... ok
t595-operator ........... ok
t411-qfunction .......... ok
t105-vector-f ........... ok
t201-elemrestriction-f .. ok
t405-qfunction .......... ok
t204-elemrestriction .... ok
t323-basis .............. ok
t325-basis .............. ok
t322-basis-f ............ ok
t131-vector ............. 
Failed 1/1 subtests 
t538-operator ........... ok
t101-vector ............. ok
t510-operator ........... ok
t410-qfunction-f ........ ok
t520-operator ........... ok
t209-elemrestriction-f .. ok
t411-qfunction-f ........ ok
t570-operator ........... ok
t412-qfunction-f ........ ok
t400-qfunction-f ........ ok
t511-operator ........... ok
t532-operator ........... ok
t564-operator ........... ok
t401-qfunction-f ........ ok
t510-operator-f ......... ok
t511-operator-f ......... ok
t502-operator ........... ok
t300-basis-f ............ ok
t536-operator-f ......... ok
t414-qfunction .......... ok
t302-basis-f ............ ok
t563-operator ........... ok
t504-operator ........... ok
t364-basis .............. ok
t310-basis .............. ok
t560-operator ........... ok
t567-operator ........... ok
t312-basis .............. ok
t415-qfunction .......... ok
t306-basis-f ............ ok
t569-operator ........... ok
t353-basis .............. ok
t523-operator ........... ok
t361-basis .............. ok
t531-operator-f ......... ok
t503-operator-f ......... ok
t523-operator-f ......... ok
t365-basis .............. ok
t562-operator ........... ok
t502-operator-f ......... ok
t539-operator ........... ok
t526-operator ........... ok
t500-operator ........... ok
t568-operator ........... ok
t537-operator ........... ok
t505-operator ........... ok
t521-operator-f ......... ok
t540-operator ........... ok
t534-operator ........... ok
t566-operator ........... ok
t530-operator ........... ok
t505-operator-f ......... ok
t504-operator-f ......... ok
t534-operator-f ......... ok
t530-operator-f ......... ok
t533-operator-f ......... ok
t524-operator ........... ok
t532-operator-f ......... ok
t524-operator-f ......... ok
t522-operator-f ......... ok
t501-operator-f ......... ok
t520-operator-f ......... ok
t522-operator ........... ok
t500-operator-f ......... ok
t535-operator ........... ok
t551-operator ........... ok
t535-operator-f ......... ok
t533-operator ........... ok
t561-operator ........... ok
t531-operator ........... ok
t357-basis .............. ok
t506-operator ........... ok
t316-basis .............. ok
t553-operator-f ......... ok
t550-operator-f ......... ok
t550-operator ........... ok
t552-operator ........... ok
t506-operator-f ......... ok
t565-operator ........... ok
t521-operator ........... ok
t552-operator-f ......... ok
t541-operator ........... ok
t318-basis .............. ok
t314-basis .............. ok
t553-operator ........... ok
t315-basis .............. ok
t540-operator-f ......... ok
t354-basis .............. ok
t554-operator ........... ok
t314-basis-f ............ ok
t356-basis .............. ok
t351-basis .............. ok
t313-basis-f ............ ok
t352-basis .............. ok
ex3-volume .............. ok
t313-basis .............. ok
ex1-volume-f ............ 
Failed 3/6 subtests 
t319-basis .............. ok
ex2-surface ............. ok
ex1-volume .............. ok

Test Summary Report
-------------------
t406-qfunction        (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
t130-vector           (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
t131-vector           (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
ex1-volume-f          (Wstat: 0 Tests: 6 Failed: 3)
  Failed tests:  1-3
Files=257, Tests=284, 24 wallclock secs ( 0.80 usr  0.34 sys + 578.11 cusr 761.38 csys = 1340.63 CPU)
Result: FAIL
make: *** [Makefile:851: prove] Error 1
```
</details>

<details>
<summary>Full make prove output — after (sycl-fixes)</summary>

```
=== Running tests for /gpu/sycl/ref (after PR) ===
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
make: 'lib' with optional backends: /gpu/sycl/ref
      LINK.c build/t000-ceed
      LINK.c build/t001-ceed
      LINK.c build/t002-ceed
      LINK.c build/t003-ceed
      LINK.c build/t004-ceed
      LINK.c build/t005-ceed
      LINK.c build/t006-ceed
      LINK.c build/t007-ceed
      LINK.c build/t008-ceed
      LINK.c build/t009-ceed
      LINK.c build/t010-config
      LINK.c build/t100-vector
      LINK.c build/t101-vector
      LINK.c build/t102-vector
      LINK.c build/t103-vector
      LINK.c build/t104-vector
      LINK.c build/t105-vector
      LINK.c build/t106-vector
      LINK.c build/t107-vector
      LINK.c build/t108-vector
      LINK.c build/t109-vector
      LINK.c build/t110-vector
      LINK.c build/t111-vector
      LINK.c build/t112-vector
      LINK.c build/t113-vector
      LINK.c build/t114-vector
      LINK.c build/t115-vector
      LINK.c build/t116-vector
      LINK.c build/t117-vector
      LINK.c build/t118-vector
      LINK.c build/t119-vector
      LINK.c build/t120-vector
      LINK.c build/t121-vector
      LINK.c build/t122-vector
      LINK.c build/t123-vector
      LINK.c build/t124-vector
      LINK.c build/t125-vector
      LINK.c build/t126-vector
      LINK.c build/t127-vector
      LINK.c build/t128-vector
      LINK.c build/t130-vector
      LINK.c build/t131-vector
      LINK.c build/t200-elemrestriction
      LINK.c build/t201-elemrestriction
      LINK.c build/t202-elemrestriction
      LINK.c build/t203-elemrestriction
      LINK.c build/t204-elemrestriction
      LINK.c build/t205-elemrestriction
      LINK.c build/t206-elemrestriction
      LINK.c build/t207-elemrestriction
      LINK.c build/t208-elemrestriction
      LINK.c build/t209-elemrestriction
      LINK.c build/t210-elemrestriction
      LINK.c build/t211-elemrestriction
      LINK.c build/t212-elemrestriction
      LINK.c build/t213-elemrestriction
      LINK.c build/t214-elemrestriction
      LINK.c build/t215-elemrestriction
      LINK.c build/t216-elemrestriction
      LINK.c build/t217-elemrestriction
      LINK.c build/t218-elemrestriction
      LINK.c build/t219-elemrestriction
      LINK.c build/t220-elemrestriction
      LINK.c build/t230-elemrestriction
      LINK.c build/t231-elemrestriction
      LINK.c build/t232-elemrestriction
      LINK.c build/t233-elemrestriction
      LINK.c build/t234-elemrestriction
      LINK.c build/t300-basis
      LINK.c build/t301-basis
      LINK.c build/t302-basis
      LINK.c build/t303-basis
      LINK.c build/t304-basis
      LINK.c build/t305-basis
      LINK.c build/t306-basis
      LINK.c build/t307-basis
      LINK.c build/t310-basis
      LINK.c build/t311-basis
      LINK.c build/t312-basis
      LINK.c build/t313-basis
      LINK.c build/t314-basis
      LINK.c build/t315-basis
      LINK.c build/t316-basis
      LINK.c build/t317-basis
      LINK.c build/t318-basis
      LINK.c build/t319-basis
      LINK.c build/t320-basis
      LINK.c build/t321-basis
      LINK.c build/t322-basis
      LINK.c build/t323-basis
      LINK.c build/t324-basis
      LINK.c build/t325-basis
      LINK.c build/t330-basis
      LINK.c build/t331-basis
      LINK.c build/t332-basis
      LINK.c build/t340-basis
      LINK.c build/t341-basis
      LINK.c build/t342-basis
      LINK.c build/t350-basis
      LINK.c build/t351-basis
      LINK.c build/t352-basis
      LINK.c build/t353-basis
      LINK.c build/t354-basis
      LINK.c build/t355-basis
      LINK.c build/t356-basis
      LINK.c build/t357-basis
      LINK.c build/t360-basis
      LINK.c build/t361-basis
      LINK.c build/t362-basis
      LINK.c build/t363-basis
      LINK.c build/t364-basis
      LINK.c build/t365-basis
      LINK.c build/t400-qfunction
      LINK.c build/t401-qfunction
      LINK.c build/t402-qfunction
      LINK.c build/t403-qfunction
      LINK.c build/t404-qfunction
      LINK.c build/t405-qfunction
      LINK.c build/t406-qfunction
      LINK.c build/t407-qfunction
      LINK.c build/t408-qfunction
      LINK.c build/t409-qfunction
      LINK.c build/t410-qfunction
      LINK.c build/t411-qfunction
      LINK.c build/t412-qfunction
      LINK.c build/t413-qfunction
      LINK.c build/t414-qfunction
      LINK.c build/t415-qfunction
      LINK.c build/t500-operator
      LINK.c build/t501-operator
      LINK.c build/t502-operator
      LINK.c build/t503-operator
      LINK.c build/t504-operator
      LINK.c build/t505-operator
      LINK.c build/t506-operator
      LINK.c build/t507-operator
      LINK.c build/t508-operator
      LINK.c build/t509-operator
      LINK.c build/t510-operator
      LINK.c build/t511-operator
      LINK.c build/t520-operator
      LINK.c build/t521-operator
      LINK.c build/t522-operator
      LINK.c build/t523-operator
      LINK.c build/t524-operator
      LINK.c build/t525-operator
      LINK.c build/t526-operator
      LINK.c build/t530-operator
      LINK.c build/t531-operator
      LINK.c build/t532-operator
      LINK.c build/t533-operator
      LINK.c build/t534-operator
      LINK.c build/t535-operator
      LINK.c build/t536-operator
      LINK.c build/t537-operator
      LINK.c build/t538-operator
      LINK.c build/t539-operator
      LINK.c build/t540-operator
      LINK.c build/t541-operator
      LINK.c build/t550-operator
      LINK.c build/t551-operator
      LINK.c build/t552-operator
      LINK.c build/t553-operator
      LINK.c build/t554-operator
      LINK.c build/t560-operator
      LINK.c build/t561-operator
      LINK.c build/t562-operator
      LINK.c build/t563-operator
      LINK.c build/t564-operator
      LINK.c build/t565-operator
      LINK.c build/t566-operator
      LINK.c build/t567-operator
      LINK.c build/t568-operator
      LINK.c build/t569-operator
      LINK.c build/t570-operator
      LINK.c build/t580-operator
      LINK.c build/t581-operator
      LINK.c build/t582-operator
      LINK.c build/t583-operator
      LINK.c build/t590-operator
      LINK.c build/t591-operator
      LINK.c build/t592-operator
      LINK.c build/t593-operator
      LINK.c build/t594-operator
      LINK.c build/t595-operator
      LINK.c build/t596-operator
      LINK.c build/t597-operator
      LINK.c build/t598-operator
      LINK.c build/t599-operator
      LINK.F build/t000-ceed-f
      LINK.F build/t001-ceed-f
      LINK.F build/t003-ceed-f
      LINK.F build/t004-ceed-f
      LINK.F build/t100-vector-f
      LINK.F build/t101-vector-f
      LINK.F build/t102-vector-f
      LINK.F build/t103-vector-f
      LINK.F build/t104-vector-f
      LINK.F build/t105-vector-f
      LINK.F build/t106-vector-f
      LINK.F build/t107-vector-f
      LINK.F build/t108-vector-f
      LINK.F build/t109-vector-f
      LINK.F build/t119-vector-f
      LINK.F build/t124-vector-f
      LINK.F build/t200-elemrestriction-f
      LINK.F build/t201-elemrestriction-f
      LINK.F build/t202-elemrestriction-f
      LINK.F build/t208-elemrestriction-f
      LINK.F build/t209-elemrestriction-f
      LINK.F build/t210-elemrestriction-f
      LINK.F build/t211-elemrestriction-f
      LINK.F build/t212-elemrestriction-f
      LINK.F build/t300-basis-f
      LINK.F build/t302-basis-f
      LINK.F build/t306-basis-f
      LINK.F build/t313-basis-f
      LINK.F build/t314-basis-f
      LINK.F build/t320-basis-f
      LINK.F build/t322-basis-f
      LINK.F build/t323-basis-f
      LINK.F build/t400-qfunction-f
      LINK.F build/t401-qfunction-f
      LINK.F build/t402-qfunction-f
      LINK.F build/t410-qfunction-f
      LINK.F build/t411-qfunction-f
      LINK.F build/t412-qfunction-f
      LINK.F build/t413-qfunction-f
      LINK.F build/t500-operator-f
      LINK.F build/t501-operator-f
      LINK.F build/t502-operator-f
      LINK.F build/t503-operator-f
      LINK.F build/t504-operator-f
      LINK.F build/t505-operator-f
      LINK.F build/t506-operator-f
      LINK.F build/t510-operator-f
      LINK.F build/t511-operator-f
      LINK.F build/t520-operator-f
      LINK.F build/t521-operator-f
      LINK.F build/t522-operator-f
      LINK.F build/t523-operator-f
      LINK.F build/t524-operator-f
      LINK.F build/t530-operator-f
      LINK.F build/t531-operator-f
      LINK.F build/t532-operator-f
      LINK.F build/t533-operator-f
      LINK.F build/t534-operator-f
      LINK.F build/t535-operator-f
      LINK.F build/t536-operator-f
      LINK.F build/t540-operator-f
      LINK.F build/t550-operator-f
      LINK.F build/t552-operator-f
      LINK.F build/t553-operator-f
      LINK.c build/ex1-volume
      LINK.c build/ex2-surface
      LINK.c build/ex3-volume
      LINK.F build/ex1-volume-f
Testing backends: /gpu/sycl/ref
prove -j 208 --exec '/opt/aurora/25.190.0/oneapi/intel-conda-miniforge/bin/python3 tests/junit.py' t000-ceed t001-ceed t002-ceed t003-ceed t004-ceed t005-ceed t006-ceed t007-ceed t008-ceed t009-ceed t010-config t100-vector t101-vector t102-vector t103-vector t104-vector t105-vector t106-vector t107-vector t108-vector t109-vector t110-vector t111-vector t112-vector t113-vector t114-vector t115-vector t116-vector t117-vector t118-vector t119-vector t120-vector t121-vector t122-vector t123-vector t124-vector t125-vector t126-vector t127-vector t128-vector t130-vector t131-vector t200-elemrestriction t201-elemrestriction t202-elemrestriction t203-elemrestriction t204-elemrestriction t205-elemrestriction t206-elemrestriction t207-elemrestriction t208-elemrestriction t209-elemrestriction t210-elemrestriction t211-elemrestriction t212-elemrestriction t213-elemrestriction t214-elemrestriction t215-elemrestriction t216-elemrestriction t217-elemrestriction t218-elemrestriction t219-elemrestriction t220-elemrestriction t230-elemrestriction t231-elemrestriction t232-elemrestriction t233-elemrestriction t234-elemrestriction t300-basis t301-basis t302-basis t303-basis t304-basis t305-basis t306-basis t307-basis t310-basis t311-basis t312-basis t313-basis t314-basis t315-basis t316-basis t317-basis t318-basis t319-basis t320-basis t321-basis t322-basis t323-basis t324-basis t325-basis t330-basis t331-basis t332-basis t340-basis t341-basis t342-basis t350-basis t351-basis t352-basis t353-basis t354-basis t355-basis t356-basis t357-basis t360-basis t361-basis t362-basis t363-basis t364-basis t365-basis t400-qfunction t401-qfunction t402-qfunction t403-qfunction t404-qfunction t405-qfunction t406-qfunction t407-qfunction t408-qfunction t409-qfunction t410-qfunction t411-qfunction t412-qfunction t413-qfunction t414-qfunction t415-qfunction t500-operator t501-operator t502-operator t503-operator t504-operator t505-operator t506-operator t507-operator t508-operator t509-operator t510-operator t511-operator t520-operator t521-operator t522-operator t523-operator t524-operator t525-operator t526-operator t530-operator t531-operator t532-operator t533-operator t534-operator t535-operator t536-operator t537-operator t538-operator t539-operator t540-operator t541-operator t550-operator t551-operator t552-operator t553-operator t554-operator t560-operator t561-operator t562-operator t563-operator t564-operator t565-operator t566-operator t567-operator t568-operator t569-operator t570-operator t580-operator t581-operator t582-operator t583-operator t590-operator t591-operator t592-operator t593-operator t594-operator t595-operator t596-operator t597-operator t598-operator t599-operator t000-ceed-f t001-ceed-f t003-ceed-f t004-ceed-f t100-vector-f t101-vector-f t102-vector-f t103-vector-f t104-vector-f t105-vector-f t106-vector-f t107-vector-f t108-vector-f t109-vector-f t119-vector-f t124-vector-f t200-elemrestriction-f t201-elemrestriction-f t202-elemrestriction-f t208-elemrestriction-f t209-elemrestriction-f t210-elemrestriction-f t211-elemrestriction-f t212-elemrestriction-f t300-basis-f t302-basis-f t306-basis-f t313-basis-f t314-basis-f t320-basis-f t322-basis-f t323-basis-f t400-qfunction-f t401-qfunction-f t402-qfunction-f t410-qfunction-f t411-qfunction-f t412-qfunction-f t413-qfunction-f t500-operator-f t501-operator-f t502-operator-f t503-operator-f t504-operator-f t505-operator-f t506-operator-f t510-operator-f t511-operator-f t520-operator-f t521-operator-f t522-operator-f t523-operator-f t524-operator-f t530-operator-f t531-operator-f t532-operator-f t533-operator-f t534-operator-f t535-operator-f t536-operator-f t540-operator-f t550-operator-f t552-operator-f t553-operator-f ex1-volume ex2-surface ex3-volume ex1-volume-f :: --mode tap --ceed-backends /gpu/sycl/ref --nproc 1 --pool-size 1 --search '.*'
t113-vector ............. ok
t007-ceed ............... ok
t110-vector ............. ok
t102-vector ............. ok
t112-vector ............. ok
t006-ceed ............... ok
t114-vector ............. ok
t115-vector ............. ok
t111-vector ............. ok
t116-vector ............. ok
t118-vector ............. ok
t301-basis .............. ok
t117-vector ............. ok
t303-basis .............. ok
t304-basis .............. ok
t305-basis .............. ok
t306-basis .............. ok
t594-operator ........... ok
t218-elemrestriction .... ok
t119-vector-f ........... ok
t126-vector ............. ok
t324-basis .............. ok
t105-vector-f ........... ok
t202-elemrestriction .... ok
t582-operator ........... ok
t592-operator ........... ok
t214-elemrestriction .... ok
t598-operator ........... ok
t404-qfunction .......... ok
t220-elemrestriction .... ok
t596-operator ........... ok
t130-vector ............. ok
t131-vector ............. ok
t000-ceed ............... ok
t003-ceed-f ............. ok
t590-operator ........... ok
t341-basis .............. ok
t320-basis .............. ok
t105-vector ............. ok
t201-elemrestriction .... ok
t210-elemrestriction-f .. ok
t010-config ............. ok
t310-basis .............. ok
t362-basis .............. ok
t009-ceed ............... ok
t207-elemrestriction .... ok
t213-elemrestriction .... ok
t102-vector-f ........... ok
t403-qfunction .......... ok
t414-qfunction .......... ok
t001-ceed-f ............. ok
t312-basis .............. ok
t124-vector-f ........... ok
t202-elemrestriction-f .. ok
t302-basis-f ............ ok
t209-elemrestriction .... ok
t563-operator ........... ok
t400-qfunction .......... ok
t104-vector ............. ok
t204-elemrestriction .... ok
t104-vector-f ........... ok
t599-operator ........... ok
t365-basis .............. ok
t580-operator ........... ok
t004-ceed-f ............. ok
t361-basis .............. ok
t125-vector ............. ok
t127-vector ............. ok
t317-basis .............. ok
t212-elemrestriction-f .. ok
t508-operator ........... ok
t106-vector ............. ok
t216-elemrestriction .... ok
t402-qfunction-f ........ ok
t412-qfunction .......... ok
t219-elemrestriction .... ok
t323-basis-f ............ ok
t234-elemrestriction .... ok
t583-operator ........... ok
t008-ceed ............... ok
t103-vector ............. ok
t500-operator ........... ok
t201-elemrestriction-f .. ok
t109-vector ............. ok
t400-qfunction-f ........ ok
t410-qfunction .......... ok
t538-operator ........... ok
t128-vector ............. ok
t215-elemrestriction .... ok
t001-ceed ............... ok
t411-qfunction .......... ok
t525-operator ........... ok
t107-vector-f ........... ok
t325-basis .............. ok
t401-qfunction .......... ok
t330-basis .............. ok
t230-elemrestriction .... ok
t106-vector-f ........... ok
t595-operator ........... ok
t342-basis .............. ok
t402-qfunction .......... ok
t217-elemrestriction .... ok
t322-basis-f ............ ok
t509-operator ........... ok
t005-ceed ............... ok
t232-elemrestriction .... ok
t406-qfunction .......... ok
t408-qfunction .......... ok
t200-elemrestriction .... ok
t511-operator ........... ok
t210-elemrestriction .... ok
t233-elemrestriction .... ok
t593-operator ........... ok
t004-ceed ............... ok
t203-elemrestriction .... ok
t581-operator ........... ok
t560-operator ........... ok
t331-basis .............. ok
t407-qfunction .......... ok
t002-ceed ............... ok
t208-elemrestriction .... ok
t591-operator ........... ok
t320-basis-f ............ ok
t340-basis .............. ok
t332-basis .............. ok
t597-operator ........... ok
t363-basis .............. ok
t003-ceed ............... ok
t101-vector-f ........... ok
t208-elemrestriction-f .. ok
t109-vector-f ........... ok
t100-vector-f ........... ok
t323-basis .............. ok
t322-basis .............. ok
t212-elemrestriction .... ok
t413-qfunction-f ........ ok
t211-elemrestriction .... ok
t211-elemrestriction-f .. ok
t321-basis .............. ok
t413-qfunction .......... ok
t200-elemrestriction-f .. ok
t231-elemrestriction .... ok
t401-qfunction-f ........ ok
t103-vector-f ........... ok
t100-vector ............. ok
t108-vector ............. ok
t000-ceed-f ............. ok
t411-qfunction-f ........ ok
t107-vector ............. ok
t123-vector ............. ok
t124-vector ............. ok
t206-elemrestriction .... ok
t108-vector-f ........... ok
t569-operator ........... ok
t205-elemrestriction .... ok
t119-vector ............. ok
t122-vector ............. ok
t120-vector ............. ok
t360-basis .............. ok
t412-qfunction-f ........ ok
t409-qfunction .......... ok
t101-vector ............. ok
t209-elemrestriction-f .. ok
t300-basis-f ............ ok
t526-operator ........... ok
t522-operator ........... ok
t510-operator-f ......... ok
t121-vector ............. ok
t405-qfunction .......... ok
t410-qfunction-f ........ ok
t510-operator ........... ok
t511-operator-f ......... ok
t520-operator ........... ok
t570-operator ........... ok
t355-basis .............. ok
t300-basis .............. ok
t536-operator-f ......... ok
t521-operator ........... ok
t564-operator ........... ok
t415-qfunction .......... ok
t536-operator ........... ok
t568-operator ........... ok
t503-operator ........... ok
t537-operator ........... ok
t307-basis .............. ok
t523-operator ........... ok
t306-basis-f ............ ok
t501-operator-f ......... ok
t505-operator ........... ok
t302-basis .............. ok
t552-operator ........... ok
t504-operator ........... ok
t350-basis .............. ok
t567-operator ........... ok
t566-operator ........... ok
t507-operator ........... ok
t502-operator ........... ok
t502-operator-f ......... ok
t524-operator ........... ok
t503-operator-f ......... ok
t531-operator ........... ok
t534-operator ........... ok
t533-operator-f ......... ok
t353-basis .............. ok
t532-operator ........... ok
t530-operator-f ......... ok
t500-operator-f ......... ok
t535-operator ........... ok
t504-operator-f ......... ok
t534-operator-f ......... ok
t520-operator-f ......... ok
t501-operator ........... ok
t311-basis .............. ok
t364-basis .............. ok
t524-operator-f ......... ok
t562-operator ........... ok
t539-operator ........... ok
t530-operator ........... ok
t550-operator ........... ok
t505-operator-f ......... ok
t522-operator-f ......... ok
t313-basis .............. ok
t561-operator ........... ok
t523-operator-f ......... ok
t540-operator ........... ok
t506-operator ........... ok
t565-operator ........... ok
t521-operator-f ......... ok
t533-operator ........... ok
t541-operator ........... ok
t531-operator-f ......... ok
t540-operator-f ......... ok
t553-operator ........... ok
t506-operator-f ......... ok
t535-operator-f ......... ok
t532-operator-f ......... ok
t553-operator-f ......... ok
t551-operator ........... ok
t552-operator-f ......... ok
t550-operator-f ......... ok
t318-basis .............. ok
t314-basis .............. ok
t351-basis .............. ok
t314-basis-f ............ ok
t554-operator ........... ok
t354-basis .............. ok
t315-basis .............. ok
ex3-volume .............. ok
t357-basis .............. ok
t316-basis .............. ok
t352-basis .............. ok
t356-basis .............. ok
t313-basis-f ............ ok
ex2-surface ............. ok
ex1-volume .............. ok
ex1-volume-f ............ ok
t319-basis .............. ok
All tests successful.
Files=257, Tests=284, 28 wallclock secs ( 0.70 usr  0.31 sys + 583.19 cusr 1212.53 csys = 1796.73 CPU)
Result: PASS
Prove exit: 0
```
</details>

LLM/GenAI Disclosure:

These fixes were developed with Claude (Anthropic) assistance: root cause analysis, code changes, and test iteration. All code was reviewed and verified by the submitter on hardware.

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.