### PR TITLE
ctx - expand CeedContextFieldType to support additional field types

### DIFF
--- a/include/ceed/backend.h
+++ b/include/ceed/backend.h
@@ -409,18 +409,46 @@ CEED_EXTERN int  CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, Ce
                                                     size_t *num_values, void *value);
 CEED_EXTERN int  CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedContextFieldType field_type,
                                                         void *value);
-CEED_EXTERN int  CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, double *values);
-CEED_EXTERN int  CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
-                                                   const double **values);
-CEED_EXTERN int  CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const double **values);
-CEED_EXTERN int  CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int32_t *values);
-CEED_EXTERN int  CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
-                                                  const int32_t **values);
-CEED_EXTERN int  CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int32_t **values);
-CEED_EXTERN int  CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, bool *values);
-CEED_EXTERN int  CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
-                                                    const bool **values);
-CEED_EXTERN int  CeedQFunctionContextRestoreBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const bool **values);
+CEED_EXTERN int CeedQFunctionContextSetCeedByte(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, char *values);  
+CEED_EXTERN int  CeedQFunctionContextGetCeedByteRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
+                                                       const char **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedByteRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const char **values); 
+CEED_EXTERN int CeedQFunctionContextSetCeedScalar(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedScalar *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedScalarRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, 
+                                                      const CeedScalar **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedScalarRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedScalar **values);
+CEED_EXTERN int CeedQFunctionContextSetCeedFloat(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, float *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedFloatRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, 
+                                                      const float **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedFloatRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const float **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedDouble(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, double *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
+                                                        const double **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const double **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedInt8(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedInt8 *values);    
+CEED_EXTERN int  CeedQFunctionContextGetCeedInt8Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
+                                                      const CeedInt8 **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedInt8Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedInt8 **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedInt(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedInt *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedIntRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, 
+                                                      const CeedInt **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedIntRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedInt **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedInt32(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int32_t *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, 
+                                                      const int32_t **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int32_t **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedInt64(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int64_t *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedInt64Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, 
+                                                      const int64_t **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedInt64Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int64_t **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedSize(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedSize *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedSizeRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, 
+                                                      const CeedSize **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedSizeRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedSize **values);
+CEED_EXTERN int  CeedQFunctionContextSetCeedBoolean(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, bool *values);
+CEED_EXTERN int  CeedQFunctionContextGetCeedBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values,
+                                                         const bool **values);
+CEED_EXTERN int  CeedQFunctionContextRestoreCeedBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const bool **values);
 CEED_EXTERN int  CeedQFunctionContextGetDataDestroy(CeedQFunctionContext ctx, CeedMemType *f_mem_type, CeedQFunctionContextDataDestroyUser *f);
 CEED_EXTERN int  CeedQFunctionContextReference(CeedQFunctionContext ctx);
 

--- a/include/ceed/ceed.h
+++ b/include/ceed/ceed.h
@@ -417,11 +417,25 @@ CEED_EXTERN int CeedQFunctionContextGetData(CeedQFunctionContext ctx, CeedMemTyp
 CEED_EXTERN int CeedQFunctionContextGetDataRead(CeedQFunctionContext ctx, CeedMemType mem_type, void *data);
 CEED_EXTERN int CeedQFunctionContextRestoreData(CeedQFunctionContext ctx, void *data);
 CEED_EXTERN int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data);
-CEED_EXTERN int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+CEED_EXTERN int CeedQFunctionContextRegisterCeedByte(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                                    const char *field_description);
-CEED_EXTERN int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+CEED_EXTERN int CeedQFunctionContextRegisterCeedScalar(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                   const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedFloat(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                   const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedDouble(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                   const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedInt8(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                   const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedInt(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                   const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedInt32(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                                   const char *field_description);
-CEED_EXTERN int CeedQFunctionContextRegisterBoolean(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+CEED_EXTERN int CeedQFunctionContextRegisterCeedInt64(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                  const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedSize(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                                  const char *field_description);
+CEED_EXTERN int CeedQFunctionContextRegisterCeedBoolean(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                                     const char *field_description);
 CEED_EXTERN int CeedQFunctionContextGetAllFieldLabels(CeedQFunctionContext ctx, const CeedContextFieldLabel **field_labels, CeedInt *num_fields);
 CEED_EXTERN int CeedContextFieldLabelGetDescription(CeedContextFieldLabel label, const char **field_name, size_t *field_offset, size_t *num_values,
@@ -489,15 +503,36 @@ CEED_EXTERN int  CeedOperatorGetNumQuadraturePoints(CeedOperator op, CeedInt *nu
 CEED_EXTERN int  CeedOperatorGetFlopsEstimate(CeedOperator op, CeedSize *flops);
 CEED_EXTERN int  CeedOperatorGetContext(CeedOperator op, CeedQFunctionContext *ctx);
 CEED_EXTERN int  CeedOperatorGetContextFieldLabel(CeedOperator op, const char *field_name, CeedContextFieldLabel *field_label);
-CEED_EXTERN int  CeedOperatorSetContextDouble(CeedOperator op, CeedContextFieldLabel field_label, double *values);
-CEED_EXTERN int  CeedOperatorGetContextDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const double **values);
-CEED_EXTERN int  CeedOperatorRestoreContextDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, const double **values);
-CEED_EXTERN int  CeedOperatorSetContextInt32(CeedOperator op, CeedContextFieldLabel field_label, int32_t *values);
-CEED_EXTERN int  CeedOperatorGetContextInt32Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values);
-CEED_EXTERN int  CeedOperatorRestoreContextInt32Read(CeedOperator op, CeedContextFieldLabel field_label, const int32_t **values);
-CEED_EXTERN int  CeedOperatorSetContextBoolean(CeedOperator op, CeedContextFieldLabel field_label, bool *values);
-CEED_EXTERN int  CeedOperatorGetContextBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const bool **values);
-CEED_EXTERN int  CeedOperatorRestoreContextBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, const bool **values);
+CEED_EXTERN int CeedOperatorSetContextCeedByte(CeedOperator op, CeedContextFieldLabel field_label, char *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedByteRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const char **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedByteRead(CeedOperator op, CeedContextFieldLabel field_label, const char **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedScalar(CeedOperator op, CeedContextFieldLabel field_label, CeedScalar *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedScalarRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedScalar **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedScalarRead(CeedOperator op, CeedContextFieldLabel field_label, const CeedScalar **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedFloat(CeedOperator op, CeedContextFieldLabel field_label, float *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedFloatRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const float **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedFloatRead(CeedOperator op, CeedContextFieldLabel field_label, const float **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedDouble(CeedOperator op, CeedContextFieldLabel field_label, double *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const double **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, const double **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedInt8(CeedOperator op, CeedContextFieldLabel field_label, CeedInt8 *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedInt8Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedInt8 **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedInt8Read(CeedOperator op, CeedContextFieldLabel field_label, const CeedInt8 **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedInt(CeedOperator op, CeedContextFieldLabel field_label, CeedInt *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedIntRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedInt **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedIntRead(CeedOperator op, CeedContextFieldLabel field_label, const CeedInt **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedInt32(CeedOperator op, CeedContextFieldLabel field_label, int32_t *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedInt32Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedInt32Read(CeedOperator op, CeedContextFieldLabel field_label, const int32_t **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedInt64(CeedOperator op, CeedContextFieldLabel field_label, int64_t *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedInt64Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const int64_t **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedInt64Read(CeedOperator op, CeedContextFieldLabel field_label, const int64_t **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedSize(CeedOperator op, CeedContextFieldLabel field_label, CeedSize *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedSizeRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedSize **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedSizeRead(CeedOperator op, CeedContextFieldLabel field_label, const CeedSize **values);
+CEED_EXTERN int  CeedOperatorSetContextCeedBoolean(CeedOperator op, CeedContextFieldLabel field_label, bool *values);
+CEED_EXTERN int  CeedOperatorGetContextCeedBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const bool **values);
+CEED_EXTERN int  CeedOperatorRestoreContextCeedBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, const bool **values);
 CEED_EXTERN int  CeedOperatorApply(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
 CEED_EXTERN int  CeedOperatorApplyAdd(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);
 CEED_EXTERN int  CeedOperatorApplyAddActive(CeedOperator op, CeedVector in, CeedVector out, CeedRequest *request);

--- a/include/ceed/types.h
+++ b/include/ceed/types.h
@@ -274,12 +274,26 @@ typedef enum {
 /// Denotes type of data stored in a CeedQFunctionContext field
 /// @ingroup CeedQFunction
 typedef enum {
+  /// Byte value, C type of char
+  CEED_CONTEXT_FIELD_BYTE = 1,
+  /// CeedScalar value
+  CEED_CONTEXT_FIELD_SCALAR = 2,
+  /// Single precision value
+  CEED_CONTEXT_FIELD_FLOAT = 3,
   /// Double precision value
-  CEED_CONTEXT_FIELD_DOUBLE = 1,
+  CEED_CONTEXT_FIELD_DOUBLE = 4,
+  ///8 bit integer value
+  CEED_CONTEXT_FIELD_INT8 = 5,
+  /// CeedInt value
+  CEED_CONTEXT_FIELD_INT = 6,
   /// 32 bit integer value
-  CEED_CONTEXT_FIELD_INT32 = 2,
+  CEED_CONTEXT_FIELD_INT32 = 7,
+  /// 64 bit integer value
+  CEED_CONTEXT_FIELD_INT64 = 8,
+  /// CeedSize value
+  CEED_CONTEXT_FIELD_SIZE = 9,
   /// Boolean value
-  CEED_CONTEXT_FIELD_BOOL = 3,
+  CEED_CONTEXT_FIELD_BOOL = 10,
 } CeedContextFieldType;
 
 #endif  // CEED_QFUNCTION_DEFS_H

--- a/interface/ceed-operator.c
+++ b/interface/ceed-operator.c
@@ -2102,6 +2102,156 @@ int CeedOperatorGetContextFieldLabel(CeedOperator op, const char *field_name, Ce
 }
 
 /**
+  @brief Set `CeedQFunctionContext` field holding byte values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedByte(CeedOperator op, CeedContextFieldLabel field_label, char *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_BYTE, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding byte values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedByteRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const char **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_BYTE, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding byte values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedByteRead(CeedOperator op, CeedContextFieldLabel field_label, const char **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_BYTE, values);
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding scalar values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedScalar(CeedOperator op, CeedContextFieldLabel field_label, CeedScalar *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_SCALAR, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding scalar values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedScalarRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedScalar **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_SCALAR, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding scalar values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedScalarRead(CeedOperator op, CeedContextFieldLabel field_label, const CeedScalar **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_SCALAR, values);
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding float precision values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedFloat(CeedOperator op, CeedContextFieldLabel field_label, float *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_FLOAT, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding float precision values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedFloatRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const float **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_FLOAT, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding float precision values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedFloatRead(CeedOperator op, CeedContextFieldLabel field_label, const float **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_FLOAT, values);
+}
+
+/**
   @brief Set `CeedQFunctionContext` field holding double precision values.
 
   For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
@@ -2114,7 +2264,7 @@ int CeedOperatorGetContextFieldLabel(CeedOperator op, const char *field_name, Ce
 
   @ref User
 **/
-int CeedOperatorSetContextDouble(CeedOperator op, CeedContextFieldLabel field_label, double *values) {
+int CeedOperatorSetContextCeedDouble(CeedOperator op, CeedContextFieldLabel field_label, double *values) {
   return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_DOUBLE, values);
 }
 
@@ -2132,7 +2282,7 @@ int CeedOperatorSetContextDouble(CeedOperator op, CeedContextFieldLabel field_la
 
   @ref User
 **/
-int CeedOperatorGetContextDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const double **values) {
+int CeedOperatorGetContextCeedDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const double **values) {
   return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_DOUBLE, num_values, values);
 }
 
@@ -2147,8 +2297,109 @@ int CeedOperatorGetContextDoubleRead(CeedOperator op, CeedContextFieldLabel fiel
 
   @ref User
 **/
-int CeedOperatorRestoreContextDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, const double **values) {
+int CeedOperatorRestoreContextCeedDoubleRead(CeedOperator op, CeedContextFieldLabel field_label, const double **values) {
   return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_DOUBLE, values);
+}
+
+
+/**
+  @brief Set `CeedQFunctionContext` field holding int8_t values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedInt8(CeedOperator op, CeedContextFieldLabel field_label, CeedInt8 *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_INT8, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding double precision values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedInt8Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedInt8 **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT8, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding double precision values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedInt8Read(CeedOperator op, CeedContextFieldLabel field_label, const CeedInt8 **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT8, values);
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding `int` values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedInt(CeedOperator op, CeedContextFieldLabel field_label, CeedInt *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_INT, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding `int` values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of `int32` values in `values`
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedIntRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedInt **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding `int` values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedIntRead(CeedOperator op, CeedContextFieldLabel field_label, const CeedInt **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT, values);
 }
 
 /**
@@ -2164,7 +2415,7 @@ int CeedOperatorRestoreContextDoubleRead(CeedOperator op, CeedContextFieldLabel 
 
   @ref User
 **/
-int CeedOperatorSetContextInt32(CeedOperator op, CeedContextFieldLabel field_label, int32_t *values) {
+int CeedOperatorSetContextCeedInt32(CeedOperator op, CeedContextFieldLabel field_label, int32_t *values) {
   return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_INT32, values);
 }
 
@@ -2182,7 +2433,7 @@ int CeedOperatorSetContextInt32(CeedOperator op, CeedContextFieldLabel field_lab
 
   @ref User
 **/
-int CeedOperatorGetContextInt32Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values) {
+int CeedOperatorGetContextCeedInt32Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values) {
   return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT32, num_values, values);
 }
 
@@ -2197,8 +2448,108 @@ int CeedOperatorGetContextInt32Read(CeedOperator op, CeedContextFieldLabel field
 
   @ref User
 **/
-int CeedOperatorRestoreContextInt32Read(CeedOperator op, CeedContextFieldLabel field_label, const int32_t **values) {
+int CeedOperatorRestoreContextCeedInt32Read(CeedOperator op, CeedContextFieldLabel field_label, const int32_t **values) {
   return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT32, values);
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding int64_t values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedInt64(CeedOperator op, CeedContextFieldLabel field_label, int64_t *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_INT64, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding int64_t values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedInt64Read(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const int64_t **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT64, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding int64_t values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedInt64Read(CeedOperator op, CeedContextFieldLabel field_label, const int64_t **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_INT64, values);
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding CeedSize values.
+
+  For composite operators, the values are set in all sub-operator `CeedQFunctionContext` that have a matching `field_name`.
+
+  @param[in,out] op          `CeedOperator`
+  @param[in]     field_label Label of field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorSetContextCeedSize(CeedOperator op, CeedContextFieldLabel field_label, CeedSize *values) {
+  return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_SIZE, values);
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding CeedSize values, read-only.
+
+  For composite operators, the values correspond to the first sub-operator `CeedQFunctionContext` that has a matching `field_name`.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorGetContextCeedSizeRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const CeedSize **values) {
+  return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_SIZE, num_values, values);
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding double precision values, read-only.
+
+  @param[in]  op          `CeedOperator`
+  @param[in]  field_label Label of field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedOperatorRestoreContextCeedSizeRead(CeedOperator op, CeedContextFieldLabel field_label, const CeedSize **values) {
+  return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_SIZE, values);
 }
 
 /**
@@ -2214,7 +2565,7 @@ int CeedOperatorRestoreContextInt32Read(CeedOperator op, CeedContextFieldLabel f
 
   @ref User
 **/
-int CeedOperatorSetContextBoolean(CeedOperator op, CeedContextFieldLabel field_label, bool *values) {
+int CeedOperatorSetContextCeedBoolean(CeedOperator op, CeedContextFieldLabel field_label, bool *values) {
   return CeedOperatorContextSetGeneric(op, field_label, CEED_CONTEXT_FIELD_BOOL, values);
 }
 
@@ -2232,7 +2583,7 @@ int CeedOperatorSetContextBoolean(CeedOperator op, CeedContextFieldLabel field_l
 
   @ref User
 **/
-int CeedOperatorGetContextBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const bool **values) {
+int CeedOperatorGetContextCeedBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, size_t *num_values, const bool **values) {
   return CeedOperatorContextGetGenericRead(op, field_label, CEED_CONTEXT_FIELD_BOOL, num_values, values);
 }
 
@@ -2247,7 +2598,7 @@ int CeedOperatorGetContextBooleanRead(CeedOperator op, CeedContextFieldLabel fie
 
   @ref User
 **/
-int CeedOperatorRestoreContextBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, const bool **values) {
+int CeedOperatorRestoreContextCeedBooleanRead(CeedOperator op, CeedContextFieldLabel field_label, const bool **values) {
   return CeedOperatorContextRestoreGenericRead(op, field_label, CEED_CONTEXT_FIELD_BOOL, values);
 }
 

--- a/interface/ceed-qfunctioncontext.c
+++ b/interface/ceed-qfunctioncontext.c
@@ -77,14 +77,35 @@ int CeedQFunctionContextRegisterGeneric(CeedQFunctionContext ctx, const char *fi
 
   // Compute field size
   switch (field_type) {
-    case CEED_CONTEXT_FIELD_DOUBLE:
-      field_size = sizeof(double);
-      break;
-    case CEED_CONTEXT_FIELD_INT32:
-      field_size = sizeof(int);
-      break;
     case CEED_CONTEXT_FIELD_BOOL:
       field_size = sizeof(bool);
+      break;
+    case CEED_CONTEXT_FIELD_BYTE:
+      field_size = sizeof(char);
+      break;
+    case CEED_CONTEXT_FIELD_INT8:
+      field_size = sizeof(CeedInt8);
+      break;
+    case CEED_CONTEXT_FIELD_INT:
+      field_size = sizeof(CeedInt);
+      break;
+    case CEED_CONTEXT_FIELD_INT32:
+      field_size = sizeof(int32_t);
+      break;
+    case CEED_CONTEXT_FIELD_INT64:
+      field_size = sizeof(int64_t);
+      break;
+    case CEED_CONTEXT_FIELD_SIZE:
+      field_size = sizeof(CeedSize);
+      break;
+    case CEED_CONTEXT_FIELD_SCALAR:
+      field_size = sizeof(CeedScalar);
+      break;
+    case CEED_CONTEXT_FIELD_FLOAT:
+      field_size = sizeof(float);
+      break;
+    case CEED_CONTEXT_FIELD_DOUBLE:
+      field_size = sizeof(double);
       break;
   }
 
@@ -351,11 +372,32 @@ int CeedQFunctionContextGetGenericRead(CeedQFunctionContext ctx, CeedContextFiel
   CeedCall(CeedQFunctionContextGetDataRead(ctx, CEED_MEM_HOST, &data));
   *(void **)values = &data[field_label->offset];
   switch (field_type) {
-    case CEED_CONTEXT_FIELD_INT32:
-      *num_values = field_label->size / sizeof(int);
+    case CEED_CONTEXT_FIELD_BYTE:
+      *num_values = field_label->size / sizeof(char);
+      break;
+    case CEED_CONTEXT_FIELD_SCALAR:
+      *num_values = field_label->size / sizeof(CeedScalar);
+      break;
+    case CEED_CONTEXT_FIELD_FLOAT:
+      *num_values = field_label->size / sizeof(float);
       break;
     case CEED_CONTEXT_FIELD_DOUBLE:
       *num_values = field_label->size / sizeof(double);
+      break;
+    case CEED_CONTEXT_FIELD_INT8:
+      *num_values = field_label->size / sizeof(CeedInt8);
+      break;
+    case CEED_CONTEXT_FIELD_INT:  
+      *num_values = field_label->size / sizeof(CeedInt);
+      break;
+    case CEED_CONTEXT_FIELD_INT32:
+      *num_values = field_label->size / sizeof(int32_t);
+      break;
+    case CEED_CONTEXT_FIELD_INT64:
+      *num_values = field_label->size / sizeof(int64_t);
+      break;
+    case CEED_CONTEXT_FIELD_SIZE:
+      *num_values = field_label->size / sizeof(CeedSize);
       break;
     case CEED_CONTEXT_FIELD_BOOL:
       *num_values = field_label->size / sizeof(bool);
@@ -387,6 +429,165 @@ int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContext
   return CEED_ERROR_SUCCESS;
 }
 
+
+// mycode 
+
+/**
+  @brief Set `CeedQFunctionContext` field holding byte values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextSetCeedByte(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, char * values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_BYTE, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding byte values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedByteRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const char **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_BYTE, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding byte values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedByteRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const char **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_BYTE, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding scalar values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextSetCeedScalar(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedScalar * values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_SCALAR, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding scalar values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedScalarRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const CeedScalar **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_SCALAR, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding scalar values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedScalarRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedScalar **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_SCALAR, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding float values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextSetCeedFloat(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, float * values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_FLOAT, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding float values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedFloatRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const float **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_FLOAT, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding float values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedFloatRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const float **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_FLOAT, values));
+  return CEED_ERROR_SUCCESS;
+}
+
 /**
   @brief Set `CeedQFunctionContext` field holding double precision values
 
@@ -398,7 +599,7 @@ int CeedQFunctionContextRestoreGenericRead(CeedQFunctionContext ctx, CeedContext
 
   @ref Backend
 **/
-int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, double *values) {
+int CeedQFunctionContextSetCeedDouble(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, double *values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, values));
   return CEED_ERROR_SUCCESS;
@@ -416,7 +617,7 @@ int CeedQFunctionContextSetDouble(CeedQFunctionContext ctx, CeedContextFieldLabe
 
   @ref Backend
 **/
-int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const double **values) {
+int CeedQFunctionContextGetCeedDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const double **values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, num_values, values));
   return CEED_ERROR_SUCCESS;
@@ -433,7 +634,7 @@ int CeedQFunctionContextGetDoubleRead(CeedQFunctionContext ctx, CeedContextField
 
   @ref Backend
 **/
-int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const double **values) {
+int CeedQFunctionContextRestoreCeedDoubleRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const double **values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_DOUBLE, values));
   return CEED_ERROR_SUCCESS;
@@ -450,7 +651,127 @@ int CeedQFunctionContextRestoreDoubleRead(CeedQFunctionContext ctx, CeedContextF
 
   @ref Backend
 **/
-int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int32_t *values) {
+
+/**
+  @brief Set `CeedQFunctionContext` field holding int8_t values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextSetCeedInt8(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedInt8 * values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_INT8, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding int8_t values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedInt8Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const CeedInt8 **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT8, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding int8_t values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedInt8Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedInt8 **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT8, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+
+
+//mycode
+
+/**
+  @brief Set `CeedQFunctionContext` field holding `CeedInt` values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+ **/
+int CeedQFunctionContextSetCeedInt(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedInt *values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_INT, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding `CeedInt` values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedIntRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const CeedInt **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding `CeedInt` values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedIntRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedInt **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding `int32` values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+ **/
+int CeedQFunctionContextSetCeedInt32(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int32_t *values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_INT32, values));
   return CEED_ERROR_SUCCESS;
@@ -468,7 +789,7 @@ int CeedQFunctionContextSetInt32(CeedQFunctionContext ctx, CeedContextFieldLabel
 
   @ref Backend
 **/
-int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values) {
+int CeedQFunctionContextGetCeedInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const int32_t **values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT32, num_values, values));
   return CEED_ERROR_SUCCESS;
@@ -485,9 +806,113 @@ int CeedQFunctionContextGetInt32Read(CeedQFunctionContext ctx, CeedContextFieldL
 
   @ref Backend
 **/
-int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int32_t **values) {
+int CeedQFunctionContextRestoreCeedInt32Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int32_t **values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT32, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding int64_t values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextSetCeedInt64(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, int64_t * values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_INT64, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding int64_t values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedInt64Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const int64_t **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT64, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding int64_t values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedInt64Read(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const int64_t **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_INT64, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Set `CeedQFunctionContext` field holding CeedSize values
+
+  @param[in,out] ctx         `CeedQFunctionContext`
+  @param[in]     field_label Label for field to set
+  @param[in]     values      Values to set
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextSetCeedSize(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, CeedSize * values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_SIZE, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Get `CeedQFunctionContext` field holding CeedSize values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to get
+  @param[out] num_values  Number of values in the field label
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextGetCeedSizeRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const CeedSize **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_SIZE, num_values, values));
+  return CEED_ERROR_SUCCESS;
+}
+
+/**
+  @brief Restore `CeedQFunctionContext` field holding CeedSize values, read-only
+
+  @param[in]  ctx         `CeedQFunctionContext`
+  @param[in]  field_label Label for field to restore
+  @param[out] values      Pointer to context values
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref Backend
+**/
+int CeedQFunctionContextRestoreCeedSizeRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const CeedSize **values) {
+  CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
+  CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_SIZE, values));
   return CEED_ERROR_SUCCESS;
 }
 
@@ -502,7 +927,7 @@ int CeedQFunctionContextRestoreInt32Read(CeedQFunctionContext ctx, CeedContextFi
 
   @ref Backend
 **/
-int CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, bool *values) {
+int CeedQFunctionContextSetCeedBoolean(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, bool *values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextSetGeneric(ctx, field_label, CEED_CONTEXT_FIELD_BOOL, values));
   return CEED_ERROR_SUCCESS;
@@ -520,7 +945,7 @@ int CeedQFunctionContextSetBoolean(CeedQFunctionContext ctx, CeedContextFieldLab
 
   @ref Backend
 **/
-int CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const bool **values) {
+int CeedQFunctionContextGetCeedBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, size_t *num_values, const bool **values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextGetGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_BOOL, num_values, values));
   return CEED_ERROR_SUCCESS;
@@ -537,7 +962,7 @@ int CeedQFunctionContextGetBooleanRead(CeedQFunctionContext ctx, CeedContextFiel
 
   @ref Backend
 **/
-int CeedQFunctionContextRestoreBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const bool **values) {
+int CeedQFunctionContextRestoreCeedBooleanRead(CeedQFunctionContext ctx, CeedContextFieldLabel field_label, const bool **values) {
   CeedCheck(field_label, CeedQFunctionContextReturnCeed(ctx), CEED_ERROR_UNSUPPORTED, "Invalid field label");
   CeedCall(CeedQFunctionContextRestoreGenericRead(ctx, field_label, CEED_CONTEXT_FIELD_BOOL, values));
   return CEED_ERROR_SUCCESS;
@@ -799,6 +1224,60 @@ int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data) {
 }
 
 /**
+  @brief Register a `CeedQFunctionContext` field holding byte value
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterCeedByte(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                     const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_BYTE, num_values);
+}
+
+/**
+  @brief Register a `CeedQFunctionContext` field holding scalar values
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterCeedScalar(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                       const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_SCALAR, num_values);
+}
+
+/**
+ @brief Register a `CeedQFunctionContext` field holding float values
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+ **/
+int CeedQFunctionContextRegisterCeedFloat(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                      const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_FLOAT, num_values);
+}
+
+/**
   @brief Register a `CeedQFunctionContext` field holding double precision values
 
   @param[in,out] ctx               `CeedQFunctionContext`
@@ -811,9 +1290,45 @@ int CeedQFunctionContextRestoreDataRead(CeedQFunctionContext ctx, void *data) {
 
   @ref User
 **/
-int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+int CeedQFunctionContextRegisterCeedDouble(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                        const char *field_description) {
   return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_DOUBLE, num_values);
+}
+
+/**
+  @brief Register a `CeedQFunctionContext` field holding int8 values
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterCeedInt8(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                     const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_INT8, num_values);
+}
+
+/**
+  @brief Register a `CeedQFunctionContext` field holding int values
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterCeedInt(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                    const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_INT, num_values);
 }
 
 /**
@@ -829,9 +1344,46 @@ int CeedQFunctionContextRegisterDouble(CeedQFunctionContext ctx, const char *fie
 
   @ref User
 **/
-int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+int CeedQFunctionContextRegisterCeedInt32(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                       const char *field_description) {
   return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_INT32, num_values);
+}
+
+/**
+  @brief Register a `CeedQFunctionContext` field holding int64 values
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+int CeedQFunctionContextRegisterCeedInt64(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                          const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_INT64, num_values);
+}
+
+/**
+  @brief Register a `CeedQFunctionContext` field holding CeedSize values
+
+  @param[in,out] ctx               `CeedQFunctionContext`
+  @param[in]     field_name        Name of field to register
+  @param[in]     field_offset      Offset of field to register
+  @param[in]     num_values        Number of values to register, must be contiguous in memory
+  @param[in]     field_description Description of field, or `NULL` for none
+
+  @return An error code: 0 - success, otherwise - failure
+
+  @ref User
+**/
+
+int CeedQFunctionContextRegisterCeedSize(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+                                         const char *field_description) {
+  return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_SIZE, num_values);
 }
 
 /**
@@ -847,7 +1399,7 @@ int CeedQFunctionContextRegisterInt32(CeedQFunctionContext ctx, const char *fiel
 
   @ref User
 **/
-int CeedQFunctionContextRegisterBoolean(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
+int CeedQFunctionContextRegisterCeedBoolean(CeedQFunctionContext ctx, const char *field_name, size_t field_offset, size_t num_values,
                                         const char *field_description) {
   return CeedQFunctionContextRegisterGeneric(ctx, field_name, field_offset, field_description, CEED_CONTEXT_FIELD_BOOL, num_values);
 }

--- a/interface/ceed-types.c
+++ b/interface/ceed-types.c
@@ -54,9 +54,16 @@ const char *const CeedElemTopologies[] = {
 };
 
 const char *const CeedContextFieldTypes[] = {
-    [CEED_CONTEXT_FIELD_DOUBLE] = "double",
-    [CEED_CONTEXT_FIELD_INT32]  = "int32",
     [CEED_CONTEXT_FIELD_BOOL]   = "bool",
+    [CEED_CONTEXT_FIELD_BYTE]   = "char",
+    [CEED_CONTEXT_FIELD_INT8]   = "CeedInt8",
+    [CEED_CONTEXT_FIELD_INT]    = "CeedInt",
+    [CEED_CONTEXT_FIELD_INT32]  = "int32",
+    [CEED_CONTEXT_FIELD_INT64]  = "int64",
+    [CEED_CONTEXT_FIELD_SIZE]   = "CeedSize",
+    [CEED_CONTEXT_FIELD_SCALAR] = "CeedScalar",
+    [CEED_CONTEXT_FIELD_FLOAT]  = "float",
+    [CEED_CONTEXT_FIELD_DOUBLE] = "double",
 };
 
 const char *const CeedFESpaces[] = {

--- a/julia/LibCEED.jl/gen/Project.toml
+++ b/julia/LibCEED.jl/gen/Project.toml
@@ -2,4 +2,4 @@
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 
 [compat]
-Clang = "0.16"
+Clang = "0.19"

--- a/julia/LibCEED.jl/src/generated/libceed_bindings.jl
+++ b/julia/LibCEED.jl/src/generated/libceed_bindings.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 #! format: off
 
@@ -73,8 +73,16 @@ end
 end
 
 @cenum CeedContextFieldType::UInt32 begin
-    CEED_CONTEXT_FIELD_DOUBLE = 1
-    CEED_CONTEXT_FIELD_INT32 = 2
+    CEED_CONTEXT_FIELD_BYTE = 1
+    CEED_CONTEXT_FIELD_SCALAR = 2
+    CEED_CONTEXT_FIELD_FLOAT = 3
+    CEED_CONTEXT_FIELD_DOUBLE = 4
+    CEED_CONTEXT_FIELD_INT8 = 5
+    CEED_CONTEXT_FIELD_INT = 6
+    CEED_CONTEXT_FIELD_INT32 = 7
+    CEED_CONTEXT_FIELD_INT64 = 8
+    CEED_CONTEXT_FIELD_SIZE = 9
+    CEED_CONTEXT_FIELD_BOOL = 10
 end
 
 mutable struct Ceed_private end
@@ -121,6 +129,34 @@ mutable struct CeedOperator_private end
 
 const CeedOperator = Ptr{CeedOperator_private}
 
+mutable struct CeedObject_private end
+
+const CeedObject = Ptr{CeedObject_private}
+
+function CeedObjectView(obj, stream)
+    ccall((:CeedObjectView, libceed), Cint, (CeedObject, Ptr{Libc.FILE}), obj, stream)
+end
+
+function CeedObjectSetNumViewTabs(obj, num_tabs)
+    ccall((:CeedObjectSetNumViewTabs, libceed), Cint, (CeedObject, CeedInt), obj, num_tabs)
+end
+
+function CeedObjectGetNumViewTabs(obj, num_tabs)
+    ccall((:CeedObjectGetNumViewTabs, libceed), Cint, (CeedObject, Ptr{CeedInt}), obj, num_tabs)
+end
+
+function CeedObjectGetCeed(obj, ceed)
+    ccall((:CeedObjectGetCeed, libceed), Cint, (CeedObject, Ptr{Ceed}), obj, ceed)
+end
+
+function CeedObjectReturnCeed(obj)
+    ccall((:CeedObjectReturnCeed, libceed), Ceed, (CeedObject,), obj)
+end
+
+function CeedObjectDestroy(obj)
+    ccall((:CeedObjectDestroy, libceed), Cint, (Ptr{CeedObject},), obj)
+end
+
 function CeedRegistryGetList(n, resources, array)
     ccall((:CeedRegistryGetList, libceed), Cint, (Ptr{Csize_t}, Ptr{Ptr{Ptr{Cchar}}}, Ptr{Ptr{CeedInt}}), n, resources, array)
 end
@@ -149,6 +185,22 @@ function CeedAddJitSourceRoot(ceed, jit_source_root)
     ccall((:CeedAddJitSourceRoot, libceed), Cint, (Ceed, Ptr{Cchar}), ceed, jit_source_root)
 end
 
+function CeedAddRustSourceRoot(ceed, rust_source_root)
+    ccall((:CeedAddRustSourceRoot, libceed), Cint, (Ceed, Ptr{Cchar}), ceed, rust_source_root)
+end
+
+function CeedAddJitDefine(ceed, jit_define)
+    ccall((:CeedAddJitDefine, libceed), Cint, (Ceed, Ptr{Cchar}), ceed, jit_define)
+end
+
+function CeedSetNumViewTabs(ceed, num_tabs)
+    ccall((:CeedSetNumViewTabs, libceed), Cint, (Ceed, CeedInt), ceed, num_tabs)
+end
+
+function CeedGetNumViewTabs(ceed, num_tabs)
+    ccall((:CeedGetNumViewTabs, libceed), Cint, (Ceed, Ptr{CeedInt}), ceed, num_tabs)
+end
+
 function CeedView(ceed, stream)
     ccall((:CeedView, libceed), Cint, (Ceed, Ptr{Libc.FILE}), ceed, stream)
 end
@@ -160,20 +212,36 @@ end
 # typedef int ( * CeedErrorHandler ) ( Ceed , const char * , int , const char * , int , const char * , va_list * )
 const CeedErrorHandler = Ptr{Cvoid}
 
-function CeedSetErrorHandler(ceed, eh)
-    ccall((:CeedSetErrorHandler, libceed), Cint, (Ceed, CeedErrorHandler), ceed, eh)
+function CeedSetErrorHandler(ceed, handler)
+    ccall((:CeedSetErrorHandler, libceed), Cint, (Ceed, CeedErrorHandler), ceed, handler)
 end
 
-function CeedGetErrorMessage(arg1, err_msg)
-    ccall((:CeedGetErrorMessage, libceed), Cint, (Ceed, Ptr{Ptr{Cchar}}), arg1, err_msg)
+function CeedGetErrorMessage(ceed, err_msg)
+    ccall((:CeedGetErrorMessage, libceed), Cint, (Ceed, Ptr{Ptr{Cchar}}), ceed, err_msg)
 end
 
-function CeedResetErrorMessage(arg1, err_msg)
-    ccall((:CeedResetErrorMessage, libceed), Cint, (Ceed, Ptr{Ptr{Cchar}}), arg1, err_msg)
+function CeedResetErrorMessage(ceed, err_msg)
+    ccall((:CeedResetErrorMessage, libceed), Cint, (Ceed, Ptr{Ptr{Cchar}}), ceed, err_msg)
 end
 
 function CeedGetVersion(major, minor, patch, release)
     ccall((:CeedGetVersion, libceed), Cint, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Bool}), major, minor, patch, release)
+end
+
+function CeedGetGitVersion(git_version)
+    ccall((:CeedGetGitVersion, libceed), Cint, (Ptr{Ptr{Cchar}},), git_version)
+end
+
+function CeedGetBuildConfiguration(build_config)
+    ccall((:CeedGetBuildConfiguration, libceed), Cint, (Ptr{Ptr{Cchar}},), build_config)
+end
+
+function CeedSetIsClang(ceed, isClang)
+    ccall((:CeedSetIsClang, libceed), Cint, (Ceed, Bool), ceed, isClang)
+end
+
+function CeedGetIsClang(ceed, isClang)
+    ccall((:CeedGetIsClang, libceed), Cint, (Ceed, Ptr{Bool}), ceed, isClang)
 end
 
 function CeedGetScalarType(scalar_type)
@@ -196,12 +264,20 @@ function CeedVectorCopy(vec, vec_copy)
     ccall((:CeedVectorCopy, libceed), Cint, (CeedVector, CeedVector), vec, vec_copy)
 end
 
+function CeedVectorCopyStrided(vec, start, stop, step, vec_copy)
+    ccall((:CeedVectorCopyStrided, libceed), Cint, (CeedVector, CeedSize, CeedSize, CeedSize, CeedVector), vec, start, stop, step, vec_copy)
+end
+
 function CeedVectorSetArray(vec, mem_type, copy_mode, array)
     ccall((:CeedVectorSetArray, libceed), Cint, (CeedVector, CeedMemType, CeedCopyMode, Ptr{CeedScalar}), vec, mem_type, copy_mode, array)
 end
 
 function CeedVectorSetValue(vec, value)
     ccall((:CeedVectorSetValue, libceed), Cint, (CeedVector, CeedScalar), vec, value)
+end
+
+function CeedVectorSetValueStrided(vec, start, stop, step, value)
+    ccall((:CeedVectorSetValueStrided, libceed), Cint, (CeedVector, CeedSize, CeedSize, CeedSize, CeedScalar), vec, start, stop, step, value)
 end
 
 function CeedVectorSyncArray(vec, mem_type)
@@ -240,6 +316,10 @@ function CeedVectorScale(x, alpha)
     ccall((:CeedVectorScale, libceed), Cint, (CeedVector, CeedScalar), x, alpha)
 end
 
+function CeedVectorFilter(x, threshold)
+    ccall((:CeedVectorFilter, libceed), Cint, (CeedVector, CeedScalar), x, threshold)
+end
+
 function CeedVectorAXPY(y, alpha, x)
     ccall((:CeedVectorAXPY, libceed), Cint, (CeedVector, CeedScalar, CeedVector), y, alpha, x)
 end
@@ -256,6 +336,14 @@ function CeedVectorReciprocal(vec)
     ccall((:CeedVectorReciprocal, libceed), Cint, (CeedVector,), vec)
 end
 
+function CeedVectorSetNumViewTabs(vec, num_tabs)
+    ccall((:CeedVectorSetNumViewTabs, libceed), Cint, (CeedVector, CeedInt), vec, num_tabs)
+end
+
+function CeedVectorGetNumViewTabs(vec, num_tabs)
+    ccall((:CeedVectorGetNumViewTabs, libceed), Cint, (CeedVector, Ptr{CeedInt}), vec, num_tabs)
+end
+
 function CeedVectorViewRange(vec, start, stop, step, fp_fmt, stream)
     ccall((:CeedVectorViewRange, libceed), Cint, (CeedVector, CeedSize, CeedSize, CeedInt, Ptr{Cchar}, Ptr{Libc.FILE}), vec, start, stop, step, fp_fmt, stream)
 end
@@ -266,6 +354,10 @@ end
 
 function CeedVectorGetCeed(vec, ceed)
     ccall((:CeedVectorGetCeed, libceed), Cint, (CeedVector, Ptr{Ceed}), vec, ceed)
+end
+
+function CeedVectorReturnCeed(vec)
+    ccall((:CeedVectorReturnCeed, libceed), Ceed, (CeedVector,), vec)
 end
 
 function CeedVectorGetLength(vec, length)
@@ -348,6 +440,10 @@ function CeedElemRestrictionGetCeed(rstr, ceed)
     ccall((:CeedElemRestrictionGetCeed, libceed), Cint, (CeedElemRestriction, Ptr{Ceed}), rstr, ceed)
 end
 
+function CeedElemRestrictionReturnCeed(rstr)
+    ccall((:CeedElemRestrictionReturnCeed, libceed), Ceed, (CeedElemRestriction,), rstr)
+end
+
 function CeedElemRestrictionGetCompStride(rstr, comp_stride)
     ccall((:CeedElemRestrictionGetCompStride, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, comp_stride)
 end
@@ -372,8 +468,20 @@ function CeedElemRestrictionGetMaxPointsInElement(rstr, max_points)
     ccall((:CeedElemRestrictionGetMaxPointsInElement, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, max_points)
 end
 
+function CeedElemRestrictionGetMinPointsInElement(rstr, min_points)
+    ccall((:CeedElemRestrictionGetMinPointsInElement, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, min_points)
+end
+
+function CeedElemRestrictionGetMinMaxPointsInElement(rstr, min_points, max_points)
+    ccall((:CeedElemRestrictionGetMinMaxPointsInElement, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}, Ptr{CeedInt}), rstr, min_points, max_points)
+end
+
 function CeedElemRestrictionGetLVectorSize(rstr, l_size)
     ccall((:CeedElemRestrictionGetLVectorSize, libceed), Cint, (CeedElemRestriction, Ptr{CeedSize}), rstr, l_size)
+end
+
+function CeedElemRestrictionGetEVectorSize(rstr, e_size)
+    ccall((:CeedElemRestrictionGetEVectorSize, libceed), Cint, (CeedElemRestriction, Ptr{CeedSize}), rstr, e_size)
 end
 
 function CeedElemRestrictionGetNumComponents(rstr, num_comp)
@@ -390,6 +498,14 @@ end
 
 function CeedElemRestrictionGetMultiplicity(rstr, mult)
     ccall((:CeedElemRestrictionGetMultiplicity, libceed), Cint, (CeedElemRestriction, CeedVector), rstr, mult)
+end
+
+function CeedElemRestrictionSetNumViewTabs(rstr, num_tabs)
+    ccall((:CeedElemRestrictionSetNumViewTabs, libceed), Cint, (CeedElemRestriction, CeedInt), rstr, num_tabs)
+end
+
+function CeedElemRestrictionGetNumViewTabs(rstr, num_tabs)
+    ccall((:CeedElemRestrictionGetNumViewTabs, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, num_tabs)
 end
 
 function CeedElemRestrictionView(rstr, stream)
@@ -428,6 +544,14 @@ function CeedBasisReferenceCopy(basis, basis_copy)
     ccall((:CeedBasisReferenceCopy, libceed), Cint, (CeedBasis, Ptr{CeedBasis}), basis, basis_copy)
 end
 
+function CeedBasisSetNumViewTabs(basis, num_tabs)
+    ccall((:CeedBasisSetNumViewTabs, libceed), Cint, (CeedBasis, CeedInt), basis, num_tabs)
+end
+
+function CeedBasisGetNumViewTabs(basis, num_tabs)
+    ccall((:CeedBasisGetNumViewTabs, libceed), Cint, (CeedBasis, Ptr{CeedInt}), basis, num_tabs)
+end
+
 function CeedBasisView(basis, stream)
     ccall((:CeedBasisView, libceed), Cint, (CeedBasis, Ptr{Libc.FILE}), basis, stream)
 end
@@ -436,12 +560,24 @@ function CeedBasisApply(basis, num_elem, t_mode, eval_mode, u, v)
     ccall((:CeedBasisApply, libceed), Cint, (CeedBasis, CeedInt, CeedTransposeMode, CeedEvalMode, CeedVector, CeedVector), basis, num_elem, t_mode, eval_mode, u, v)
 end
 
+function CeedBasisApplyAdd(basis, num_elem, t_mode, eval_mode, u, v)
+    ccall((:CeedBasisApplyAdd, libceed), Cint, (CeedBasis, CeedInt, CeedTransposeMode, CeedEvalMode, CeedVector, CeedVector), basis, num_elem, t_mode, eval_mode, u, v)
+end
+
 function CeedBasisApplyAtPoints(basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v)
     ccall((:CeedBasisApplyAtPoints, libceed), Cint, (CeedBasis, CeedInt, Ptr{CeedInt}, CeedTransposeMode, CeedEvalMode, CeedVector, CeedVector, CeedVector), basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v)
 end
 
+function CeedBasisApplyAddAtPoints(basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v)
+    ccall((:CeedBasisApplyAddAtPoints, libceed), Cint, (CeedBasis, CeedInt, Ptr{CeedInt}, CeedTransposeMode, CeedEvalMode, CeedVector, CeedVector, CeedVector), basis, num_elem, num_points, t_mode, eval_mode, x_ref, u, v)
+end
+
 function CeedBasisGetCeed(basis, ceed)
     ccall((:CeedBasisGetCeed, libceed), Cint, (CeedBasis, Ptr{Ceed}), basis, ceed)
+end
+
+function CeedBasisReturnCeed(basis)
+    ccall((:CeedBasisReturnCeed, libceed), Ceed, (CeedBasis,), basis)
 end
 
 function CeedBasisGetDimension(basis, dim)
@@ -559,12 +695,24 @@ function CeedQFunctionSetUserFlopsEstimate(qf, flops)
     ccall((:CeedQFunctionSetUserFlopsEstimate, libceed), Cint, (CeedQFunction, CeedSize), qf, flops)
 end
 
+function CeedQFunctionSetNumViewTabs(qf, num_tabs)
+    ccall((:CeedQFunctionSetNumViewTabs, libceed), Cint, (CeedQFunction, CeedInt), qf, num_tabs)
+end
+
+function CeedQFunctionGetNumViewTabs(qf, num_tabs)
+    ccall((:CeedQFunctionGetNumViewTabs, libceed), Cint, (CeedQFunction, Ptr{CeedInt}), qf, num_tabs)
+end
+
 function CeedQFunctionView(qf, stream)
     ccall((:CeedQFunctionView, libceed), Cint, (CeedQFunction, Ptr{Libc.FILE}), qf, stream)
 end
 
 function CeedQFunctionGetCeed(qf, ceed)
     ccall((:CeedQFunctionGetCeed, libceed), Cint, (CeedQFunction, Ptr{Ceed}), qf, ceed)
+end
+
+function CeedQFunctionReturnCeed(qf)
+    ccall((:CeedQFunctionReturnCeed, libceed), Ceed, (CeedQFunction,), qf)
 end
 
 function CeedQFunctionApply(qf, Q, u, v)
@@ -585,6 +733,10 @@ end
 
 function CeedQFunctionFieldGetEvalMode(qf_field, eval_mode)
     ccall((:CeedQFunctionFieldGetEvalMode, libceed), Cint, (CeedQFunctionField, Ptr{CeedEvalMode}), qf_field, eval_mode)
+end
+
+function CeedQFunctionFieldGetData(qf_field, field_name, size, eval_mode)
+    ccall((:CeedQFunctionFieldGetData, libceed), Cint, (CeedQFunctionField, Ptr{Ptr{Cchar}}, Ptr{CeedInt}, Ptr{CeedEvalMode}), qf_field, field_name, size, eval_mode)
 end
 
 # typedef int ( * CeedQFunctionContextDataDestroyUser ) ( void * data )
@@ -622,12 +774,44 @@ function CeedQFunctionContextRestoreDataRead(ctx, data)
     ccall((:CeedQFunctionContextRestoreDataRead, libceed), Cint, (CeedQFunctionContext, Ptr{Cvoid}), ctx, data)
 end
 
-function CeedQFunctionContextRegisterDouble(ctx, field_name, field_offset, num_values, field_description)
-    ccall((:CeedQFunctionContextRegisterDouble, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+function CeedQFunctionContextRegisterCeedByte(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedByte, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
 end
 
-function CeedQFunctionContextRegisterInt32(ctx, field_name, field_offset, num_values, field_description)
-    ccall((:CeedQFunctionContextRegisterInt32, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+function CeedQFunctionContextRegisterCeedScalar(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedScalar, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedFloat(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedFloat, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedDouble(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedDouble, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedInt8(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedInt8, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedInt(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedInt, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedInt32(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedInt32, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedInt64(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedInt64, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedSize(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedSize, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
+end
+
+function CeedQFunctionContextRegisterCeedBoolean(ctx, field_name, field_offset, num_values, field_description)
+    ccall((:CeedQFunctionContextRegisterCeedBoolean, libceed), Cint, (CeedQFunctionContext, Ptr{Cchar}, Csize_t, Csize_t, Ptr{Cchar}), ctx, field_name, field_offset, num_values, field_description)
 end
 
 function CeedQFunctionContextGetAllFieldLabels(ctx, field_labels, num_fields)
@@ -640,6 +824,14 @@ end
 
 function CeedQFunctionContextGetContextSize(ctx, ctx_size)
     ccall((:CeedQFunctionContextGetContextSize, libceed), Cint, (CeedQFunctionContext, Ptr{Csize_t}), ctx, ctx_size)
+end
+
+function CeedQFunctionContextSetNumViewTabs(ctx, num_tabs)
+    ccall((:CeedQFunctionContextSetNumViewTabs, libceed), Cint, (CeedQFunctionContext, CeedInt), ctx, num_tabs)
+end
+
+function CeedQFunctionContextGetNumViewTabs(ctx, num_tabs)
+    ccall((:CeedQFunctionContextGetNumViewTabs, libceed), Cint, (CeedQFunctionContext, Ptr{CeedInt}), ctx, num_tabs)
 end
 
 function CeedQFunctionContextView(ctx, stream)
@@ -658,6 +850,10 @@ function CeedOperatorCreate(ceed, qf, dqf, dqfT, op)
     ccall((:CeedOperatorCreate, libceed), Cint, (Ceed, CeedQFunction, CeedQFunction, CeedQFunction, Ptr{CeedOperator}), ceed, qf, dqf, dqfT, op)
 end
 
+function CeedOperatorCreateAtPoints(ceed, qf, dqf, dqfT, op)
+    ccall((:CeedOperatorCreateAtPoints, libceed), Cint, (Ceed, CeedQFunction, CeedQFunction, CeedQFunction, Ptr{CeedOperator}), ceed, qf, dqf, dqfT, op)
+end
+
 function CeedOperatorCreateComposite(ceed, op)
     ccall((:CeedOperatorCreateComposite, libceed), Cint, (Ceed, Ptr{CeedOperator}), ceed, op)
 end
@@ -666,12 +862,24 @@ function CeedOperatorReferenceCopy(op, op_copy)
     ccall((:CeedOperatorReferenceCopy, libceed), Cint, (CeedOperator, Ptr{CeedOperator}), op, op_copy)
 end
 
-function CeedOperatorSetField(op, field_name, r, b, v)
-    ccall((:CeedOperatorSetField, libceed), Cint, (CeedOperator, Ptr{Cchar}, CeedElemRestriction, CeedBasis, CeedVector), op, field_name, r, b, v)
+function CeedOperatorSetField(op, field_name, rstr, basis, vec)
+    ccall((:CeedOperatorSetField, libceed), Cint, (CeedOperator, Ptr{Cchar}, CeedElemRestriction, CeedBasis, CeedVector), op, field_name, rstr, basis, vec)
 end
 
 function CeedOperatorGetFields(op, num_input_fields, input_fields, num_output_fields, output_fields)
     ccall((:CeedOperatorGetFields, libceed), Cint, (CeedOperator, Ptr{CeedInt}, Ptr{Ptr{CeedOperatorField}}, Ptr{CeedInt}, Ptr{Ptr{CeedOperatorField}}), op, num_input_fields, input_fields, num_output_fields, output_fields)
+end
+
+function CeedOperatorAtPointsSetPoints(op, rstr_points, point_coords)
+    ccall((:CeedOperatorAtPointsSetPoints, libceed), Cint, (CeedOperator, CeedElemRestriction, CeedVector), op, rstr_points, point_coords)
+end
+
+function CeedOperatorAtPointsGetPoints(op, rstr_points, point_coords)
+    ccall((:CeedOperatorAtPointsGetPoints, libceed), Cint, (CeedOperator, Ptr{CeedElemRestriction}, Ptr{CeedVector}), op, rstr_points, point_coords)
+end
+
+function CeedOperatorIsAtPoints(op, is_at_points)
+    ccall((:CeedOperatorIsAtPoints, libceed), Cint, (CeedOperator, Ptr{Bool}), op, is_at_points)
 end
 
 function CeedOperatorCompositeAddSub(composite_op, sub_op)
@@ -684,6 +892,18 @@ end
 
 function CeedOperatorCompositeGetSubList(op, sub_operators)
     ccall((:CeedOperatorCompositeGetSubList, libceed), Cint, (CeedOperator, Ptr{Ptr{CeedOperator}}), op, sub_operators)
+end
+
+function CeedOperatorCompositeGetSubByName(op, op_name, sub_op)
+    ccall((:CeedOperatorCompositeGetSubByName, libceed), Cint, (CeedOperator, Ptr{Cchar}, Ptr{CeedOperator}), op, op_name, sub_op)
+end
+
+function CeedOperatorCompositeSetSequential(op, is_sequential)
+    ccall((:CeedOperatorCompositeSetSequential, libceed), Cint, (CeedOperator, Bool), op, is_sequential)
+end
+
+function CeedOperatorCompositeIsSequential(op, is_sequential)
+    ccall((:CeedOperatorCompositeIsSequential, libceed), Cint, (CeedOperator, Ptr{Bool}), op, is_sequential)
 end
 
 function CeedOperatorCheckReady(op)
@@ -734,6 +954,10 @@ function CeedOperatorLinearAssembleSymbolic(op, num_entries, rows, cols)
     ccall((:CeedOperatorLinearAssembleSymbolic, libceed), Cint, (CeedOperator, Ptr{CeedSize}, Ptr{Ptr{CeedInt}}, Ptr{Ptr{CeedInt}}), op, num_entries, rows, cols)
 end
 
+function CeedOperatorLinearAssembleGetNumEntries(op, num_entries)
+    ccall((:CeedOperatorLinearAssembleGetNumEntries, libceed), Cint, (CeedOperator, Ptr{CeedSize}), op, num_entries)
+end
+
 function CeedOperatorLinearAssemble(op, values)
     ccall((:CeedOperatorLinearAssemble, libceed), Cint, (CeedOperator, CeedVector), op, values)
 end
@@ -762,12 +986,32 @@ function CeedOperatorSetName(op, name)
     ccall((:CeedOperatorSetName, libceed), Cint, (CeedOperator, Ptr{Cchar}), op, name)
 end
 
+function CeedOperatorGetName(op, name)
+    ccall((:CeedOperatorGetName, libceed), Cint, (CeedOperator, Ptr{Ptr{Cchar}}), op, name)
+end
+
+function CeedOperatorSetNumViewTabs(op, num_tabs)
+    ccall((:CeedOperatorSetNumViewTabs, libceed), Cint, (CeedOperator, CeedInt), op, num_tabs)
+end
+
+function CeedOperatorGetNumViewTabs(op, num_tabs)
+    ccall((:CeedOperatorGetNumViewTabs, libceed), Cint, (CeedOperator, Ptr{CeedInt}), op, num_tabs)
+end
+
 function CeedOperatorView(op, stream)
     ccall((:CeedOperatorView, libceed), Cint, (CeedOperator, Ptr{Libc.FILE}), op, stream)
 end
 
+function CeedOperatorViewTerse(op, stream)
+    ccall((:CeedOperatorViewTerse, libceed), Cint, (CeedOperator, Ptr{Libc.FILE}), op, stream)
+end
+
 function CeedOperatorGetCeed(op, ceed)
     ccall((:CeedOperatorGetCeed, libceed), Cint, (CeedOperator, Ptr{Ceed}), op, ceed)
+end
+
+function CeedOperatorReturnCeed(op)
+    ccall((:CeedOperatorReturnCeed, libceed), Ceed, (CeedOperator,), op)
 end
 
 function CeedOperatorGetNumElements(op, num_elem)
@@ -790,28 +1034,124 @@ function CeedOperatorGetContextFieldLabel(op, field_name, field_label)
     ccall((:CeedOperatorGetContextFieldLabel, libceed), Cint, (CeedOperator, Ptr{Cchar}, Ptr{CeedContextFieldLabel}), op, field_name, field_label)
 end
 
-function CeedOperatorSetContextDouble(op, field_label, values)
-    ccall((:CeedOperatorSetContextDouble, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Cdouble}), op, field_label, values)
+function CeedOperatorSetContextCeedByte(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedByte, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Cchar}), op, field_label, values)
 end
 
-function CeedOperatorGetContextDoubleRead(op, field_label, num_values, values)
-    ccall((:CeedOperatorGetContextDoubleRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cdouble}}), op, field_label, num_values, values)
+function CeedOperatorGetContextCeedByteRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedByteRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cchar}}), op, field_label, num_values, values)
 end
 
-function CeedOperatorRestoreContextDoubleRead(op, field_label, values)
-    ccall((:CeedOperatorRestoreContextDoubleRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Cdouble}}), op, field_label, values)
+function CeedOperatorRestoreContextCeedByteRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedByteRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Cchar}}), op, field_label, values)
 end
 
-function CeedOperatorSetContextInt32(op, field_label, values)
-    ccall((:CeedOperatorSetContextInt32, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Cint}), op, field_label, values)
+function CeedOperatorSetContextCeedScalar(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedScalar, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{CeedScalar}), op, field_label, values)
 end
 
-function CeedOperatorGetContextInt32Read(op, field_label, num_values, values)
-    ccall((:CeedOperatorGetContextInt32Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cint}}), op, field_label, num_values, values)
+function CeedOperatorGetContextCeedScalarRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedScalarRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedScalar}}), op, field_label, num_values, values)
 end
 
-function CeedOperatorRestoreContextInt32Read(op, field_label, values)
-    ccall((:CeedOperatorRestoreContextInt32Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Cint}}), op, field_label, values)
+function CeedOperatorRestoreContextCeedScalarRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedScalarRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{CeedScalar}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedFloat(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedFloat, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Cfloat}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedFloatRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedFloatRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cfloat}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedFloatRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedFloatRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Cfloat}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedDouble(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedDouble, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Cdouble}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedDoubleRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedDoubleRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cdouble}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedDoubleRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedDoubleRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Cdouble}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedInt8(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedInt8, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{CeedInt8}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedInt8Read(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedInt8Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedInt8}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedInt8Read(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedInt8Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{CeedInt8}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedInt(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedInt, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{CeedInt}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedIntRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedIntRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedInt}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedIntRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedIntRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{CeedInt}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedInt32(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedInt32, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Int32}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedInt32Read(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedInt32Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Int32}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedInt32Read(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedInt32Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Int32}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedInt64(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedInt64, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Int64}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedInt64Read(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedInt64Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Int64}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedInt64Read(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedInt64Read, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Int64}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedSize(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedSize, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{CeedSize}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedSizeRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedSizeRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedSize}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedSizeRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedSizeRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{CeedSize}}), op, field_label, values)
+end
+
+function CeedOperatorSetContextCeedBoolean(op, field_label, values)
+    ccall((:CeedOperatorSetContextCeedBoolean, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Bool}), op, field_label, values)
+end
+
+function CeedOperatorGetContextCeedBooleanRead(op, field_label, num_values, values)
+    ccall((:CeedOperatorGetContextCeedBooleanRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Bool}}), op, field_label, num_values, values)
+end
+
+function CeedOperatorRestoreContextCeedBooleanRead(op, field_label, values)
+    ccall((:CeedOperatorRestoreContextCeedBooleanRead, libceed), Cint, (CeedOperator, CeedContextFieldLabel, Ptr{Ptr{Bool}}), op, field_label, values)
 end
 
 function CeedOperatorApply(op, in, out, request)
@@ -822,8 +1162,40 @@ function CeedOperatorApplyAdd(op, in, out, request)
     ccall((:CeedOperatorApplyAdd, libceed), Cint, (CeedOperator, CeedVector, CeedVector, Ptr{CeedRequest}), op, in, out, request)
 end
 
+function CeedOperatorApplyAddActive(op, in, out, request)
+    ccall((:CeedOperatorApplyAddActive, libceed), Cint, (CeedOperator, CeedVector, CeedVector, Ptr{CeedRequest}), op, in, out, request)
+end
+
+function CeedOperatorAssemblyDataStrip(op)
+    ccall((:CeedOperatorAssemblyDataStrip, libceed), Cint, (CeedOperator,), op)
+end
+
 function CeedOperatorDestroy(op)
     ccall((:CeedOperatorDestroy, libceed), Cint, (Ptr{CeedOperator},), op)
+end
+
+function CeedCompositeOperatorCreate(a, b)
+    ccall((:CeedCompositeOperatorCreate, libceed), Cint, (Ceed, Ptr{CeedOperator}), a, b)
+end
+
+function CeedCompositeOperatorAddSub(a, b)
+    ccall((:CeedCompositeOperatorAddSub, libceed), Cint, (CeedOperator, CeedOperator), a, b)
+end
+
+function CeedCompositeOperatorGetNumSub(a, b)
+    ccall((:CeedCompositeOperatorGetNumSub, libceed), Cint, (CeedOperator, Ptr{CeedInt}), a, b)
+end
+
+function CeedCompositeOperatorGetSubList(a, b)
+    ccall((:CeedCompositeOperatorGetSubList, libceed), Cint, (CeedOperator, Ptr{Ptr{CeedOperator}}), a, b)
+end
+
+function CeedCompositeOperatorGetSubByName(a, b, c)
+    ccall((:CeedCompositeOperatorGetSubByName, libceed), Cint, (CeedOperator, Ptr{Cchar}, Ptr{CeedOperator}), a, b, c)
+end
+
+function CeedCompositeOperatorGetMultiplicity(a, b, c, d)
+    ccall((:CeedCompositeOperatorGetMultiplicity, libceed), Cint, (CeedOperator, CeedInt, Ptr{CeedInt}, CeedVector), a, b, c, d)
 end
 
 function CeedOperatorGetFieldByName(op, field_name, op_field)
@@ -844,6 +1216,10 @@ end
 
 function CeedOperatorFieldGetVector(op_field, vec)
     ccall((:CeedOperatorFieldGetVector, libceed), Cint, (CeedOperatorField, Ptr{CeedVector}), op_field, vec)
+end
+
+function CeedOperatorFieldGetData(op_field, field_name, rstr, basis, vec)
+    ccall((:CeedOperatorFieldGetData, libceed), Cint, (CeedOperatorField, Ptr{Ptr{Cchar}}, Ptr{CeedElemRestriction}, Ptr{CeedBasis}, Ptr{CeedVector}), op_field, field_name, rstr, basis, vec)
 end
 
 function CeedIntPow(base, power)
@@ -890,6 +1266,10 @@ function CeedReallocArray(n, unit, p)
     ccall((:CeedReallocArray, libceed), Cint, (Csize_t, Csize_t, Ptr{Cvoid}), n, unit, p)
 end
 
+function CeedSetBackendFunctionImpl(ceed, type, object, func_name, f)
+    ccall((:CeedSetBackendFunctionImpl, libceed), Cint, (Ceed, Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cvoid}), ceed, type, object, func_name, f)
+end
+
 @cenum CeedDebugColor::UInt32 begin
     CEED_DEBUG_COLOR_SUCCESS = 108
     CEED_DEBUG_COLOR_WARNING = 208
@@ -915,6 +1295,38 @@ end
 
 function CeedFree(p)
     ccall((:CeedFree, libceed), Cint, (Ptr{Cvoid},), p)
+end
+
+function CeedObjectCreate(ceed, view_function, destroy_function, obj)
+    ccall((:CeedObjectCreate, libceed), Cint, (Ceed, Ptr{Cvoid}, Ptr{Cvoid}, CeedObject), ceed, view_function, destroy_function, obj)
+end
+
+function CeedObjectReference(obj)
+    ccall((:CeedObjectReference, libceed), Cint, (CeedObject,), obj)
+end
+
+function CeedObjectDereference(obj)
+    ccall((:CeedObjectDereference, libceed), Cint, (CeedObject,), obj)
+end
+
+function CeedObjectDestroy_Private(obj)
+    ccall((:CeedObjectDestroy_Private, libceed), Cint, (CeedObject,), obj)
+end
+
+function CeedSetHostBoolArray(source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+    ccall((:CeedSetHostBoolArray, libceed), Cint, (Ptr{Bool}, CeedCopyMode, CeedSize, Ptr{Ptr{Bool}}, Ptr{Ptr{Bool}}, Ptr{Ptr{Bool}}), source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+end
+
+function CeedSetHostCeedInt8Array(source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+    ccall((:CeedSetHostCeedInt8Array, libceed), Cint, (Ptr{CeedInt8}, CeedCopyMode, CeedSize, Ptr{Ptr{CeedInt8}}, Ptr{Ptr{CeedInt8}}, Ptr{Ptr{CeedInt8}}), source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+end
+
+function CeedSetHostCeedIntArray(source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+    ccall((:CeedSetHostCeedIntArray, libceed), Cint, (Ptr{CeedInt}, CeedCopyMode, CeedSize, Ptr{Ptr{CeedInt}}, Ptr{Ptr{CeedInt}}, Ptr{Ptr{CeedInt}}), source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+end
+
+function CeedSetHostCeedScalarArray(source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
+    ccall((:CeedSetHostCeedScalarArray, libceed), Cint, (Ptr{CeedScalar}, CeedCopyMode, CeedSize, Ptr{Ptr{CeedScalar}}, Ptr{Ptr{CeedScalar}}, Ptr{Ptr{CeedScalar}}), source_array, copy_mode, num_values, target_array_owned, target_array_borrowed, target_array)
 end
 
 function CeedRegister(prefix, init, priority)
@@ -953,24 +1365,16 @@ function CeedSetObjectDelegate(ceed, delegate, obj_name)
     ccall((:CeedSetObjectDelegate, libceed), Cint, (Ceed, Ceed, Ptr{Cchar}), ceed, delegate, obj_name)
 end
 
-function CeedGetOperatorFallbackResource(ceed, resource)
-    ccall((:CeedGetOperatorFallbackResource, libceed), Cint, (Ceed, Ptr{Ptr{Cchar}}), ceed, resource)
-end
-
 function CeedGetOperatorFallbackCeed(ceed, fallback_ceed)
     ccall((:CeedGetOperatorFallbackCeed, libceed), Cint, (Ceed, Ptr{Ceed}), ceed, fallback_ceed)
 end
 
-function CeedSetOperatorFallbackResource(ceed, resource)
-    ccall((:CeedSetOperatorFallbackResource, libceed), Cint, (Ceed, Ptr{Cchar}), ceed, resource)
+function CeedSetOperatorFallbackCeed(ceed, fallback_ceed)
+    ccall((:CeedSetOperatorFallbackCeed, libceed), Cint, (Ceed, Ceed), ceed, fallback_ceed)
 end
 
 function CeedSetDeterministic(ceed, is_deterministic)
     ccall((:CeedSetDeterministic, libceed), Cint, (Ceed, Bool), ceed, is_deterministic)
-end
-
-function CeedSetBackendFunction(ceed, type, object, func_name, f)
-    ccall((:CeedSetBackendFunction, libceed), Cint, (Ceed, Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cvoid}), ceed, type, object, func_name, f)
 end
 
 function CeedGetData(ceed, data)
@@ -983,6 +1387,46 @@ end
 
 function CeedReference(ceed)
     ccall((:CeedReference, libceed), Cint, (Ceed,), ceed)
+end
+
+function CeedGetWorkVector(ceed, len, vec)
+    ccall((:CeedGetWorkVector, libceed), Cint, (Ceed, CeedSize, Ptr{CeedVector}), ceed, len, vec)
+end
+
+function CeedRestoreWorkVector(ceed, vec)
+    ccall((:CeedRestoreWorkVector, libceed), Cint, (Ceed, Ptr{CeedVector}), ceed, vec)
+end
+
+function CeedClearWorkVectors(ceed, min_len)
+    ccall((:CeedClearWorkVectors, libceed), Cint, (Ceed, CeedSize), ceed, min_len)
+end
+
+function CeedGetWorkVectorMemoryUsage(ceed, usage_mb)
+    ccall((:CeedGetWorkVectorMemoryUsage, libceed), Cint, (Ceed, Ptr{CeedScalar}), ceed, usage_mb)
+end
+
+function CeedGetJitSourceRoots(ceed, num_source_roots, jit_source_roots)
+    ccall((:CeedGetJitSourceRoots, libceed), Cint, (Ceed, Ptr{CeedInt}, Ptr{Ptr{Ptr{Cchar}}}), ceed, num_source_roots, jit_source_roots)
+end
+
+function CeedGetRustSourceRoots(ceed, num_source_roots, rust_source_roots)
+    ccall((:CeedGetRustSourceRoots, libceed), Cint, (Ceed, Ptr{CeedInt}, Ptr{Ptr{Ptr{Cchar}}}), ceed, num_source_roots, rust_source_roots)
+end
+
+function CeedRestoreJitSourceRoots(ceed, jit_source_roots)
+    ccall((:CeedRestoreJitSourceRoots, libceed), Cint, (Ceed, Ptr{Ptr{Ptr{Cchar}}}), ceed, jit_source_roots)
+end
+
+function CeedRestoreRustSourceRoots(ceed, rust_source_roots)
+    ccall((:CeedRestoreRustSourceRoots, libceed), Cint, (Ceed, Ptr{Ptr{Ptr{Cchar}}}), ceed, rust_source_roots)
+end
+
+function CeedGetJitDefines(ceed, num_defines, jit_defines)
+    ccall((:CeedGetJitDefines, libceed), Cint, (Ceed, Ptr{CeedInt}, Ptr{Ptr{Ptr{Cchar}}}), ceed, num_defines, jit_defines)
+end
+
+function CeedRestoreJitDefines(ceed, jit_defines)
+    ccall((:CeedRestoreJitDefines, libceed), Cint, (Ceed, Ptr{Ptr{Ptr{Cchar}}}), ceed, jit_defines)
 end
 
 function CeedVectorHasValidArray(vec, has_valid_array)
@@ -1025,12 +1469,16 @@ function CeedElemRestrictionIsStrided(rstr, is_strided)
     ccall((:CeedElemRestrictionIsStrided, libceed), Cint, (CeedElemRestriction, Ptr{Bool}), rstr, is_strided)
 end
 
-function CeedElemRestrictionIsPoints(rstr, is_points)
-    ccall((:CeedElemRestrictionIsPoints, libceed), Cint, (CeedElemRestriction, Ptr{Bool}), rstr, is_points)
+function CeedElemRestrictionIsAtPoints(rstr, is_points)
+    ccall((:CeedElemRestrictionIsAtPoints, libceed), Cint, (CeedElemRestriction, Ptr{Bool}), rstr, is_points)
+end
+
+function CeedElemRestrictionAtPointsAreCompatible(rstr_a, rstr_b, are_compatible)
+    ccall((:CeedElemRestrictionAtPointsAreCompatible, libceed), Cint, (CeedElemRestriction, CeedElemRestriction, Ptr{Bool}), rstr_a, rstr_b, are_compatible)
 end
 
 function CeedElemRestrictionGetStrides(rstr, strides)
-    ccall((:CeedElemRestrictionGetStrides, libceed), Cint, (CeedElemRestriction, Ptr{NTuple{3, CeedInt}}), rstr, strides)
+    ccall((:CeedElemRestrictionGetStrides, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, strides)
 end
 
 function CeedElemRestrictionHasBackendStrides(rstr, has_backend_strides)
@@ -1061,12 +1509,28 @@ function CeedElemRestrictionRestoreCurlOrientations(rstr, curl_orients)
     ccall((:CeedElemRestrictionRestoreCurlOrientations, libceed), Cint, (CeedElemRestriction, Ptr{Ptr{CeedInt8}}), rstr, curl_orients)
 end
 
+function CeedElemRestrictionGetLLayout(rstr, layout)
+    ccall((:CeedElemRestrictionGetLLayout, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, layout)
+end
+
+function CeedElemRestrictionSetLLayout(rstr, layout)
+    ccall((:CeedElemRestrictionSetLLayout, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, layout)
+end
+
 function CeedElemRestrictionGetELayout(rstr, layout)
-    ccall((:CeedElemRestrictionGetELayout, libceed), Cint, (CeedElemRestriction, Ptr{NTuple{3, CeedInt}}), rstr, layout)
+    ccall((:CeedElemRestrictionGetELayout, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, layout)
 end
 
 function CeedElemRestrictionSetELayout(rstr, layout)
     ccall((:CeedElemRestrictionSetELayout, libceed), Cint, (CeedElemRestriction, Ptr{CeedInt}), rstr, layout)
+end
+
+function CeedElemRestrictionGetAtPointsElementOffset(rstr, elem, elem_offset)
+    ccall((:CeedElemRestrictionGetAtPointsElementOffset, libceed), Cint, (CeedElemRestriction, CeedInt, Ptr{CeedSize}), rstr, elem, elem_offset)
+end
+
+function CeedElemRestrictionSetAtPointsEVectorSize(rstr, e_size)
+    ccall((:CeedElemRestrictionSetAtPointsEVectorSize, libceed), Cint, (CeedElemRestriction, CeedSize), rstr, e_size)
 end
 
 function CeedElemRestrictionGetData(rstr, data)
@@ -1095,8 +1559,16 @@ function CeedBasisGetCollocatedGrad(basis, colo_grad_1d)
     ccall((:CeedBasisGetCollocatedGrad, libceed), Cint, (CeedBasis, Ptr{CeedScalar}), basis, colo_grad_1d)
 end
 
+function CeedBasisGetChebyshevInterp1D(basis, chebyshev_interp_1d)
+    ccall((:CeedBasisGetChebyshevInterp1D, libceed), Cint, (CeedBasis, Ptr{CeedScalar}), basis, chebyshev_interp_1d)
+end
+
 function CeedBasisIsTensor(basis, is_tensor)
     ccall((:CeedBasisIsTensor, libceed), Cint, (CeedBasis, Ptr{Bool}), basis, is_tensor)
+end
+
+function CeedBasisIsCollocated(basis, is_collocated)
+    ccall((:CeedBasisIsCollocated, libceed), Cint, (CeedBasis, Ptr{Bool}), basis, is_collocated)
 end
 
 function CeedBasisGetData(basis, data)
@@ -1115,8 +1587,8 @@ function CeedBasisGetNumQuadratureComponents(basis, eval_mode, q_comp)
     ccall((:CeedBasisGetNumQuadratureComponents, libceed), Cint, (CeedBasis, CeedEvalMode, Ptr{CeedInt}), basis, eval_mode, q_comp)
 end
 
-function CeedBasisGetFlopsEstimate(basis, t_mode, eval_mode, flops)
-    ccall((:CeedBasisGetFlopsEstimate, libceed), Cint, (CeedBasis, CeedTransposeMode, CeedEvalMode, Ptr{CeedSize}), basis, t_mode, eval_mode, flops)
+function CeedBasisGetFlopsEstimate(basis, t_mode, eval_mode, is_at_points, num_points, flops)
+    ccall((:CeedBasisGetFlopsEstimate, libceed), Cint, (CeedBasis, CeedTransposeMode, CeedEvalMode, Bool, CeedInt, Ptr{CeedSize}), basis, t_mode, eval_mode, is_at_points, num_points, flops)
 end
 
 function CeedBasisGetFESpace(basis, fe_space)
@@ -1135,6 +1607,10 @@ function CeedBasisSetTensorContract(basis, contract)
     ccall((:CeedBasisSetTensorContract, libceed), Cint, (CeedBasis, CeedTensorContract), basis, contract)
 end
 
+function CeedBasisCreateH1Fallback(ceed, topo, num_comp, num_nodes, nqpts, interp, grad, q_ref, q_weights, basis)
+    ccall((:CeedBasisCreateH1Fallback, libceed), Cint, (Ceed, CeedElemTopology, CeedInt, CeedInt, CeedInt, Ptr{CeedScalar}, Ptr{CeedScalar}, Ptr{CeedScalar}, Ptr{CeedScalar}, CeedBasis), ceed, topo, num_comp, num_nodes, nqpts, interp, grad, q_ref, q_weights, basis)
+end
+
 function CeedTensorContractCreate(ceed, contract)
     ccall((:CeedTensorContractCreate, libceed), Cint, (Ceed, Ptr{CeedTensorContract}), ceed, contract)
 end
@@ -1149,6 +1625,10 @@ end
 
 function CeedTensorContractGetCeed(contract, ceed)
     ccall((:CeedTensorContractGetCeed, libceed), Cint, (CeedTensorContract, Ptr{Ceed}), contract, ceed)
+end
+
+function CeedTensorContractReturnCeed(contract)
+    ccall((:CeedTensorContractReturnCeed, libceed), Ceed, (CeedTensorContract,), contract)
 end
 
 function CeedTensorContractGetData(contract, data)
@@ -1189,6 +1669,10 @@ end
 
 function CeedQFunctionGetKernelName(qf, kernel_name)
     ccall((:CeedQFunctionGetKernelName, libceed), Cint, (CeedQFunction, Ptr{Ptr{Cchar}}), qf, kernel_name)
+end
+
+function CeedQFunctionGetName(qf, name)
+    ccall((:CeedQFunctionGetName, libceed), Cint, (CeedQFunction, Ptr{Ptr{Cchar}}), qf, name)
 end
 
 function CeedQFunctionGetSourcePath(qf, source_path)
@@ -1239,6 +1723,14 @@ function CeedQFunctionSetData(qf, data)
     ccall((:CeedQFunctionSetData, libceed), Cint, (CeedQFunction, Ptr{Cvoid}), qf, data)
 end
 
+function CeedQFunctionIsImmutable(qf, is_immutable)
+    ccall((:CeedQFunctionIsImmutable, libceed), Cint, (CeedQFunction, Ptr{Bool}), qf, is_immutable)
+end
+
+function CeedQFunctionSetImmutable(qf)
+    ccall((:CeedQFunctionSetImmutable, libceed), Cint, (CeedQFunction,), qf)
+end
+
 function CeedQFunctionReference(qf)
     ccall((:CeedQFunctionReference, libceed), Cint, (CeedQFunction,), qf)
 end
@@ -1249,6 +1741,10 @@ end
 
 function CeedQFunctionContextGetCeed(ctx, ceed)
     ccall((:CeedQFunctionContextGetCeed, libceed), Cint, (CeedQFunctionContext, Ptr{Ceed}), ctx, ceed)
+end
+
+function CeedQFunctionContextReturnCeed(ctx)
+    ccall((:CeedQFunctionContextReturnCeed, libceed), Ceed, (CeedQFunctionContext,), ctx)
 end
 
 function CeedQFunctionContextHasValidData(ctx, has_valid_data)
@@ -1287,28 +1783,124 @@ function CeedQFunctionContextRestoreGenericRead(ctx, field_label, field_type, va
     ccall((:CeedQFunctionContextRestoreGenericRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, CeedContextFieldType, Ptr{Cvoid}), ctx, field_label, field_type, value)
 end
 
-function CeedQFunctionContextSetDouble(ctx, field_label, values)
-    ccall((:CeedQFunctionContextSetDouble, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Cdouble}), ctx, field_label, values)
+function CeedQFunctionContextSetCeedByte(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedByte, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Cchar}), ctx, field_label, values)
 end
 
-function CeedQFunctionContextGetDoubleRead(ctx, field_label, num_values, values)
-    ccall((:CeedQFunctionContextGetDoubleRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cdouble}}), ctx, field_label, num_values, values)
+function CeedQFunctionContextGetCeedByteRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedByteRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cchar}}), ctx, field_label, num_values, values)
 end
 
-function CeedQFunctionContextRestoreDoubleRead(ctx, field_label, values)
-    ccall((:CeedQFunctionContextRestoreDoubleRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Cdouble}}), ctx, field_label, values)
+function CeedQFunctionContextRestoreCeedByteRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedByteRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Cchar}}), ctx, field_label, values)
 end
 
