### PR TITLE
CI - fix python CI by adding missing apt update

### DIFF
--- a/.github/workflows/python-test-with-style.yml
+++ b/.github/workflows/python-test-with-style.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v5
     - name: PETSc install
       run: |
+        sudo apt-get update
         sudo apt install -y python3-pip python3 libpetsc-real-dev python3-mpi4py python3-petsc4py
     - name: Python dependencies
       run: |


### PR DESCRIPTION
Purpose:

Fix python CI failures

LLM/GenAI Disclosure:

I put the error message into google and the AI summary told me to add `sudo apt-get update`

By submitting this PR, the author certifies to its contents as described by the [Developer's Certificate of Origin](https://developercertificate.org/).
Please follow the [Contributing Guidelines](https://github.com/CEED/libCEED/blob/main/CONTRIBUTING.md) for all PRs.
