### PR TITLE
cuda-ref: use cudaMemcpyAsync for QFunction context

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
+++ b/backends/cuda-ref/ceed-cuda-ref-qfunctioncontext.c
@@ -37,15 +37,7 @@ static inline int CeedQFunctionContextSyncH2D_Cuda(const CeedQFunctionContext ct
     impl->d_data = impl->d_data_owned;
   }
 
-  // Use async memcpy during CUDA Graph capture for compatibility
-  enum cudaStreamCaptureStatus capture_status;
-
-  cudaStreamIsCapturing(cudaStreamPerThread, &capture_status);
-  if (capture_status != cudaStreamCaptureStatusNone) {
-    CeedCallCuda(ceed, cudaMemcpyAsync(impl->d_data, impl->h_data, ctx_size, cudaMemcpyHostToDevice, cudaStreamPerThread));
-  } else {
-    CeedCallCuda(ceed, cudaMemcpy(impl->d_data, impl->h_data, ctx_size, cudaMemcpyHostToDevice));
-  }
+  CeedCallCuda(ceed, cudaMemcpyAsync(impl->d_data, impl->h_data, ctx_size, cudaMemcpyHostToDevice, cudaStreamPerThread));
 
   CeedCallBackend(CeedDestroy(&ceed));
   return CEED_ERROR_SUCCESS;


### PR DESCRIPTION
Use `cudaMemcpyAsync` for QFunction context.
