### PR TITLE
Skip redundant active input gathers

### DIFF
--- a/backends/opt/ceed-opt-operator.c
+++ b/backends/opt/ceed-opt-operator.c
@@ -340,7 +340,7 @@ static inline int CeedOperatorInputBasis_Opt(CeedInt e, CeedInt Q, CeedQFunction
     CeedCallBackend(CeedQFunctionFieldGetEvalMode(qf_input_fields[i], &eval_mode));
     CeedCallBackend(CeedQFunctionFieldGetSize(qf_input_fields[i], &size));
     // Restrict block active input
-    if (is_active && impl->block_rstr[i]) {
+    if (is_active && impl->block_rstr[i] && !impl->skip_rstr_in[i]) {
       CeedCallBackend(CeedElemRestrictionApplyBlock(impl->block_rstr[i], e / block_size, CEED_NOTRANSPOSE, in_vec, impl->e_vecs_in[i], request));
     }
     // Basis action


### PR DESCRIPTION
This PR skips redudant element gathers when operators share the saem vector and restrictions, including inputs using different evaluation modes.

This speeds up operator-focused benchmarks in Palace by 5 % and realistic runs by 1-2 %.

LLM/GenAI Disclosure: This optimization was found by GPT 6.