### PR TITLE
Add releasenotes redirect

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,7 @@ The version number must be updated in
 * `Doxyfile`
 * `CITATION.cff`
 
-Additionally, the release notes in `doc/sphinx/source/releasenotes.md` should be updated.
+Additionally, review and update `CHANGELOG.md`.
 Use `git log --first-parent v0.7..` to get a sense of the pull requests that have been merged and thus might warrant emphasizing in the release notes.
 While doing this, gather a couple sentences for key features to highlight on [GitHub releases](https://github.com/CEED/libCEED/releases).
 The "Current Main" heading needs to be named for the release.

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -10,4 +10,5 @@ sphinxcontrib-katex
 sphinxcontrib-mermaid
 sphinxcontrib-svg2pdfconverter
 sphinxext-altair
+sphinxext-rediraffe
 docutils

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
     "sphinxcontrib.rsvgconverter",
+    "sphinxext.rediraffe",
 ]
 
 # The following, if true, allows figures, tables and code-blocks to be
@@ -104,6 +105,10 @@ exclude_patterns = [
     "examples/README.md",
     "examples/*/README.md",
 ]
+
+rediraffe_redirects = {
+    "releasenotes.md": "CHANGELOG.md",
+}
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"


### PR DESCRIPTION
There is a link from https://ceed.exascaleproject.org/news/ to https://libceed.org/en/latest/releasenotes/#v0-10-mar-21-2022, and there may be other links and/or bookmarks in the wild. This file was moved to CHANGELOG.md in 92bb245f4c6e54fbf413db953ebd76bc05ff7cfe, which broke the above link. Add that redirect.

LLM/GenAI Disclosure: none
