### PR TITLE
Fix XSMM Header Bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,7 +562,7 @@ ifneq ($(wildcard $(XSMM_DIR)/lib/libxsmm.*),)
   PKG_LIBS += $(BLAS_LIB)
   libceed.c += $(xsmm.c)
   libceed.h += $(xsmm.h)
-  $(xsmm.c:%.c=$(OBJDIR)/%.o) $(xsmm.c:%=%.tidy) $(xsmm.c:%=%.tidy-fix) $(xsmm.h:%=%.tidy-fix): CPPFLAGS += -I$(XSMM_DIR)/include
+  $(xsmm.c:%.c=$(OBJDIR)/%.o) $(xsmm.c:%=%.tidy) $(xsmm.c:%=%.tidy-fix) $(xsmm.h:%=%.tidy-fix): CPPFLAGS += -I$(XSMM_DIR)/include -I$(XSMM_DIR)/include/libxsmm
   BACKENDS_MAKE += $(XSMM_BACKENDS)
 endif
 

--- a/examples/petsc/Makefile
+++ b/examples/petsc/Makefile
@@ -12,7 +12,7 @@ COMMON ?= ../../common.mk
 #       PETSC_ARCH - for example when using PETSc installed through Spack.
 PETSc.pc := $(PETSC_DIR)/$(PETSC_ARCH)/lib/pkgconfig/PETSc.pc
 CEED_DIR ?= ../..
-ceed.pc := $(CEED_DIR)/lib/pkgconfig/ceed.pc
+ceed.pc  := $(CEED_DIR)/lib/pkgconfig/ceed.pc
 
 CC = $(call pkgconf, --variable=ccompiler $(PETSc.pc) $(ceed.pc))
 CFLAGS = -std=c11 \
@@ -21,9 +21,9 @@ CFLAGS = -std=c11 \
   $(OPT)
 CPPFLAGS = $(call pkgconf, --cflags-only-I $(PETSc.pc) $(ceed.pc)) \
   $(call pkgconf, --variable=cflags_dep $(PETSc.pc))
-LDFLAGS = $(call pkgconf, --libs-only-L --libs-only-other $(PETSc.pc) $(ceed.pc))
+LDFLAGS  = $(call pkgconf, --libs-only-L --libs-only-other $(PETSc.pc) $(ceed.pc))
 LDFLAGS += $(patsubst -L%, $(call pkgconf, --variable=ldflag_rpath $(PETSc.pc))%, $(call pkgconf, --libs-only-L $(PETSc.pc) $(ceed.pc)))
-LDLIBS = $(call pkgconf, --libs-only-l $(PETSc.pc) $(ceed.pc)) -lm
+LDLIBS   = $(call pkgconf, --libs-only-l $(PETSc.pc) $(ceed.pc)) -lm
 
 OBJDIR := build
 SRCDIR := src


### PR DESCRIPTION
Purpose:

https://github.com/libxsmm/libxsmm/pull/1077

LIBXSMM introduced a bug - installed and non-installed builds put their headers in different places. This checks both places.

This was causing Ratel CI to fail

Closes: #NlA

LLM/GenAI Disclosure:

None

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
