### PR TITLE
fluids - change HIP backends to use VECHIP and MATAIJHIPSPARSE by default

### DIFF
--- a/examples/fluids/navierstokes.c
+++ b/examples/fluids/navierstokes.c
@@ -147,23 +147,28 @@ int main(int argc, char **argv) {
       break;
     case CEED_MEM_DEVICE: {
       const char *resolved;
+
       PetscCallCeed(ceed, CeedGetResource(ceed, &resolved));
-      if (strstr(resolved, "/gpu/cuda"))
+      if (strstr(resolved, "/gpu/cuda")) {
         vec_type = VECCUDA;
-      else if (strstr(resolved, "/gpu/hip"))
+      } else if (strstr(resolved, "/gpu/hip")) {
+        vec_type = VECHIP;
+      } else if (strstr(resolved, "/gpu/sycl")) {
         vec_type = VECKOKKOS;
-      else if (strstr(resolved, "/gpu/sycl"))
-        vec_type = VECKOKKOS;
-      else
+      } else {
         vec_type = VECSTANDARD;
+      }
     }
   }
-  if (strstr(vec_type, VECCUDA))
+  if (strstr(vec_type, VECCUDA)) {
     mat_type = MATAIJCUSPARSE;
-  else if (strstr(vec_type, VECKOKKOS))
+  } else if (strstr(vec_type, VECHIP)) {
+    mat_type = MATAIJHIPSPARSE;
+  } else if (strstr(vec_type, VECKOKKOS)) {
     mat_type = MATAIJKOKKOS;
-  else
+  } else {
     mat_type = MATAIJ;
+  }
   PetscCall(CreateDM(comm, problem, mat_type, vec_type, &dm));
   user->dm = dm;
   PetscCall(DMSetApplicationContext(dm, user));

--- a/examples/fluids/src/mat-ceed.c
+++ b/examples/fluids/src/mat-ceed.c
@@ -467,12 +467,15 @@ PetscErrorCode MatCreateCeed(DM dm_x, DM dm_y, CeedOperator op_mult, CeedOperato
     MatType coo_mat_type;
 
     PetscCall(VecGetType(ctx->X_loc, &vec_type));
-    if (strstr(vec_type, VECCUDA))
+    if (strstr(vec_type, VECCUDA)) {
       coo_mat_type = MATAIJCUSPARSE;
-    else if (strstr(vec_type, VECKOKKOS))
+    } else if (strstr(vec_type, VECHIP)) {
+      coo_mat_type = MATAIJHIPSPARSE;
+    } else if (strstr(vec_type, VECKOKKOS)) {
       coo_mat_type = MATAIJKOKKOS;
-    else
+    } else {
       coo_mat_type = MATAIJ;
+    }
     PetscCall(PetscStrallocpy(coo_mat_type, &ctx->coo_mat_type));
   }
   // -- Set mat operations


### PR DESCRIPTION
Purpose:

We used Kokkos in the past, but PETSc now has good HIP support.

Closes: NA

LLM/GenAI Disclosure:

None