### PR TITLE
Magma include: use using dim instead of num_comp

### DIFF
--- a/backends/magma/ceed-magma-basis.c
+++ b/backends/magma/ceed-magma-basis.c
@@ -554,7 +554,7 @@ int CeedBasisCreateTensorH1_Magma(CeedInt dim, CeedInt P_1d, CeedInt Q_1d, const
            "d.h>\n"
            "// Weight basis source\n"
            "#include <ceed/jit-source/magma/magma-basis-weight-%" CeedInt_FMT "d.h>\n",
-           num_comp, num_comp, num_comp);
+           dim, dim, dim);
 
   CeedCallBackend(CeedCompileMagma(ceed_delegate, basis_kernel_source, "basis_h1_tensor", &impl->module, 5, "BASIS_DIM", dim, "BASIS_NUM_COMP",
                                    num_comp, "BASIS_P", P_1d, "BASIS_Q", Q_1d, "BASIS_MAX_P_Q", CeedIntMax(P_1d, Q_1d)));


### PR DESCRIPTION
Found in
https://github.com/awslabs/palace/actions/runs/26517671781/job/78111329701?pr=738

PR #1968 changes the `snprintf` to use `num_comp` instead of `dim` as a suffix, so that our 1D fields try to load the 3D headers
