### PR TITLE
Allow user set CUDA Clang

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,13 +69,14 @@ noether-cpu:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran
+    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran GCOV=gcov
     - export NPROC_POOL=8
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- FC ------------------" && $FC --version
-    - echo "-------------- GCOV ----------------" && gcov --version
+    - echo "-------------- GCOV ----------------" && $GCOV --version
+    - echo "GCOV=$GCOV" > job.env
     # Libraries for backends
     # -- LIBXSMM 7 April 2024
     - cd .. && export XSMM_HASH=94ee71576870152feb62f3f0cf6b061d036dcdb5 && { [[ -d libxsmm-$XSMM_HASH ]] || { curl -L https://github.com/libxsmm/libxsmm/archive/$XSMM_HASH.tar.gz -o xsmm.tar.gz && tar zvxf xsmm.tar.gz && rm xsmm.tar.gz && make -C libxsmm-$XSMM_HASH -j$(nproc); }; } && export XSMM_DIR=$PWD/libxsmm-$XSMM_HASH && cd libCEED
@@ -120,7 +121,8 @@ noether-cpu:
   after_script:
     - |
       if [ -f .SUCCESS ]; then
-        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+        source job.env;
+        lcov --directory . --capture --gcov-tool $GCOV --output-file coverage.info --ignore-errors source,mismatch;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
@@ -177,7 +179,7 @@ noether-rust-qfunctions:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc CEED_USE_CLANG_CUDA=1
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc GCOV=gcov-14 CEED_USE_CLANG_CUDA=1
     - export NPROC_POOL=1
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
@@ -185,8 +187,8 @@ noether-rust-qfunctions:
     - echo "-------------- FC ------------------" && $FC --version
     - echo "-------------- NVCC ----------------" && $NVCC --version
     - echo "-------------- Rustc ---------------" && rustc --version
-    - echo "-------------- Clang++ -------------" && clang++ --version
-    - echo "-------------- GCOV ----------------" && gcov-14 --version
+    - echo "-------------- GCOV ----------------" && $GCOV --version
+    - echo "GCOV=$GCOV" > job.env
   script:
     - rm -f .SUCCESS
     # Rustup
@@ -208,7 +210,8 @@ noether-rust-qfunctions:
   after_script:
     - |
       if [ -f .SUCCESS ]; then
-        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+        source job.env;
+        lcov --directory . --capture --gcov-tool $GCOV --output-file coverage.info --ignore-errors source,mismatch;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
@@ -230,14 +233,15 @@ noether-cuda:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc GCOV=gcov-14
     - export NPROC_POOL=4
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- FC ------------------" && $FC --version
     - echo "-------------- NVCC ----------------" && $NVCC --version
-    - echo "-------------- GCOV ----------------" && gcov-14 --version
+    - echo "-------------- GCOV ----------------" && $GCOV --version
+    - echo "GCOV=$GCOV" > job.env
     # ASAN
     - echo "-------------- ASAN ----------------"
     - export ASAN=1 AFLAGS="-fsanitize=address -fsanitize=leak" ASAN_OPTIONS=protect_shadow_gap=0
@@ -290,7 +294,8 @@ noether-cuda:
   after_script:
     - |
       if [ -f .SUCCESS ]; then
-        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+        source job.env;
+        lcov --directory . --capture --gcov-tool $GCOV --output-file coverage.info --ignore-errors source,mismatch;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
@@ -317,14 +322,15 @@ noether-cuda:
 #  interruptible: true
 #  before_script:
 #    # Environment
-#    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran HIPCC=hipcc
+#    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran HIPCC=hipcc GCOV=gcov
 #    - export NPROC_POOL=4
 #    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
 #    - echo "-------------- CC ------------------" && $CC --version
 #    - echo "-------------- CXX -----------------" && $CXX --version
 #    - echo "-------------- FC ------------------" && $FC --version
 #    - echo "-------------- HIPCC ---------------" && $HIPCC --version
-#    - echo "-------------- GCOV ----------------" && gcov --version
+#    - echo "-------------- GCOV ----------------" && $GCOV --version
+#    - echo "GCOV=$GCOV" > job.env
 #    # Libraries for backends
 #    # -- MAGMA from dev branch
 #    - echo "-------------- MAGMA ---------------"
@@ -357,7 +363,8 @@ noether-cuda:
 #  after_script:
 #    - |
 #      if [ -f .SUCCESS ]; then
-#        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+#        source job.env;
+#        lcov --directory . --capture --gcov-tool $GCOV --output-file coverage.info --ignore-errors source,mismatch;
 #        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
 #        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
 #        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
@@ -379,14 +386,15 @@ noether-rocm:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran HIPCC=hipcc
+    - export COVERAGE=1 CC=gcc CXX=g++ FC=gfortran HIPCC=hipcc GCOV=gcov
     - export NPROC_POOL=4
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- FC ------------------" && $FC --version
     - echo "-------------- HIPCC ---------------" && $HIPCC --version
-    - echo "-------------- GCOV ----------------" && gcov --version
+    - echo "-------------- GCOV ----------------" && $GCOV --version
+    - echo "GCOV=$GCOV" > job.env
     # Libraries for backends
     # -- MAGMA from dev branch
     - echo "-------------- MAGMA ---------------"
@@ -418,13 +426,14 @@ noether-float:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC= NVCC=nvcc
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC= NVCC=nvcc GCOV=gcov-14
     - export NPROC_POOL=8
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version
     - echo "-------------- CXX -----------------" && $CXX --version
     - echo "-------------- NVCC ----------------" && $NVCC --version
-    - echo "-------------- GCOV ----------------" && gcov-14 --version
+    - echo "-------------- GCOV ----------------" && $GCOV --version
+    - echo "GCOV=$GCOV" > job.env
     # Libraries for backends
 # ROCm tests currently disabled
 # -- MAGMA from dev branch
@@ -459,7 +468,8 @@ noether-float:
   after_script:
     - |
       if [ $(cat .job_status) == "SUCCESS" ]; then
-        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+        source job.env;
+        lcov --directory . --capture --gcov-tool $GCOV --output-file coverage.info --ignore-errors source,mismatch;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
         bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,54 +170,54 @@ noether-cpu:
 # ----------------------------------------------------------------------------------------
 # Rust + CUDA
 # ----------------------------------------------------------------------------------------
-#noether-rust-qfunctions:
-#  stage: test:gpu-and-float
-#  tags:
-#    - cuda
-#  interruptible: true
-#  before_script:
-#    # Environment
-#    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc GPU_CLANG=1
-#    - export NPROC_POOL=1
-#    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
-#    - echo "-------------- CC ------------------" && $CC --version
-#    - echo "-------------- CXX -----------------" && $CXX --version
-#    - echo "-------------- FC ------------------" && $FC --version
-#    - echo "-------------- NVCC ----------------" && $NVCC --version
-#    - echo "-------------- Rustc ---------------" && rustc --version
-#    - echo "-------------- Clang++ -------------" && clang++ --version
-#    - echo "-------------- GCOV ----------------" && gcov-14 --version
-#  script:
-#    - rm -f .SUCCESS
-#    # Rustup
-#    - rustup update nightly
-#    - rustup component add rust-src --toolchain nightly
-#    - rustup component add llvm-tools --toolchain nightly
-#    # libCEED
-#    - make configure OPT='-g -O0 -fno-inline -march=native -ffp-contract=fast' CUDA_DIR=/usr/local/cuda-12.9
-#    - echo "-------------- libCEED -------------" && make info
-#    - make clean
-#    - make -k -j$NPROC_CPU -l$NPROC_CPU
-#    # -- libCEED only tests
-#    - echo "-------------- Rust QFunction tests -----"
-#    #    Note: PETSC_DIR is set by default in GitLab runner env, unsetting to isolate core tests
-#    - export PETSC_DIR= PETSC_ARCH=
-#    - make -k -j$((NPROC_GPU / NPROC_POOL)) JUNIT_BATCH="rust-qfunction" junit search=rustqfunction
-#    # Report status
-#    - touch .SUCCESS
-#  after_script:
-#    - |
-#      if [ -f .SUCCESS ]; then
-#        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
-#        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
-#        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
-#        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
-#      fi
-#  artifacts:
-#    paths:
-#      - build/*.junit
-#    reports:
-#      junit: build/*.junit
+noether-rust-qfunctions:
+  stage: test:gpu-and-float
+  tags:
+    - cuda
+  interruptible: true
+  before_script:
+    # Environment
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc CEED_CLANG_CUDA_CXX=clang++-22
+    - export NPROC_POOL=1
+    - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
+    - echo "-------------- CC ------------------" && $CC --version
+    - echo "-------------- CXX -----------------" && $CXX --version
+    - echo "-------------- FC ------------------" && $FC --version
+    - echo "-------------- NVCC ----------------" && $NVCC --version
+    - echo "-------------- Rustc ---------------" && rustc --version
+    - echo "-------------- Clang++ -------------" && clang++ --version
+    - echo "-------------- GCOV ----------------" && gcov-14 --version
+  script:
+    - rm -f .SUCCESS
+    # Rustup
+    - rustup update nightly
+    - rustup component add rust-src --toolchain nightly
+    - rustup component add llvm-tools --toolchain nightly
+    # libCEED
+    - make configure OPT='-g -O0 -fno-inline -march=native -ffp-contract=fast' CUDA_DIR=/usr/local/cuda-12.9
+    - echo "-------------- libCEED -------------" && make info
+    - make clean
+    - make -k -j$NPROC_CPU -l$NPROC_CPU
+    # -- libCEED only tests
+    - echo "-------------- Rust QFunction tests -----"
+    #    Note: PETSC_DIR is set by default in GitLab runner env, unsetting to isolate core tests
+    - export PETSC_DIR= PETSC_ARCH=
+    - make -k -j$((NPROC_GPU / NPROC_POOL)) JUNIT_BATCH="rust-qfunction" junit search=rustqfunction
+    # Report status
+    - touch .SUCCESS
+  after_script:
+    - |
+      if [ -f .SUCCESS ]; then
+        lcov --directory . --capture --output-file coverage.info --ignore-errors source,mismatch;
+        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F interface;
+        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F gallery;
+        bash <(curl -s https://codecov.io/bash) -f coverage.info -t ${CODECOV_ACCESS_TOKEN} -F backends;
+      fi
+  artifacts:
+    paths:
+      - build/*.junit
+    reports:
+      junit: build/*.junit
 
 
 # ----------------------------------------------------------------------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ noether-rust-qfunctions:
   interruptible: true
   before_script:
     # Environment
-    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc CEED_CLANG_CUDA_CXX=clang++-22
+    - export COVERAGE=1 CC=gcc-14 CXX=g++-14 FC=gfortran-14 NVCC=nvcc CEED_USE_CLANG_CUDA=1
     - export NPROC_POOL=1
     - echo "-------------- nproc ---------------" && NPROC_CPU=$(nproc) && NPROC_GPU=$(($(nproc)<8?$(nproc):8)) && echo "NPROC_CPU" $NPROC_CPU && echo "NPROC_GPU" $NPROC_GPU
     - echo "-------------- CC ------------------" && $CC --version

--- a/Makefile
+++ b/Makefile
@@ -799,7 +799,7 @@ external_examples := \
 	$(if $(DEAL_II_DIR),$(dealiiexamples)) \
 	$(if $(PETSC_DIR),$(fluidsexamples)) \
 	$(if $(PETSC_DIR),$(solidsexamples)) \
-	$(if $(or $(RUST_QF),$(GPU_CLANG)),$(rustqfunctionsexamples))
+	$(if $(or $(CEED_USE_CLANG_CUDA),$(CEED_CLANG_CUDA_CXX)),$(rustqfunctionsexamples))
 
 allexamples = $(examples) $(external_examples)
 

--- a/backends/cuda/ceed-cuda-common.c
+++ b/backends/cuda/ceed-cuda-common.c
@@ -42,7 +42,7 @@ int CeedDestroy_Cuda(Ceed ceed) {
 
   CeedCallBackend(CeedGetData(ceed, &data));
   if (data->cublas_handle) CeedCallCublas(ceed, cublasDestroy(data->cublas_handle));
-  CeedCallBackend(CeedFree(&data->llvm_command));
+  CeedCallBackend(CeedFree(&data->llvm_cxx));
   CeedCallBackend(CeedFree(&data));
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/cuda/ceed-cuda-common.c
+++ b/backends/cuda/ceed-cuda-common.c
@@ -42,6 +42,7 @@ int CeedDestroy_Cuda(Ceed ceed) {
 
   CeedCallBackend(CeedGetData(ceed, &data));
   if (data->cublas_handle) CeedCallCublas(ceed, cublasDestroy(data->cublas_handle));
+  CeedCallBackend(CeedFree(&data->llvm_command));
   CeedCallBackend(CeedFree(&data));
   return CEED_ERROR_SUCCESS;
 }

--- a/backends/cuda/ceed-cuda-common.h
+++ b/backends/cuda/ceed-cuda-common.h
@@ -66,7 +66,7 @@ static const char *cublasGetErrorName(cublasStatus_t error) {
 
 typedef struct {
   int                   device_id;
-  char                 *llvm_command;
+  char                 *llvm_cxx;
   cublasHandle_t        cublas_handle;
   struct cudaDeviceProp device_prop;
 } Ceed_Cuda;

--- a/backends/cuda/ceed-cuda-common.h
+++ b/backends/cuda/ceed-cuda-common.h
@@ -66,8 +66,7 @@ static const char *cublasGetErrorName(cublasStatus_t error) {
 
 typedef struct {
   int                   device_id;
-  bool                  use_llvm_version;
-  int                   llvm_version;
+  char                 *llvm_command;
   cublasHandle_t        cublas_handle;
   struct cudaDeviceProp device_prop;
 } Ceed_Cuda;

--- a/backends/cuda/ceed-cuda-compile.cpp
+++ b/backends/cuda/ceed-cuda-compile.cpp
@@ -158,7 +158,7 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
                using_clang ? "Compiling CUDA with Clang backend (with Rust QFunction support)"
                            : "Compiling CUDA with NVRTC backend (without Rust QFunction support)."
                              "\nTo use the Clang backend, set the environment variable CEED_USE_CLANG_CUDA=1"
-                             "or CEED_CLANG_CUDA_CXX=my_clang++");
+                             " or CEED_CLANG_CUDA_CXX=my_clang++");
 
   // Get kernel specific options, such as kernel constants
   if (num_defines > 0) {
@@ -303,16 +303,16 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
     Ceed_Cuda *ceed_data;
 
     CeedCallBackend(CeedGetData(ceed, &ceed_data));
-    char *llvm_command = ceed_data->llvm_command;
+    char *llvm_cxx = ceed_data->llvm_cxx;
 
     // First check for user LLVM version
-    if (!llvm_command) {
+    if (!llvm_cxx) {
       const char *user_cxx = getenv("CEED_CLANG_CUDA_CXX");
       CeedDebug(ceed, "Attempting to detect user specified LLVM compiler\nUser LLVM compiler: %s\n", user_cxx);
 
       // Check if valid Clang
-      bool is_valid = true;
-      {
+      bool is_valid = false;
+      if (user_cxx) {
         std::string command = std::string(user_cxx) + " --version 2>&1";
 
         CeedDebug(ceed, "Checking user LLVM compiler...");
@@ -321,14 +321,14 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
 
       if (is_valid) {
         CeedDebug(ceed, "User specified LLVM compiler is valid\n");
-        CeedCall(CeedStringAllocCopy(user_cxx, &ceed_data->llvm_command));
-        llvm_command = ceed_data->llvm_command;
+        CeedCall(CeedStringAllocCopy(user_cxx, &ceed_data->llvm_cxx));
+        llvm_cxx = ceed_data->llvm_cxx;
       } else {
         CeedDebug(ceed, "Could not invoke user specified LLVM compiler\n");
       }
     }
     // Next query Rust for LLVM version
-    if (!llvm_command) {
+    if (!llvm_cxx) {
       command = "$(find $(rustup run " + std::string(rust_toolchain) + " rustc --print sysroot) -name llvm-link) --version";
       CeedDebug(ceed, "Attempting to detect Rust LLVM version\ncommand:\n$ %s", command.c_str());
       FILE *output_stream = popen((command + std::string(" 2>&1")).c_str(), "r");
@@ -355,7 +355,7 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
         CeedDebug(ceed, "Detected Rust LLVM version: %d", llvm_version);
 
         // Check if valid Clang
-        bool        is_valid = true;
+        bool        is_valid = false;
         std::string rust_cxx = std::string("clang++-") + std::to_string(llvm_version);
         {
           std::string command = std::string(rust_cxx) + " --version 2>&1";
@@ -366,19 +366,19 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
 
         if (is_valid) {
           CeedDebug(ceed, "Detected Rust LLVM compiler: %s\n", rust_cxx.c_str());
-          CeedCall(CeedStringAllocCopy(rust_cxx.c_str(), &ceed_data->llvm_command));
-          llvm_command = ceed_data->llvm_command;
+          CeedCall(CeedStringAllocCopy(rust_cxx.c_str(), &ceed_data->llvm_cxx));
+          llvm_cxx = ceed_data->llvm_cxx;
         }
       }
-      if (!llvm_command) CeedDebug(ceed, "Could not invoke detected Rust LLVM compiler\n");
+      if (!llvm_cxx) CeedDebug(ceed, "Could not invoke detected Rust LLVM compiler\n");
     }
     // Default to clang++
-    if (!llvm_command) {
+    if (!llvm_cxx) {
       CeedDebug(ceed, "Default LLVM compiler: clang++\n");
-      CeedCall(CeedStringAllocCopy("clang++", &ceed_data->llvm_command));
-      llvm_command = ceed_data->llvm_command;
+      CeedCall(CeedStringAllocCopy("clang++", &ceed_data->llvm_cxx));
+      llvm_cxx = ceed_data->llvm_cxx;
       {
-        std::string command = std::string(llvm_command) + " --version 2>&1";
+        std::string command = std::string(llvm_cxx) + " --version 2>&1";
 
         CeedDebug(ceed, "Checking default LLVM compiler...");
         CeedCallSystem_Unchecked(ceed, command.c_str(), "checking default LLVM compiler", NULL);
@@ -387,9 +387,9 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
 
     // Compile wrapper kernel
     CeedCallCuda(ceed, cudaGetDeviceProperties(&prop, ceed_data->device_id));
-    command = (llvm_command ? std::string(llvm_command) : std::string("clang++")) + " -flto=thin --cuda-gpu-arch=sm_" + std::to_string(prop.major) +
-              std::to_string(prop.minor) + " --cuda-device-only -emit-llvm -S temp/kernel_" + std::to_string(build_id) +
-              "_0_source.cu -o temp/kernel_" + std::to_string(build_id) + "_1_wrapped.ll ";
+    command = std::string(llvm_cxx) + " -flto=thin --cuda-gpu-arch=sm_" + std::to_string(prop.major) + std::to_string(prop.minor) +
+              " --cuda-device-only -emit-llvm -S temp/kernel_" + std::to_string(build_id) + "_0_source.cu -o temp/kernel_" +
+              std::to_string(build_id) + "_1_wrapped.ll ";
     command += opts[4];
     CeedCallSystem(ceed, command.c_str(), "JiT kernel source");
     CeedCallSystem(ceed, ("chmod 0777 temp/kernel_" + std::to_string(build_id) + "_1_wrapped.ll").c_str(), "update JiT file permissions");

--- a/backends/cuda/ceed-cuda-compile.cpp
+++ b/backends/cuda/ceed-cuda-compile.cpp
@@ -40,12 +40,13 @@
     CeedChk_Nvrtc(ceed, ierr_q_); \
   } while (0)
 
-#define CeedCallSystem(ceed, command, message) CeedCallBackend(CeedCallSystem_Core(ceed, command, message))
+#define CeedCallSystem(ceed, command, message) CeedCallBackend(CeedCallSystem_Core(ceed, command, message, true, NULL))
+#define CeedCallSystem_Unchecked(ceed, command, message, is_success) CeedCallBackend(CeedCallSystem_Core(ceed, command, message, false, is_success))
 
 //------------------------------------------------------------------------------
 // Call system command and capture stdout + stderr
 //------------------------------------------------------------------------------
-static int CeedCallSystem_Core(Ceed ceed, const char *command, const char *message) {
+static int CeedCallSystem_Core(Ceed ceed, const char *command, const char *message, bool err_on_fail, bool *is_success) {
   CeedDebug(ceed, "Running command:\n$ %s", command);
   FILE *output_stream = popen((command + std::string(" 2>&1")).c_str(), "r");
 
@@ -54,11 +55,12 @@ static int CeedCallSystem_Core(Ceed ceed, const char *command, const char *messa
   char        line[CEED_MAX_RESOURCE_LEN] = "";
   std::string output                      = "";
 
-  while (fgets(line, sizeof(line), output_stream) != nullptr) {
-    output += line;
-  }
+  while (fgets(line, sizeof(line), output_stream) != nullptr) output += line;
   CeedDebug(ceed, "output:\n%s\n", output.c_str());
-  CeedCheck(pclose(output_stream) == 0, ceed, CEED_ERROR_BACKEND, "Failed to %s\ncommand:\n$ %s\nerror:\n%s", message, command, output.c_str());
+  CeedInt ierr = pclose(output_stream);
+
+  if (is_success) *is_success = ierr == 0;
+  if (err_on_fail) CeedCheck(ierr == 0, ceed, CEED_ERROR_BACKEND, "Failed to %s\ncommand:\n$ %s\nerror:\n%s", message, command, output.c_str());
   return CEED_ERROR_SUCCESS;
 }
 
@@ -155,7 +157,8 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
   CeedDebug256(ceed, CEED_DEBUG_COLOR_SUCCESS,
                using_clang ? "Compiling CUDA with Clang backend (with Rust QFunction support)"
                            : "Compiling CUDA with NVRTC backend (without Rust QFunction support)."
-                             "\nTo use the Clang backend, set the environment variable GPU_CLANG=1");
+                             "\nTo use the Clang backend, set the environment variable CEED_USE_CLANG_CUDA=1"
+                             "or CEED_CLANG_CUDA_CXX=my_clang++");
 
   // Get kernel specific options, such as kernel constants
   if (num_defines > 0) {
@@ -300,12 +303,34 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
     Ceed_Cuda *ceed_data;
 
     CeedCallBackend(CeedGetData(ceed, &ceed_data));
-    bool use_llvm_version = ceed_data->use_llvm_version;
-    int  llvm_version     = ceed_data->llvm_version;
+    char *llvm_command = ceed_data->llvm_command;
 
-    if (llvm_version == 0) {
+    // First check for user LLVM version
+    if (!llvm_command) {
+      const char *user_cxx = getenv("CEED_CLANG_CUDA_CXX");
+      CeedDebug(ceed, "Attempting to detect user specified LLVM compiler\nUser LLVM compiler: %s\n", user_cxx);
+
+      // Check if valid Clang
+      bool is_valid = true;
+      {
+        std::string command = std::string(user_cxx) + " --version 2>&1";
+
+        CeedDebug(ceed, "Checking user LLVM compiler...");
+        CeedCallSystem_Unchecked(ceed, command.c_str(), "checking user LLVM compiler", &is_valid);
+      }
+
+      if (is_valid) {
+        CeedDebug(ceed, "User specified LLVM compiler is valid\n");
+        CeedCall(CeedStringAllocCopy(user_cxx, &ceed_data->llvm_command));
+        llvm_command = ceed_data->llvm_command;
+      } else {
+        CeedDebug(ceed, "Could not invoke user specified LLVM compiler\n");
+      }
+    }
+    // Next query Rust for LLVM version
+    if (!llvm_command) {
       command = "$(find $(rustup run " + std::string(rust_toolchain) + " rustc --print sysroot) -name llvm-link) --version";
-      CeedDebug(ceed, "Attempting to detect Rust LLVM version.\ncommand:\n$ %s", command.c_str());
+      CeedDebug(ceed, "Attempting to detect Rust LLVM version\ncommand:\n$ %s", command.c_str());
       FILE *output_stream = popen((command + std::string(" 2>&1")).c_str(), "r");
 
       CeedCheck(output_stream != nullptr, ceed, CEED_ERROR_BACKEND, "Failed to detect Rust LLVM version");
@@ -313,9 +338,7 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
       char        line[CEED_MAX_RESOURCE_LEN] = "";
       std::string output                      = "";
 
-      while (fgets(line, sizeof(line), output_stream) != nullptr) {
-        output += line;
-      }
+      while (fgets(line, sizeof(line), output_stream) != nullptr) output += line;
       CeedDebug(ceed, "output:\n%s", output.c_str());
       CeedCheck(pclose(output_stream) == 0, ceed, CEED_ERROR_BACKEND, "Failed to detect Rust LLVM version\ncommand:\n$ %s\nerror:\n%s",
                 command.c_str(), output.c_str());
@@ -327,23 +350,45 @@ static int CeedCompileCore_Cuda(Ceed ceed, const char *source, const bool throw_
       char *next_dot = strchr((char *)version_substring, '.');
 
       if (next_dot) {
-        next_dot[0]             = '\0';
-        ceed_data->llvm_version = llvm_version = std::stoi(version_substring);
-        CeedDebug(ceed, "Rust LLVM version number: %d\n", llvm_version);
+        next_dot[0]          = '\0';
+        CeedInt llvm_version = std::stoi(version_substring);
+        CeedDebug(ceed, "Detected Rust LLVM version: %d", llvm_version);
 
-        command                     = std::string("clang++-") + std::to_string(llvm_version);
-        output_stream               = popen((command + std::string(" 2>&1")).c_str(), "r");
-        ceed_data->use_llvm_version = use_llvm_version = pclose(output_stream) == 0;
-      } else {
-        ceed_data->llvm_version     = -1;
-        ceed_data->use_llvm_version = use_llvm_version = false;
+        // Check if valid Clang
+        bool        is_valid = true;
+        std::string rust_cxx = std::string("clang++-") + std::to_string(llvm_version);
+        {
+          std::string command = std::string(rust_cxx) + " --version 2>&1";
+
+          CeedDebug(ceed, "Checking Rust LLVM compiler...");
+          CeedCallSystem_Unchecked(ceed, command.c_str(), "checking Rust LLVM compiler", &is_valid);
+        }
+
+        if (is_valid) {
+          CeedDebug(ceed, "Detected Rust LLVM compiler: %s\n", rust_cxx.c_str());
+          CeedCall(CeedStringAllocCopy(rust_cxx.c_str(), &ceed_data->llvm_command));
+          llvm_command = ceed_data->llvm_command;
+        }
+      }
+      if (!llvm_command) CeedDebug(ceed, "Could not invoke detected Rust LLVM compiler\n");
+    }
+    // Default to clang++
+    if (!llvm_command) {
+      CeedDebug(ceed, "Default LLVM compiler: clang++\n");
+      CeedCall(CeedStringAllocCopy("clang++", &ceed_data->llvm_command));
+      llvm_command = ceed_data->llvm_command;
+      {
+        std::string command = std::string(llvm_command) + " --version 2>&1";
+
+        CeedDebug(ceed, "Checking default LLVM compiler...");
+        CeedCallSystem_Unchecked(ceed, command.c_str(), "checking default LLVM compiler", NULL);
       }
     }
 
     // Compile wrapper kernel
     CeedCallCuda(ceed, cudaGetDeviceProperties(&prop, ceed_data->device_id));
-    command = "clang++" + (use_llvm_version ? (std::string("-") + std::to_string(llvm_version)) : "") + " -flto=thin --cuda-gpu-arch=sm_" +
-              std::to_string(prop.major) + std::to_string(prop.minor) + " --cuda-device-only -emit-llvm -S temp/kernel_" + std::to_string(build_id) +
+    command = (llvm_command ? std::string(llvm_command) : std::string("clang++")) + " -flto=thin --cuda-gpu-arch=sm_" + std::to_string(prop.major) +
+              std::to_string(prop.minor) + " --cuda-device-only -emit-llvm -S temp/kernel_" + std::to_string(build_id) +
               "_0_source.cu -o temp/kernel_" + std::to_string(build_id) + "_1_wrapped.ll ";
     command += opts[4];
     CeedCallSystem(ceed, command.c_str(), "JiT kernel source");

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1378,7 +1378,7 @@ int CeedInit(const char *resource, Ceed *ceed) {
   // By default, make CUDA compile without Clang, use nvrtc instead
   // Note that this is overridden if a Rust file is included (Rust requires Clang)
   const char *cuda_clang_flag = getenv("CEED_USE_CLANG_CUDA");
-  bool        use_cuda_clang  = cuda_clang_flag && !strcmp(cuda_clang_flag, "0") && !strcmp(cuda_clang_flag, "false");
+  bool        use_cuda_clang  = cuda_clang_flag && strcmp(cuda_clang_flag, "0") && strcmp(cuda_clang_flag, "false");
 
   (*ceed)->cuda_compile_with_clang = use_cuda_clang || getenv("CEED_CLANG_CUDA_CXX");
 

--- a/interface/ceed.c
+++ b/interface/ceed.c
@@ -1375,15 +1375,12 @@ int CeedInit(const char *resource, Ceed *ceed) {
   // Note: there will always be the default root for every Ceed but all additional paths are added to the top-most parent
   CeedCall(CeedAddJitSourceRoot(*ceed, (char *)CeedJitSourceRootDefault));
 
-  // By default, make cuda compile without clang, use nvrtc instead
-  // Note that this is overridden if a rust file is included (rust requires clang)
-  const char *env = getenv("GPU_CLANG");
+  // By default, make CUDA compile without Clang, use nvrtc instead
+  // Note that this is overridden if a Rust file is included (Rust requires Clang)
+  const char *cuda_clang_flag = getenv("CEED_USE_CLANG_CUDA");
+  bool        use_cuda_clang  = cuda_clang_flag && !strcmp(cuda_clang_flag, "0") && !strcmp(cuda_clang_flag, "false");
 
-  if (env && strcmp(env, "1") == 0) {
-    (*ceed)->cuda_compile_with_clang = true;
-  } else {
-    (*ceed)->cuda_compile_with_clang = false;
-  }
+  (*ceed)->cuda_compile_with_clang = use_cuda_clang || getenv("CEED_CLANG_CUDA_CXX");
 
   // Backend specific setup
   CeedCall(backends[match_index].init(&resource[match_help], *ceed));


### PR DESCRIPTION
Purpose:

This PR lets the user specify the Clang CXX for CUDA JiT. If this is not valid or not set, then we attempt to detect the Clang version in the Rust toolchain. Finally we default to `clang++` if neither is successful.

Closes: #1965

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