-function CeedQFunctionContextSetInt32(ctx, field_label, values)
-    ccall((:CeedQFunctionContextSetInt32, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Cint}), ctx, field_label, values)
+function CeedQFunctionContextSetCeedScalar(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedScalar, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{CeedScalar}), ctx, field_label, values)
 end
 
-function CeedQFunctionContextGetInt32Read(ctx, field_label, num_values, values)
-    ccall((:CeedQFunctionContextGetInt32Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cint}}), ctx, field_label, num_values, values)
+function CeedQFunctionContextGetCeedScalarRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedScalarRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedScalar}}), ctx, field_label, num_values, values)
 end
 
-function CeedQFunctionContextRestoreInt32Read(ctx, field_label, values)
-    ccall((:CeedQFunctionContextRestoreInt32Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Cint}}), ctx, field_label, values)
+function CeedQFunctionContextRestoreCeedScalarRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedScalarRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{CeedScalar}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedFloat(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedFloat, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Cfloat}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedFloatRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedFloatRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cfloat}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedFloatRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedFloatRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Cfloat}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedDouble(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedDouble, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Cdouble}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedDoubleRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedDoubleRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Cdouble}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedDoubleRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedDoubleRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Cdouble}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedInt8(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedInt8, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{CeedInt8}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedInt8Read(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedInt8Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedInt8}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedInt8Read(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedInt8Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{CeedInt8}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedInt(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedInt, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{CeedInt}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedIntRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedIntRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedInt}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedIntRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedIntRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{CeedInt}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedInt32(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedInt32, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Int32}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedInt32Read(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedInt32Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Int32}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedInt32Read(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedInt32Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Int32}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedInt64(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedInt64, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Int64}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedInt64Read(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedInt64Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Int64}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedInt64Read(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedInt64Read, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Int64}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedSize(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedSize, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{CeedSize}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedSizeRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedSizeRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{CeedSize}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedSizeRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedSizeRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{CeedSize}}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextSetCeedBoolean(ctx, field_label, values)
+    ccall((:CeedQFunctionContextSetCeedBoolean, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Bool}), ctx, field_label, values)
+end
+
+function CeedQFunctionContextGetCeedBooleanRead(ctx, field_label, num_values, values)
+    ccall((:CeedQFunctionContextGetCeedBooleanRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Csize_t}, Ptr{Ptr{Bool}}), ctx, field_label, num_values, values)
+end
+
+function CeedQFunctionContextRestoreCeedBooleanRead(ctx, field_label, values)
+    ccall((:CeedQFunctionContextRestoreCeedBooleanRead, libceed), Cint, (CeedQFunctionContext, CeedContextFieldLabel, Ptr{Ptr{Bool}}), ctx, field_label, values)
 end
 
 function CeedQFunctionContextGetDataDestroy(ctx, f_mem_type, f)
