### PR TITLE
feat(hip): add vector filter backend

### DIFF
--- a/backends/hip-ref/ceed-hip-ref-vector.c
+++ b/backends/hip-ref/ceed-hip-ref-vector.c
@@ -828,6 +828,36 @@ static int CeedVectorScale_Hip(CeedVector x, CeedScalar alpha) {
 }
 
 //------------------------------------------------------------------------------
+// Filter or clip a vector using a threshold value on the host
+//------------------------------------------------------------------------------
+static int CeedHostFilter_Hip(CeedScalar *x_array, CeedScalar threshold, CeedSize length) {
+  CeedPragmaSIMD for (CeedSize i = 0; i < length; i++) {
+    if (fabs(x_array[i]) <= threshold) x_array[i] = 0.0;
+  }
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Filter or clip a vector using a threshold value on device (impl in .hip.cpp file)
+//------------------------------------------------------------------------------
+int CeedDeviceFilter_Hip(CeedScalar *x_array, CeedScalar threshold, CeedSize length);
+
+//------------------------------------------------------------------------------
+// Filter or clip a vector using a threshold value
+//------------------------------------------------------------------------------
+static int CeedVectorFilter_Hip(CeedVector vec, CeedScalar threshold) {
+  CeedSize       length;
+  CeedVector_Hip *impl;
+
+  CeedCallBackend(CeedVectorGetData(vec, &impl));
+  CeedCallBackend(CeedVectorGetLength(vec, &length));
+  // Set value for synced device/host array
+  if (impl->d_array) CeedCallBackend(CeedDeviceFilter_Hip(impl->d_array, threshold, length));
+  if (impl->h_array) CeedCallBackend(CeedHostFilter_Hip(impl->h_array, threshold, length));
+  return CEED_ERROR_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
 // Compute y = alpha x + y on the host
 //------------------------------------------------------------------------------
 static int CeedHostAXPY_Hip(CeedScalar *y_array, CeedScalar alpha, CeedScalar *x_array, CeedSize length) {
@@ -990,6 +1020,7 @@ int CeedVectorCreate_Hip(CeedSize n, CeedVector vec) {
   CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "Norm", CeedVectorNorm_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "Reciprocal", CeedVectorReciprocal_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "Scale", CeedVectorScale_Hip));
+  CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "Filter", CeedVectorFilter_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "AXPY", CeedVectorAXPY_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "AXPBY", CeedVectorAXPBY_Hip));
   CeedCallBackend(CeedSetBackendFunction(ceed, "Vector", vec, "PointwiseMult", CeedVectorPointwiseMult_Hip));

--- a/backends/hip-ref/kernels/hip-ref-vector.hip.cpp
+++ b/backends/hip-ref/kernels/hip-ref-vector.hip.cpp
@@ -125,6 +125,30 @@ extern "C" int CeedDeviceScale_Hip(CeedScalar *x_array, CeedScalar alpha, CeedSi
 }
 
 //------------------------------------------------------------------------------
+// Kernel for filter
+//------------------------------------------------------------------------------
+__global__ static void filterValueK(CeedScalar *__restrict__ x, CeedScalar threshold, CeedSize size) {
+  const CeedSize index = threadIdx.x + (CeedSize)blockDim.x * blockIdx.x;
+
+  if (index < size) {
+    if (fabs(x[index]) <= threshold) x[index] = 0.0;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Filter or clip vector components to zero if their absolute value is less than or equal to threshold on device
+//------------------------------------------------------------------------------
+extern "C" int CeedDeviceFilter_Hip(CeedScalar *x_array, CeedScalar threshold, CeedSize length) {
+  const int      block_size = 512;
+  const CeedSize vec_size   = length;
+  int            grid_size  = vec_size / block_size;
+
+  if (block_size * grid_size < vec_size) grid_size += 1;
+  hipLaunchKernelGGL(filterValueK, dim3(grid_size), dim3(block_size), 0, 0, x_array, threshold, length);
+  return 0;
+}
+
+//------------------------------------------------------------------------------
 // Kernel for axpy
 //------------------------------------------------------------------------------
 __global__ static void axpyValueK(CeedScalar *__restrict__ y, CeedScalar alpha, CeedScalar *__restrict__ x, CeedSize size) {


### PR DESCRIPTION
## Summary

- add the `CeedVectorFilter` host and HIP-device implementations to `/gpu/hip/ref`
- register the backend operation so the existing public API uses the HIP path
- keep the threshold semantics aligned with the existing CUDA reference backend

This follows the remaining HIP work identified in #1830 and ports the already-merged CUDA implementation from #1988. The existing `tests/t129-vector.c` covers the public operation for vector sizes including zero and threshold boundary cases.

## Validation

- `git diff --check` passed
- local HIP compilation was not available because this Windows checkout has neither `hipcc` nor GNU `make`; the HIP source will need the repository CI environment for compile and test validation

## LLM/GenAI disclosure

I used Codex to help inspect the existing CUDA implementation and draft the HIP adaptation. I reviewed the resulting diff and am responsible for the submitted code.