### PR TITLE
ci - CUDA wants GCC 14 or earlier

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ noether-rust-qfunctions:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran NVCC=nvcc GPU_CLANG=1
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc GPU_CLANG=1
     - export NPROC_POOL=1
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
@@ -186,7 +186,7 @@ noether-rust-qfunctions:
     - echo "-------------- NVCC ----------------" && $NVCC --version
     - echo "-------------- Rustc ---------------" && rustc --version
     - echo "-------------- Clang++ -------------" && clang++ --version
-    - echo "-------------- GCOV ----------------" && gcov --version
+    - echo "-------------- GCOV ----------------" && gcov-14 --version
   script:
     - rm -f .SUCCESS
     # Rustup
@@ -230,14 +230,14 @@ noether-cuda:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran NVCC=nvcc
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc
     - export NPROC_POOL=4
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- FC ------------------" && $FC --version
     - echo "-------------- NVCC ----------------" && $NVCC --version
-    - echo "-------------- GCOV ----------------" && gcov --version
+    - echo "-------------- GCOV ----------------" && gcov-14 --version
     # ASAN
     - echo "-------------- ASAN ----------------"
     - export ASAN=1 AFLAGS="-fsanitize=address -fsanitize=leak" ASAN_OPTIONS=protect_shadow_gap=0
@@ -418,13 +418,13 @@ noether-float:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc CXX=g++ FC= NVCC=nvcc
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC= NVCC=nvcc
     - export NPROC_POOL=8
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- NVCC ----------------" && $NVCC --version
-    - echo "-------------- GCOV ----------------" && gcov --version
+    - echo "-------------- GCOV ----------------" && gcov-14 --version
     # Libraries for backends
 # ROCm tests currently disabled
 # -- MAGMA from dev branch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,54 +170,54 @@ noether-cpu:
 # ----------------------------------------------------------------------------------------
 # Rust + CUDA
 # ----------------------------------------------------------------------------------------