@@ -1319,8 +1911,16 @@ function CeedQFunctionContextReference(ctx)
     ccall((:CeedQFunctionContextReference, libceed), Cint, (CeedQFunctionContext,), ctx)
 end
 
+function CeedOperatorGetBasisPointer(basis, eval_mode, identity, basis_ptr)
+    ccall((:CeedOperatorGetBasisPointer, libceed), Cint, (CeedBasis, CeedEvalMode, Ptr{CeedScalar}, Ptr{Ptr{CeedScalar}}), basis, eval_mode, identity, basis_ptr)
+end
+
 function CeedOperatorCreateActivePointBlockRestriction(rstr, pointblock_rstr)
     ccall((:CeedOperatorCreateActivePointBlockRestriction, libceed), Cint, (CeedElemRestriction, Ptr{CeedElemRestriction}), rstr, pointblock_rstr)
+end
+
+function CeedOperatorGetQFunctionAssemblyData(op, data)
+    ccall((:CeedOperatorGetQFunctionAssemblyData, libceed), Cint, (CeedOperator, Ptr{CeedQFunctionAssemblyData}), op, data)
 end
 
 function CeedQFunctionAssemblyDataCreate(ceed, data)
@@ -1351,6 +1951,10 @@ function CeedQFunctionAssemblyDataIsSetup(data, is_setup)
     ccall((:CeedQFunctionAssemblyDataIsSetup, libceed), Cint, (CeedQFunctionAssemblyData, Ptr{Bool}), data, is_setup)
 end
 
