### PR TITLE
More Fortran Cleanup

### DIFF
--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -308,11 +308,10 @@ CEED_EXTERN void fCeedElemRestrictionCreate(int *ceed, int *num_elem, int *elem_
 #define fCeedElemRestrictionCreateOriented FORTRAN_NAME(ceedelemrestrictioncreateoriented, CEEDELEMRESTRICTIONCREATEORIENTED)
 CEED_EXTERN void fCeedElemRestrictionCreateOriented(int *ceed, int *num_elem, int *elem_size, int *num_comp, int *comp_stride, int *l_vec_size,
                                                     int *mem_type, int *copy_mode, const int *offsets, const bool *orients, int *rstr, int *err) {
-  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-
   const int  *offsets_c = offsets;
   const bool *orients_c = orients;
 
+  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
   CeedCallFortran(CeedElemRestrictionCreateOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size,
                                                     (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, orients_c,
                                                     &CeedElemRestriction_dict[num_CeedElemRestriction]));
@@ -323,11 +322,10 @@ CEED_EXTERN void fCeedElemRestrictionCreateOriented(int *ceed, int *num_elem, in
 CEED_EXTERN void fCeedElemRestrictionCreateCurlOriented(int *ceed, int *num_elem, int *elem_size, int *num_comp, int *comp_stride, int *l_vec_size,
                                                         int *mem_type, int *copy_mode, const int *offsets, const int8_t *curl_orients, int *rstr,
                                                         int *err) {
-  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-
   const int    *offsets_c      = offsets;
   const int8_t *curl_orients_c = curl_orients;
 
+  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
   CeedCallFortran(CeedElemRestrictionCreateCurlOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size,
                                                         (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, curl_orients_c,
                                                         &CeedElemRestriction_dict[num_CeedElemRestriction]));
@@ -347,10 +345,9 @@ CEED_EXTERN void fCeedElemRestrictionCreateStrided(int *ceed, int *num_elem, int
 #define fCeedElemRestrictionCreateBlocked FORTRAN_NAME(ceedelemrestrictioncreateblocked, CEEDELEMRESTRICTIONCREATEBLOCKED)
 CEED_EXTERN void fCeedElemRestrictionCreateBlocked(int *ceed, int *num_elem, int *elem_size, int *block_size, int *num_comp, int *comp_stride,
                                                    int *l_vec_size, int *mem_type, int *copy_mode, const int *offsets, int *rstr, int *err) {
-  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-
   const int *offsets_c = offsets;
 
+  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
   CeedCallFortran(CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
                                                    (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c,
                                                    &CeedElemRestriction_dict[num_CeedElemRestriction]));
@@ -361,11 +358,10 @@ CEED_EXTERN void fCeedElemRestrictionCreateBlocked(int *ceed, int *num_elem, int
 CEED_EXTERN void fCeedElemRestrictionCreateBlockedOriented(int *ceed, int *num_elem, int *elem_size, int *block_size, int *num_comp, int *comp_stride,
                                                            int *l_vec_size, int *mem_type, int *copy_mode, const int *offsets, const bool *orients,
                                                            int *rstr, int *err) {
-  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-
   const int  *offsets_c = offsets;
   const bool *orients_c = orients;
 
+  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
   CeedCallFortran(CeedElemRestrictionCreateBlockedOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
                                                            (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, orients_c,
                                                            &CeedElemRestriction_dict[num_CeedElemRestriction]));
@@ -377,11 +373,10 @@ CEED_EXTERN void fCeedElemRestrictionCreateBlockedOriented(int *ceed, int *num_e
 CEED_EXTERN void fCeedElemRestrictionCreateBlockedCurlOriented(int *ceed, int *num_elem, int *elem_size, int *block_size, int *num_comp,
                                                                int *comp_stride, int *l_vec_size, int *mem_type, int *copy_mode, const int *offsets,
                                                                const int8_t *curl_orients, int *rstr, int *err) {
-  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-
   const int    *offsets_c      = offsets;
   const int8_t *curl_orients_c = curl_orients;
 
+  if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
   CeedCallFortran(CeedElemRestrictionCreateBlockedCurlOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride,
                                                                *l_vec_size, (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c,
                                                                curl_orients_c, &CeedElemRestriction_dict[num_CeedElemRestriction]));
@@ -645,7 +640,9 @@ CEED_EXTERN void fCeedQFunctionContextGetData(int *ctx, int *mem_type, CeedScala
 
 #define fCeedQFunctionContextRestoreData FORTRAN_NAME(ceedqfunctioncontextrestoredata, CEEDQFUNCTIONCONTEXTRESTOREDATA)
 CEED_EXTERN void fCeedQFunctionContextRestoreData(int *ctx, CeedScalar *data, int64_t *offset, int *err) {
-  CeedCallFortran(CeedQFunctionContextRestoreData(CeedQFunctionContext_dict[*ctx], (void **)&data));
+  CeedScalar *data_c = data + *offset;
+
+  CeedCallFortran(CeedQFunctionContextRestoreData(CeedQFunctionContext_dict[*ctx], (void **)&data_c));
   *offset = 0;
 }
 
@@ -691,7 +688,7 @@ static inline void fCeedQFunctionAccept(int *qf) {
 
 // Note: Device backends are generating their own kernels from single source files, so only Host backends need to use this Fortran stub
 static int CeedQFunctionFortranStub(void *ctx, int num_qpts, const CeedScalar *const *u, CeedScalar *const *v) {
-  int                  ierr;
+  int                  ierr      = CEED_ERROR_SUCCESS;
   CeedFortranContext   ctx_data  = ctx;
   CeedQFunctionContext inner_ctx = ctx_data->inner_ctx;
   CeedScalar          *ctx_f     = NULL;
@@ -725,7 +722,6 @@ CEED_EXTERN void fCeedQFunctionCreateInterior(
 
   CeedCallFortran(CeedQFunctionCreateInterior(Ceed_dict[*ceed], *vec_length, CeedQFunctionFortranStub, source_c, qf_c));
   fCeedQFunctionAccept(qf);
-
   {
     CeedQFunctionContext ctx_c;
     CeedFortranContext   ctx_data;
@@ -875,10 +871,9 @@ static inline void fCeedOperatorAccept(int *op) {
 
 #define fCeedOperatorCreate FORTRAN_NAME(ceedoperatorcreate, CEEDOPERATORCREATE)
 CEED_EXTERN void fCeedOperatorCreate(int *ceed, int *qf, int *dqf, int *dqfT, int *op, int *err) {
-  if (num_CeedOperator == max_CeedOperator) fCeedOperatorExpandDict();
-
   CeedQFunction dqf_c = CEED_QFUNCTION_NONE, dqfT_c = CEED_QFUNCTION_NONE;
 
+  if (num_CeedOperator == max_CeedOperator) fCeedOperatorExpandDict();
   if (*dqf != FORTRAN_QFUNCTION_NONE) dqf_c = CeedQFunction_dict[*dqf];
   if (*dqfT != FORTRAN_QFUNCTION_NONE) dqfT_c = CeedQFunction_dict[*dqfT];
   CeedCallFortran(CeedOperatorCreate(Ceed_dict[*ceed], CeedQFunction_dict[*qf], dqf_c, dqfT_c, &CeedOperator_dict[num_CeedOperator]));
@@ -927,11 +922,11 @@ static inline void fCeedBasisFortranToC(int basis_f, CeedBasis *basis_c) {
 
 #define fCeedOperatorSetField FORTRAN_NAME(ceedoperatorsetfield, CEEDOPERATORSETFIELD)
 CEED_EXTERN void fCeedOperatorSetField(int *op, const char *field_name, int *rstr, int *basis, int *vec, int *err, fortran_charlen_t field_name_len) {
-  FIX_STRING(field_name);
   CeedVector          vec_c;
   CeedElemRestriction rstr_c;
   CeedBasis           basis_c;
 
+  FIX_STRING(field_name);
   fCeedVectorFortranToC(*vec, &vec_c);
   fCeedElemRestrictionFortranToC(*rstr, &rstr_c);
   fCeedBasisFortranToC(*basis, &basis_c);
@@ -995,7 +990,6 @@ CEED_EXTERN void fCeedOperatorLinearAssembleDiagonal(int *op, int *assembled_vec
 #define fCeedOperatorMultigridLevelCreate FORTRAN_NAME(ceedoperatormultigridlevelcreate, CEEDOPERATORMULTIGRIDLEVELCREATE)
 CEED_EXTERN void fCeedOperatorMultigridLevelCreate(int *op_fine, int *p_mult_fine, int *rstr_coarse, int *basis_coarse, int *op_coarse,
                                                    int *op_prolong, int *op_restrict, int *err) {
-  // Operators
   CeedOperator op_coarse_c, op_prolong_c, op_restrict_c;
 
   // C interface call
@@ -1016,7 +1010,6 @@ CEED_EXTERN void fCeedOperatorMultigridLevelCreate(int *op_fine, int *p_mult_fin
 CEED_EXTERN void fCeedOperatorMultigridLevelCreateTensorH1(int *op_fine, int *p_mult_fine, int *rstr_coarse, int *basis_coarse,
                                                            const CeedScalar *interp_c_to_f, int *op_coarse, int *op_prolong, int *op_restrict,
                                                            int *err) {
-  // Operators
   CeedOperator op_coarse_c, op_prolong_c, op_restrict_c;
 
   // C interface call
@@ -1037,7 +1030,6 @@ CEED_EXTERN void fCeedOperatorMultigridLevelCreateTensorH1(int *op_fine, int *p_
 #define fCeedOperatorMultigridLevelCreateH1 FORTRAN_NAME(ceedoperatormultigridlevelcreateh1, CEEDOPERATORMULTIGRIDLEVELCREATEH1)
 CEED_EXTERN void fCeedOperatorMultigridLevelCreateH1(int *op_fine, int *p_mult_fine, int *rstr_coarse, int *basis_coarse,
                                                      const CeedScalar *interp_c_to_f, int *op_coarse, int *op_prolong, int *op_restrict, int *err) {
-  // Operators
   CeedOperator op_coarse_c, op_prolong_c, op_restrict_c;
 
   // C interface call

--- a/interface/ceed-fortran.c
+++ b/interface/ceed-fortran.c
@@ -25,6 +25,12 @@
 #define FORTRAN_BASIS_NONE -8
 #define FORTRAN_QFUNCTION_NONE -9
 
+#define CeedCallFortran(...) \
+  do {                       \
+    *err = __VA_ARGS__;      \
+    if (*err) return;        \
+  } while (0)
+
 static CeedRequest *CeedRequest_dict       = NULL;
 static int          max_CeedRequest        = 0;
 static int          num_CeedRequest        = 0;
@@ -39,6 +45,19 @@ static inline void fCeedRequestAccept(int *request) {
   *request = num_CeedRequest;
   num_CeedRequest++;
   num_active_CeedRequest++;
+}
+
+static inline void fCeedRequestFortranToC(int request_f, CeedRequest **request_c) {
+  switch (request_f) {
+    case FORTRAN_REQUEST_IMMEDIATE:
+      *request_c = CEED_REQUEST_IMMEDIATE;
+      break;
+    case FORTRAN_REQUEST_ORDERED:
+      *request_c = CEED_REQUEST_ORDERED;
+      break;
+    default:
+      *request_c = &CeedRequest_dict[num_CeedRequest];
+  }
 }
 
 #define fCeedRequestWait FORTRAN_NAME(ceedrequestwait, CEEDREQUESTWAIT)
@@ -106,37 +125,36 @@ static inline void fCeedAccept(int *ceed) {
 CEED_EXTERN void fCeedInit(const char *resource, int *ceed, int *err, fortran_charlen_t resource_len) {
   FIX_STRING(resource);
   if (num_Ceed == max_Ceed) fCeedExpandDict();
-  *err = CeedInit(resource_c, &Ceed_dict[num_Ceed]);
-  if (*err == 0) fCeedAccept(ceed);
+  CeedCallFortran(CeedInit(resource_c, &Ceed_dict[num_Ceed]));
+  fCeedAccept(ceed);
 }
 
 #define fCeedIsDeterministic FORTRAN_NAME(ceedisdeterministic, CEEDISDETERMINISTIC)
 CEED_EXTERN void fCeedIsDeterministic(int *ceed, int *is_deterministic, int *err) {
-  *err = CeedIsDeterministic(Ceed_dict[*ceed], (bool *)is_deterministic);
+  CeedCallFortran(CeedIsDeterministic(Ceed_dict[*ceed], (bool *)is_deterministic));
 }
 
 #define fCeedGetPreferredMemType FORTRAN_NAME(ceedgetpreferredmemtype, CEEDGETPREFERREDMEMTYPE)
-CEED_EXTERN void fCeedGetPreferredMemType(int *ceed, int *type, int *err) { *err = CeedGetPreferredMemType(Ceed_dict[*ceed], (CeedMemType *)type); }
+CEED_EXTERN void fCeedGetPreferredMemType(int *ceed, int *type, int *err) {
+  CeedCallFortran(CeedGetPreferredMemType(Ceed_dict[*ceed], (CeedMemType *)type));
+}
 
 #define fCeedSetNumViewTabs FORTRAN_NAME(ceedsetnumviewtabs, CEEDSETNUMVIEWTABS)
-CEED_EXTERN void fCeedSetNumViewTabs(int *ceed, int *num_tabs, int *err) { *err = CeedSetNumViewTabs(Ceed_dict[*ceed], *num_tabs); }
+CEED_EXTERN void fCeedSetNumViewTabs(int *ceed, int *num_tabs, int *err) { CeedCallFortran(CeedSetNumViewTabs(Ceed_dict[*ceed], *num_tabs)); }
 
 #define fCeedView FORTRAN_NAME(ceedview, CEEDVIEW)
-CEED_EXTERN void fCeedView(int *ceed, int *err) { *err = CeedView(Ceed_dict[*ceed], stdout); }
+CEED_EXTERN void fCeedView(int *ceed, int *err) { CeedCallFortran(CeedView(Ceed_dict[*ceed], stdout)); }
 
 #define fCeedDestroy FORTRAN_NAME(ceeddestroy, CEEDDESTROY)
 CEED_EXTERN void fCeedDestroy(int *ceed, int *err) {
   if (*ceed == FORTRAN_NULL) return;
-  *err = CeedDestroy(&Ceed_dict[*ceed]);
-
-  if (*err == 0) {
-    *ceed = FORTRAN_NULL;
-    num_active_Ceed--;
-    if (num_active_Ceed == 0) {
-      CeedFree(&Ceed_dict);
-      num_Ceed = 0;
-      max_Ceed = 0;
-    }
+  CeedCallFortran(CeedDestroy(&Ceed_dict[*ceed]));
+  *ceed = FORTRAN_NULL;
+  num_active_Ceed--;
+  if (num_active_Ceed == 0) {
+    CeedFree(&Ceed_dict);
+    num_Ceed = 0;
+    max_Ceed = 0;
   }
 }
 
@@ -162,36 +180,36 @@ static inline void fCeedVectorAccept(int *vec) {
 #define fCeedVectorCreate FORTRAN_NAME(ceedvectorcreate, CEEDVECTORCREATE)
 CEED_EXTERN void fCeedVectorCreate(int *ceed, int *length, int *vec, int *err) {
   if (num_CeedVector == max_CeedVector) fCeedVectorExpandDict();
-  *err = CeedVectorCreate(Ceed_dict[*ceed], *length, &CeedVector_dict[num_CeedVector]);
-  if (*err == 0) fCeedVectorAccept(vec);
+  CeedCallFortran(CeedVectorCreate(Ceed_dict[*ceed], *length, &CeedVector_dict[num_CeedVector]));
+  fCeedVectorAccept(vec);
 }
 
 #define fCeedVectorSetArray FORTRAN_NAME(ceedvectorsetarray, CEEDVECTORSETARRAY)
 CEED_EXTERN void fCeedVectorSetArray(int *vec, int *mem_type, int *copy_mode, CeedScalar *array, int64_t *offset, int *err) {
-  *err = CeedVectorSetArray(CeedVector_dict[*vec], (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, (CeedScalar *)(array + *offset));
+  CeedCallFortran(CeedVectorSetArray(CeedVector_dict[*vec], (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, (CeedScalar *)(array + *offset)));
 }
 
 #define fCeedVectorTakeArray FORTRAN_NAME(ceedvectortakearray, CEEDVECTORTAKEARRAY)
 CEED_EXTERN void fCeedVectorTakeArray(int *vec, int *mem_type, CeedScalar *array, int64_t *offset, int *err) {
   CeedScalar *array_c;
 
-  *err    = CeedVectorTakeArray(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c);
+  CeedCallFortran(CeedVectorTakeArray(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c));
   *offset = array_c - array;
 }
 
 #define fCeedVectorSyncArray FORTRAN_NAME(ceedvectorsyncarray, CEEDVECTORSYNCARRAY)
 CEED_EXTERN void fCeedVectorSyncArray(int *vec, int *mem_type, int *err) {
-  *err = CeedVectorSyncArray(CeedVector_dict[*vec], (CeedMemType)*mem_type);
+  CeedCallFortran(CeedVectorSyncArray(CeedVector_dict[*vec], (CeedMemType)*mem_type));
 }
 
 #define fCeedVectorSetValue FORTRAN_NAME(ceedvectorsetvalue, CEEDVECTORSETVALUE)
-CEED_EXTERN void fCeedVectorSetValue(int *vec, CeedScalar *value, int *err) { *err = CeedVectorSetValue(CeedVector_dict[*vec], *value); }
+CEED_EXTERN void fCeedVectorSetValue(int *vec, CeedScalar *value, int *err) { CeedCallFortran(CeedVectorSetValue(CeedVector_dict[*vec], *value)); }
 
 #define fCeedVectorGetArray FORTRAN_NAME(ceedvectorgetarray, CEEDVECTORGETARRAY)
 CEED_EXTERN void fCeedVectorGetArray(int *vec, int *mem_type, CeedScalar *array, int64_t *offset, int *err) {
   CeedScalar *array_c;
 
-  *err    = CeedVectorGetArray(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c);
+  CeedCallFortran(CeedVectorGetArray(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c));
   *offset = array_c - array;
 }
 
@@ -199,7 +217,7 @@ CEED_EXTERN void fCeedVectorGetArray(int *vec, int *mem_type, CeedScalar *array,
 CEED_EXTERN void fCeedVectorGetArrayRead(int *vec, int *mem_type, CeedScalar *array, int64_t *offset, int *err) {
   const CeedScalar *array_c;
 
-  *err    = CeedVectorGetArrayRead(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c);
+  CeedCallFortran(CeedVectorGetArrayRead(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c));
   *offset = array_c - array;
 }
 
@@ -207,51 +225,52 @@ CEED_EXTERN void fCeedVectorGetArrayRead(int *vec, int *mem_type, CeedScalar *ar
 CEED_EXTERN void fCeedVectorGetArrayWrite(int *vec, int *mem_type, CeedScalar *array, int64_t *offset, int *err) {
   CeedScalar *array_c;
 
-  *err    = CeedVectorGetArrayWrite(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c);
+  CeedCallFortran(CeedVectorGetArrayWrite(CeedVector_dict[*vec], (CeedMemType)*mem_type, &array_c));
   *offset = array_c - array;
 }
 
 #define fCeedVectorRestoreArray FORTRAN_NAME(ceedvectorrestorearray, CEEDVECTORRESTOREARRAY)
 CEED_EXTERN void fCeedVectorRestoreArray(int *vec, CeedScalar *array, int64_t *offset, int *err) {
-  CeedScalar *array_offset = array + *offset;
+  CeedScalar *array_c = array + *offset;
 
-  *err    = CeedVectorRestoreArray(CeedVector_dict[*vec], &array_offset);
+  CeedCallFortran(CeedVectorRestoreArray(CeedVector_dict[*vec], &array_c));
   *offset = 0;
 }
 
 #define fCeedVectorRestoreArrayRead FORTRAN_NAME(ceedvectorrestorearrayread, CEEDVECTORRESTOREARRAYREAD)
 CEED_EXTERN void fCeedVectorRestoreArrayRead(int *vec, const CeedScalar *array, int64_t *offset, int *err) {
-  *err    = CeedVectorRestoreArrayRead(CeedVector_dict[*vec], &array);
+  const CeedScalar *array_c = array + *offset;
+
+  CeedCallFortran(CeedVectorRestoreArrayRead(CeedVector_dict[*vec], &array_c));
   *offset = 0;
 }
 
 #define fCeedVectorNorm FORTRAN_NAME(ceedvectornorm, CEEDVECTORNORM)
 CEED_EXTERN void fCeedVectorNorm(int *vec, int *norm_type, CeedScalar *norm, int *err) {
-  *err = CeedVectorNorm(CeedVector_dict[*vec], (CeedNormType)*norm_type, norm);
+  CeedCallFortran(CeedVectorNorm(CeedVector_dict[*vec], (CeedNormType)*norm_type, norm));
 }
 
 #define fCeedVectorReciprocal FORTRAN_NAME(ceedvectorreciprocal, CEEDVECTORRECIPROCAL)
-CEED_EXTERN void fCeedVectorReciprocal(int *vec, int *err) { *err = CeedVectorReciprocal(CeedVector_dict[*vec]); }
+CEED_EXTERN void fCeedVectorReciprocal(int *vec, int *err) { CeedCallFortran(CeedVectorReciprocal(CeedVector_dict[*vec])); }
 
 #define fCeedVectorSetNumViewTabs FORTRAN_NAME(ceedvectorsetnumviewtabs, CEEDVECTORSETNUMVIEWTABS)
-CEED_EXTERN void fCeedVectorSetNumViewTabs(int *vec, int *num_tabs, int *err) { *err = CeedVectorSetNumViewTabs(CeedVector_dict[*vec], *num_tabs); }
+CEED_EXTERN void fCeedVectorSetNumViewTabs(int *vec, int *num_tabs, int *err) {
+  CeedCallFortran(CeedVectorSetNumViewTabs(CeedVector_dict[*vec], *num_tabs));
+}
 
 #define fCeedVectorView FORTRAN_NAME(ceedvectorview, CEEDVECTORVIEW)
-CEED_EXTERN void fCeedVectorView(int *vec, int *err) { *err = CeedVectorView(CeedVector_dict[*vec], "%12.8f", stdout); }
+CEED_EXTERN void fCeedVectorView(int *vec, int *err) { CeedCallFortran(CeedVectorView(CeedVector_dict[*vec], "%12.8f", stdout)); }
 
 #define fCeedVectorDestroy FORTRAN_NAME(ceedvectordestroy, CEEDVECTORDESTROY)
 CEED_EXTERN void fCeedVectorDestroy(int *vec, int *err) {
   if (*vec == FORTRAN_NULL) return;
-  *err = CeedVectorDestroy(&CeedVector_dict[*vec]);
-
-  if (*err == 0) {
-    *vec = FORTRAN_NULL;
-    num_active_CeedVector--;
-    if (num_active_CeedVector == 0) {
-      CeedFree(&CeedVector_dict);
-      num_CeedVector = 0;
-      max_CeedVector = 0;
-    }
+  CeedCallFortran(CeedVectorDestroy(&CeedVector_dict[*vec]));
+  *vec = FORTRAN_NULL;
+  num_active_CeedVector--;
+  if (num_active_CeedVector == 0) {
+    CeedFree(&CeedVector_dict);
+    num_CeedVector = 0;
+    max_CeedVector = 0;
   }
 }
 
@@ -281,9 +300,9 @@ CEED_EXTERN void fCeedElemRestrictionCreate(int *ceed, int *num_elem, int *elem_
 
   const int *offsets_c = offsets;
 
-  *err = CeedElemRestrictionCreate(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size, (CeedMemType)*mem_type,
-                                   (CeedCopyMode)*copy_mode, offsets_c, &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreate(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size, (CeedMemType)*mem_type,
+                                            (CeedCopyMode)*copy_mode, offsets_c, &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateOriented FORTRAN_NAME(ceedelemrestrictioncreateoriented, CEEDELEMRESTRICTIONCREATEORIENTED)
@@ -294,9 +313,10 @@ CEED_EXTERN void fCeedElemRestrictionCreateOriented(int *ceed, int *num_elem, in
   const int  *offsets_c = offsets;
   const bool *orients_c = orients;
 
-  *err = CeedElemRestrictionCreateOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size, (CeedMemType)*mem_type,
-                                           (CeedCopyMode)*copy_mode, offsets_c, orients_c, &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size,
+                                                    (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, orients_c,
+                                                    &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateCurlOriented FORTRAN_NAME(ceedelemrestrictioncreatecurloriented, CEEDELEMRESTRICTIONCREATECURLORIENTED)
@@ -308,20 +328,20 @@ CEED_EXTERN void fCeedElemRestrictionCreateCurlOriented(int *ceed, int *num_elem
   const int    *offsets_c      = offsets;
   const int8_t *curl_orients_c = curl_orients;
 
-  *err =
-      CeedElemRestrictionCreateCurlOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size, (CeedMemType)*mem_type,
-                                            (CeedCopyMode)*copy_mode, offsets_c, curl_orients_c, &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateCurlOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *comp_stride, *l_vec_size,
+                                                        (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, curl_orients_c,
+                                                        &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateStrided FORTRAN_NAME(ceedelemrestrictioncreatestrided, CEEDELEMRESTRICTIONCREATESTRIDED)
 CEED_EXTERN void fCeedElemRestrictionCreateStrided(int *ceed, int *num_elem, int *elem_size, int *num_comp, int *l_vec_size, int *strides, int *rstr,
                                                    int *err) {
   if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-  *err = CeedElemRestrictionCreateStrided(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *l_vec_size,
-                                          *strides == FORTRAN_STRIDES_BACKEND ? CEED_STRIDES_BACKEND : strides,
-                                          &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateStrided(Ceed_dict[*ceed], *num_elem, *elem_size, *num_comp, *l_vec_size,
+                                                   *strides == FORTRAN_STRIDES_BACKEND ? CEED_STRIDES_BACKEND : strides,
+                                                   &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateBlocked FORTRAN_NAME(ceedelemrestrictioncreateblocked, CEEDELEMRESTRICTIONCREATEBLOCKED)
@@ -331,10 +351,10 @@ CEED_EXTERN void fCeedElemRestrictionCreateBlocked(int *ceed, int *num_elem, int
 
   const int *offsets_c = offsets;
 
-  *err = CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
-                                          (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c,
-                                          &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateBlocked(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
+                                                   (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c,
+                                                   &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateBlockedOriented FORTRAN_NAME(ceedelemrestrictioncreateblockedoriented, CEEDELEMRESTRICTIONCREATEBLOCKEDORIENTED)
@@ -346,10 +366,10 @@ CEED_EXTERN void fCeedElemRestrictionCreateBlockedOriented(int *ceed, int *num_e
   const int  *offsets_c = offsets;
   const bool *orients_c = orients;
 
-  *err = CeedElemRestrictionCreateBlockedOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
-                                                  (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, orients_c,
-                                                  &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateBlockedOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
+                                                           (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, orients_c,
+                                                           &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateBlockedCurlOriented \
@@ -362,100 +382,82 @@ CEED_EXTERN void fCeedElemRestrictionCreateBlockedCurlOriented(int *ceed, int *n
   const int    *offsets_c      = offsets;
   const int8_t *curl_orients_c = curl_orients;
 
-  *err = CeedElemRestrictionCreateBlockedCurlOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride, *l_vec_size,
-                                                      (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c, curl_orients_c,
-                                                      &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateBlockedCurlOriented(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *comp_stride,
+                                                               *l_vec_size, (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, offsets_c,
+                                                               curl_orients_c, &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionCreateBlockedStrided FORTRAN_NAME(ceedelemrestrictioncreateblockedstrided, CEEDELEMRESTRICTIONCREATEBLOCKEDSTRIDED)
 CEED_EXTERN void fCeedElemRestrictionCreateBlockedStrided(int *ceed, int *num_elem, int *elem_size, int *block_size, int *num_comp, int *l_vec_size,
                                                           int *strides, int *rstr, int *err) {
   if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
-  *err = CeedElemRestrictionCreateBlockedStrided(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *l_vec_size, strides,
-                                                 &CeedElemRestriction_dict[num_CeedElemRestriction]);
-  if (*err == 0) fCeedElemRestrictionAccept(rstr);
+  CeedCallFortran(CeedElemRestrictionCreateBlockedStrided(Ceed_dict[*ceed], *num_elem, *elem_size, *block_size, *num_comp, *l_vec_size, strides,
+                                                          &CeedElemRestriction_dict[num_CeedElemRestriction]));
+  fCeedElemRestrictionAccept(rstr);
 }
 
 #define fCeedElemRestrictionApply FORTRAN_NAME(ceedelemrestrictionapply, CEEDELEMRESTRICTIONAPPLY)
 CEED_EXTERN void fCeedElemRestrictionApply(int *rstr, int *t_mode, int *u, int *ru, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
+  fCeedRequestFortranToC(*request, &request_c);
 
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
-
-  *err = CeedElemRestrictionApply(CeedElemRestriction_dict[*rstr], (CeedTransposeMode)*t_mode, CeedVector_dict[*u], CeedVector_dict[*ru], request_c);
-  if (*err == 0 && create_request) fCeedRequestAccept(request);
+  CeedCallFortran(CeedElemRestrictionApply(CeedElemRestriction_dict[*rstr], (CeedTransposeMode)*t_mode, CeedVector_dict[*u], CeedVector_dict[*ru],
+                                           request_c));
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedElemRestrictionApplyBlock FORTRAN_NAME(ceedelemrestrictionapplyblock, CEEDELEMRESTRICTIONAPPLYBLOCK)
 CEED_EXTERN void fCeedElemRestrictionApplyBlock(int *rstr, int *block, int *t_mode, int *u, int *ru, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
+  fCeedRequestFortranToC(*request, &request_c);
 
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
-
-  *err = CeedElemRestrictionApplyBlock(CeedElemRestriction_dict[*rstr], *block, (CeedTransposeMode)*t_mode, CeedVector_dict[*u], CeedVector_dict[*ru],
-                                       request_c);
-  if (*err == 0 && create_request) fCeedRequestAccept(request);
+  CeedCallFortran(CeedElemRestrictionApplyBlock(CeedElemRestriction_dict[*rstr], *block, (CeedTransposeMode)*t_mode, CeedVector_dict[*u],
+                                                CeedVector_dict[*ru], request_c));
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedElemRestrictionGetMultiplicity FORTRAN_NAME(ceedelemrestrictiongetmultiplicity, CEEDELEMRESTRICTIONGETMULTIPLICITY)
 CEED_EXTERN void fCeedElemRestrictionGetMultiplicity(int *rstr, int *mult, int *err) {
-  *err = CeedElemRestrictionGetMultiplicity(CeedElemRestriction_dict[*rstr], CeedVector_dict[*mult]);
+  CeedCallFortran(CeedElemRestrictionGetMultiplicity(CeedElemRestriction_dict[*rstr], CeedVector_dict[*mult]));
 }
 
 #define fCeedElemRestrictionGetELayout FORTRAN_NAME(ceedelemrestrictiongetelayout, CEEDELEMRESTRICTIONGETELAYOUT)
 CEED_EXTERN void fCeedElemRestrictionGetELayout(int *rstr, int *layout, int *err) {
   CeedInt layout_c[3];
 
-  *err = CeedElemRestrictionGetELayout(CeedElemRestriction_dict[*rstr], layout_c);
+  CeedCallFortran(CeedElemRestrictionGetELayout(CeedElemRestriction_dict[*rstr], layout_c));
   for (int i = 0; i < 3; i++) layout[i] = layout_c[i];
 }
 
 #define fCeedElemRestrictionSetNumViewTabs FORTRAN_NAME(ceedelemrestrictionsetnumviewtabs, CEEDELEMRESTRICTIONSETNUMVIEWTABS)
 CEED_EXTERN void fCeedElemRestrictionSetNumViewTabs(int *rstr, int *num_tabs, int *err) {
-  *err = CeedElemRestrictionSetNumViewTabs(CeedElemRestriction_dict[*rstr], *num_tabs);
+  CeedCallFortran(CeedElemRestrictionSetNumViewTabs(CeedElemRestriction_dict[*rstr], *num_tabs));
 }
 
 #define fCeedElemRestrictionView FORTRAN_NAME(ceedelemrestrictionview, CEEDELEMRESTRICTIONVIEW)
-CEED_EXTERN void fCeedElemRestrictionView(int *rstr, int *err) { *err = CeedElemRestrictionView(CeedElemRestriction_dict[*rstr], stdout); }
+CEED_EXTERN void fCeedElemRestrictionView(int *rstr, int *err) { CeedCallFortran(CeedElemRestrictionView(CeedElemRestriction_dict[*rstr], stdout)); }
 
 #define fCeedElemRestrictionDestroy FORTRAN_NAME(ceedelemrestrictiondestroy, CEEDELEMRESTRICTIONDESTROY)
 CEED_EXTERN void fCeedElemRestrictionDestroy(int *rstr, int *err) {
   if (*rstr == FORTRAN_NULL) return;
-  *err = CeedElemRestrictionDestroy(&CeedElemRestriction_dict[*rstr]);
-
-  if (*err == 0) {
-    *rstr = FORTRAN_NULL;
-    num_active_CeedElemRestriction--;
-    if (num_active_CeedElemRestriction == 0) {
-      CeedFree(&CeedElemRestriction_dict);
-      num_CeedElemRestriction = 0;
-      max_CeedElemRestriction = 0;
-    }
+  CeedCallFortran(CeedElemRestrictionDestroy(&CeedElemRestriction_dict[*rstr]));
+  *rstr = FORTRAN_NULL;
+  num_active_CeedElemRestriction--;
+  if (num_active_CeedElemRestriction == 0) {
+    CeedFree(&CeedElemRestriction_dict);
+    num_CeedElemRestriction = 0;
+    max_CeedElemRestriction = 0;
   }
 }
 
@@ -481,8 +483,9 @@ static inline void fCeedBasisAccept(int *basis) {
 #define fCeedBasisCreateTensorH1Lagrange FORTRAN_NAME(ceedbasiscreatetensorh1lagrange, CEEDBASISCREATETENSORH1LAGRANGE)
 CEED_EXTERN void fCeedBasisCreateTensorH1Lagrange(int *ceed, int *dim, int *num_comp, int *P, int *Q, int *quad_mode, int *basis, int *err) {
   if (num_CeedBasis == max_CeedBasis) fCeedBasisExpandDict();
-  *err = CeedBasisCreateTensorH1Lagrange(Ceed_dict[*ceed], *dim, *num_comp, *P, *Q, (CeedQuadMode)*quad_mode, &CeedBasis_dict[num_CeedBasis]);
-  if (*err == 0) fCeedBasisAccept(basis);
+  CeedCallFortran(CeedBasisCreateTensorH1Lagrange(Ceed_dict[*ceed], *dim, *num_comp, *P, *Q, (CeedQuadMode)*quad_mode,
+                                                  &CeedBasis_dict[num_CeedBasis]));
+  fCeedBasisAccept(basis);
 }
 
 #define fCeedBasisCreateTensorH1 FORTRAN_NAME(ceedbasiscreatetensorh1, CEEDBASISCREATETENSORH1)
@@ -490,68 +493,72 @@ CEED_EXTERN void fCeedBasisCreateTensorH1(int *ceed, int *dim, int *num_comp, in
                                           const CeedScalar *grad_1d, const CeedScalar *q_ref_1d, const CeedScalar *q_weight_1d, int *basis,
                                           int *err) {
   if (num_CeedBasis == max_CeedBasis) fCeedBasisExpandDict();
-  *err = CeedBasisCreateTensorH1(Ceed_dict[*ceed], *dim, *num_comp, *P_1d, *Q_1d, interp_1d, grad_1d, q_ref_1d, q_weight_1d,
-                                 &CeedBasis_dict[num_CeedBasis]);
-  if (*err == 0) fCeedBasisAccept(basis);
+  CeedCallFortran(CeedBasisCreateTensorH1(Ceed_dict[*ceed], *dim, *num_comp, *P_1d, *Q_1d, interp_1d, grad_1d, q_ref_1d, q_weight_1d,
+                                          &CeedBasis_dict[num_CeedBasis]));
+  fCeedBasisAccept(basis);
 }
 
 #define fCeedBasisCreateH1 FORTRAN_NAME(ceedbasiscreateh1, CEEDBASISCREATEH1)
 CEED_EXTERN void fCeedBasisCreateH1(int *ceed, int *topo, int *num_comp, int *num_nodes, int *num_qpts, const CeedScalar *interp,
                                     const CeedScalar *grad, const CeedScalar *q_ref, const CeedScalar *q_weight, int *basis, int *err) {
   if (num_CeedBasis == max_CeedBasis) fCeedBasisExpandDict();
-  *err = CeedBasisCreateH1(Ceed_dict[*ceed], (CeedElemTopology)*topo, *num_comp, *num_nodes, *num_qpts, interp, grad, q_ref, q_weight,
-                           &CeedBasis_dict[num_CeedBasis]);
-  if (*err == 0) fCeedBasisAccept(basis);
+  CeedCallFortran(CeedBasisCreateH1(Ceed_dict[*ceed], (CeedElemTopology)*topo, *num_comp, *num_nodes, *num_qpts, interp, grad, q_ref, q_weight,
+                                    &CeedBasis_dict[num_CeedBasis]));
+  fCeedBasisAccept(basis);
 }
 
 #define fCeedBasisCreateHdiv FORTRAN_NAME(ceedbasiscreatehdiv, CEEDBASISCREATEHDIV)
 CEED_EXTERN void fCeedBasisCreateHdiv(int *ceed, int *topo, int *num_comp, int *num_nodes, int *num_qpts, const CeedScalar *interp,
                                       const CeedScalar *div, const CeedScalar *q_ref, const CeedScalar *q_weight, int *basis, int *err) {
   if (num_CeedBasis == max_CeedBasis) fCeedBasisExpandDict();
-  *err = CeedBasisCreateHdiv(Ceed_dict[*ceed], (CeedElemTopology)*topo, *num_comp, *num_nodes, *num_qpts, interp, div, q_ref, q_weight,
-                             &CeedBasis_dict[num_CeedBasis]);
-  if (*err == 0) fCeedBasisAccept(basis);
+  CeedCallFortran(CeedBasisCreateHdiv(Ceed_dict[*ceed], (CeedElemTopology)*topo, *num_comp, *num_nodes, *num_qpts, interp, div, q_ref, q_weight,
+                                      &CeedBasis_dict[num_CeedBasis]));
+  fCeedBasisAccept(basis);
 }
 
 #define fCeedBasisCreateHcurl FORTRAN_NAME(ceedbasiscreatehcurl, CEEDBASISCREATEHCURL)
 CEED_EXTERN void fCeedBasisCreateHcurl(int *ceed, int *topo, int *num_comp, int *num_nodes, int *num_qpts, const CeedScalar *interp,
                                        const CeedScalar *curl, const CeedScalar *q_ref, const CeedScalar *q_weight, int *basis, int *err) {
   if (num_CeedBasis == max_CeedBasis) fCeedBasisExpandDict();
-  *err = CeedBasisCreateHcurl(Ceed_dict[*ceed], (CeedElemTopology)*topo, *num_comp, *num_nodes, *num_qpts, interp, curl, q_ref, q_weight,
-                              &CeedBasis_dict[num_CeedBasis]);
-  if (*err == 0) fCeedBasisAccept(basis);
+  CeedCallFortran(CeedBasisCreateHcurl(Ceed_dict[*ceed], (CeedElemTopology)*topo, *num_comp, *num_nodes, *num_qpts, interp, curl, q_ref, q_weight,
+                                       &CeedBasis_dict[num_CeedBasis]));
+  fCeedBasisAccept(basis);
 }
 
 #define fCeedBasisSetNumViewTabs FORTRAN_NAME(ceedbasissetnumviewtabs, CEEDBASISSETNUMVIEWTABS)
-CEED_EXTERN void fCeedBasisSetNumViewTabs(int *basis, int *num_tabs, int *err) { *err = CeedBasisSetNumViewTabs(CeedBasis_dict[*basis], *num_tabs); }
+CEED_EXTERN void fCeedBasisSetNumViewTabs(int *basis, int *num_tabs, int *err) {
+  CeedCallFortran(CeedBasisSetNumViewTabs(CeedBasis_dict[*basis], *num_tabs));
+}
 
 #define fCeedBasisView FORTRAN_NAME(ceedbasisview, CEEDBASISVIEW)
-CEED_EXTERN void fCeedBasisView(int *basis, int *err) { *err = CeedBasisView(CeedBasis_dict[*basis], stdout); }
+CEED_EXTERN void fCeedBasisView(int *basis, int *err) { CeedCallFortran(CeedBasisView(CeedBasis_dict[*basis], stdout)); }
 
 #define fCeedBasisGetCollocatedGrad FORTRAN_NAME(ceedbasisgetcollocatedgrad, CEEDBASISGETCOLLOCATEDGRAD)
 CEED_EXTERN void fCeedBasisGetCollocatedGrad(int *basis, CeedScalar *colo_grad_1d, int *err) {
-  *err = CeedBasisGetCollocatedGrad(CeedBasis_dict[*basis], colo_grad_1d);
+  CeedCallFortran(CeedBasisGetCollocatedGrad(CeedBasis_dict[*basis], colo_grad_1d));
 }
 
 #define fCeedBasisApply FORTRAN_NAME(ceedbasisapply, CEEDBASISAPPLY)
 CEED_EXTERN void fCeedBasisApply(int *basis, int *num_elem, int *t_mode, int *eval_mode, int *u, int *v, int *err) {
-  *err = CeedBasisApply(CeedBasis_dict[*basis], *num_elem, (CeedTransposeMode)*t_mode, (CeedEvalMode)*eval_mode,
-                        *u == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*u], CeedVector_dict[*v]);
+  CeedCallFortran(CeedBasisApply(CeedBasis_dict[*basis], *num_elem, (CeedTransposeMode)*t_mode, (CeedEvalMode)*eval_mode,
+                                 *u == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*u], CeedVector_dict[*v]));
 }
 
 #define fCeedBasisGetNumNodes FORTRAN_NAME(ceedbasisgetnumnodes, CEEDBASISGETNUMNODES)
-CEED_EXTERN void fCeedBasisGetNumNodes(int *basis, int *num_nodes, int *err) { *err = CeedBasisGetNumNodes(CeedBasis_dict[*basis], num_nodes); }
+CEED_EXTERN void fCeedBasisGetNumNodes(int *basis, int *num_nodes, int *err) {
+  CeedCallFortran(CeedBasisGetNumNodes(CeedBasis_dict[*basis], num_nodes));
+}
 
 #define fCeedBasisGetNumQuadraturePoints FORTRAN_NAME(ceedbasisgetnumquadraturepoints, CEEDBASISGETNUMQUADRATUREPOINTS)
 CEED_EXTERN void fCeedBasisGetNumQuadraturePoints(int *basis, int *num_q_pts, int *err) {
-  *err = CeedBasisGetNumQuadraturePoints(CeedBasis_dict[*basis], num_q_pts);
+  CeedCallFortran(CeedBasisGetNumQuadraturePoints(CeedBasis_dict[*basis], num_q_pts));
 }
 
 #define fCeedBasisGetInterp1D FORTRAN_NAME(ceedbasisgetinterp1d, CEEDBASISGETINTERP1D)
 CEED_EXTERN void fCeedBasisGetInterp1D(int *basis, CeedScalar *interp_1d, int64_t *offset, int *err) {
   const CeedScalar *interp_1d_c;
 
-  *err    = CeedBasisGetInterp1D(CeedBasis_dict[*basis], &interp_1d_c);
+  CeedCallFortran(CeedBasisGetInterp1D(CeedBasis_dict[*basis], &interp_1d_c));
   *offset = interp_1d_c - interp_1d;
 }
 
@@ -559,7 +566,7 @@ CEED_EXTERN void fCeedBasisGetInterp1D(int *basis, CeedScalar *interp_1d, int64_
 CEED_EXTERN void fCeedBasisGetGrad1D(int *basis, CeedScalar *grad_1d, int64_t *offset, int *err) {
   const CeedScalar *grad_1d_c;
 
-  *err    = CeedBasisGetGrad1D(CeedBasis_dict[*basis], &grad_1d_c);
+  CeedCallFortran(CeedBasisGetGrad1D(CeedBasis_dict[*basis], &grad_1d_c));
   *offset = grad_1d_c - grad_1d;
 }
 
@@ -567,34 +574,31 @@ CEED_EXTERN void fCeedBasisGetGrad1D(int *basis, CeedScalar *grad_1d, int64_t *o
 CEED_EXTERN void fCeedBasisGetQRef(int *basis, CeedScalar *q_ref, int64_t *offset, int *err) {
   const CeedScalar *q_ref_c;
 
-  *err    = CeedBasisGetQRef(CeedBasis_dict[*basis], &q_ref_c);
+  CeedCallFortran(CeedBasisGetQRef(CeedBasis_dict[*basis], &q_ref_c));
   *offset = q_ref_c - q_ref;
 }
 
 #define fCeedBasisDestroy FORTRAN_NAME(ceedbasisdestroy, CEEDBASISDESTROY)
 CEED_EXTERN void fCeedBasisDestroy(int *basis, int *err) {
   if (*basis == FORTRAN_NULL) return;
-  *err = CeedBasisDestroy(&CeedBasis_dict[*basis]);
-
-  if (*err == 0) {
-    *basis = FORTRAN_NULL;
-    num_active_CeedBasis--;
-    if (num_active_CeedBasis == 0) {
-      CeedFree(&CeedBasis_dict);
-      num_CeedBasis = 0;
-      max_CeedBasis = 0;
-    }
+  CeedCallFortran(CeedBasisDestroy(&CeedBasis_dict[*basis]));
+  *basis = FORTRAN_NULL;
+  num_active_CeedBasis--;
+  if (num_active_CeedBasis == 0) {
+    CeedFree(&CeedBasis_dict);
+    num_CeedBasis = 0;
+    max_CeedBasis = 0;
   }
 }
 
 #define fCeedGaussQuadrature FORTRAN_NAME(ceedgaussquadrature, CEEDGAUSSQUADRATURE)
 CEED_EXTERN void fCeedGaussQuadrature(int *Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d, int *err) {
-  *err = CeedGaussQuadrature(*Q, q_ref_1d, q_weight_1d);
+  CeedCallFortran(CeedGaussQuadrature(*Q, q_ref_1d, q_weight_1d));
 }
 
 #define fCeedLobattoQuadrature FORTRAN_NAME(ceedlobattoquadrature, CEEDLOBATTOQUADRATURE)
 CEED_EXTERN void fCeedLobattoQuadrature(int *Q, CeedScalar *q_ref_1d, CeedScalar *q_weight_1d, int *err) {
-  *err = CeedLobattoQuadrature(*Q, q_ref_1d, q_weight_1d);
+  CeedCallFortran(CeedLobattoQuadrature(*Q, q_ref_1d, q_weight_1d));
 }
 
 // -----------------------------------------------------------------------------
@@ -619,52 +623,50 @@ static inline void fCeedQFunctionContextAccept(int *ctx) {
 #define fCeedQFunctionContextCreate FORTRAN_NAME(ceedqfunctioncontextcreate, CEEDQFUNCTIONCONTEXTCREATE)
 CEED_EXTERN void fCeedQFunctionContextCreate(int *ceed, int *ctx, int *err) {
   if (num_CeedQFunctionContext == max_CeedQFunctionContext) fCeedQFunctionContextExpandDict();
-  *err = CeedQFunctionContextCreate(Ceed_dict[*ceed], &CeedQFunctionContext_dict[num_CeedQFunctionContext]);
-  if (*err == 0) fCeedQFunctionContextAccept(ctx);
+  CeedCallFortran(CeedQFunctionContextCreate(Ceed_dict[*ceed], &CeedQFunctionContext_dict[num_CeedQFunctionContext]));
+  fCeedQFunctionContextAccept(ctx);
 }
 
 #define fCeedQFunctionContextSetData FORTRAN_NAME(ceedqfunctioncontextsetdata, CEEDQFUNCTIONCONTEXTSETDATA)
 CEED_EXTERN void fCeedQFunctionContextSetData(int *ctx, int *mem_type, int *copy_mode, CeedInt *n, CeedScalar *data, int64_t *offset, int *err) {
   size_t ctx_size = ((size_t)*n) * sizeof(CeedScalar);
 
-  *err = CeedQFunctionContextSetData(CeedQFunctionContext_dict[*ctx], (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, ctx_size, data + *offset);
+  CeedCallFortran(CeedQFunctionContextSetData(CeedQFunctionContext_dict[*ctx], (CeedMemType)*mem_type, (CeedCopyMode)*copy_mode, ctx_size,
+                                              data + *offset));
 }
 
 #define fCeedQFunctionContextGetData FORTRAN_NAME(ceedqfunctioncontextgetdata, CEEDQFUNCTIONCONTEXTGETDATA)
 CEED_EXTERN void fCeedQFunctionContextGetData(int *ctx, int *mem_type, CeedScalar *data, int64_t *offset, int *err) {
   CeedScalar *data_c;
 
-  *err    = CeedQFunctionContextGetData(CeedQFunctionContext_dict[*ctx], (CeedMemType)*mem_type, &data_c);
+  CeedCallFortran(CeedQFunctionContextGetData(CeedQFunctionContext_dict[*ctx], (CeedMemType)*mem_type, &data_c));
   *offset = data_c - data;
 }
 
 #define fCeedQFunctionContextRestoreData FORTRAN_NAME(ceedqfunctioncontextrestoredata, CEEDQFUNCTIONCONTEXTRESTOREDATA)
 CEED_EXTERN void fCeedQFunctionContextRestoreData(int *ctx, CeedScalar *data, int64_t *offset, int *err) {
-  *err    = CeedQFunctionContextRestoreData(CeedQFunctionContext_dict[*ctx], (void **)&data);
+  CeedCallFortran(CeedQFunctionContextRestoreData(CeedQFunctionContext_dict[*ctx], (void **)&data));
   *offset = 0;
 }
 
 #define fCeedQFunctionContextSetNumViewTabs FORTRAN_NAME(ceedqfunctioncontextsetnumviewtabs, CEEDQFUNCTIONCONTEXTSETNUMVIEWTABS)
 CEED_EXTERN void fCeedQFunctionContextSetNumViewTabs(int *ctx, int *num_tabs, int *err) {
-  *err = CeedQFunctionContextSetNumViewTabs(CeedQFunctionContext_dict[*ctx], *num_tabs);
+  CeedCallFortran(CeedQFunctionContextSetNumViewTabs(CeedQFunctionContext_dict[*ctx], *num_tabs));
 }
 
 #define fCeedQFunctionContextView FORTRAN_NAME(ceedqfunctioncontextview, CEEDQFUNCTIONCONTEXTVIEW)
-CEED_EXTERN void fCeedQFunctionContextView(int *ctx, int *err) { *err = CeedQFunctionContextView(CeedQFunctionContext_dict[*ctx], stdout); }
+CEED_EXTERN void fCeedQFunctionContextView(int *ctx, int *err) { CeedCallFortran(CeedQFunctionContextView(CeedQFunctionContext_dict[*ctx], stdout)); }
 
 #define fCeedQFunctionContextDestroy FORTRAN_NAME(ceedqfunctioncontextdestroy, CEEDQFUNCTIONCONTEXTDESTROY)
 CEED_EXTERN void fCeedQFunctionContextDestroy(int *ctx, int *err) {
   if (*ctx == FORTRAN_NULL) return;
-  *err = CeedQFunctionContextDestroy(&CeedQFunctionContext_dict[*ctx]);
-
-  if (*err == 0) {
-    *ctx = FORTRAN_NULL;
-    num_active_CeedQFunctionContext--;
-    if (num_active_CeedQFunctionContext == 0) {
-      CeedFree(&CeedQFunctionContext_dict);
-      num_CeedQFunctionContext = 0;
-      max_CeedQFunctionContext = 0;
-    }
+  CeedCallFortran(CeedQFunctionContextDestroy(&CeedQFunctionContext_dict[*ctx]));
+  *ctx = FORTRAN_NULL;
+  num_active_CeedQFunctionContext--;
+  if (num_active_CeedQFunctionContext == 0) {
+    CeedFree(&CeedQFunctionContext_dict);
+    num_CeedQFunctionContext = 0;
+    max_CeedQFunctionContext = 0;
   }
 }
 
@@ -721,56 +723,52 @@ CEED_EXTERN void fCeedQFunctionCreateInterior(
 
   CeedQFunction *qf_c = &CeedQFunction_dict[num_CeedQFunction];
 
-  *err = CeedQFunctionCreateInterior(Ceed_dict[*ceed], *vec_length, CeedQFunctionFortranStub, source_c, qf_c);
-  if (*err == 0) fCeedQFunctionAccept(qf);
+  CeedCallFortran(CeedQFunctionCreateInterior(Ceed_dict[*ceed], *vec_length, CeedQFunctionFortranStub, source_c, qf_c));
+  fCeedQFunctionAccept(qf);
 
-  CeedQFunctionContext ctx_c;
-  CeedFortranContext   ctx_data;
+  {
+    CeedQFunctionContext ctx_c;
+    CeedFortranContext   ctx_data;
 
-  *err = CeedCalloc(1, &ctx_data);
-  if (*err) return;
-
-  ctx_data->f         = f;
-  ctx_data->inner_ctx = NULL;
-
-  *err = CeedQFunctionContextCreate(Ceed_dict[*ceed], &ctx_c);
-  if (*err) return;
-  *err = CeedQFunctionContextSetData(ctx_c, CEED_MEM_HOST, CEED_OWN_POINTER, sizeof(*ctx_data), ctx_data);
-  if (*err) return;
-  *err = CeedQFunctionSetContext(*qf_c, ctx_c);
-  if (*err) return;
-  CeedQFunctionContextDestroy(&ctx_c);
-  if (*err) return;
-  *err = CeedQFunctionSetFortranStatus(*qf_c, true);
+    CeedCallFortran(CeedCalloc(1, &ctx_data));
+    ctx_data->f         = f;
+    ctx_data->inner_ctx = NULL;
+    CeedCallFortran(CeedQFunctionContextCreate(Ceed_dict[*ceed], &ctx_c));
+    CeedCallFortran(CeedQFunctionContextSetData(ctx_c, CEED_MEM_HOST, CEED_OWN_POINTER, sizeof(*ctx_data), ctx_data));
+    CeedCallFortran(CeedQFunctionSetContext(*qf_c, ctx_c));
+    CeedCallFortran(CeedQFunctionContextDestroy(&ctx_c));
+    CeedCallFortran(CeedQFunctionSetFortranStatus(*qf_c, true));
+  }
 }
 
 #define fCeedQFunctionCreateInteriorByName FORTRAN_NAME(ceedqfunctioncreateinteriorbyname, CEEDQFUNCTIONCREATEINTERIORBYNAME)
 CEED_EXTERN void fCeedQFunctionCreateInteriorByName(int *ceed, const char *name, int *qf, int *err, fortran_charlen_t name_len) {
   FIX_STRING(name);
   if (num_CeedQFunction == max_CeedQFunction) fCeedQFunctionExpandDict();
-  *err = CeedQFunctionCreateInteriorByName(Ceed_dict[*ceed], name_c, &CeedQFunction_dict[num_CeedQFunction]);
-  if (*err == 0) fCeedQFunctionAccept(qf);
+  CeedCallFortran(CeedQFunctionCreateInteriorByName(Ceed_dict[*ceed], name_c, &CeedQFunction_dict[num_CeedQFunction]));
+  fCeedQFunctionAccept(qf);
 }
 
 #define fCeedQFunctionCreateIdentity FORTRAN_NAME(ceedqfunctioncreateidentity, CEEDQFUNCTIONCREATEIDENTITY)
 CEED_EXTERN void fCeedQFunctionCreateIdentity(int *ceed, int *size, int *inmode, int *outmode, int *qf, int *err) {
   if (num_CeedQFunction == max_CeedQFunction) fCeedQFunctionExpandDict();
-  *err = CeedQFunctionCreateIdentity(Ceed_dict[*ceed], *size, (CeedEvalMode)*inmode, (CeedEvalMode)*outmode, &CeedQFunction_dict[num_CeedQFunction]);
-  if (*err == 0) fCeedQFunctionAccept(qf);
+  CeedCallFortran(CeedQFunctionCreateIdentity(Ceed_dict[*ceed], *size, (CeedEvalMode)*inmode, (CeedEvalMode)*outmode,
+                                              &CeedQFunction_dict[num_CeedQFunction]));
+  fCeedQFunctionAccept(qf);
 }
 
 #define fCeedQFunctionAddInput FORTRAN_NAME(ceedqfunctionaddinput, CEEDQFUNCTIONADDINPUT)
 CEED_EXTERN void fCeedQFunctionAddInput(int *qf, const char *field_name, CeedInt *num_comp, CeedEvalMode *eval_mode, int *err,
                                         fortran_charlen_t field_name_len) {
   FIX_STRING(field_name);
-  *err = CeedQFunctionAddInput(CeedQFunction_dict[*qf], field_name_c, *num_comp, *eval_mode);
+  CeedCallFortran(CeedQFunctionAddInput(CeedQFunction_dict[*qf], field_name_c, *num_comp, *eval_mode));
 }
 
 #define fCeedQFunctionAddOutput FORTRAN_NAME(ceedqfunctionaddoutput, CEEDQFUNCTIONADDOUTPUT)
 CEED_EXTERN void fCeedQFunctionAddOutput(int *qf, const char *field_name, CeedInt *num_comp, CeedEvalMode *eval_mode, int *err,
                                          fortran_charlen_t field_name_len) {
   FIX_STRING(field_name);
-  *err = CeedQFunctionAddOutput(CeedQFunction_dict[*qf], field_name_c, *num_comp, *eval_mode);
+  CeedCallFortran(CeedQFunctionAddOutput(CeedQFunction_dict[*qf], field_name_c, *num_comp, *eval_mode));
 }
 
 #define fCeedQFunctionSetContext FORTRAN_NAME(ceedqfunctionsetcontext, CEEDQFUNCTIONSETCONTEXT)
@@ -779,23 +777,20 @@ CEED_EXTERN void fCeedQFunctionSetContext(int *qf, int *ctx, int *err) {
   CeedQFunctionContext ctx_f = CeedQFunctionContext_dict[*ctx];
   CeedFortranContext   ctx_data;
 
-  *err = CeedQFunctionGetContext(CeedQFunction_dict[*qf], &ctx_c);
-  if (*err) return;
-  *err = CeedQFunctionContextGetData(ctx_c, CEED_MEM_HOST, &ctx_data);
-  if (*err) return;
+  CeedCallFortran(CeedQFunctionGetContext(CeedQFunction_dict[*qf], &ctx_c));
+  CeedCallFortran(CeedQFunctionContextGetData(ctx_c, CEED_MEM_HOST, &ctx_data));
   ctx_data->inner_ctx = ctx_f;
-  *err                = CeedQFunctionContextRestoreData(ctx_c, (void **)&ctx_data);
-  if (*err) return;
-  *err = CeedQFunctionContextDestroy(&ctx_c);
+  CeedCallFortran(CeedQFunctionContextRestoreData(ctx_c, (void **)&ctx_data));
+  CeedCallFortran(CeedQFunctionContextDestroy(&ctx_c));
 }
 
 #define fCeedQFunctionSetNumViewTabs FORTRAN_NAME(ceedqfunctionsetnumviewtabs, CEEDQFUNCTIONSETNUMVIEWTABS)
 CEED_EXTERN void fCeedQFunctionSetNumViewTabs(int *qf, int *num_tabs, int *err) {
-  *err = CeedQFunctionSetNumViewTabs(CeedQFunction_dict[*qf], *num_tabs);
+  CeedCallFortran(CeedQFunctionSetNumViewTabs(CeedQFunction_dict[*qf], *num_tabs));
 }
 
 #define fCeedQFunctionView FORTRAN_NAME(ceedqfunctionview, CEEDQFUNCTIONVIEW)
-CEED_EXTERN void fCeedQFunctionView(int *qf, int *err) { *err = CeedQFunctionView(CeedQFunction_dict[*qf], stdout); }
+CEED_EXTERN void fCeedQFunctionView(int *qf, int *err) { CeedCallFortran(CeedQFunctionView(CeedQFunction_dict[*qf], stdout)); }
 
 #define fCeedQFunctionApply FORTRAN_NAME(ceedqfunctionapply, CEEDQFUNCTIONAPPLY)
 // TODO Need Fixing, double pointer
@@ -805,8 +800,7 @@ CEED_EXTERN void fCeedQFunctionApply(int *qf, int *num_qpts, int *u, int *u1, in
   CeedVector *in;
   CeedVector *out;
 
-  *err = CeedCalloc(CEED_FIELD_MAX, &in);
-  if (*err) return;
+  CeedCallFortran(CeedCalloc(CEED_FIELD_MAX, &in));
   in[0]  = *u == FORTRAN_NULL ? NULL : CeedVector_dict[*u];
   in[1]  = *u1 == FORTRAN_NULL ? NULL : CeedVector_dict[*u1];
   in[2]  = *u2 == FORTRAN_NULL ? NULL : CeedVector_dict[*u2];
@@ -824,8 +818,7 @@ CEED_EXTERN void fCeedQFunctionApply(int *qf, int *num_qpts, int *u, int *u1, in
   in[14] = *u14 == FORTRAN_NULL ? NULL : CeedVector_dict[*u14];
   in[15] = *u15 == FORTRAN_NULL ? NULL : CeedVector_dict[*u15];
 
-  *err = CeedCalloc(CEED_FIELD_MAX, &out);
-  if (*err) return;
+  CeedCallFortran(CeedCalloc(CEED_FIELD_MAX, &out));
   out[0]  = *v == FORTRAN_NULL ? NULL : CeedVector_dict[*v];
   out[1]  = *v1 == FORTRAN_NULL ? NULL : CeedVector_dict[*v1];
   out[2]  = *v2 == FORTRAN_NULL ? NULL : CeedVector_dict[*v2];
@@ -843,27 +836,21 @@ CEED_EXTERN void fCeedQFunctionApply(int *qf, int *num_qpts, int *u, int *u1, in
   out[14] = *v14 == FORTRAN_NULL ? NULL : CeedVector_dict[*v14];
   out[15] = *v15 == FORTRAN_NULL ? NULL : CeedVector_dict[*v15];
 
-  *err = CeedQFunctionApply(CeedQFunction_dict[*qf], *num_qpts, in, out);
-  if (*err) return;
-
-  *err = CeedFree(&in);
-  if (*err) return;
-  *err = CeedFree(&out);
+  CeedCallFortran(CeedQFunctionApply(CeedQFunction_dict[*qf], *num_qpts, in, out));
+  CeedCallFortran(CeedFree(&in));
+  CeedCallFortran(CeedFree(&out));
 }
 
 #define fCeedQFunctionDestroy FORTRAN_NAME(ceedqfunctiondestroy, CEEDQFUNCTIONDESTROY)
 CEED_EXTERN void fCeedQFunctionDestroy(int *qf, int *err) {
   if (*qf == FORTRAN_NULL) return;
-
-  *err = CeedQFunctionDestroy(&CeedQFunction_dict[*qf]);
-  if (*err == 0) {
-    *qf = FORTRAN_NULL;
-    num_active_CeedQFunction--;
-    if (num_active_CeedQFunction == 0) {
-      *err              = CeedFree(&CeedQFunction_dict);
-      num_CeedQFunction = 0;
-      max_CeedQFunction = 0;
-    }
+  CeedCallFortran(CeedQFunctionDestroy(&CeedQFunction_dict[*qf]));
+  *qf = FORTRAN_NULL;
+  num_active_CeedQFunction--;
+  if (num_active_CeedQFunction == 0) {
+    *err              = CeedFree(&CeedQFunction_dict);
+    num_CeedQFunction = 0;
+    max_CeedQFunction = 0;
   }
 }
 
@@ -891,18 +878,51 @@ CEED_EXTERN void fCeedOperatorCreate(int *ceed, int *qf, int *dqf, int *dqfT, in
   if (num_CeedOperator == max_CeedOperator) fCeedOperatorExpandDict();
 
   CeedQFunction dqf_c = CEED_QFUNCTION_NONE, dqfT_c = CEED_QFUNCTION_NONE;
+
   if (*dqf != FORTRAN_QFUNCTION_NONE) dqf_c = CeedQFunction_dict[*dqf];
   if (*dqfT != FORTRAN_QFUNCTION_NONE) dqfT_c = CeedQFunction_dict[*dqfT];
-
-  *err = CeedOperatorCreate(Ceed_dict[*ceed], CeedQFunction_dict[*qf], dqf_c, dqfT_c, &CeedOperator_dict[num_CeedOperator]);
-  if (*err == 0) fCeedOperatorAccept(op);
+  CeedCallFortran(CeedOperatorCreate(Ceed_dict[*ceed], CeedQFunction_dict[*qf], dqf_c, dqfT_c, &CeedOperator_dict[num_CeedOperator]));
+  fCeedOperatorAccept(op);
 }
 
 #define fCeedOperatorCreateComposite FORTRAN_NAME(ceedoperatorcreatecomposite, CEEDOPERATORCREATECOMPOSITE)
 CEED_EXTERN void fCeedOperatorCreateComposite(int *ceed, int *op, int *err) {
   if (num_CeedOperator == max_CeedOperator) fCeedOperatorExpandDict();
-  *err = CeedOperatorCreateComposite(Ceed_dict[*ceed], &CeedOperator_dict[num_CeedOperator]);
-  if (*err == 0) fCeedOperatorAccept(op);
+  CeedCallFortran(CeedOperatorCreateComposite(Ceed_dict[*ceed], &CeedOperator_dict[num_CeedOperator]));
+  fCeedOperatorAccept(op);
+}
+
+static inline void fCeedVectorFortranToC(int vec_f, CeedVector *vec_c) {
+  switch (vec_f) {
+    case FORTRAN_VECTOR_ACTIVE:
+      *vec_c = CEED_VECTOR_ACTIVE;
+      break;
+    case FORTRAN_VECTOR_NONE:
+      *vec_c = CEED_VECTOR_NONE;
+      break;
+    default:
+      *vec_c = CeedVector_dict[vec_f];
+  }
+}
+
+static inline void fCeedElemRestrictionFortranToC(int rstr_f, CeedElemRestriction *rstr_c) {
+  switch (rstr_f) {
+    case FORTRAN_ELEMRESTRICTION_NONE:
+      *rstr_c = CEED_ELEMRESTRICTION_NONE;
+      break;
+    default:
+      *rstr_c = CeedElemRestriction_dict[rstr_f];
+  }
+}
+
+static inline void fCeedBasisFortranToC(int basis_f, CeedBasis *basis_c) {
+  switch (basis_f) {
+    case FORTRAN_BASIS_NONE:
+      *basis_c = CEED_BASIS_NONE;
+      break;
+    default:
+      *basis_c = CeedBasis_dict[basis_f];
+  }
 }
 
 #define fCeedOperatorSetField FORTRAN_NAME(ceedoperatorsetfield, CEEDOPERATORSETFIELD)
@@ -912,66 +932,37 @@ CEED_EXTERN void fCeedOperatorSetField(int *op, const char *field_name, int *rst
   CeedElemRestriction rstr_c;
   CeedBasis           basis_c;
 
-  if (*vec == FORTRAN_NULL) {
-    vec_c = NULL;
-  } else if (*vec == FORTRAN_VECTOR_ACTIVE) {
-    vec_c = CEED_VECTOR_ACTIVE;
-  } else if (*vec == FORTRAN_VECTOR_NONE) {
-    vec_c = CEED_VECTOR_NONE;
-  } else {
-    vec_c = CeedVector_dict[*vec];
-  }
-  if (*rstr == FORTRAN_NULL) {
-    rstr_c = NULL;
-  } else if (*rstr == FORTRAN_ELEMRESTRICTION_NONE) {
-    rstr_c = CEED_ELEMRESTRICTION_NONE;
-  } else {
-    rstr_c = CeedElemRestriction_dict[*rstr];
-  }
-  if (*basis == FORTRAN_NULL) {
-    basis_c = NULL;
-  } else if (*basis == FORTRAN_BASIS_NONE) {
-    basis_c = CEED_BASIS_NONE;
-  } else {
-    basis_c = CeedBasis_dict[*basis];
-  }
-
-  *err = CeedOperatorSetField(CeedOperator_dict[*op], field_name_c, rstr_c, basis_c, vec_c);
+  fCeedVectorFortranToC(*vec, &vec_c);
+  fCeedElemRestrictionFortranToC(*rstr, &rstr_c);
+  fCeedBasisFortranToC(*basis, &basis_c);
+  CeedCallFortran(CeedOperatorSetField(CeedOperator_dict[*op], field_name_c, rstr_c, basis_c, vec_c));
 }
 
 #define fCeedOperatorCompositeAddSub FORTRAN_NAME(ceedoperatorcompositeaddsub, CEEDOPERATORCOMPOSITEADDSUB)
 CEED_EXTERN void fCeedOperatorCompositeAddSub(int *composite_op, int *sub_op, int *err) {
-  *err = CeedOperatorCompositeAddSub(CeedOperator_dict[*composite_op], CeedOperator_dict[*sub_op]);
+  CeedCallFortran(CeedOperatorCompositeAddSub(CeedOperator_dict[*composite_op], CeedOperator_dict[*sub_op]));
 }
 
 #define fCeedOperatorSetName FORTRAN_NAME(ceedoperatorsetname, CEEDOPERATORSETNAME)
 CEED_EXTERN void fCeedOperatorSetName(int *op, const char *name, int *err, fortran_charlen_t name_len) {
   FIX_STRING(name);
-  *err = CeedOperatorSetName(CeedOperator_dict[*op], name_c);
+  CeedCallFortran(CeedOperatorSetName(CeedOperator_dict[*op], name_c));
 }
 
 #define fCeedOperatorSetNumViewTabs FORTRAN_NAME(ceedoperatorsetnumviewtabs, CEEDOPERATORSETNUMVIEWTABS)
 CEED_EXTERN void fCeedOperatorSetNumViewTabs(int *op, int *num_tabs, int *err) {
-  *err = CeedOperatorSetNumViewTabs(CeedOperator_dict[*op], *num_tabs);
+  CeedCallFortran(CeedOperatorSetNumViewTabs(CeedOperator_dict[*op], *num_tabs));
 }
 
 #define fCeedOperatorLinearAssembleQFunction FORTRAN_NAME(ceedoperatorlinearassembleqfunction, CEEDOPERATORLINEARASSEMBLEQFUNCTION)
 CEED_EXTERN void fCeedOperatorLinearAssembleQFunction(int *op, int *assembled_vec, int *assembled_rstr, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
-
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
+  fCeedRequestFortranToC(*request, &request_c);
 
   // Vector
   if (num_CeedVector == max_CeedVector) fCeedVectorExpandDict();
@@ -980,35 +971,25 @@ CEED_EXTERN void fCeedOperatorLinearAssembleQFunction(int *op, int *assembled_ve
   if (num_CeedElemRestriction == max_CeedElemRestriction) fCeedElemRestrictionExpandDict();
 
   // Assembly
-  *err = CeedOperatorLinearAssembleQFunction(CeedOperator_dict[*op], &CeedVector_dict[num_CeedVector],
-                                             &CeedElemRestriction_dict[num_CeedElemRestriction], request_c);
-  if (*err == 0) {
-    fCeedVectorAccept(assembled_vec);
-    fCeedElemRestrictionAccept(assembled_rstr);
-    if (create_request) fCeedRequestAccept(request);
-  }
+  CeedCallFortran(CeedOperatorLinearAssembleQFunction(CeedOperator_dict[*op], &CeedVector_dict[num_CeedVector],
+                                                      &CeedElemRestriction_dict[num_CeedElemRestriction], request_c));
+  fCeedVectorAccept(assembled_vec);
+  fCeedElemRestrictionAccept(assembled_rstr);
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedOperatorLinearAssembleDiagonal FORTRAN_NAME(ceedoperatorlinearassemblediagonal, CEEDOPERATORLINEARASSEMBLEDIAGONAL)
 CEED_EXTERN void fCeedOperatorLinearAssembleDiagonal(int *op, int *assembled_vec, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
+  fCeedRequestFortranToC(*request, &request_c);
 
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
-
-  *err = CeedOperatorLinearAssembleDiagonal(CeedOperator_dict[*op], CeedVector_dict[*assembled_vec], request_c);
-  if (*err == 0 && create_request) fCeedRequestAccept(request);
+  CeedCallFortran(CeedOperatorLinearAssembleDiagonal(CeedOperator_dict[*op], CeedVector_dict[*assembled_vec], request_c));
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedOperatorMultigridLevelCreate FORTRAN_NAME(ceedoperatormultigridlevelcreate, CEEDOPERATORMULTIGRIDLEVELCREATE)
@@ -1018,10 +999,8 @@ CEED_EXTERN void fCeedOperatorMultigridLevelCreate(int *op_fine, int *p_mult_fin
   CeedOperator op_coarse_c, op_prolong_c, op_restrict_c;
 
   // C interface call
-  *err = CeedOperatorMultigridLevelCreate(CeedOperator_dict[*op_fine], CeedVector_dict[*p_mult_fine], CeedElemRestriction_dict[*rstr_coarse],
-                                          CeedBasis_dict[*basis_coarse], &op_coarse_c, &op_prolong_c, &op_restrict_c);
-
-  if (*err) return;
+  CeedCallFortran(CeedOperatorMultigridLevelCreate(CeedOperator_dict[*op_fine], CeedVector_dict[*p_mult_fine], CeedElemRestriction_dict[*rstr_coarse],
+                                                   CeedBasis_dict[*basis_coarse], &op_coarse_c, &op_prolong_c, &op_restrict_c));
   while (num_CeedOperator + 2 >= max_CeedOperator) max_CeedOperator += max_CeedOperator / 2 + 1;
   CeedRealloc(max_CeedOperator, &CeedOperator_dict);
   CeedOperator_dict[num_CeedOperator] = op_coarse_c;
@@ -1041,10 +1020,9 @@ CEED_EXTERN void fCeedOperatorMultigridLevelCreateTensorH1(int *op_fine, int *p_
   CeedOperator op_coarse_c, op_prolong_c, op_restrict_c;
 
   // C interface call
-  *err = CeedOperatorMultigridLevelCreateTensorH1(CeedOperator_dict[*op_fine], CeedVector_dict[*p_mult_fine], CeedElemRestriction_dict[*rstr_coarse],
-                                                  CeedBasis_dict[*basis_coarse], interp_c_to_f, &op_coarse_c, &op_prolong_c, &op_restrict_c);
-
-  if (*err) return;
+  CeedCallFortran(CeedOperatorMultigridLevelCreateTensorH1(CeedOperator_dict[*op_fine], CeedVector_dict[*p_mult_fine],
+                                                           CeedElemRestriction_dict[*rstr_coarse], CeedBasis_dict[*basis_coarse], interp_c_to_f,
+                                                           &op_coarse_c, &op_prolong_c, &op_restrict_c));
   while (num_CeedOperator + 2 >= max_CeedOperator) max_CeedOperator += max_CeedOperator / 2 + 1;
   CeedRealloc(max_CeedOperator, &CeedOperator_dict);
   CeedOperator_dict[num_CeedOperator] = op_coarse_c;
@@ -1063,10 +1041,9 @@ CEED_EXTERN void fCeedOperatorMultigridLevelCreateH1(int *op_fine, int *p_mult_f
   CeedOperator op_coarse_c, op_prolong_c, op_restrict_c;
 
   // C interface call
-  *err = CeedOperatorMultigridLevelCreateH1(CeedOperator_dict[*op_fine], CeedVector_dict[*p_mult_fine], CeedElemRestriction_dict[*rstr_coarse],
-                                            CeedBasis_dict[*basis_coarse], interp_c_to_f, &op_coarse_c, &op_prolong_c, &op_restrict_c);
-
-  if (*err) return;
+  CeedCallFortran(CeedOperatorMultigridLevelCreateH1(CeedOperator_dict[*op_fine], CeedVector_dict[*p_mult_fine],
+                                                     CeedElemRestriction_dict[*rstr_coarse], CeedBasis_dict[*basis_coarse], interp_c_to_f,
+                                                     &op_coarse_c, &op_prolong_c, &op_restrict_c));
   while (num_CeedOperator + 2 >= max_CeedOperator) max_CeedOperator += max_CeedOperator / 2 + 1;
   CeedRealloc(max_CeedOperator, &CeedOperator_dict);
   CeedOperator_dict[num_CeedOperator] = op_coarse_c;
@@ -1079,98 +1056,68 @@ CEED_EXTERN void fCeedOperatorMultigridLevelCreateH1(int *op_fine, int *p_mult_f
 }
 
 #define fCeedOperatorView FORTRAN_NAME(ceedoperatorview, CEEDOPERATORVIEW)
-CEED_EXTERN void fCeedOperatorView(int *op, int *err) { *err = CeedOperatorView(CeedOperator_dict[*op], stdout); }
+CEED_EXTERN void fCeedOperatorView(int *op, int *err) { CeedCallFortran(CeedOperatorView(CeedOperator_dict[*op], stdout)); }
 
 #define fCeedOperatorCreateFDMElementInverse FORTRAN_NAME(ceedoperatorcreatefdmelementinverse, CEEDOPERATORCREATEFDMELEMENTINVERSE)
 CEED_EXTERN void fCeedOperatorCreateFDMElementInverse(int *op, int *fdm_inv, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
-
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
+  fCeedRequestFortranToC(*request, &request_c);
 
   // Operator
   if (num_CeedOperator == max_CeedOperator) fCeedOperatorExpandDict();
 
-  *err = CeedOperatorCreateFDMElementInverse(CeedOperator_dict[*op], &CeedOperator_dict[num_CeedOperator], request_c);
-  if (*err == 0) {
-    fCeedOperatorAccept(fdm_inv);
-    if (create_request) fCeedRequestAccept(request);
-  }
+  CeedCallFortran(CeedOperatorCreateFDMElementInverse(CeedOperator_dict[*op], &CeedOperator_dict[num_CeedOperator], request_c));
+  fCeedOperatorAccept(fdm_inv);
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedOperatorApply FORTRAN_NAME(ceedoperatorapply, CEEDOPERATORAPPLY)
 CEED_EXTERN void fCeedOperatorApply(int *op, int *in, int *out, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
+  CeedVector   in_c  = (*in == FORTRAN_NULL) ? NULL : (*in == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*in]);
+  CeedVector   out_c = (*out == FORTRAN_NULL) ? NULL : (*out == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*out]);
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
+  fCeedRequestFortranToC(*request, &request_c);
 
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
-
-  CeedVector in_c  = (*in == FORTRAN_NULL) ? NULL : (*in == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*in]);
-  CeedVector out_c = (*out == FORTRAN_NULL) ? NULL : (*out == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*out]);
-
-  *err = CeedOperatorApply(CeedOperator_dict[*op], in_c, out_c, request_c);
-  if (*err == 0 && create_request) fCeedRequestAccept(request);
+  CeedCallFortran(CeedOperatorApply(CeedOperator_dict[*op], in_c, out_c, request_c));
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedOperatorApplyAdd FORTRAN_NAME(ceedoperatorapplyadd, CEEDOPERATORAPPLYADD)
 CEED_EXTERN void fCeedOperatorApplyAdd(int *op, int *in, int *out, int *request, int *err) {
-  bool create_request = true;
+  bool         create_request = true;
+  CeedRequest *request_c;
+  CeedVector   in_c  = (*in == FORTRAN_NULL) ? NULL : (*in == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*in]);
+  CeedVector   out_c = (*out == FORTRAN_NULL) ? NULL : (*out == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*out]);
 
   // Check if input is CEED_REQUEST_ORDERED(-2) or CEED_REQUEST_IMMEDIATE(-1)
   if (*request == FORTRAN_REQUEST_IMMEDIATE || *request == FORTRAN_REQUEST_ORDERED) create_request = false;
   if (create_request && num_CeedRequest == max_CeedRequest) fCeedRequestExpandDict();
+  fCeedRequestFortranToC(*request, &request_c);
 
-  CeedRequest *request_c;
-
-  if (*request == FORTRAN_REQUEST_IMMEDIATE) {
-    request_c = CEED_REQUEST_IMMEDIATE;
-  } else if (*request == FORTRAN_REQUEST_ORDERED) {
-    request_c = CEED_REQUEST_ORDERED;
-  } else {
-    request_c = &CeedRequest_dict[num_CeedRequest];
-  }
-
-  CeedVector in_c  = (*in == FORTRAN_NULL) ? NULL : (*in == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*in]);
-  CeedVector out_c = (*out == FORTRAN_NULL) ? NULL : (*out == FORTRAN_VECTOR_NONE ? CEED_VECTOR_NONE : CeedVector_dict[*out]);
-
-  *err = CeedOperatorApplyAdd(CeedOperator_dict[*op], in_c, out_c, request_c);
-  if (*err == 0 && create_request) fCeedRequestAccept(request);
+  CeedCallFortran(CeedOperatorApplyAdd(CeedOperator_dict[*op], in_c, out_c, request_c));
+  if (create_request) fCeedRequestAccept(request);
 }
 
 #define fCeedOperatorDestroy FORTRAN_NAME(ceedoperatordestroy, CEEDOPERATORDESTROY)
 CEED_EXTERN void fCeedOperatorDestroy(int *op, int *err) {
   if (*op == FORTRAN_NULL) return;
-  *err = CeedOperatorDestroy(&CeedOperator_dict[*op]);
-  if (*err == 0) {
-    *op = FORTRAN_NULL;
-    num_active_CeedOperator--;
-    if (num_active_CeedOperator == 0) {
-      *err             = CeedFree(&CeedOperator_dict);
-      num_CeedOperator = 0;
-      max_CeedOperator = 0;
-    }
+  CeedCallFortran(CeedOperatorDestroy(&CeedOperator_dict[*op]));
+  *op = FORTRAN_NULL;
+  num_active_CeedOperator--;
+  if (num_active_CeedOperator == 0) {
+    *err             = CeedFree(&CeedOperator_dict);
+    num_CeedOperator = 0;
+    max_CeedOperator = 0;
   }
 }
 


### PR DESCRIPTION
Purpose:

I realized that error handling was repetitive and inconsistent, so I added `CeedCallFortran()` to clean that up. Now `ceed-fortran.c` should feel more familiar to developers who know the style in our other files

Closes: #N/A

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