-noether-rust-qfunctions:
-  stage: test:gpu-and-float
-  tags:
-    - cuda
-  interruptible: true
-  before_script:
-    # Environment
-    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc GPU_CLANG=1
-    - export NPROC_POOL=1
-    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
-    - echo "-------------- CC ------------------" && $CC --version
-    - echo "-------------- CXX -----------------" && $CXX --version
-    - echo "-------------- FC ------------------" && $FC --version
-    - echo "-------------- NVCC ----------------" && $NVCC --version
-    - echo "-------------- Rustc ---------------" && rustc --version
-    - echo "-------------- Clang++ -------------" && clang++ --version
-    - echo "-------------- GCOV ----------------" && gcov-14 --version
-  script:
-    - rm -f .SUCCESS
-    # Rustup
-    - rustup update nightly
-    - rustup component add rust-src --toolchain nightly
-    - rustup component add llvm-tools --toolchain nightly
-    # libCEED
-    - make configure OPT='-g -O0 -fno-inline -march=native -ffp-contract=fast' CUDA_DIR=/usr/local/cuda-12.9
-    - echo "-------------- libCEED -------------" && make info
-    - make clean
-    - make -k -j$NPROC_CPU -l$NPROC_CPU
-    # -- libCEED only tests
-    - echo "-------------- Rust QFunction tests -----"
-    #    Note: PETSC_DIR is set by default in GitLab runner env, unsetting to isolate core tests
-    - export PETSC_DIR= PETSC_ARCH=
-    - make -k -j$((NPROC_GPU / NPROC_POOL)) JUNIT_BATCH="rust-qfunction" junit search=rustqfunction
-    # Report status
-    - touch .SUCCESS
-  after_script:
-    - |
-      if [ -f .SUCCESS ]; then
-        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
-        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
-        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
-        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
-      fi
-  artifacts:
-    paths:
-      - build/*.junit
-    reports:
-      junit: build/*.junit
+#noether-rust-qfunctions:
+#  stage: test:gpu-and-float
+#  tags:
+#    - cuda
+#  interruptible: true
+#  before_script:
+#    # Environment
+#    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc GPU_CLANG=1
+#    - export NPROC_POOL=1
+#    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
+#    - echo "-------------- CC ------------------" && $CC --version
+#    - echo "-------------- CXX -----------------" && $CXX --version
+#    - echo "-------------- FC ------------------" && $FC --version
+#    - echo "-------------- NVCC ----------------" && $NVCC --version
+#    - echo "-------------- Rustc ---------------" && rustc --version
+#    - echo "-------------- Clang++ -------------" && clang++ --version
+#    - echo "-------------- GCOV ----------------" && gcov-14 --version
+#  script:
+#    - rm -f .SUCCESS
+#    # Rustup
+#    - rustup update nightly
+#    - rustup component add rust-src --toolchain nightly
+#    - rustup component add llvm-tools --toolchain nightly
+#    # libCEED
+#    - make configure OPT='-g -O0 -fno-inline -march=native -ffp-contract=fast' CUDA_DIR=/usr/local/cuda-12.9
+#    - echo "-------------- libCEED -------------" && make info
+#    - make clean
+#    - make -k -j$NPROC_CPU -l$NPROC_CPU
+#    # -- libCEED only tests
+#    - echo "-------------- Rust QFunction tests -----"
+#    #    Note: PETSC_DIR is set by default in GitLab runner env, unsetting to isolate core tests
+#    - export PETSC_DIR= PETSC_ARCH=
+#    - make -k -j$((NPROC_GPU / NPROC_POOL)) JUNIT_BATCH="rust-qfunction" junit search=rustqfunction
+#    # Report status
+#    - touch .SUCCESS
+#  after_script:
+#    - |
+#      if [ -f .SUCCESS ]; then
+#        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+#        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
+#        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
+#        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
+#      fi
+#  artifacts:
+#    paths:
+#      - build/*.junit
+#    reports:
+#      junit: build/*.junit
 
 
 # ----------------------------------------------------------------------------------------

--- a/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
+++ b/backends/cuda-gen/ceed-cuda-gen-operator-build.cpp
@@ -13,6 +13,7 @@
 #include <ceed/jit-tools.h>
 #include <cuda_runtime.h>
 
+#include <cassert>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -391,6 +392,9 @@ static int CeedOperatorBuildKernelRestriction_Cuda_gen(std::ostringstream &code,
   CeedRestrictionType       rstr_type = CEED_RESTRICTION_STANDARD;
   CeedElemRestriction_Cuda *rstr_data;
   CeedElemRestriction       elem_rstr;
+
+  // Verify bounds
+  assert(i >= 0 && i < CEED_CUDA_NUMBER_FIELDS);
 
   // Get field data
   CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_field, &elem_rstr));

--- a/backends/hip-gen/ceed-hip-gen-operator-build.cpp
+++ b/backends/hip-gen/ceed-hip-gen-operator-build.cpp
@@ -12,6 +12,7 @@
 #include <ceed/gen-tools.h>
 #include <ceed/jit-tools.h>
 
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -419,6 +420,9 @@ static int CeedOperatorBuildKernelRestriction_Hip_gen(std::ostringstream &code, 
   CeedRestrictionType      rstr_type = CEED_RESTRICTION_STANDARD;
   CeedElemRestriction_Hip *rstr_data;
   CeedElemRestriction      elem_rstr;
+
+  // Verify bounds
+  assert(i >= 0 && i < CEED_HIP_NUMBER_FIELDS);
 
   // Get field data
   CeedCallBackend(CeedOperatorFieldGetElemRestriction(op_field, &elem_rstr));

--- a/interface/ceed-qfunction.c
+++ b/interface/ceed-qfunction.c
@@ -836,6 +836,7 @@ int CeedQFunctionAddInput(CeedQFunction qf, const char *field_name, CeedInt size
 
   CeedCall(CeedQFunctionIsImmutable(qf, &is_immutable));
   CeedCheck(!is_immutable, CeedQFunctionReturnCeed(qf), CEED_ERROR_MAJOR, "QFunction cannot be changed after set as immutable");
+  CeedCheck(qf->num_input_fields < CEED_FIELD_MAX, CeedQFunctionReturnCeed(qf), CEED_ERROR_MINOR, "Can only add %d input fields", CEED_FIELD_MAX);
   CeedCheck(eval_mode != CEED_EVAL_WEIGHT || size == 1, CeedQFunctionReturnCeed(qf), CEED_ERROR_DIMENSION, "CEED_EVAL_WEIGHT should have size 1");
   for (CeedInt i = 0; i < qf->num_input_fields; i++) {
     CeedCheck(strcmp(field_name, qf->input_fields[i]->field_name), CeedQFunctionReturnCeed(qf), CEED_ERROR_MINOR,
@@ -878,6 +879,7 @@ int CeedQFunctionAddOutput(CeedQFunction qf, const char *field_name, CeedInt siz
 
   CeedCall(CeedQFunctionIsImmutable(qf, &is_immutable));
   CeedCheck(!is_immutable, CeedQFunctionReturnCeed(qf), CEED_ERROR_MAJOR, "CeedQFunction cannot be changed after set as immutable");
+  CeedCheck(qf->num_output_fields < CEED_FIELD_MAX, CeedQFunctionReturnCeed(qf), CEED_ERROR_MINOR, "Can only add %d output fields", CEED_FIELD_MAX);
   CeedCheck(eval_mode != CEED_EVAL_WEIGHT, CeedQFunctionReturnCeed(qf), CEED_ERROR_DIMENSION,
             "Cannot create CeedQFunction output with CEED_EVAL_WEIGHT");
   for (CeedInt i = 0; i < qf->num_input_fields; i++) {


### PR DESCRIPTION
Purpose:

Repairing CI on Nother for libCEED

- Swap CUDA jobs to using `gcc-14` and `g++-14` (later versions not supported)
- Fix `clang-tidy` warning about field data indices
- Disable the Rust+CUDA job while we fix that further

Closes: #N/A

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
