### PR TITLE
cuda-ref: use cudaMemcpyAsync for vector H2D

### DIFF
--- a/backends/cuda-ref/ceed-cuda-ref-vector.c
+++ b/backends/cuda-ref/ceed-cuda-ref-vector.c
@@ -57,7 +57,7 @@ static inline int CeedVectorSyncH2D_Cuda(const CeedVector vec) {
     CeedCallCuda(CeedVectorReturnCeed(vec), cudaMalloc((void **)&impl->d_array_owned, bytes));
     impl->d_array = impl->d_array_owned;
   }
-  CeedCallCuda(CeedVectorReturnCeed(vec), cudaMemcpy(impl->d_array, impl->h_array, bytes, cudaMemcpyHostToDevice));
+  CeedCallCuda(CeedVectorReturnCeed(vec), cudaMemcpyAsync(impl->d_array, impl->h_array, bytes, cudaMemcpyHostToDevice, cudaStreamPerThread));
   return CEED_ERROR_SUCCESS;
 }
 


### PR DESCRIPTION
Purpose: 

Use `cudaMemcpyAsync` on `cudaStreamPerThread` for vector H2D sync, same as `QFunction` context and vector memset.

Closes: N/A

LLM/GenAI Disclosure:

None


