### PR TITLE
Clang-Tidy in CI Fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ noether-asan:
     - make -k -j$((NPROC_CPU / NPROC_POOL)) BACKENDS="$BACKENDS_CPU" JUNIT_BATCH="memcheck" junit realsearch=%
     # Clang-tidy
     - echo "-------------- clang-tidy ----------" && clang-tidy --version
-    - TIDY_OPTS="-fix-errors" make -j$NPROC_CPU tidy && git diff --color=always --exit-code
+    - TIDY_OPTS="-fix-errors -warnings-as-errors=" make -j$NPROC_CPU tidy
     # Report status
     - touch .SUCCESS
   artifacts:
@@ -284,7 +284,7 @@ noether-cuda:
     - make -k -j$((NPROC_GPU / NPROC_POOL)) BACKENDS="$BACKENDS_GPU" JUNIT_BATCH="cuda" junit search=dealii DEAL_II_DIR=$DEAL_II_DIR
     # Clang-tidy
     - echo "-------------- clang-tidy ----------" && clang-tidy --version
-    - TIDY_OPTS="-fix-errors" make -j$NPROC_CPU tidy && git diff --color=always --exit-code
+    - TIDY_OPTS="-fix-errors -warnings-as-errors=" make -j$NPROC_CPU tidy
     # Report status
     - touch .SUCCESS
   after_script:
@@ -351,7 +351,7 @@ noether-cuda:
 #    - make -k -j$((NPROC_GPU / NPROC_POOL)) BACKENDS="$BACKENDS_GPU" JUNIT_BATCH="hip" junit search="petsc fluids solids"
 #    # Clang-tidy
 #    - echo "-------------- clang-tidy ----------" && clang-tidy --version
-#    - TIDY_OPTS="-fix-errors" make -j$NPROC_CPU tidy && git diff --color=always --exit-code
+#    - TIDY_OPTS="-fix-errors -warnings-as-errors=" make -j$NPROC_CPU tidy
 #    # Report status
 #    - touch .SUCCESS
 #  after_script:
@@ -402,7 +402,7 @@ noether-rocm:
     - make -j$NPROC_CPU
     # Clang-tidy
     - echo "-------------- clang-tidy ----------" && clang-tidy --version
-    - TIDY_OPTS="-fix-errors" make -j$NPROC_CPU tidy && git diff --color=always --exit-code
+    - TIDY_OPTS="-fix-errors -warnings-as-errors=" make -j$NPROC_CPU tidy
     # Report status
     - touch .SUCCESS
 

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -41,8 +41,6 @@ typedef size_t fortran_charlen_t;
 typedef int fortran_charlen_t;
 #endif
 
-#define Splice(a, b) a##b
-
 // Fortran strings are generally unterminated and the length is passed as an
 // extra argument after all the normal arguments.  Some compilers (I only know
 // of Windows) place the length argument immediately after the string parameter
@@ -51,11 +49,13 @@ typedef int fortran_charlen_t;
 // We can't just NULL-terminate the string in-place because that could overwrite
 // other strings or attempt to write to read-only memory.  This macro allocates
 // a string to hold the null-terminated version of the string that C expects.
-#define FIX_STRING(stringname)                                                                                                            \
-  char Splice(stringname, _c)[1024];                                                                                                      \
-  if (Splice(stringname, _len) > 1023) *err = CeedError(NULL, 1, "Fortran string length too long %zd", (size_t)Splice(stringname, _len)); \
-  strncpy(Splice(stringname, _c), stringname, Splice(stringname, _len));                                                                  \
-  Splice(stringname, _c)[Splice(stringname, _len)] = 0;
+#define CEED_MAX_FORTRAN_STRING_LEN 1024
+#define FIX_STRING(stringname)                                                             \
+  char stringname##_c[CEED_MAX_FORTRAN_STRING_LEN] = {'\0'};                               \
+  if (stringname##_len > CEED_MAX_FORTRAN_STRING_LEN - 1) {                                \
+    *err = CeedError(NULL, 1, "Fortran string too long: %zd", (size_t)(stringname##_len)); \
+  }                                                                                        \
+  strncpy(stringname##_c, stringname, CeedIntMin(stringname##_len, CEED_MAX_FORTRAN_STRING_LEN - 1));
 
 // -----------------------------------------------------------------------------
 // Ceed


### PR DESCRIPTION
Purpose:

First I fix a minor logic bug in the Fortran string copying logic. Then I force `clang-tidy` to always throw an error when warnings occur.

Closes: #N/A

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