+function CeedQFunctionAssemblyDataSetBlockAssembling(data, is_block_assembling)
+    ccall((:CeedQFunctionAssemblyDataSetBlockAssembling, libceed), Cint, (CeedQFunctionAssemblyData, Bool), data, is_block_assembling)
+end
+
 function CeedQFunctionAssemblyDataSetObjects(data, vec, rstr)
     ccall((:CeedQFunctionAssemblyDataSetObjects, libceed), Cint, (CeedQFunctionAssemblyData, CeedVector, CeedElemRestriction), data, vec, rstr)
 end
@@ -1361,6 +1965,10 @@ end
 
 function CeedQFunctionAssemblyDataDestroy(data)
     ccall((:CeedQFunctionAssemblyDataDestroy, libceed), Cint, (Ptr{CeedQFunctionAssemblyData},), data)
+end
+
+function CeedOperatorGetOperatorAssemblyData(op, data)
+    ccall((:CeedOperatorGetOperatorAssemblyData, libceed), Cint, (CeedOperator, Ptr{CeedOperatorAssemblyData}), op, data)
 end
 
 function CeedOperatorAssemblyDataCreate(ceed, op, data)
@@ -1383,10 +1991,6 @@ function CeedOperatorAssemblyDataDestroy(data)
     ccall((:CeedOperatorAssemblyDataDestroy, libceed), Cint, (Ptr{CeedOperatorAssemblyData},), data)
 end
 
