### PR TITLE
xsmm - require 2.0 or later

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -448,7 +448,7 @@ noether-float:
     - echo "-------------- MAGMA ---------------"
     - export MAGMA_DIR=/projects/MAGMA && git -C $MAGMA_DIR -c safe.directory=$MAGMA_DIR describe
     # -- LIBXSMM 25 May 2026
-    - cd .. && export XSMM_HASH=0cea22fdc34ec54bc59ffb47a43cb3e28b26d3e0 && { [[ -d libxsmm-$XSMM_HASH ]] || { curl -L https://github.com/libxsmm/libxsmm/archive/$XSMM_HASH.tar.gz -o xsmm.tar.gz && tar zvxf xsmm.tar.gz && rm xsmm.tar.gz && make -C libxsmm-$XSMM_HASH -j$(nproc); }; } && export XSMM_DIR=$PWD/libxsmm-$XSMM_HASH && cd libCEED
+    - cd .. && export XSMM_HASH=5ce29626ddad947f0d5c433ce78c58ff64dfbbdb && { [[ -d libxsmm-$XSMM_HASH ]] || { curl -L https://github.com/libxsmm/libxsmm/archive/$XSMM_HASH.tar.gz -o xsmm.tar.gz && tar zvxf xsmm.tar.gz && rm xsmm.tar.gz && make -C libxsmm-$XSMM_HASH -j$(nproc); }; } && export XSMM_DIR=$PWD/libxsmm-$XSMM_HASH && cd libCEED
     - echo "-------------- LIBXSMM -------------" && basename $XSMM_DIR
   script:
     - rm -f .SUCCESS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ noether-cpu:
     - echo "GCOV=$GCOV" > job.env
     # Libraries for backends
     # -- LIBXSMM 25 May 2026
-    - cd .. && export XSMM_HASH=0cea22fdc34ec54bc59ffb47a43cb3e28b26d3e0 && { [[ -d libxsmm-$XSMM_HASH ]] || { curl -L https://github.com/libxsmm/libxsmm/archive/$XSMM_HASH.tar.gz -o xsmm.tar.gz && tar zvxf xsmm.tar.gz && rm xsmm.tar.gz && make -C libxsmm-$XSMM_HASH -j$(nproc); }; } && export XSMM_DIR=$PWD/libxsmm-$XSMM_HASH && cd libCEED
+    - cd .. && export XSMM_HASH=5ce29626ddad947f0d5c433ce78c58ff64dfbbdb && { [[ -d libxsmm-$XSMM_HASH ]] || { curl -L https://github.com/libxsmm/libxsmm/archive/$XSMM_HASH.tar.gz -o xsmm.tar.gz && tar zvxf xsmm.tar.gz && rm xsmm.tar.gz && make -C libxsmm-$XSMM_HASH -j$(nproc); }; } && export XSMM_DIR=$PWD/libxsmm-$XSMM_HASH && cd libCEED
     - echo "-------------- LIBXSMM -------------" && basename $XSMM_DIR
   script:
     - rm -f .SUCCESS

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ This backend can be run in serial or blocked mode and defaults to running in the
 
 The `/cpu/self/xsmm/*` backends rely upon the [LIBXSMM](https://github.com/libxsmm/libxsmm) package to provide vectorized CPU performance.
 If linking MKL and LIBXSMM is desired but the Makefile is not detecting `MKLROOT`, linking libCEED against MKL can be forced by setting the environment variable `MKL=1`.
-The LIBXSMM `main` development branch from 7 April 2024 or newer is required.
+The LIBXSMM version 2.0 or newer is required.
 
 The `/gpu/cuda/*` backends provide GPU performance strictly using CUDA.
 

--- a/backends/xsmm/ceed-xsmm.h
+++ b/backends/xsmm/ceed-xsmm.h
@@ -8,5 +8,10 @@
 
 #include <ceed.h>
 #include <ceed/backend.h>
+#include <libxsmm.h>
+
+#if !LIBXSMM_VERSION_GE(2, 0, 0, 0)
+#error "LIBXSMM 2.0 or later is required"
+#endif
 
 CEED_INTERN int CeedTensorContractCreate_Xsmm(CeedTensorContract contract);


### PR DESCRIPTION
Purpose:

Update min LIBXSMM version to 2.0

Closes: #N/A

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