-function CeedOperatorGetOperatorAssemblyData(op, data)
-    ccall((:CeedOperatorGetOperatorAssemblyData, libceed), Cint, (CeedOperator, Ptr{CeedOperatorAssemblyData}), op, data)
-end
-
 function CeedOperatorGetActiveBasis(op, active_basis)
     ccall((:CeedOperatorGetActiveBasis, libceed), Cint, (CeedOperator, Ptr{CeedBasis}), op, active_basis)
 end
@@ -1405,6 +2009,14 @@ end
 
 function CeedOperatorGetNumArgs(op, num_args)
     ccall((:CeedOperatorGetNumArgs, libceed), Cint, (CeedOperator, Ptr{CeedInt}), op, num_args)
+end
+
+function CeedOperatorHasTensorBases(op, has_tensor_bases)
+    ccall((:CeedOperatorHasTensorBases, libceed), Cint, (CeedOperator, Ptr{Bool}), op, has_tensor_bases)
+end
+
+function CeedOperatorIsImmutable(op, is_immutable)
+    ccall((:CeedOperatorIsImmutable, libceed), Cint, (CeedOperator, Ptr{Bool}), op, is_immutable)
 end
 
 function CeedOperatorIsSetupDone(op, is_setup_done)
@@ -1443,6 +2055,14 @@ function CeedOperatorGetFallbackParentCeed(op, parent)
     ccall((:CeedOperatorGetFallbackParentCeed, libceed), Cint, (CeedOperator, Ptr{Ceed}), op, parent)
 end
 
+function CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback(op, build_objects, assembled, rstr, request)
+    ccall((:CeedOperatorLinearAssembleQFunctionBuildOrUpdateFallback, libceed), Cint, (CeedOperator, Bool, Ptr{CeedVector}, Ptr{CeedElemRestriction}, Ptr{CeedRequest}), op, build_objects, assembled, rstr, request)
+end
+
+function CeedOperatorAssembleSingle(op, offset, values)
+    ccall((:CeedOperatorAssembleSingle, libceed), Cint, (CeedOperator, CeedSize, CeedVector), op, offset, values)
+end
+
 function CeedOperatorSetSetupDone(op)
     ccall((:CeedOperatorSetSetupDone, libceed), Cint, (CeedOperator,), op)
 end
@@ -1459,6 +2079,10 @@ function CeedHouseholderApplyQ(mat_A, mat_Q, tau, t_mode, m, n, k, row, col)
     ccall((:CeedHouseholderApplyQ, libceed), Cint, (Ptr{CeedScalar}, Ptr{CeedScalar}, Ptr{CeedScalar}, CeedTransposeMode, CeedInt, CeedInt, CeedInt, CeedInt, CeedInt), mat_A, mat_Q, tau, t_mode, m, n, k, row, col)
 end
 
+function CeedMatrixPseudoinverse(ceed, mat, m, n, mat_pinv)
+    ccall((:CeedMatrixPseudoinverse, libceed), Cint, (Ceed, Ptr{CeedScalar}, CeedInt, CeedInt, Ptr{CeedScalar}), ceed, mat, m, n, mat_pinv)
+end
+
 function CeedSymmetricSchurDecomposition(ceed, mat, lambda, n)
     ccall((:CeedSymmetricSchurDecomposition, libceed), Cint, (Ceed, Ptr{CeedScalar}, Ptr{CeedScalar}, CeedInt), ceed, mat, lambda, n)
 end
@@ -1473,6 +2097,8 @@ end
 
 # Skipping MacroDefinition: CEED_QFUNCTION_HELPER CEED_QFUNCTION_HELPER_ATTR static inline
 
+# Skipping MacroDefinition: CeedPragmaSIMD _Pragma ( "clang loop vectorize(enable)" )
+
 const CeedInt_FMT = "d"
 
 const CeedSize_FMT = "td"
@@ -1485,7 +2111,9 @@ const CEED_VERSION_MINOR = 12
 
 const CEED_VERSION_PATCH = 0
 
-const CEED_VERSION_RELEASE = true
+const CEED_VERSION_RELEASE = false
+
+# Skipping MacroDefinition: DEPRECATED ( msg ) __attribute__ ( ( deprecated ( msg ) ) )
 
 # Skipping MacroDefinition: CEED_INTERN extern CEED_VISIBILITY ( hidden )
 
@@ -1502,3 +2130,5 @@ const CEED_FIELD_MAX = 16
 # Skipping MacroDefinition: CeedPragmaOptimizeOff _Pragma ( "clang optimize off" )
 
 # Skipping MacroDefinition: CeedPragmaOptimizeOn _Pragma ( "clang optimize on" )
+
+const CEED_TAB_WIDTH = 2


### PR DESCRIPTION
Purpose:

Adds seven new `CeedContextFieldType` values - `BYTE`, `INT8`, `INT`, `INT64`, `SIZE`, `SCALAR`,
and `FLOAT` - alongside the existing `DOUBLE`, `INT32`, and `BOOL`, with matching
`CeedQFunctionContextRegisterCeed*` / `Set*` / `Get*Read` / `Restore*Read` functions on both
`CeedQFunctionContext` and `CeedOperator`.

As we agreed in the issue discussion, this renumbers the existing `CeedContextFieldType` enum
(an intentional ABI break, approved ahead of the 1.0 release) and gives every accessor function
a `Ceed`-prefixed name for the libCEED-typedef'd types, as per @jeremylt 's and @zatkins-dev 's suggestion.

`CEED_CONTEXT_FIELD_SCALAR`, `FLOAT`, and `DOUBLE` are kept as distinct field types.

One thing I want to mention is: 
The discussion we had earlier didn't say an exact enum ordering for the final 10-type set - the only ordering anyone said was the case order of
the `switch` @jeremylt  posted (BOOL, BYTE, INT8, INT, INT32, INT64, SIZE, SCALAR, FLOAT, DOUBLE).
I've used 
``` cpp
typedef enum {
  /// Byte value, C type of char
  CEED_CONTEXT_FIELD_BYTE = 1,
  /// CeedScalar value
  CEED_CONTEXT_FIELD_SCALAR = 2,
  /// Single precision value
  CEED_CONTEXT_FIELD_FLOAT = 3,
  /// Double precision value
  CEED_CONTEXT_FIELD_DOUBLE = 4,
  ///8 bit integer value
  CEED_CONTEXT_FIELD_INT8 = 5,
  /// CeedInt value
  CEED_CONTEXT_FIELD_INT = 6,
  /// 32 bit integer value
  CEED_CONTEXT_FIELD_INT32 = 7,
  /// 64 bit integer value
  CEED_CONTEXT_FIELD_INT64 = 8,
  /// CeedSize value
  CEED_CONTEXT_FIELD_SIZE = 9,
  /// Boolean value
  CEED_CONTEXT_FIELD_BOOL = 10,
} CeedContextFieldType;
```

I am happy to change the ordering if anything else was intended.

This PR is currently a draft. The below tasks remain, before it's ready for full review:

- [ ] Extend `tests/t407-qfunction.c` to cover all ten field types (currently covers three)
- [ ] Confirm the enum ordering above
- [ ] `make prove-all` clean run including `examples/fluids`

These will be completed by tomorrow afternoon

Closes: #2004 

LLM/GenAI Disclosure:

I used Claude to help me understand the existing `CeedQFunctionContext`
 in `interface/ceed-qfunctioncontext.c` and `interface/ceed-operator.c` before
writing this change, and to review my diff against the design decisions from the issue thread -
it pointed out a few bugs (a `CeedSize`/`size_t` signature mismatch that failed to compile, a
stale `CeedContextFieldTypes[]` string table) which **I then fixed myself.** 

**ALL CODE SOURCE CHANGES IN THIS PR ARE WRITTEN BY ME.**

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
